### PR TITLE
fix: stop rewriting all _meta.md files when listing workflows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ MODULE_PATH := github.com/compozy/compozy
 endif
 LDFLAGS := -X $(MODULE_PATH)/internal/version.Version=$(VERSION) -X $(MODULE_PATH)/internal/version.Commit=$(GIT_COMMIT) -X $(MODULE_PATH)/internal/version.Date=$(BUILD_DATE)
 
-.PHONY: all test lint fmt clean build deps help verify tidy test-coverage test-nocache check-go-version setup link-skills
+.PHONY: all test lint fmt clean build install deps help verify tidy test-coverage test-nocache check-go-version setup link-skills
 
 # -----------------------------------------------------------------------------
 # Setup & Version Checks
@@ -77,6 +77,9 @@ build: check-go-version
 	mkdir -p $(BINARY_DIR)
 	$(GOBUILD) -ldflags "$(LDFLAGS)" -o $(BINARY_DIR)/$(BINARY_NAME) ./cmd/compozy
 	chmod +x $(BINARY_DIR)/$(BINARY_NAME)
+
+install: build
+	$(GOCMD) install -ldflags "$(LDFLAGS)" ./cmd/compozy
 
 # -----------------------------------------------------------------------------
 # Code Quality & Formatting
@@ -129,6 +132,7 @@ test-nocache:
 help:
 	@echo "Available targets:"
 	@echo "  make build          - Build the compozy binary"
+	@echo "  make install        - Build and install to GOPATH/bin"
 	@echo "  make test           - Run tests with race detector"
 	@echo "  make lint           - Run golangci-lint"
 	@echo "  make fmt            - Format code"

--- a/internal/cli/form.go
+++ b/internal/cli/form.go
@@ -566,7 +566,7 @@ func listStartTaskSubdirs(baseDir string) []string {
 
 	filtered := make([]string, 0, len(dirs))
 	for _, dir := range dirs {
-		meta, err := tasks.RefreshTaskMeta(filepath.Join(baseDir, dir))
+		meta, err := tasks.ReadTaskMeta(filepath.Join(baseDir, dir))
 		if err != nil {
 			filtered = append(filtered, dir)
 			continue

--- a/internal/cli/form_test.go
+++ b/internal/cli/form_test.go
@@ -5,9 +5,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/huh/v2"
 	core "github.com/compozy/compozy/internal/core"
+	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/core/tasks"
 	"github.com/spf13/cobra"
 )
 
@@ -93,12 +96,22 @@ func TestStartFormFallsBackToInputWhenAllTaskDirsAreCompleted(t *testing.T) {
 
 	tmp := t.TempDir()
 	baseDir := filepath.Join(tmp, ".compozy", "tasks")
+	now := time.Now().UTC()
 	for _, name := range []string{"alpha", "beta"} {
 		workflowDir := filepath.Join(baseDir, name)
 		if err := os.MkdirAll(workflowDir, 0o755); err != nil {
 			t.Fatalf("create workflow dir: %v", err)
 		}
 		writeFormTaskFile(t, workflowDir, "task_01.md", "completed")
+		if err := tasks.WriteTaskMeta(workflowDir, model.TaskMeta{
+			CreatedAt: now,
+			UpdatedAt: now,
+			Total:     1,
+			Completed: 1,
+			Pending:   0,
+		}); err != nil {
+			t.Fatalf("write meta for %s: %v", name, err)
+		}
 	}
 
 	keys := formFieldKeysWithBaseDir(
@@ -211,7 +224,7 @@ func TestListTaskSubdirs(t *testing.T) {
 	})
 }
 
-func TestListStartTaskSubdirsFiltersCompletedWorkflowsAndBootstrapsMeta(t *testing.T) {
+func TestListStartTaskSubdirsFiltersCompletedWorkflows(t *testing.T) {
 	t.Parallel()
 
 	baseDir := filepath.Join(t.TempDir(), ".compozy", "tasks")
@@ -227,6 +240,20 @@ func TestListStartTaskSubdirsFiltersCompletedWorkflowsAndBootstrapsMeta(t *testi
 	writeFormTaskFile(t, pendingDir, "task_01.md", "pending")
 	writeFormTaskFile(t, completedDir, "task_01.md", "completed")
 
+	// Pre-create _meta.md for the completed workflow so ReadTaskMeta can
+	// detect it as fully done. In normal usage, _meta.md is kept current by
+	// prior compozy start runs or compozy sync.
+	now := time.Now().UTC()
+	if err := tasks.WriteTaskMeta(completedDir, model.TaskMeta{
+		CreatedAt: now,
+		UpdatedAt: now,
+		Total:     1,
+		Completed: 1,
+		Pending:   0,
+	}); err != nil {
+		t.Fatalf("write completed meta: %v", err)
+	}
+
 	dirs := listStartTaskSubdirs(baseDir)
 	want := []string{"alpha", "gamma"}
 	if len(dirs) != len(want) {
@@ -238,9 +265,11 @@ func TestListStartTaskSubdirsFiltersCompletedWorkflowsAndBootstrapsMeta(t *testi
 		}
 	}
 
-	for _, dir := range []string{pendingDir, completedDir, emptyDir} {
-		if _, err := os.Stat(filepath.Join(dir, "_meta.md")); err != nil {
-			t.Fatalf("expected bootstrapped meta in %s: %v", dir, err)
+	// Listing must NOT create _meta.md as a side effect in workflows that
+	// did not already have one.
+	for _, dir := range []string{pendingDir, emptyDir} {
+		if _, err := os.Stat(filepath.Join(dir, "_meta.md")); err == nil {
+			t.Fatalf("listing should not bootstrap _meta.md in %s", dir)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Running `compozy start` without `--name` opens an interactive form that lists available workflows. To build that list, `listStartTaskSubdirs` called `RefreshTaskMeta` on every workflow directory — which rewrites each `_meta.md` file with fresh timestamps and counts, even though the user only intends to work on one workflow.

This means selecting a single task silently touches files in every sibling workflow.

## Fix

Replace `RefreshTaskMeta` with `ReadTaskMeta` in the form listing path. The listing now reads existing metadata without side effects. Workflows that have never been started (no `_meta.md` yet) still appear in the selector — their metadata gets created later, when the user actually runs the workflow through `configureWorkflowInput`.

## Also included

Add a `make install` target that builds and installs the binary to `GOPATH/bin` in one step, preserving version ldflags.

## Changes

- **`internal/cli/form.go`** — `listStartTaskSubdirs` now calls `ReadTaskMeta` instead of `RefreshTaskMeta`
- **`internal/cli/form_test.go`** — tests updated to pre-create `_meta.md` for completed workflows (matching real-world state) and assert that listing does not bootstrap metadata as a side effect
- **`Makefile`** — new `install` target, `.PHONY` and `help` updated

## Test plan

- [x] `make verify` passes (fmt, lint, 1110 tests, build)
- [x] `make install` builds and installs to `~/go/bin`
- [ ] Run `compozy start` interactively — confirm only the selected workflow's `_meta.md` is written
- [ ] Run `compozy start --name <workflow>` — confirm behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Makefile install target to build and install the CLI to GOPATH/bin.

* **Refactor**
  * Improved internal task metadata handling to make start-listing behavior more consistent.

* **Tests**
  * Strengthened tests for task start workflows and ensured metadata-related behaviors are explicitly covered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->