### PR TITLE
fix: fail for unsupported --add-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Provide exactly one prompt source: a positional prompt, `--prompt-file`, or `std
 | `--max-retries`              | `0`         | Retry execution-stage ACP failures or timeouts N times                      |
 | `--retry-backoff-multiplier` | `1.5`       | Multiplier applied to the next timeout after each retry                     |
 | `--tail-lines`               | `0`         | Maximum log lines retained per job in UI (`0` = full history)               |
-| `--add-dir`                  |             | Additional directories to allow (repeatable)                                |
+| `--add-dir`                  |             | Additional directories to allow (repeatable; currently `claude` and `codex` only) |
 | `--auto-commit`              | `false`     | Include automatic commit instructions when the prompt asks for code changes |
 | `--dry-run`                  | `false`     | Preview prompts without executing                                           |
 
@@ -493,7 +493,7 @@ When present, `.compozy/config.toml` can provide defaults for runtime flags such
 | `--max-retries`              | `0`         | Retry execution-stage ACP failures or timeouts N times        |
 | `--retry-backoff-multiplier` | `1.5`       | Multiplier applied to the next timeout after each retry       |
 | `--tail-lines`               | `0`         | Maximum log lines retained per job in UI (`0` = full history) |
-| `--add-dir`                  |             | Additional directories to allow (repeatable)                  |
+| `--add-dir`                  |             | Additional directories to allow (repeatable; currently `claude` and `codex` only) |
 | `--auto-commit`              | `false`     | Auto-commit after each task                                   |
 | `--include-completed`        | `false`     | Re-run completed tasks                                        |
 | `--dry-run`                  | `false`     | Preview prompts without executing                             |
@@ -546,7 +546,7 @@ defaults such as `--concurrent`, `--batch-size`, and `--include-resolved`.
 | `--max-retries`              | `0`         | Retry execution-stage ACP failures or timeouts N times        |
 | `--retry-backoff-multiplier` | `1.5`       | Multiplier applied to the next timeout after each retry       |
 | `--tail-lines`               | `0`         | Maximum log lines retained per job in UI (`0` = full history) |
-| `--add-dir`                  |             | Additional directories to allow (repeatable)                  |
+| `--add-dir`                  |             | Additional directories to allow (repeatable; currently `claude` and `codex` only) |
 | `--auto-commit`              | `false`     | Auto-commit after each batch                                  |
 | `--dry-run`                  | `false`     | Preview prompts without executing                             |
 

--- a/internal/cli/form.go
+++ b/internal/cli/form.go
@@ -396,7 +396,7 @@ func (fb *formBuilder) addAddDirsField(target *string) {
 			Title("Additional Directories (optional)").
 			Placeholder("../shared, ../docs").
 			Description(
-				"Comma-separated directories to pass via --add-dir for Codex and Claude only; quote paths that contain commas",
+				"Comma-separated directories to pass via --add-dir for Claude and Codex only; quote paths that contain commas",
 			).
 			Value(target)
 	})

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -386,7 +386,8 @@ func addCommonFlags(cmd *cobra.Command, state *commandState, opts commonFlagOpti
 		&state.addDirs,
 		"add-dir",
 		nil,
-		"Additional directory to allow for ACP runtimes that support extra writable roots (repeatable or comma-separated)",
+		"Additional directory to allow for ACP runtimes that support extra writable roots "+
+			"(currently claude and codex; repeatable or comma-separated)",
 	)
 	cmd.Flags().IntVar(
 		&state.tailLines,

--- a/internal/cli/testdata/exec_help.golden
+++ b/internal/cli/testdata/exec_help.golden
@@ -20,7 +20,7 @@ Examples:
 
 Flags:
       --access-mode string               Runtime access policy: default keeps native safeguards; full requests the most permissive mode Compozy can configure (default "full")
-      --add-dir strings                  Additional directory to allow for ACP runtimes that support extra writable roots (repeatable or comma-separated)
+      --add-dir strings                  Additional directory to allow for ACP runtimes that support extra writable roots (currently claude and codex; repeatable or comma-separated)
       --auto-commit                      Include automatic commit instructions at task/batch completion
       --dry-run                          Only generate prompts; do not run IDE tool
       --format string                    Output format: text, json, or raw-json (default "text")

--- a/internal/cli/testdata/start_help.golden
+++ b/internal/cli/testdata/start_help.golden
@@ -12,7 +12,7 @@ Examples:
 
 Flags:
       --access-mode string               Runtime access policy: default keeps native safeguards; full requests the most permissive mode Compozy can configure (default "full")
-      --add-dir strings                  Additional directory to allow for ACP runtimes that support extra writable roots (repeatable or comma-separated)
+      --add-dir strings                  Additional directory to allow for ACP runtimes that support extra writable roots (currently claude and codex; repeatable or comma-separated)
       --auto-commit                      Include automatic commit instructions at task/batch completion
       --dry-run                          Only generate prompts; do not run IDE tool
       --force                            Continue after task metadata validation fails in non-interactive mode

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -450,6 +450,9 @@ func hasConfiguredAddDirs(addDirs []string) bool {
 }
 
 func supportedAddDirIDEs() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
 	ides := make([]string, 0, len(supportedRegistryIDEOrder))
 	for _, ide := range supportedRegistryIDEOrder {
 		spec, ok := registry[ide]

--- a/internal/core/agent/registry.go
+++ b/internal/core/agent/registry.go
@@ -73,10 +73,11 @@ var (
 	registryMu = sync.RWMutex{}
 	registry   = map[string]Spec{
 		model.IDEClaude: {
-			ID:           model.IDEClaude,
-			DisplayName:  "Claude",
-			DefaultModel: model.DefaultClaudeModel,
-			Command:      "claude-agent-acp",
+			ID:              model.IDEClaude,
+			DisplayName:     "Claude",
+			DefaultModel:    model.DefaultClaudeModel,
+			Command:         "claude-agent-acp",
+			SupportsAddDirs: true,
 			Fallbacks: []Launcher{
 				{
 					Command:   "npx",
@@ -91,10 +92,11 @@ var (
 			},
 		},
 		model.IDECodex: {
-			ID:           model.IDECodex,
-			DisplayName:  "Codex",
-			DefaultModel: model.DefaultCodexModel,
-			Command:      "codex-acp",
+			ID:              model.IDECodex,
+			DisplayName:     "Codex",
+			DefaultModel:    model.DefaultCodexModel,
+			Command:         "codex-acp",
+			SupportsAddDirs: true,
 			Fallbacks: []Launcher{
 				{
 					Command:   "npx",
@@ -282,10 +284,14 @@ func ValidateRuntimeConfig(cfg *model.RuntimeConfig) error {
 	if err := validateRuntimeMode(cfg.Mode); err != nil {
 		return err
 	}
-	if _, err := lookupAgentSpec(cfg.IDE); err != nil {
+	spec, err := lookupAgentSpec(cfg.IDE)
+	if err != nil {
 		return fmt.Errorf("invalid --ide value %q: must be %s", cfg.IDE, quotedSupportedIDEs())
 	}
 	if err := validateRuntimeAccessMode(cfg.AccessMode); err != nil {
+		return err
+	}
+	if err := validateAddDirSupport("--add-dir", spec, cfg.AddDirs); err != nil {
 		return err
 	}
 	if cfg.Mode == model.ExecutionModePRDTasks && cfg.BatchSize != 1 {
@@ -307,6 +313,15 @@ func ValidateRuntimeConfig(cfg *model.RuntimeConfig) error {
 		return fmt.Errorf("retry-backoff-multiplier must be positive (got %.2f)", cfg.RetryBackoffMultiplier)
 	}
 	return nil
+}
+
+// ValidateAddDirSupport verifies that the selected runtime supports extra writable roots.
+func ValidateAddDirSupport(fieldName string, ide string, addDirs []string) error {
+	spec, err := lookupAgentSpec(strings.TrimSpace(ide))
+	if err != nil {
+		return err
+	}
+	return validateAddDirSupport(fieldName, spec, addDirs)
 }
 
 func validateRuntimeMode(mode model.ExecutionMode) error {
@@ -410,6 +425,40 @@ func runtimePromptSourceCount(cfg *model.RuntimeConfig) int {
 		sources++
 	}
 	return sources
+}
+
+func validateAddDirSupport(fieldName string, spec Spec, addDirs []string) error {
+	if !hasConfiguredAddDirs(addDirs) || spec.SupportsAddDirs {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s is only supported for %s; runtime %q does not support extra writable roots",
+		fieldName,
+		strings.Join(supportedAddDirIDEs(), ", "),
+		spec.ID,
+	)
+}
+
+func hasConfiguredAddDirs(addDirs []string) bool {
+	for _, dir := range addDirs {
+		if strings.TrimSpace(dir) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func supportedAddDirIDEs() []string {
+	ides := make([]string, 0, len(supportedRegistryIDEOrder))
+	for _, ide := range supportedRegistryIDEOrder {
+		spec, ok := registry[ide]
+		if !ok || !spec.SupportsAddDirs {
+			continue
+		}
+		ides = append(ides, spec.ID)
+	}
+	return ides
 }
 
 // EnsureAvailable verifies that the configured ACP agent binary is installed and executable.

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -15,29 +15,32 @@ func TestAgentRegistryEntries(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name       string
-		ide        string
-		reasoning  string
-		addDirs    []string
-		accessMode string
-		wantLaunch []string
-		wantProbe  []string
+		name                string
+		ide                 string
+		reasoning           string
+		addDirs             []string
+		accessMode          string
+		wantSupportsAddDirs bool
+		wantLaunch          []string
+		wantProbe           []string
 	}{
 		{
-			name:       "claude",
-			ide:        model.IDEClaude,
-			reasoning:  "medium",
-			addDirs:    []string{"../shared", "../docs"},
-			accessMode: model.AccessModeFull,
-			wantLaunch: []string{"claude-agent-acp"},
-			wantProbe:  []string{"claude-agent-acp", "--help"},
+			name:                "claude",
+			ide:                 model.IDEClaude,
+			reasoning:           "medium",
+			addDirs:             []string{"../shared", "../docs"},
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: true,
+			wantLaunch:          []string{"claude-agent-acp"},
+			wantProbe:           []string{"claude-agent-acp", "--help"},
 		},
 		{
-			name:       "codex",
-			ide:        model.IDECodex,
-			reasoning:  "medium",
-			addDirs:    []string{"../shared", "../docs"},
-			accessMode: model.AccessModeFull,
+			name:                "codex",
+			ide:                 model.IDECodex,
+			reasoning:           "medium",
+			addDirs:             []string{"../shared", "../docs"},
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: true,
 			wantLaunch: []string{
 				"codex-acp",
 				"-c",
@@ -50,10 +53,11 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe: []string{"codex-acp", "--help"},
 		},
 		{
-			name:       "droid",
-			ide:        model.IDEDroid,
-			reasoning:  "medium",
-			accessMode: model.AccessModeFull,
+			name:                "droid",
+			ide:                 model.IDEDroid,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
 			wantLaunch: []string{
 				"droid",
 				"exec",
@@ -68,36 +72,40 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe: []string{"droid", "exec", "--help"},
 		},
 		{
-			name:       "cursor",
-			ide:        model.IDECursor,
-			reasoning:  "medium",
-			accessMode: model.AccessModeFull,
-			wantLaunch: []string{"cursor-agent", "acp"},
-			wantProbe:  []string{"cursor-agent", "acp", "--help"},
+			name:                "cursor",
+			ide:                 model.IDECursor,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
+			wantLaunch:          []string{"cursor-agent", "acp"},
+			wantProbe:           []string{"cursor-agent", "acp", "--help"},
 		},
 		{
-			name:       "opencode",
-			ide:        model.IDEOpenCode,
-			reasoning:  "medium",
-			accessMode: model.AccessModeFull,
-			wantLaunch: []string{"opencode", "acp"},
-			wantProbe:  []string{"opencode", "acp", "--help"},
+			name:                "opencode",
+			ide:                 model.IDEOpenCode,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
+			wantLaunch:          []string{"opencode", "acp"},
+			wantProbe:           []string{"opencode", "acp", "--help"},
 		},
 		{
-			name:       "pi",
-			ide:        model.IDEPi,
-			reasoning:  "medium",
-			accessMode: model.AccessModeFull,
-			wantLaunch: []string{"pi-acp"},
-			wantProbe:  []string{"pi-acp", "--help"},
+			name:                "pi",
+			ide:                 model.IDEPi,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
+			wantLaunch:          []string{"pi-acp"},
+			wantProbe:           []string{"pi-acp", "--help"},
 		},
 		{
-			name:       "gemini",
-			ide:        model.IDEGemini,
-			reasoning:  "medium",
-			accessMode: model.AccessModeFull,
-			wantLaunch: []string{"gemini", "--acp"},
-			wantProbe:  []string{"gemini", "--acp", "--help"},
+			name:                "gemini",
+			ide:                 model.IDEGemini,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
+			wantLaunch:          []string{"gemini", "--acp"},
+			wantProbe:           []string{"gemini", "--acp", "--help"},
 		},
 	}
 
@@ -110,6 +118,14 @@ func TestAgentRegistryEntries(t *testing.T) {
 			if err != nil {
 				t.Fatalf("lookup agent spec: %v", err)
 			}
+			if spec.SupportsAddDirs != tc.wantSupportsAddDirs {
+				t.Fatalf(
+					"unexpected add-dir support for %s: got %t want %t",
+					tc.ide,
+					spec.SupportsAddDirs,
+					tc.wantSupportsAddDirs,
+				)
+			}
 
 			gotLaunch := spec.launchCommand(resolveModel(spec, ""), tc.reasoning, tc.addDirs, tc.accessMode)
 			if !slices.Equal(gotLaunch, tc.wantLaunch) {
@@ -119,6 +135,46 @@ func TestAgentRegistryEntries(t *testing.T) {
 				t.Fatalf("unexpected probe command for %s: got %v want %v", tc.ide, gotProbe, tc.wantProbe)
 			}
 		})
+	}
+}
+
+func TestValidateRuntimeConfigRejectsAddDirsForUnsupportedIDE(t *testing.T) {
+	t.Parallel()
+
+	cfg := &model.RuntimeConfig{
+		Mode:                   model.ExecutionModePRReview,
+		IDE:                    model.IDECursor,
+		OutputFormat:           model.OutputFormatText,
+		BatchSize:              1,
+		AddDirs:                []string{"../shared"},
+		MaxRetries:             1,
+		RetryBackoffMultiplier: 1.5,
+	}
+
+	err := ValidateRuntimeConfig(cfg)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--add-dir") || !strings.Contains(err.Error(), model.IDECursor) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRuntimeConfigAcceptsAddDirsForSupportedIDE(t *testing.T) {
+	t.Parallel()
+
+	cfg := &model.RuntimeConfig{
+		Mode:                   model.ExecutionModePRReview,
+		IDE:                    model.IDECodex,
+		OutputFormat:           model.OutputFormatText,
+		BatchSize:              1,
+		AddDirs:                []string{"../shared"},
+		MaxRetries:             1,
+		RetryBackoffMultiplier: 1.5,
+	}
+
+	if err := ValidateRuntimeConfig(cfg); err != nil {
+		t.Fatalf("validate runtime config: %v", err)
 	}
 }
 
@@ -553,52 +609,60 @@ func TestDriverCatalogExposesCanonicalCommandsAndFallbacks(t *testing.T) {
 	}
 
 	cases := []struct {
-		ide               string
-		wantCommand       []string
-		wantProbe         []string
-		wantFallbackCount int
+		ide                 string
+		wantCommand         []string
+		wantProbe           []string
+		wantFallbackCount   int
+		wantSupportsAddDirs bool
 	}{
 		{
-			ide:               model.IDEClaude,
-			wantCommand:       []string{"claude-agent-acp"},
-			wantProbe:         []string{"claude-agent-acp", "--help"},
-			wantFallbackCount: 1,
+			ide:                 model.IDEClaude,
+			wantCommand:         []string{"claude-agent-acp"},
+			wantProbe:           []string{"claude-agent-acp", "--help"},
+			wantFallbackCount:   1,
+			wantSupportsAddDirs: true,
 		},
 		{
-			ide:               model.IDECodex,
-			wantCommand:       []string{"codex-acp"},
-			wantProbe:         []string{"codex-acp", "--help"},
-			wantFallbackCount: 1,
+			ide:                 model.IDECodex,
+			wantCommand:         []string{"codex-acp"},
+			wantProbe:           []string{"codex-acp", "--help"},
+			wantFallbackCount:   1,
+			wantSupportsAddDirs: true,
 		},
 		{
-			ide:               model.IDEDroid,
-			wantCommand:       []string{"droid", "exec", "--output-format", "acp"},
-			wantProbe:         []string{"droid", "exec", "--help"},
-			wantFallbackCount: 1,
+			ide:                 model.IDEDroid,
+			wantCommand:         []string{"droid", "exec", "--output-format", "acp"},
+			wantProbe:           []string{"droid", "exec", "--help"},
+			wantFallbackCount:   1,
+			wantSupportsAddDirs: false,
 		},
 		{
-			ide:               model.IDECursor,
-			wantCommand:       []string{"cursor-agent", "acp"},
-			wantProbe:         []string{"cursor-agent", "acp", "--help"},
-			wantFallbackCount: 0,
+			ide:                 model.IDECursor,
+			wantCommand:         []string{"cursor-agent", "acp"},
+			wantProbe:           []string{"cursor-agent", "acp", "--help"},
+			wantFallbackCount:   0,
+			wantSupportsAddDirs: false,
 		},
 		{
-			ide:               model.IDEOpenCode,
-			wantCommand:       []string{"opencode", "acp"},
-			wantProbe:         []string{"opencode", "acp", "--help"},
-			wantFallbackCount: 0,
+			ide:                 model.IDEOpenCode,
+			wantCommand:         []string{"opencode", "acp"},
+			wantProbe:           []string{"opencode", "acp", "--help"},
+			wantFallbackCount:   0,
+			wantSupportsAddDirs: false,
 		},
 		{
-			ide:               model.IDEPi,
-			wantCommand:       []string{"pi-acp"},
-			wantProbe:         []string{"pi-acp", "--help"},
-			wantFallbackCount: 1,
+			ide:                 model.IDEPi,
+			wantCommand:         []string{"pi-acp"},
+			wantProbe:           []string{"pi-acp", "--help"},
+			wantFallbackCount:   1,
+			wantSupportsAddDirs: false,
 		},
 		{
-			ide:               model.IDEGemini,
-			wantCommand:       []string{"gemini", "--acp"},
-			wantProbe:         []string{"gemini", "--acp", "--help"},
-			wantFallbackCount: 1,
+			ide:                 model.IDEGemini,
+			wantCommand:         []string{"gemini", "--acp"},
+			wantProbe:           []string{"gemini", "--acp", "--help"},
+			wantFallbackCount:   1,
+			wantSupportsAddDirs: false,
 		},
 	}
 
@@ -624,6 +688,14 @@ func TestDriverCatalogExposesCanonicalCommandsAndFallbacks(t *testing.T) {
 				tc.ide,
 				len(entry.FallbackLaunchers),
 				tc.wantFallbackCount,
+			)
+		}
+		if entry.SupportsAddDirs != tc.wantSupportsAddDirs {
+			t.Fatalf(
+				"unexpected add-dir support for %s: got %t want %t",
+				tc.ide,
+				entry.SupportsAddDirs,
+				tc.wantSupportsAddDirs,
 			)
 		}
 	}

--- a/internal/core/api_test.go
+++ b/internal/core/api_test.go
@@ -48,3 +48,27 @@ func TestConfigValidateRejectsExecModeWithoutPromptSource(t *testing.T) {
 		t.Fatal("expected exec config without prompt source to fail validation")
 	}
 }
+
+func TestConfigValidateRejectsAddDirsForUnsupportedIDE(t *testing.T) {
+	t.Parallel()
+
+	err := Config{
+		IDE:     IDECursor,
+		AddDirs: []string{"../shared"},
+	}.Validate()
+	if err == nil {
+		t.Fatal("expected unsupported add-dir runtime to fail validation")
+	}
+}
+
+func TestConfigValidateAcceptsAddDirsForSupportedIDE(t *testing.T) {
+	t.Parallel()
+
+	err := Config{
+		IDE:     IDEClaude,
+		AddDirs: []string{"../shared"},
+	}.Validate()
+	if err != nil {
+		t.Fatalf("expected supported add-dir runtime to validate: %v", err)
+	}
+}

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -189,7 +189,11 @@ func (cfg ProjectConfig) Validate() error {
 }
 
 func validateDefaults(cfg DefaultsConfig) error {
-	return validateRuntimeOverrides("defaults", RuntimeOverrides(cfg))
+	overrides := RuntimeOverrides(cfg)
+	if err := validateRuntimeOverrides("defaults", overrides); err != nil {
+		return err
+	}
+	return validateRuntimeAddDirs("defaults", overrides, nil)
 }
 
 func validateStart(_ StartConfig) error {
@@ -235,6 +239,9 @@ func validateFetchReviews(cfg FetchReviewsConfig) error {
 
 func validateExec(defaults DefaultsConfig, cfg ExecConfig) error {
 	if err := validateRuntimeOverrides("exec", cfg.RuntimeOverrides); err != nil {
+		return err
+	}
+	if err := validateRuntimeAddDirs("exec", cfg.RuntimeOverrides, &defaults); err != nil {
 		return err
 	}
 
@@ -340,6 +347,35 @@ func validateRuntimeTimeout(section string, cfg RuntimeOverrides) error {
 		return fmt.Errorf("%s must be greater than zero (got %s)", runtimeFieldName(section, "timeout"), timeout)
 	}
 	return nil
+}
+
+func validateRuntimeAddDirs(section string, cfg RuntimeOverrides, defaults *DefaultsConfig) error {
+	addDirs, fieldName := effectiveAddDirs(section, cfg, defaults)
+	if len(addDirs) == 0 {
+		return nil
+	}
+
+	return agent.ValidateAddDirSupport(fieldName, effectiveIDE(cfg, defaults), addDirs)
+}
+
+func effectiveIDE(cfg RuntimeOverrides, defaults *DefaultsConfig) string {
+	if cfg.IDE != nil && strings.TrimSpace(*cfg.IDE) != "" {
+		return strings.TrimSpace(*cfg.IDE)
+	}
+	if defaults != nil && defaults.IDE != nil && strings.TrimSpace(*defaults.IDE) != "" {
+		return strings.TrimSpace(*defaults.IDE)
+	}
+	return model.IDECodex
+}
+
+func effectiveAddDirs(section string, cfg RuntimeOverrides, defaults *DefaultsConfig) ([]string, string) {
+	if cfg.AddDirs != nil {
+		return *cfg.AddDirs, runtimeFieldName(section, "add_dirs")
+	}
+	if defaults != nil && defaults.AddDirs != nil {
+		return *defaults.AddDirs, runtimeFieldName("defaults", "add_dirs")
+	}
+	return nil, ""
 }
 
 func validateRuntimeTailLines(section string, cfg RuntimeOverrides) error {

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -415,6 +415,35 @@ retry_backoff_multiplier = 0
 `,
 			wantErr: "exec.retry_backoff_multiplier",
 		},
+		{
+			name: "defaults add dirs reject unsupported defaults ide",
+			content: `
+[defaults]
+ide = "cursor-agent"
+add_dirs = ["../shared"]
+`,
+			wantErr: "defaults.add_dirs",
+		},
+		{
+			name: "exec add dirs reject unsupported exec ide",
+			content: `
+[exec]
+ide = "cursor-agent"
+add_dirs = ["../shared"]
+`,
+			wantErr: "exec.add_dirs",
+		},
+		{
+			name: "defaults add dirs inherited by exec reject unsupported exec ide",
+			content: `
+[defaults]
+add_dirs = ["../shared"]
+
+[exec]
+ide = "cursor-agent"
+`,
+			wantErr: "defaults.add_dirs",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled extra writable roots via the --add-dir option for Claude and Codex runtimes.

* **Chores**
  * Clarified --add-dir help text to list supported runtimes.
  * Added runtime validation to reject add-dir usage with unsupported IDEs.

* **Tests**
  * Added unit tests covering add-dir support and validation across configs and runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->