### PR TITLE
feat(build): add AUR support and automation via GoReleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -243,8 +243,11 @@ aurs:
       - compozy
     conflicts:
       - compozy
+      - compozy-git
     package: |-
       # Binaries
+      # GoReleaser wraps files in a directory named after the archive
+      cd "${srcdir}/${pkgname%-bin}_${pkgver}_linux_"*
       install -Dm755 "${pkgname%-bin}" "${pkgdir}/usr/bin/${pkgname%-bin}"
 
       # License

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -228,3 +228,32 @@ npms:
     access: public
     license: BSL-1.1
     homepage: "https://compozy.com"
+
+# Arch User Repository (AUR) configuration
+aurs:
+  - name: compozy-bin
+    homepage: "https://github.com/compozy/compozy"
+    description: "Compozy CLI"
+    maintainers:
+      - "Compozy Team <support@compozy.com>"
+    license: "MIT"
+    private_key: '{{ .Env.AUR_KEY }}'
+    git_url: 'ssh://aur@aur.archlinux.org/compozy-bin.git'
+    provides:
+      - compozy
+    conflicts:
+      - compozy
+    package: |-
+      # Binaries
+      install -Dm755 "${pkgname%-bin}" "${pkgdir}/usr/bin/${pkgname%-bin}"
+
+      # License
+      install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+      # README
+      install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "AUR package update for {{ .ProjectName }} version {{ .Tag }}"
+

--- a/aur-pkg/PKGBUILD
+++ b/aur-pkg/PKGBUILD
@@ -7,13 +7,17 @@ arch=('x86_64' 'aarch64')
 url="https://github.com/compozy/compozy"
 license=('MIT')
 provides=('compozy')
-conflicts=('compozy')
+conflicts=('compozy' 'compozy-git')
 source_x86_64=("${pkgname}-${pkgver}-x86_64.tar.gz::${url}/releases/download/v${pkgver}/compozy_${pkgver}_linux_x86_64.tar.gz")
 source_aarch64=("${pkgname}-${pkgver}-aarch64.tar.gz::${url}/releases/download/v${pkgver}/compozy_${pkgver}_linux_arm64.tar.gz")
-sha256sums_x86_64=('SKIP')
-sha256sums_aarch64=('SKIP')
+sha256sums_x86_64=('eaec0ad0fc33bb2821b90d9f96d483edc30b1f5e064f04ffbc6a72193aee69af')
+sha256sums_aarch64=('5e36dddb31320c70fded3bdff5ca4bfa2923c7291cc145a8f43fd12044dea7fe')
 
 package() {
+  local _arch_dir="compozy_${pkgver}_linux_x86_64"
+  [[ "${CARCH}" == "aarch64" ]] && _arch_dir="compozy_${pkgver}_linux_arm64"
+
+  cd "${_arch_dir}"
   install -Dm755 compozy "${pkgdir}/usr/bin/compozy"
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
   install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"

--- a/aur-pkg/PKGBUILD
+++ b/aur-pkg/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: Compozy Team <support@compozy.com>
+pkgname=compozy-bin
+pkgver=0.1.6
+pkgrel=1
+pkgdesc="Compozy CLI - Modern agentic workflow for software development (binary release)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/compozy/compozy"
+license=('MIT')
+provides=('compozy')
+conflicts=('compozy')
+source_x86_64=("${pkgname}-${pkgver}-x86_64.tar.gz::${url}/releases/download/v${pkgver}/compozy_${pkgver}_linux_x86_64.tar.gz")
+source_aarch64=("${pkgname}-${pkgver}-aarch64.tar.gz::${url}/releases/download/v${pkgver}/compozy_${pkgver}_linux_arm64.tar.gz")
+sha256sums_x86_64=('SKIP')
+sha256sums_aarch64=('SKIP')
+
+package() {
+  install -Dm755 compozy "${pkgdir}/usr/bin/compozy"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/aur-pkg/PKGBUILD-src
+++ b/aur-pkg/PKGBUILD-src
@@ -1,0 +1,44 @@
+# Maintainer: Compozy Team <support@compozy.com>
+pkgname=compozy
+pkgver=0.1.6
+pkgrel=1
+pkgdesc="Compozy CLI - Modern agentic workflow for software development"
+arch=('x86_64' 'aarch64')
+url="https://github.com/compozy/compozy"
+license=('MIT')
+depends=('glibc')
+makedepends=('go')
+provides=('compozy')
+conflicts=('compozy-git' 'compozy-bin')
+source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+build() {
+  cd "${pkgname}-${pkgver}"
+  export CGO_CPPFLAGS="${CPPFLAGS}"
+  export CGO_CFLAGS="${CFLAGS}"
+  export CGO_CXXFLAGS="${CXXFLAGS}"
+  export CGO_LDFLAGS="${LDFLAGS}"
+  export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
+
+  local _commit=$(git rev-parse --short HEAD 2>/dev/null || echo "v${pkgver}")
+  local _date=$(date -u -d "@${SOURCE_DATE_EPOCH:- $(date +%s)}" +'%Y-%m-%dT%H:%M:%SZ')
+
+  go build -o build/compozy \
+    -ldflags "-X github.com/compozy/compozy/internal/version.Version=v${pkgver} \
+              -X github.com/compozy/compozy/internal/version.Commit=${_commit} \
+              -X github.com/compozy/compozy/internal/version.Date=${_date}" \
+    ./cmd/compozy
+}
+
+check() {
+  cd "${pkgname}-${pkgver}"
+  go test ./...
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+  install -Dm755 build/compozy "${pkgdir}/usr/bin/compozy"
+  install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 README.md "${pkgdir}/usr/share/doc/${pkgname}/README.md"
+}

--- a/aur-pkg/PKGBUILD-src
+++ b/aur-pkg/PKGBUILD-src
@@ -9,9 +9,9 @@ license=('MIT')
 depends=('glibc')
 makedepends=('go')
 provides=('compozy')
-conflicts=('compozy-git' 'compozy-bin')
+conflicts=('compozy' 'compozy-git' 'compozy-bin')
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
-sha256sums=('SKIP')
+sha256sums=('56cfbc5ebe55f8a93527eb87d86ad163a0eb774518751ea561070e9abe421bad')
 
 build() {
   cd "${pkgname}-${pkgver}"
@@ -22,7 +22,7 @@ build() {
   export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
 
   local _commit=$(git rev-parse --short HEAD 2>/dev/null || echo "v${pkgver}")
-  local _date=$(date -u -d "@${SOURCE_DATE_EPOCH:- $(date +%s)}" +'%Y-%m-%dT%H:%M:%SZ')
+  local _date=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" +'%Y-%m-%dT%H:%M:%SZ')
 
   go build -o build/compozy \
     -ldflags "-X github.com/compozy/compozy/internal/version.Version=v${pkgver} \

--- a/aur-pkg/README.md
+++ b/aur-pkg/README.md
@@ -1,0 +1,21 @@
+# AUR Support for Compozy
+
+This directory contains PKGBUILD templates for making Compozy available in the Arch User Repository (AUR).
+
+## Files
+
+- `PKGBUILD`: Stable binary release package (`compozy-bin`). Recommended for most users as it's faster to install.
+- `PKGBUILD-src`: Stable source release package (`compozy`). Builds from source using Go.
+
+## How to use
+
+1.  Create a new repository on AUR (e.g., `compozy-bin`).
+2.  Clone it locally.
+3.  Copy the relevant `PKGBUILD` from this directory to your AUR repository.
+4.  Run `makepkg --printsrcinfo > .SRCINFO`.
+5.  Commit and push to AUR.
+
+## Maintainer Note
+
+Replace the `Maintainer` line with your own name and email if you are the one uploading it to AUR.
+Currently set to `Compozy Team`.

--- a/aur-pkg/TODO.md
+++ b/aur-pkg/TODO.md
@@ -1,0 +1,57 @@
+# TODO: Finalizing AUR Automation for Compozy
+
+After merging this Pull Request, the repository owner needs to perform these one-time setup steps to enable automatic updates to the Arch User Repository (AUR).
+
+## 1. Create an AUR Account
+If you don't already have one, create an account at [aur.archlinux.org](https://aur.archlinux.org/).
+- **Username:** `compozy` (recommended) or your personal username.
+- **SSH Public Key:** You will need to add a public key here (see Step 2).
+
+## 2. Generate and Configure SSH Keys
+GoReleaser needs an SSH key to push updates to the AUR.
+
+1. **Generate a new keypair** (no passphrase):
+   ```bash
+   ssh-keygen -t ed25519 -f ~/.ssh/aur_compozy -N ""
+   ```
+2. **Add the Public Key to AUR:**
+   - Copy the content of `~/.ssh/aur_compozy.pub`.
+   - Log in to AUR -> My Account -> SSH Public Key -> Paste the key and Save.
+
+3. **Add the Private Key to GitHub Secrets:**
+   - Copy the content of the private key: `cat ~/.ssh/aur_compozy`.
+   - In your GitHub repository: **Settings > Secrets and variables > Actions > New repository secret**.
+   - **Name:** `AUR_KEY`
+   - **Secret:** (Paste the entire private key block including BEGIN/END lines).
+
+## 3. Claim the AUR Package (First Time Only)
+The automation can update existing packages but cannot create them. You must perform the initial push manually:
+
+```bash
+# Clone the (currently empty) AUR repo
+git clone ssh://aur@aur.archlinux.org/compozy-bin.git
+cd compozy-bin
+
+# Copy the PKGBUILD from this PR's aur-pkg directory
+cp /path/to/compozy/aur-pkg/PKGBUILD .
+
+# Generate the .SRCINFO file required by AUR
+makepkg --printsrcinfo > .SRCINFO
+
+# Commit and push to claim ownership
+git add PKGBUILD .SRCINFO
+git commit -m "Initial commit for compozy-bin"
+git push origin master
+```
+
+## 4. Update .goreleaser.yml (If needed)
+Ensure the `release.github.owner` in `.goreleaser.yml` matches the upstream organization (`compozy`).
+
+## 5. Verify the Automation
+The next time you push a version tag (e.g., `v0.1.7`), the GitHub Action will:
+1. Build the binaries.
+2. Create the GitHub Release.
+3. Automatically update the AUR package with the new version and correct SHA256 checksums.
+
+---
+**Note:** If you want someone else (like @guifavretto) to maintain the package while you handle releases, you can add them as a **Co-maintainer** in the AUR web interface.


### PR DESCRIPTION
This PR adds support for automatically publishing `compozy-bin` to the Arch User Repository (AUR) using GoReleaser.

### What's included:
- **GoReleaser Integration:** Configured `.goreleaser.yml` to automatically generate the PKGBUILD, update checksums, and push to the AUR.
- **AUR Package Templates:** Added an `aur-pkg/` folder containing the `PKGBUILD` and `PKGBUILD-src` templates for Arch Linux users.
- **Maintainer Guide:** Added a `TODO.md` file in the `aur-pkg/` directory with a step-by-step guide for the upstream maintainers to claim the package and set up the `AUR_KEY` repository secret.

Please check `aur-pkg/TODO.md` for the final steps needed on your end to activate this automation after merging!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Arch Linux binary package definition for easy installation on x86_64 and aarch64.
  * Added Arch Linux source package definition with reproducible build flags, testing, and embedded version metadata.
  * Both packages install the CLI binary plus license and README to standard system documentation and license paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->