### PR TITLE
ci(release): Release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+### 🎉 Features
+
+- Exec command (#60)
+### 🐛 Bug Fixes
+
+- Close issue #61 (#63)- Fail for unsupported --add-dir (#66)
+### 📚 Documentation
+
+- Context7 and exa skills
+## 0.1.8 - 2026-04-05
+
 ### ♻️  Refactoring
 
 - Rename idea-factory artifacts from issue to idea (#56)
 ### 🎉 Features
 
 - Add GitHub Copilot CLI as ACP runtime (#57)
+### 🔧 CI/CD
+
+- *(release)* Prepare release v0.1.8 (#59)
+
 ## 0.1.7 - 2026-04-05
 
 ### ♻️  Refactoring
@@ -164,7 +179,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
-[unreleased]: https://github.com///compare/v0.1.7...HEAD
+[unreleased]: https://github.com///compare/v0.1.8...HEAD
+[0.1.8]: https://github.com///compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com///compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com///compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com///compare/v0.1.4...v0.1.5

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "compozy",
-    "version": "0.1.8",
-    "private": true,
-    "scripts": {
-        "prepare": "husky"
-    },
-    "devDependencies": {
-        "@commitlint/cli": "^20.5.0",
-        "@commitlint/config-conventional": "^20.5.0",
-        "husky": "^9.1.7"
-    },
-    "packageManager": "bun@1.3.11"
+  "devDependencies": {
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
+    "husky": "^9.1.7"
+  },
+  "name": "compozy",
+  "packageManager": "bun@1.3.11",
+  "private": true,
+  "scripts": {
+    "prepare": "husky"
+  },
+  "version": "0.1.9"
 }


### PR DESCRIPTION
## Release v0.1.9
This PR prepares the release of version v0.1.9.
### Changelog
# Changelog
All notable changes to this project will be documented in this file.
The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
## Unreleased
### 🎉 Features
- Exec command (#60)
### 🐛 Bug Fixes
- Close issue #61 (#63)- Fail for unsupported --add-dir (#66)