### PR TITLE
ci(release): Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+### 🎉 Features
+
+- *(repo)* Add archive command
+
+## 0.1.2 - 2026-04-02
+
 ### 🐛 Bug Fixes
 
 - *(repo)* Close tui when finish
@@ -13,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 📚 Documentation
 
 - *(repo)* Update readme
+
+### 🔧 CI/CD
+
+- *(release)* Prepare release v0.1.2 (#28)
 
 ## 0.1.1 - 2026-04-02
 
@@ -81,7 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
-[unreleased]: https://github.com///compare/v0.1.1...HEAD
+[unreleased]: https://github.com///compare/v0.1.2...HEAD
+[0.1.2]: https://github.com///compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com///compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com///releases/tag/v0.1.0
 ---

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "name": "compozy",
   "private": true,
-  "version": "0.1.2"
+  "version": "0.1.3"
 }


### PR DESCRIPTION

## Release v0.1.3

This PR prepares the release of version v0.1.3.

### Changelog

# Changelog

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
## Unreleased

### 🎉 Features

- *(repo)* Add archive command

[unreleased]: https://github.com///compare/v0.1.2...HEAD
---
*Generated by [git-cliff](https://git-cliff.org)*
