### PR TITLE
fix(repo): correct opencode run flags and add stdin support

### DIFF
--- a/internal/core/agent/ide.go
+++ b/internal/core/agent/ide.go
@@ -357,10 +357,13 @@ func buildOpenCodeCommand(modelName string, reasoningEffort string) string {
 	}
 	args := []string{
 		model.IDEOpenCode, "run",
-		"--print",
 		"--format", "json",
-		"--thinking", reasoningEffort,
-		"--model", modelToUse,
+		"--variant", reasoningEffort,
+		"--thinking",
+		"-",
+	}
+	if modelToUse != "" {
+		args = append(args, "--model", modelToUse)
 	}
 	return formatShellCommand(args)
 }
@@ -368,9 +371,10 @@ func buildOpenCodeCommand(modelName string, reasoningEffort string) string {
 func openCodeCommand(ctx context.Context, modelName, reasoning string) *exec.Cmd {
 	args := []string{
 		"run",
-		"--print",
 		"--format", "json",
-		"--thinking", reasoning,
+		"--variant", reasoning,
+		"--thinking",
+		"-",
 	}
 	if modelName != "" {
 		args = append(args, "--model", modelName)

--- a/internal/core/agent/ide_test.go
+++ b/internal/core/agent/ide_test.go
@@ -122,7 +122,7 @@ func TestBuildOpenCodeCommandFormat(t *testing.T) {
 	t.Parallel()
 
 	cmd := buildOpenCodeCommand("", "medium")
-	want := "opencode run --print --format json --thinking medium --model " + model.DefaultOpenCodeModel
+	want := "opencode run --format json --variant medium --thinking - --model " + model.DefaultOpenCodeModel
 	if cmd != want {
 		t.Fatalf("unexpected opencode command string\nwant: %s\ngot:  %s", want, cmd)
 	}
@@ -132,7 +132,7 @@ func TestBuildOpenCodeCommandCustomModel(t *testing.T) {
 	t.Parallel()
 
 	cmd := buildOpenCodeCommand("openai/gpt-4o", "high")
-	want := "opencode run --print --format json --thinking high --model openai/gpt-4o"
+	want := "opencode run --format json --variant high --thinking - --model openai/gpt-4o"
 	if cmd != want {
 		t.Fatalf("unexpected opencode command string\nwant: %s\ngot:  %s", want, cmd)
 	}


### PR DESCRIPTION
Esta alteração corrige a integração do Compozy com o IDE **OpenCode**, ajustando a forma como o CLI é invocado para garantir compatibilidade com as flags atuais e suporte à leitura de prompts via `stdin`.

## Mudanças Realizadas:

### 1. Correção de Flags no `opencode run`
*   **Remoção da flag `--print`**: Esta flag não é suportada e causava erros de execução no comando `opencode run`.
*   **Correção da flag `--thinking`**: Alterada de string (nível de esforço) para um booleano (`boolean`), que é o tipo esperado pelo CLI do OpenCode para habilitar a exibição dos blocos de pensamento.
*   **Introdução da flag `--variant`**: Adicionada para passar o nível de esforço de raciocínio (reasoning effort) de forma explícita, conforme o novo padrão do OpenCode.

### 2. Suporte a Leitura de Stdin
*   **Adição do argumento posicional `-`**: Essencial para que o comando `opencode run` aceite o prompt via `stdin` (pipe), permitindo a execução automatizada e não interativa pelo Compozy.

### 3. Atualização de Testes Unitários
*   Os testes em `internal/core/agent/ide_test.go` foram atualizados para validar a nova estrutura do comando, garantindo que futuras mudanças não quebrem a integração com o OpenCode.

## Verificação e Validação:
- Todas as verificações do pipeline de CI (`make verify`) passaram com sucesso (fmt, lint, test, build).
- Validado via `opencode run --help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal command-line argument handling for improved integration with OpenCode CLI tools. Changes include modified argument passing mechanisms and conditional model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->