### PR TITLE
refactor: add nitpicks for coderabbit

### DIFF
--- a/.compozy/tasks/nitpicks/reviews-001/_meta.md
+++ b/.compozy/tasks/nitpicks/reviews-001/_meta.md
@@ -1,0 +1,11 @@
+---
+provider: coderabbit
+pr: "75"
+round: 1
+created_at: 2026-04-10T15:35:45.314999Z
+---
+
+## Summary
+- Total: 5
+- Resolved: 5
+- Unresolved: 0

--- a/.compozy/tasks/nitpicks/reviews-001/issue_001.md
+++ b/.compozy/tasks/nitpicks/reviews-001/issue_001.md
@@ -1,0 +1,93 @@
+---
+status: resolved
+file: internal/cli/form_test.go
+line: 154
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc56KkLx,comment:PRRC_kwDORy7nkc62sRi8
+---
+
+# Issue 001: _⚠️ Potential issue_ | _🟠 Major_
+## Review Comment
+
+_⚠️ Potential issue_ | _🟠 Major_
+
+**Wrap this new test case in `t.Run("Should...")` to match test policy.**
+
+The assertion is good, but this new case should follow the required subtest pattern.
+
+<details>
+<summary>Suggested adjustment</summary>
+
+```diff
+ func TestFetchReviewsFormIncludesNitpicksToggle(t *testing.T) {
+ 	t.Parallel()
+ 
+-	keys := formFieldKeys(newFetchReviewsCommand(nil), newCommandState(commandKindFetchReviews, core.ModePRReview))
+-
+-	assertFieldKeysPresent(t, keys, "name", "provider", "pr", "round", "nitpicks")
++	t.Run("Should include nitpicks toggle in fetch-reviews form", func(t *testing.T) {
++		t.Parallel()
++		keys := formFieldKeys(newFetchReviewsCommand(nil), newCommandState(commandKindFetchReviews, core.ModePRReview))
++		assertFieldKeysPresent(t, keys, "name", "provider", "pr", "round", "nitpicks")
++	})
+ }
+```
+</details>
+
+As per coding guidelines, `**/*_test.go`: `MUST use t.Run("Should...") pattern for ALL test cases`.
+
+<!-- suggestion_start -->
+
+<details>
+<summary>📝 Committable suggestion</summary>
+
+> ‼️ **IMPORTANT**
+> Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements.
+
+```suggestion
+func TestFetchReviewsFormIncludesNitpicksToggle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should include nitpicks toggle in fetch-reviews form", func(t *testing.T) {
+		t.Parallel()
+		keys := formFieldKeys(newFetchReviewsCommand(nil), newCommandState(commandKindFetchReviews, core.ModePRReview))
+		assertFieldKeysPresent(t, keys, "name", "provider", "pr", "round", "nitpicks")
+	})
+}
+```
+
+</details>
+
+<!-- suggestion_end -->
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@internal/cli/form_test.go` around lines 148 - 154, Wrap the
+TestFetchReviewsFormIncludesNitpicksToggle body in a t.Run subtest with a
+"Should..." name to follow the t.Run pattern: call t.Run("Should include
+nitpicks toggle in fetch reviews form", func(t *testing.T) { ... }) and move the
+existing parallelization, setup (newFetchReviewsCommand(nil),
+newCommandState(commandKindFetchReviews, core.ModePRReview)) and the assertion
+assertFieldKeysPresent(t, keys, "name", "provider", "pr", "round", "nitpicks")
+inside that func; keep t.Parallel() at the start of the top-level test and/or
+inside the subtest as appropriate.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:poseidon:hawk:dbc050c4-4733-4672-b5ca-0278ed2a94f2 -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Root cause: `TestFetchReviewsFormIncludesNitpicksToggle` is a standalone top-level assertion block and does not follow the repository's required `t.Run("Should ...")` subtest convention used for new Go test cases.
+- Impact: This keeps the newly added fetch-reviews coverage out of alignment with the repo's enforced test structure, which makes this file inconsistent with the expected table/subtest style.
+- Fix approach: Wrap the existing assertions in a single `t.Run("Should ...")` subtest and keep the top-level `t.Parallel()` so the test matches the local policy without changing behavior.
+- Resolution: `TestFetchReviewsFormIncludesNitpicksToggle` now wraps the nitpicks-toggle assertion in a `t.Run("Should ...")` subtest while preserving the original behavior and parallel top-level test execution.
+- Verification: `go test ./internal/cli ./internal/core ./internal/core/provider/coderabbit` passed, and `env -u COMPOZY_NO_UPDATE_NOTIFIER make verify` passed cleanly.

--- a/.compozy/tasks/nitpicks/reviews-001/issue_002.md
+++ b/.compozy/tasks/nitpicks/reviews-001/issue_002.md
@@ -1,0 +1,27 @@
+---
+status: resolved
+file: internal/cli/workspace_config_test.go
+line: 152
+severity: nitpick
+author: coderabbitai[bot]
+provider_ref: review:4090534249,nitpick_hash:5359ddd0ae2f
+review_hash: 5359ddd0ae2f
+source_review_id: "4090534249"
+source_review_submitted_at: "2026-04-10T14:58:54Z"
+---
+
+# Issue 002: Use a single table-driven t.Run("Should...") block for these nitpicks cases.
+## Review Comment
+
+These two tests cover the same setup with one override toggle. Folding them into a small table keeps the fetch-reviews workspace-default coverage aligned and avoids adding more one-off top-level cases here.
+
+As per coding guidelines, "`**/*_test.go`: Use table-driven tests with subtests (`t.Run`) as the default pattern for Go tests`" and "`MUST use t.Run(\"Should...\") pattern for ALL test cases`".
+
+## Triage
+
+- Decision: `valid`
+- Root cause: The two fetch-reviews nitpicks workspace-default tests duplicate nearly identical setup and differ only in whether the command flag is explicitly set, so they drift away from the repo's default table-driven/subtest pattern.
+- Impact: Leaving them as separate one-off top-level tests makes this area harder to extend and inconsistent with the Go testing conventions enforced elsewhere in the repository.
+- Fix approach: Collapse the two cases into a single table-driven test with `t.Run("Should ...")` subtests so the shared setup stays centralized and each behavior branch remains explicit.
+- Resolution: The workspace-default nitpicks coverage now lives in one table-driven test with `t.Run("Should ...")` subtests for the config-default and explicit-flag cases.
+- Verification: `go test ./internal/cli ./internal/core ./internal/core/provider/coderabbit` passed, and `env -u COMPOZY_NO_UPDATE_NOTIFIER make verify` passed cleanly.

--- a/.compozy/tasks/nitpicks/reviews-001/issue_003.md
+++ b/.compozy/tasks/nitpicks/reviews-001/issue_003.md
@@ -1,0 +1,48 @@
+---
+status: resolved
+file: internal/core/fetch.go
+line: 195
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc56KkMA,comment:PRRC_kwDORy7nkc62sRjS
+---
+
+# Issue 003: _⚠️ Potential issue_ | _🟠 Major_
+## Review Comment
+
+_⚠️ Potential issue_ | _🟠 Major_
+
+**Track `SourceReviewID` in the history state too.**
+
+This filter only re-imports a resolved nitpick when `submitted_at` is *strictly* later. Provider-side dedup already treats equal timestamps with a higher `SourceReviewID` as newer, so a reposted nitpick in the same second can be accepted upstream and then dropped here once the older copy was resolved. Persist and compare `SourceReviewID` alongside the timestamp so both code paths use the same freshness rule.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@internal/core/fetch.go` around lines 153 - 195, nitpickHistoryState currently
+only stores SourceReviewSubmittedAt so filterFetchedNitpicks can drop reposts
+with identical timestamps; extend nitpickHistoryState to include SourceReviewID
+and update loadNitpickHistory/save logic to persist it, then in
+filterFetchedNitpicks when deciding to re-import a resolved nitpick compare both
+parsed timestamp (via parseReviewSubmittedAt(item.SourceReviewSubmittedAt)) and,
+if timestamps are equal, compare item.SourceReviewID against
+record.SourceReviewID (use the same ordering semantics as the provider: higher
+SourceReviewID is newer) so reposts in the same second are treated consistently.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:medusa:grasshopper:3c6a12e0-accd-4d1e-a3db-5a1d78606f67 -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Root cause: `filterFetchedNitpicks` only compares `SourceReviewSubmittedAt` when deciding whether a resolved nitpick should be re-imported, but CodeRabbit deduplicates same-second reposts using review ID as the tiebreaker.
+- Impact: A reposted nitpick with the same timestamp but a newer `SourceReviewID` can be accepted upstream and then dropped by fetch history, causing real nitpicks to disappear from later rounds.
+- Fix approach: Persist `SourceReviewID` in `nitpickHistoryState`, use it as the equal-timestamp freshness tiebreaker when filtering, and update fetch regression coverage to prove same-second higher review IDs are re-imported.
+- Resolution: Fetch nitpick history now keeps `SourceReviewID` in memory, uses it as the same-timestamp freshness tiebreaker during filtering, and retains the newest historical record with the same ordering rule.
+- Verification: `go test ./internal/cli ./internal/core ./internal/core/provider/coderabbit` passed, and `env -u COMPOZY_NO_UPDATE_NOTIFIER make verify` passed cleanly.

--- a/.compozy/tasks/nitpicks/reviews-001/issue_004.md
+++ b/.compozy/tasks/nitpicks/reviews-001/issue_004.md
@@ -1,0 +1,52 @@
+---
+status: resolved
+file: internal/core/fetch_test.go
+line: 304
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc56KkL-,comment:PRRC_kwDORy7nkc62sRjP
+---
+
+# Issue 004: _🛠️ Refactor suggestion_ | _🟠 Major_
+## Review Comment
+
+_🛠️ Refactor suggestion_ | _🟠 Major_
+
+**Collapse these nitpick-history cases into table-driven `t.Run("Should ...")` subtests.**
+
+The three scenarios are the same behavior matrix with different fixtures, so a table-driven test will keep this easier to extend and bring it back in line with the repo’s required Go test pattern.
+
+As per coding guidelines, "`**/*_test.go`: Use table-driven tests with subtests (`t.Run`) as the default pattern for Go tests", "Use `t.Parallel()` for independent Go test subtests", and "MUST use `t.Run(\"Should...\")` pattern for ALL test cases".
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@internal/core/fetch_test.go` around lines 112 - 304, Collapse the three tests
+(TestFetchReviewsSkipsResolvedStaleNitpickHashes,
+TestFetchReviewsReimportsUnresolvedNitpickHashes,
+TestFetchReviewsReimportsResolvedNitpickWhenProviderReviewIsNewer) into a single
+table-driven test that iterates cases and uses t.Run("Should ...") subtests; for
+each case call t.Parallel() and perform the per-case setup (tmpDir, prdDir,
+writeHistoricalNitpickRound, overriding defaultProviderRegistry, and t.Cleanup)
+inside the subtest so fixtures are isolated, then call fetchReviews and assert
+result.Total per case. Keep the same unique symbols (fetchReviews,
+writeHistoricalNitpickRound, defaultProviderRegistry, stubReviewProvider) to
+locate and reuse existing setup/fixtures when building the table entries.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:medusa:grasshopper:3c6a12e0-accd-4d1e-a3db-5a1d78606f67 -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Root cause: The three nitpick-history tests repeat the same provider/round fixture setup and assert a small behavior matrix in separate top-level tests instead of expressing the scenarios as isolated subtests.
+- Impact: The duplication makes the history behavior harder to extend, and it is a poor fit for the repository's default table-driven `t.Run("Should ...")` pattern for Go tests.
+- Fix approach: Replace the duplicated top-level tests with one table-driven test that builds fixtures per case inside `t.Run("Should ...")` subtests, while preserving isolation and covering the same regression matrix.
+- Resolution: The nitpick-history regressions now run through one table-driven `t.Run("Should ...")` matrix that covers stale resolved nitpicks, unresolved nitpicks, newer timestamps, and same-second newer review IDs.
+- Verification: `go test ./internal/cli ./internal/core ./internal/core/provider/coderabbit` passed, and `env -u COMPOZY_NO_UPDATE_NOTIFIER make verify` passed cleanly.

--- a/.compozy/tasks/nitpicks/reviews-001/issue_005.md
+++ b/.compozy/tasks/nitpicks/reviews-001/issue_005.md
@@ -1,0 +1,50 @@
+---
+status: resolved
+file: internal/core/provider/coderabbit/nitpicks.go
+line: 355
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc56KkMC,comment:PRRC_kwDORy7nkc62sRjV
+---
+
+# Issue 005: _⚠️ Potential issue_ | _🟠 Major_
+## Review Comment
+
+_⚠️ Potential issue_ | _🟠 Major_
+
+**The nitpick hash is too coarse-grained.**
+
+`ReviewHash` currently ignores the location, so two identical nitpicks in the same file but on different lines collapse into one entry in `latestByHash`. Once one of those gets resolved, the history filter can also suppress the other in later rounds. The hash needs an additional stable location discriminator instead of just `file + title + body`.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against the current code and only fix it if needed.
+
+In `@internal/core/provider/coderabbit/nitpicks.go` around lines 346 - 355, The
+current buildNitpickHash function is too coarse because it omits a stable
+location discriminator; modify buildNitpickHash to include a stable location
+component (e.g., a normalized line/column span or token range) in the canonical
+string so identical nitpicks at different locations produce different hashes.
+Specifically, add a location parameter (stableLocation or startLine:endLine) to
+the buildNitpickHash signature, incorporate canonicalHashValue(location) into
+the canonical join alongside "file:", "title:", and "body:" (and still use
+firstParagraph(body)), and ensure callers that compute nitpick hashes (places
+that populate latestByHash) pass the stable location value; keep using
+sha256.Sum256 and nitpickHashLength unchanged.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:medusa:grasshopper:3c6a12e0-accd-4d1e-a3db-5a1d78606f67 -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Root cause: `buildNitpickHash` only hashes provider, file, title, and the first paragraph of the body, so identical nitpick text in the same file but at different locations collapses into one dedup key.
+- Impact: Distinct nitpicks can overwrite each other in `latestByHash`, and once one location is resolved the history filter can suppress the other location in later rounds.
+- Fix approach: Add a stable location component to the nitpick hash input, update the caller that computes hashes to pass that location, and add a focused parser regression test in `internal/core/provider/coderabbit/nitpicks_test.go` even though that test file is outside the batch code-file list because the behavior change needs direct coverage.
+- Resolution: CodeRabbit nitpick hashes now include the normalized location string, and a focused regression test in `internal/core/provider/coderabbit/nitpicks_test.go` proves identical nitpick text at different locations stays distinct.
+- Verification: `go test ./internal/cli ./internal/core ./internal/core/provider/coderabbit` passed, and `env -u COMPOZY_NO_UPDATE_NOTIFIER make verify` passed cleanly.

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -29,6 +29,12 @@ func newFetchReviewsCommandWithDefaults(dispatcher *kernel.Dispatcher, defaults 
 	cmd.Flags().StringVar(&state.pr, "pr", "", "Pull request number")
 	cmd.Flags().StringVar(&state.name, "name", "", "Workflow name (used for .compozy/tasks/<name>)")
 	cmd.Flags().IntVar(&state.round, "round", 0, "Review round number (default: next available round)")
+	cmd.Flags().BoolVar(
+		&state.nitpicks,
+		"nitpicks",
+		false,
+		"Include CodeRabbit nitpick comments from pull request review bodies",
+	)
 	return cmd
 }
 

--- a/internal/cli/form.go
+++ b/internal/cli/form.go
@@ -47,6 +47,7 @@ type formInputs struct {
 	reasoningEffort  string
 	includeCompleted bool
 	includeResolved  bool
+	nitpicks         bool
 	dryRun           bool
 	autoCommit       bool
 }
@@ -67,6 +68,7 @@ func newFormInputsFromState(state *commandState) *formInputs {
 	if state.round > 0 {
 		inputs.round = strconv.Itoa(state.round)
 	}
+	inputs.nitpicks = state.nitpicks
 	inputs.reviewsDir = state.reviewsDir
 	inputs.tasksDir = state.tasksDir
 	if state.concurrent > 0 {
@@ -103,6 +105,12 @@ func (fi *formInputs) register(builder *formBuilder) {
 	builder.addAddDirsField(&fi.addDirs)
 	builder.addReasoningEffortField(&fi.reasoningEffort)
 	builder.addConfirmField(
+		"nitpicks",
+		"Include Nitpicks?",
+		"Import CodeRabbit nitpick comments from pull request review bodies",
+		&fi.nitpicks,
+	)
+	builder.addConfirmField(
 		"dry-run",
 		"Dry Run?",
 		"Only generate prompts without running IDE tool",
@@ -133,6 +141,7 @@ func (fi *formInputs) apply(cmd *cobra.Command, state *commandState) {
 	applyInput(cmd, "pr", fi.pr, passThroughInput[string], func(val string) { state.pr = val })
 	applyInput(cmd, "provider", fi.provider, passThroughInput[string], func(val string) { state.provider = val })
 	applyInput(cmd, "round", fi.round, parseIntInput, func(val int) { state.round = val })
+	applyInput(cmd, "nitpicks", fi.nitpicks, passThroughInput[bool], func(val bool) { state.nitpicks = val })
 	applyInput(cmd, "reviews-dir", fi.reviewsDir, passThroughInput[string], func(val string) { state.reviewsDir = val })
 	applyInput(cmd, "tasks-dir", fi.tasksDir, passThroughInput[string], func(val string) { state.tasksDir = val })
 	applyInput(cmd, "concurrent", fi.concurrent, parseIntInput, func(val int) { state.concurrent = val })

--- a/internal/cli/form_test.go
+++ b/internal/cli/form_test.go
@@ -148,9 +148,13 @@ func TestFetchReviewsAlwaysUsesTextInput(t *testing.T) {
 func TestFetchReviewsFormIncludesNitpicksToggle(t *testing.T) {
 	t.Parallel()
 
-	keys := formFieldKeys(newFetchReviewsCommand(nil), newCommandState(commandKindFetchReviews, core.ModePRReview))
+	t.Run("Should include nitpicks toggle in the fetch-reviews form", func(t *testing.T) {
+		t.Parallel()
 
-	assertFieldKeysPresent(t, keys, "name", "provider", "pr", "round", "nitpicks")
+		keys := formFieldKeys(newFetchReviewsCommand(nil), newCommandState(commandKindFetchReviews, core.ModePRReview))
+
+		assertFieldKeysPresent(t, keys, "name", "provider", "pr", "round", "nitpicks")
+	})
 }
 
 func TestListTaskSubdirs(t *testing.T) {

--- a/internal/cli/form_test.go
+++ b/internal/cli/form_test.go
@@ -145,6 +145,14 @@ func TestFetchReviewsAlwaysUsesTextInput(t *testing.T) {
 	}
 }
 
+func TestFetchReviewsFormIncludesNitpicksToggle(t *testing.T) {
+	t.Parallel()
+
+	keys := formFieldKeys(newFetchReviewsCommand(nil), newCommandState(commandKindFetchReviews, core.ModePRReview))
+
+	assertFieldKeysPresent(t, keys, "name", "provider", "pr", "round", "nitpicks")
+}
+
 func TestListTaskSubdirs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/kernel_dispatch_test.go
+++ b/internal/cli/kernel_dispatch_test.go
@@ -296,6 +296,7 @@ func TestNewFetchReviewsRunnerDispatchesTypedCommand(t *testing.T) {
 		Provider:      "coderabbit",
 		PR:            "259",
 		Round:         2,
+		Nitpicks:      true,
 	})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("fetch runner error = %v, want %v", err, wantErr)
@@ -305,6 +306,9 @@ func TestNewFetchReviewsRunnerDispatchesTypedCommand(t *testing.T) {
 	}
 	if handler.got.Provider != "coderabbit" || handler.got.PR != "259" || handler.got.Round != 2 {
 		t.Fatalf("unexpected fetch command: %#v", handler.got)
+	}
+	if !handler.got.Nitpicks {
+		t.Fatal("expected nitpicks flag to pass through")
 	}
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -211,7 +211,7 @@ func TestFetchReviewsHelpShowsFetchFlagsOnly(t *testing.T) {
 		t.Fatalf("execute fetch-reviews help: %v", err)
 	}
 
-	required := []string{"--provider", "--pr", "--name", "--round"}
+	required := []string{"--provider", "--pr", "--name", "--round", "--nitpicks"}
 	for _, snippet := range required {
 		if !strings.Contains(output, snippet) {
 			t.Fatalf("expected fetch-reviews help to include %q\noutput:\n%s", snippet, output)

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -22,6 +22,7 @@ type workflowIdentity struct {
 	name       string
 	provider   string
 	round      int
+	nitpicks   bool
 	reviewsDir string
 	tasksDir   string
 }
@@ -270,6 +271,7 @@ func (s *commandState) buildConfig() (core.Config, error) {
 		Round:         s.round,
 		Provider:      s.provider,
 		PR:            s.pr,
+		Nitpicks:      s.nitpicks,
 		ReviewsDir:    s.reviewsDir,
 		TasksDir:      s.tasksDir,
 

--- a/internal/cli/workspace_config.go
+++ b/internal/cli/workspace_config.go
@@ -78,6 +78,7 @@ func (s *commandState) applyProjectConfig(cmd *cobra.Command, cfg workspace.Proj
 		)
 	case commandKindFetchReviews:
 		applyConfig(cmd, "provider", cfg.FetchReviews.Provider, func(val string) { s.provider = val })
+		applyConfig(cmd, "nitpicks", cfg.FetchReviews.Nitpicks, func(val bool) { s.nitpicks = val })
 	case commandKindExec:
 		applyConfig(cmd, "ide", cfg.Exec.IDE, func(val string) { s.ide = val })
 		applyConfig(cmd, "model", cfg.Exec.Model, func(val string) { s.model = val })

--- a/internal/cli/workspace_config_test.go
+++ b/internal/cli/workspace_config_test.go
@@ -149,6 +149,64 @@ verbose = true
 	}
 }
 
+func TestApplyWorkspaceDefaultsAppliesFetchReviewsNitpicks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIWorkspaceConfig(t, root, `
+[fetch_reviews]
+nitpicks = true
+`)
+
+	state := newCommandState(commandKindFetchReviews, core.ModePRReview)
+	cmd := &cobra.Command{Use: "fetch-reviews"}
+	cmd.Flags().Bool("nitpicks", false, "include nitpicks")
+
+	chdirCLITest(t, startDir)
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if !state.nitpicks {
+		t.Fatal("expected fetch_reviews.nitpicks workspace default to apply")
+	}
+}
+
+func TestApplyWorkspaceDefaultsPreservesExplicitFetchReviewsNitpicksFlag(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIWorkspaceConfig(t, root, `
+[fetch_reviews]
+nitpicks = true
+`)
+
+	state := newCommandState(commandKindFetchReviews, core.ModePRReview)
+	cmd := &cobra.Command{Use: "fetch-reviews"}
+	cmd.Flags().Bool("nitpicks", false, "include nitpicks")
+	if err := cmd.Flags().Set("nitpicks", "false"); err != nil {
+		t.Fatalf("set nitpicks flag: %v", err)
+	}
+	state.nitpicks = false
+
+	chdirCLITest(t, startDir)
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if state.nitpicks {
+		t.Fatal("expected explicit --nitpicks flag to override workspace config")
+	}
+}
+
 func TestApplyWorkspaceDefaultsPreservesExplicitExecFormatFlag(t *testing.T) {
 	t.Parallel()
 
@@ -457,6 +515,7 @@ func TestBuildConfigMapsEmbeddedStateGroups(t *testing.T) {
 			pr:         "259",
 			provider:   "coderabbit",
 			round:      4,
+			nitpicks:   true,
 			reviewsDir: "/workspace/.compozy/tasks/demo/reviews-004",
 			tasksDir:   "/workspace/.compozy/tasks/demo",
 		},
@@ -499,6 +558,9 @@ func TestBuildConfigMapsEmbeddedStateGroups(t *testing.T) {
 
 	if cfg.Name != "demo" || cfg.PR != "259" || cfg.Provider != "coderabbit" || cfg.Round != 4 {
 		t.Fatalf("unexpected identity config: %#v", cfg)
+	}
+	if !cfg.Nitpicks {
+		t.Fatal("expected nitpicks to pass through buildConfig")
 	}
 	if cfg.IDE != core.IDECodex || cfg.Model != "gpt-5.4" || cfg.AccessMode != core.AccessModeDefault {
 		t.Fatalf("unexpected runtime config: %#v", cfg)

--- a/internal/cli/workspace_config_test.go
+++ b/internal/cli/workspace_config_test.go
@@ -149,61 +149,59 @@ verbose = true
 	}
 }
 
-func TestApplyWorkspaceDefaultsAppliesFetchReviewsNitpicks(t *testing.T) {
+func TestApplyWorkspaceDefaultsFetchReviewsNitpicks(t *testing.T) {
 	t.Parallel()
 
-	root := t.TempDir()
-	startDir := filepath.Join(root, "pkg", "feature")
-	if err := os.MkdirAll(startDir, 0o755); err != nil {
-		t.Fatalf("mkdir start dir: %v", err)
+	cases := []struct {
+		name            string
+		setExplicitFlag bool
+		wantNitpicks    bool
+	}{
+		{
+			name:         "apply fetch-reviews nitpicks from workspace config when the flag is unset",
+			wantNitpicks: true,
+		},
+		{
+			name:            "preserve an explicit fetch-reviews nitpicks flag over workspace config",
+			setExplicitFlag: true,
+			wantNitpicks:    false,
+		},
 	}
-	writeCLIWorkspaceConfig(t, root, `
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("Should "+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			startDir := filepath.Join(root, "pkg", "feature")
+			if err := os.MkdirAll(startDir, 0o755); err != nil {
+				t.Fatalf("mkdir start dir: %v", err)
+			}
+			writeCLIWorkspaceConfig(t, root, `
 [fetch_reviews]
 nitpicks = true
 `)
 
-	state := newCommandState(commandKindFetchReviews, core.ModePRReview)
-	cmd := &cobra.Command{Use: "fetch-reviews"}
-	cmd.Flags().Bool("nitpicks", false, "include nitpicks")
+			state := newCommandState(commandKindFetchReviews, core.ModePRReview)
+			cmd := &cobra.Command{Use: "fetch-reviews"}
+			cmd.Flags().Bool("nitpicks", false, "include nitpicks")
+			if tc.setExplicitFlag {
+				if err := cmd.Flags().Set("nitpicks", "false"); err != nil {
+					t.Fatalf("set nitpicks flag: %v", err)
+				}
+				state.nitpicks = false
+			}
 
-	chdirCLITest(t, startDir)
+			chdirCLITest(t, startDir)
 
-	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
-		t.Fatalf("apply workspace defaults: %v", err)
-	}
-	if !state.nitpicks {
-		t.Fatal("expected fetch_reviews.nitpicks workspace default to apply")
-	}
-}
-
-func TestApplyWorkspaceDefaultsPreservesExplicitFetchReviewsNitpicksFlag(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	startDir := filepath.Join(root, "pkg", "feature")
-	if err := os.MkdirAll(startDir, 0o755); err != nil {
-		t.Fatalf("mkdir start dir: %v", err)
-	}
-	writeCLIWorkspaceConfig(t, root, `
-[fetch_reviews]
-nitpicks = true
-`)
-
-	state := newCommandState(commandKindFetchReviews, core.ModePRReview)
-	cmd := &cobra.Command{Use: "fetch-reviews"}
-	cmd.Flags().Bool("nitpicks", false, "include nitpicks")
-	if err := cmd.Flags().Set("nitpicks", "false"); err != nil {
-		t.Fatalf("set nitpicks flag: %v", err)
-	}
-	state.nitpicks = false
-
-	chdirCLITest(t, startDir)
-
-	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
-		t.Fatalf("apply workspace defaults: %v", err)
-	}
-	if state.nitpicks {
-		t.Fatal("expected explicit --nitpicks flag to override workspace config")
+			if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+				t.Fatalf("apply workspace defaults: %v", err)
+			}
+			if state.nitpicks != tc.wantNitpicks {
+				t.Fatalf("unexpected nitpicks setting: got %t, want %t", state.nitpicks, tc.wantNitpicks)
+			}
+		})
 	}
 }
 

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -98,6 +98,7 @@ type Config struct {
 	Round                  int
 	Provider               string
 	PR                     string
+	Nitpicks               bool
 	ReviewsDir             string
 	TasksDir               string
 	DryRun                 bool
@@ -308,6 +309,7 @@ func (cfg Config) RuntimeConfig() *model.RuntimeConfig {
 		Round:                  cfg.Round,
 		Provider:               cfg.Provider,
 		PR:                     cfg.PR,
+		Nitpicks:               cfg.Nitpicks,
 		ReviewsDir:             cfg.ReviewsDir,
 		TasksDir:               cfg.TasksDir,
 		DryRun:                 cfg.DryRun,

--- a/internal/core/fetch.go
+++ b/internal/core/fetch.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/core/provider"
 	"github.com/compozy/compozy/internal/core/providerdefaults"
 	"github.com/compozy/compozy/internal/core/reviews"
 )
@@ -21,12 +22,8 @@ func fetchReviews(ctx context.Context, cfg *model.RuntimeConfig) (*FetchResult, 
 		return nil, err
 	}
 
-	prdDir := reviews.TaskDirectoryForWorkspace(cfg.WorkspaceRoot, cfg.Name)
-	resolvedPRDDir, err := filepath.Abs(prdDir)
+	resolvedPRDDir, err := resolveFetchPRDDirectory(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("resolve prd dir: %w", err)
-	}
-	if err := ensureFetchPRDDirectory(resolvedPRDDir); err != nil {
 		return nil, err
 	}
 
@@ -39,10 +36,8 @@ func fetchReviews(ctx context.Context, cfg *model.RuntimeConfig) (*FetchResult, 
 	}
 
 	reviewsDir := reviews.ReviewDirectory(resolvedPRDDir, round)
-	if _, err := os.Stat(reviewsDir); err == nil {
-		return nil, fmt.Errorf("review round already exists: %s", reviewsDir)
-	} else if !os.IsNotExist(err) {
-		return nil, fmt.Errorf("check review round directory: %w", err)
+	if err := ensureReviewRoundDoesNotExist(reviewsDir); err != nil {
+		return nil, err
 	}
 
 	registry := defaultProviderRegistry()
@@ -51,7 +46,14 @@ func fetchReviews(ctx context.Context, cfg *model.RuntimeConfig) (*FetchResult, 
 		return nil, err
 	}
 
-	items, err := reviewProvider.FetchReviews(ctx, cfg.PR)
+	items, err := reviewProvider.FetchReviews(ctx, provider.FetchRequest{
+		PR:              cfg.PR,
+		IncludeNitpicks: cfg.Nitpicks,
+	})
+	if err != nil {
+		return nil, err
+	}
+	items, err = filterFetchedNitpicks(resolvedPRDDir, round, items)
 	if err != nil {
 		return nil, err
 	}
@@ -94,6 +96,18 @@ func fetchReviews(ctx context.Context, cfg *model.RuntimeConfig) (*FetchResult, 
 	}, nil
 }
 
+func resolveFetchPRDDirectory(cfg *model.RuntimeConfig) (string, error) {
+	prdDir := reviews.TaskDirectoryForWorkspace(cfg.WorkspaceRoot, cfg.Name)
+	resolvedPRDDir, err := filepath.Abs(prdDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve prd dir: %w", err)
+	}
+	if err := ensureFetchPRDDirectory(resolvedPRDDir); err != nil {
+		return "", err
+	}
+	return resolvedPRDDir, nil
+}
+
 func validateFetchConfig(cfg *model.RuntimeConfig) error {
 	if cfg == nil {
 		return fmt.Errorf("runtime config is nil")
@@ -125,4 +139,115 @@ func ensureFetchPRDDirectory(dir string) error {
 		return fmt.Errorf("prd path is not a directory: %s", dir)
 	}
 	return nil
+}
+
+func ensureReviewRoundDoesNotExist(reviewsDir string) error {
+	if _, err := os.Stat(reviewsDir); err == nil {
+		return fmt.Errorf("review round already exists: %s", reviewsDir)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("check review round directory: %w", err)
+	}
+	return nil
+}
+
+type nitpickHistoryState struct {
+	Resolved                bool
+	Round                   int
+	SourceReviewSubmittedAt time.Time
+}
+
+func filterFetchedNitpicks(
+	prdDir string,
+	currentRound int,
+	items []provider.ReviewItem,
+) ([]provider.ReviewItem, error) {
+	if len(items) == 0 {
+		return nil, nil
+	}
+
+	history, err := loadNitpickHistory(prdDir, currentRound)
+	if err != nil {
+		return nil, err
+	}
+	if len(history) == 0 {
+		return items, nil
+	}
+
+	filtered := make([]provider.ReviewItem, 0, len(items))
+	for idx := range items {
+		item := &items[idx]
+		if strings.TrimSpace(item.ReviewHash) == "" {
+			filtered = append(filtered, *item)
+			continue
+		}
+
+		record, ok := history[item.ReviewHash]
+		if !ok || !record.Resolved {
+			filtered = append(filtered, *item)
+			continue
+		}
+
+		if parseReviewSubmittedAt(item.SourceReviewSubmittedAt).After(record.SourceReviewSubmittedAt) {
+			filtered = append(filtered, *item)
+		}
+	}
+
+	return filtered, nil
+}
+
+func loadNitpickHistory(prdDir string, currentRound int) (map[string]nitpickHistoryState, error) {
+	rounds, err := reviews.DiscoverRounds(prdDir)
+	if err != nil {
+		return nil, err
+	}
+
+	history := make(map[string]nitpickHistoryState)
+	for _, round := range rounds {
+		if round >= currentRound {
+			continue
+		}
+
+		reviewDir := reviews.ReviewDirectory(prdDir, round)
+		entries, err := reviews.ReadReviewEntries(reviewDir)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, entry := range entries {
+			ctx, err := reviews.ParseReviewContext(entry.Content)
+			if err != nil {
+				return nil, fmt.Errorf("parse nitpick history %s: %w", entry.AbsPath, err)
+			}
+			hash := strings.TrimSpace(ctx.ReviewHash)
+			if hash == "" {
+				continue
+			}
+
+			next := nitpickHistoryState{
+				Resolved:                strings.EqualFold(strings.TrimSpace(ctx.Status), "resolved"),
+				Round:                   round,
+				SourceReviewSubmittedAt: parseReviewSubmittedAt(ctx.SourceReviewSubmittedAt),
+			}
+			current, ok := history[hash]
+			if !ok || next.Round > current.Round ||
+				(next.Round == current.Round && next.SourceReviewSubmittedAt.After(current.SourceReviewSubmittedAt)) {
+				history[hash] = next
+			}
+		}
+	}
+
+	return history, nil
+}
+
+func parseReviewSubmittedAt(value string) time.Time {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}
+	}
+
+	parsed, err := time.Parse(time.RFC3339, trimmed)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
 }

--- a/internal/core/fetch.go
+++ b/internal/core/fetch.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -153,6 +154,7 @@ func ensureReviewRoundDoesNotExist(reviewsDir string) error {
 type nitpickHistoryState struct {
 	Resolved                bool
 	Round                   int
+	SourceReviewID          string
 	SourceReviewSubmittedAt time.Time
 }
 
@@ -187,7 +189,7 @@ func filterFetchedNitpicks(
 			continue
 		}
 
-		if parseReviewSubmittedAt(item.SourceReviewSubmittedAt).After(record.SourceReviewSubmittedAt) {
+		if fetchedNitpickIsNewer(*item, record) {
 			filtered = append(filtered, *item)
 		}
 	}
@@ -226,11 +228,11 @@ func loadNitpickHistory(prdDir string, currentRound int) (map[string]nitpickHist
 			next := nitpickHistoryState{
 				Resolved:                strings.EqualFold(strings.TrimSpace(ctx.Status), "resolved"),
 				Round:                   round,
+				SourceReviewID:          strings.TrimSpace(ctx.SourceReviewID),
 				SourceReviewSubmittedAt: parseReviewSubmittedAt(ctx.SourceReviewSubmittedAt),
 			}
 			current, ok := history[hash]
-			if !ok || next.Round > current.Round ||
-				(next.Round == current.Round && next.SourceReviewSubmittedAt.After(current.SourceReviewSubmittedAt)) {
+			if !ok || nitpickHistoryEntryIsNewer(next, current) {
 				history[hash] = next
 			}
 		}
@@ -250,4 +252,49 @@ func parseReviewSubmittedAt(value string) time.Time {
 		return time.Time{}
 	}
 	return parsed
+}
+
+func fetchedNitpickIsNewer(item provider.ReviewItem, record nitpickHistoryState) bool {
+	itemTime := parseReviewSubmittedAt(item.SourceReviewSubmittedAt)
+	if itemTime.After(record.SourceReviewSubmittedAt) {
+		return true
+	}
+	if record.SourceReviewSubmittedAt.After(itemTime) {
+		return false
+	}
+	return compareSourceReviewIDs(item.SourceReviewID, record.SourceReviewID) > 0
+}
+
+func nitpickHistoryEntryIsNewer(candidate nitpickHistoryState, current nitpickHistoryState) bool {
+	if candidate.Round != current.Round {
+		return candidate.Round > current.Round
+	}
+	if candidate.SourceReviewSubmittedAt.After(current.SourceReviewSubmittedAt) {
+		return true
+	}
+	if current.SourceReviewSubmittedAt.After(candidate.SourceReviewSubmittedAt) {
+		return false
+	}
+	return compareSourceReviewIDs(candidate.SourceReviewID, current.SourceReviewID) > 0
+}
+
+func compareSourceReviewIDs(left string, right string) int {
+	leftID, leftErr := parseSourceReviewID(left)
+	rightID, rightErr := parseSourceReviewID(right)
+	if leftErr == nil && rightErr == nil {
+		switch {
+		case leftID > rightID:
+			return 1
+		case leftID < rightID:
+			return -1
+		default:
+			return 0
+		}
+	}
+
+	return strings.Compare(strings.TrimSpace(left), strings.TrimSpace(right))
+}
+
+func parseSourceReviewID(value string) (int64, error) {
+	return strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 }

--- a/internal/core/fetch_test.go
+++ b/internal/core/fetch_test.go
@@ -6,9 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/core/provider"
+	"github.com/compozy/compozy/internal/core/reviews"
 )
 
 type stubReviewProvider struct {
@@ -18,7 +20,7 @@ type stubReviewProvider struct {
 
 func (s stubReviewProvider) Name() string { return s.name }
 
-func (s stubReviewProvider) FetchReviews(context.Context, string) ([]provider.ReviewItem, error) {
+func (s stubReviewProvider) FetchReviews(context.Context, provider.FetchRequest) ([]provider.ReviewItem, error) {
 	return append([]provider.ReviewItem(nil), s.items...), nil
 }
 
@@ -104,5 +106,233 @@ func TestFetchReviewsAutoIncrementsRound(t *testing.T) {
 	}
 	if result.Round != 2 {
 		t.Fatalf("expected auto-incremented round 2, got %d", result.Round)
+	}
+}
+
+func TestFetchReviewsSkipsResolvedStaleNitpickHashes(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	prdDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
+	if err := os.MkdirAll(prdDir, 0o755); err != nil {
+		t.Fatalf("mkdir prd dir: %v", err)
+	}
+	writeHistoricalNitpickRound(
+		t,
+		prdDir,
+		1,
+		provider.ReviewItem{
+			Title:                   "Keep helper reuse consistent",
+			File:                    "internal/app/service.go",
+			Line:                    42,
+			Severity:                "nitpick",
+			Author:                  "coderabbitai[bot]",
+			Body:                    "Use the existing helper instead of duplicating logic.",
+			ReviewHash:              "hash-stale",
+			SourceReviewID:          "4001",
+			SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+		},
+		true,
+	)
+
+	restore := defaultProviderRegistry
+	defaultProviderRegistry = func() *provider.Registry {
+		registry := provider.NewRegistry()
+		registry.Register(stubReviewProvider{
+			name: "stub",
+			items: []provider.ReviewItem{
+				{
+					Title:                   "Keep helper reuse consistent",
+					File:                    "internal/app/service.go",
+					Line:                    42,
+					Severity:                "nitpick",
+					Author:                  "coderabbitai[bot]",
+					Body:                    "Use the existing helper instead of duplicating logic.",
+					ReviewHash:              "hash-stale",
+					SourceReviewID:          "4002",
+					SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+				},
+				{
+					Title:       "Add nil check",
+					File:        "internal/app/service.go",
+					Line:        18,
+					Author:      "coderabbitai[bot]",
+					Body:        "Please add a nil check before dereferencing the pointer.",
+					ProviderRef: "thread:PRT_1,comment:RC_1",
+				},
+			},
+		})
+		return registry
+	}
+	t.Cleanup(func() { defaultProviderRegistry = restore })
+
+	result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
+		Name:     "demo",
+		Provider: "stub",
+		PR:       "259",
+	})
+	if err != nil {
+		t.Fatalf("fetch reviews: %v", err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected stale resolved nitpick to be filtered, got total %d", result.Total)
+	}
+}
+
+func TestFetchReviewsReimportsUnresolvedNitpickHashes(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	prdDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
+	if err := os.MkdirAll(prdDir, 0o755); err != nil {
+		t.Fatalf("mkdir prd dir: %v", err)
+	}
+	writeHistoricalNitpickRound(
+		t,
+		prdDir,
+		1,
+		provider.ReviewItem{
+			Title:                   "Keep helper reuse consistent",
+			File:                    "internal/app/service.go",
+			Line:                    42,
+			Severity:                "nitpick",
+			Author:                  "coderabbitai[bot]",
+			Body:                    "Use the existing helper instead of duplicating logic.",
+			ReviewHash:              "hash-open",
+			SourceReviewID:          "4001",
+			SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+		},
+		false,
+	)
+
+	restore := defaultProviderRegistry
+	defaultProviderRegistry = func() *provider.Registry {
+		registry := provider.NewRegistry()
+		registry.Register(stubReviewProvider{
+			name: "stub",
+			items: []provider.ReviewItem{
+				{
+					Title:                   "Keep helper reuse consistent",
+					File:                    "internal/app/service.go",
+					Line:                    42,
+					Severity:                "nitpick",
+					Author:                  "coderabbitai[bot]",
+					Body:                    "Use the existing helper instead of duplicating logic.",
+					ReviewHash:              "hash-open",
+					SourceReviewID:          "4002",
+					SourceReviewSubmittedAt: "2026-04-10T10:05:00Z",
+				},
+			},
+		})
+		return registry
+	}
+	t.Cleanup(func() { defaultProviderRegistry = restore })
+
+	result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
+		Name:     "demo",
+		Provider: "stub",
+		PR:       "259",
+	})
+	if err != nil {
+		t.Fatalf("fetch reviews: %v", err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected unresolved nitpick to be re-imported, got total %d", result.Total)
+	}
+}
+
+func TestFetchReviewsReimportsResolvedNitpickWhenProviderReviewIsNewer(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	prdDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
+	if err := os.MkdirAll(prdDir, 0o755); err != nil {
+		t.Fatalf("mkdir prd dir: %v", err)
+	}
+	writeHistoricalNitpickRound(
+		t,
+		prdDir,
+		1,
+		provider.ReviewItem{
+			Title:                   "Keep helper reuse consistent",
+			File:                    "internal/app/service.go",
+			Line:                    42,
+			Severity:                "nitpick",
+			Author:                  "coderabbitai[bot]",
+			Body:                    "Use the existing helper instead of duplicating logic.",
+			ReviewHash:              "hash-returned",
+			SourceReviewID:          "4001",
+			SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+		},
+		true,
+	)
+
+	restore := defaultProviderRegistry
+	defaultProviderRegistry = func() *provider.Registry {
+		registry := provider.NewRegistry()
+		registry.Register(stubReviewProvider{
+			name: "stub",
+			items: []provider.ReviewItem{
+				{
+					Title:                   "Keep helper reuse consistent",
+					File:                    "internal/app/service.go",
+					Line:                    42,
+					Severity:                "nitpick",
+					Author:                  "coderabbitai[bot]",
+					Body:                    "Use the existing helper instead of duplicating logic.",
+					ReviewHash:              "hash-returned",
+					SourceReviewID:          "4002",
+					SourceReviewSubmittedAt: "2026-04-10T10:30:00Z",
+				},
+			},
+		})
+		return registry
+	}
+	t.Cleanup(func() { defaultProviderRegistry = restore })
+
+	result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
+		Name:     "demo",
+		Provider: "stub",
+		PR:       "259",
+	})
+	if err != nil {
+		t.Fatalf("fetch reviews: %v", err)
+	}
+	if result.Total != 1 {
+		t.Fatalf("expected newer nitpick to be re-imported, got total %d", result.Total)
+	}
+}
+
+func writeHistoricalNitpickRound(
+	t *testing.T,
+	prdDir string,
+	round int,
+	item provider.ReviewItem,
+	resolved bool,
+) {
+	t.Helper()
+
+	reviewDir := reviews.ReviewDirectory(prdDir, round)
+	if err := reviews.WriteRound(reviewDir, model.RoundMeta{
+		Provider:  "stub",
+		PR:        "259",
+		Round:     round,
+		CreatedAt: time.Date(2026, 4, 10, 10, 0, 0, 0, time.UTC),
+	}, []provider.ReviewItem{item}); err != nil {
+		t.Fatalf("write historical round: %v", err)
+	}
+
+	if !resolved {
+		return
+	}
+
+	issuePath := filepath.Join(reviewDir, "issue_001.md")
+	content, err := os.ReadFile(issuePath)
+	if err != nil {
+		t.Fatalf("read issue file: %v", err)
+	}
+	updated := strings.Replace(string(content), "status: pending", "status: resolved", 1)
+	if err := os.WriteFile(issuePath, []byte(updated), 0o600); err != nil {
+		t.Fatalf("write resolved issue file: %v", err)
 	}
 }

--- a/internal/core/fetch_test.go
+++ b/internal/core/fetch_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +18,8 @@ type stubReviewProvider struct {
 	name  string
 	items []provider.ReviewItem
 }
+
+var fetchReviewProviderRegistryMu sync.Mutex
 
 func (s stubReviewProvider) Name() string { return s.name }
 
@@ -109,38 +112,31 @@ func TestFetchReviewsAutoIncrementsRound(t *testing.T) {
 	}
 }
 
-func TestFetchReviewsSkipsResolvedStaleNitpickHashes(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Chdir(tmpDir)
+func TestFetchReviewsNitpickHistoryFiltering(t *testing.T) {
+	t.Parallel()
 
-	prdDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
-	if err := os.MkdirAll(prdDir, 0o755); err != nil {
-		t.Fatalf("mkdir prd dir: %v", err)
-	}
-	writeHistoricalNitpickRound(
-		t,
-		prdDir,
-		1,
-		provider.ReviewItem{
-			Title:                   "Keep helper reuse consistent",
-			File:                    "internal/app/service.go",
-			Line:                    42,
-			Severity:                "nitpick",
-			Author:                  "coderabbitai[bot]",
-			Body:                    "Use the existing helper instead of duplicating logic.",
-			ReviewHash:              "hash-stale",
-			SourceReviewID:          "4001",
-			SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
-		},
-		true,
-	)
-
-	restore := defaultProviderRegistry
-	defaultProviderRegistry = func() *provider.Registry {
-		registry := provider.NewRegistry()
-		registry.Register(stubReviewProvider{
-			name: "stub",
-			items: []provider.ReviewItem{
+	cases := []struct {
+		name            string
+		historicalItem  provider.ReviewItem
+		historicalState string
+		fetchedItems    []provider.ReviewItem
+		wantTotal       int
+	}{
+		{
+			name: "filter resolved nitpicks when the fetched review is older",
+			historicalItem: provider.ReviewItem{
+				Title:                   "Keep helper reuse consistent",
+				File:                    "internal/app/service.go",
+				Line:                    42,
+				Severity:                "nitpick",
+				Author:                  "coderabbitai[bot]",
+				Body:                    "Use the existing helper instead of duplicating logic.",
+				ReviewHash:              "hash-stale",
+				SourceReviewID:          "4002",
+				SourceReviewSubmittedAt: "2026-04-10T10:30:00Z",
+			},
+			historicalState: "resolved",
+			fetchedItems: []provider.ReviewItem{
 				{
 					Title:                   "Keep helper reuse consistent",
 					File:                    "internal/app/service.go",
@@ -149,7 +145,7 @@ func TestFetchReviewsSkipsResolvedStaleNitpickHashes(t *testing.T) {
 					Author:                  "coderabbitai[bot]",
 					Body:                    "Use the existing helper instead of duplicating logic.",
 					ReviewHash:              "hash-stale",
-					SourceReviewID:          "4002",
+					SourceReviewID:          "4003",
 					SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
 				},
 				{
@@ -161,56 +157,23 @@ func TestFetchReviewsSkipsResolvedStaleNitpickHashes(t *testing.T) {
 					ProviderRef: "thread:PRT_1,comment:RC_1",
 				},
 			},
-		})
-		return registry
-	}
-	t.Cleanup(func() { defaultProviderRegistry = restore })
-
-	result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
-		Name:     "demo",
-		Provider: "stub",
-		PR:       "259",
-	})
-	if err != nil {
-		t.Fatalf("fetch reviews: %v", err)
-	}
-	if result.Total != 1 {
-		t.Fatalf("expected stale resolved nitpick to be filtered, got total %d", result.Total)
-	}
-}
-
-func TestFetchReviewsReimportsUnresolvedNitpickHashes(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Chdir(tmpDir)
-
-	prdDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
-	if err := os.MkdirAll(prdDir, 0o755); err != nil {
-		t.Fatalf("mkdir prd dir: %v", err)
-	}
-	writeHistoricalNitpickRound(
-		t,
-		prdDir,
-		1,
-		provider.ReviewItem{
-			Title:                   "Keep helper reuse consistent",
-			File:                    "internal/app/service.go",
-			Line:                    42,
-			Severity:                "nitpick",
-			Author:                  "coderabbitai[bot]",
-			Body:                    "Use the existing helper instead of duplicating logic.",
-			ReviewHash:              "hash-open",
-			SourceReviewID:          "4001",
-			SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+			wantTotal: 1,
 		},
-		false,
-	)
-
-	restore := defaultProviderRegistry
-	defaultProviderRegistry = func() *provider.Registry {
-		registry := provider.NewRegistry()
-		registry.Register(stubReviewProvider{
-			name: "stub",
-			items: []provider.ReviewItem{
+		{
+			name: "re-import unresolved nitpick hashes",
+			historicalItem: provider.ReviewItem{
+				Title:                   "Keep helper reuse consistent",
+				File:                    "internal/app/service.go",
+				Line:                    42,
+				Severity:                "nitpick",
+				Author:                  "coderabbitai[bot]",
+				Body:                    "Use the existing helper instead of duplicating logic.",
+				ReviewHash:              "hash-open",
+				SourceReviewID:          "4001",
+				SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+			},
+			historicalState: "pending",
+			fetchedItems: []provider.ReviewItem{
 				{
 					Title:                   "Keep helper reuse consistent",
 					File:                    "internal/app/service.go",
@@ -223,56 +186,23 @@ func TestFetchReviewsReimportsUnresolvedNitpickHashes(t *testing.T) {
 					SourceReviewSubmittedAt: "2026-04-10T10:05:00Z",
 				},
 			},
-		})
-		return registry
-	}
-	t.Cleanup(func() { defaultProviderRegistry = restore })
-
-	result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
-		Name:     "demo",
-		Provider: "stub",
-		PR:       "259",
-	})
-	if err != nil {
-		t.Fatalf("fetch reviews: %v", err)
-	}
-	if result.Total != 1 {
-		t.Fatalf("expected unresolved nitpick to be re-imported, got total %d", result.Total)
-	}
-}
-
-func TestFetchReviewsReimportsResolvedNitpickWhenProviderReviewIsNewer(t *testing.T) {
-	tmpDir := t.TempDir()
-	t.Chdir(tmpDir)
-
-	prdDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
-	if err := os.MkdirAll(prdDir, 0o755); err != nil {
-		t.Fatalf("mkdir prd dir: %v", err)
-	}
-	writeHistoricalNitpickRound(
-		t,
-		prdDir,
-		1,
-		provider.ReviewItem{
-			Title:                   "Keep helper reuse consistent",
-			File:                    "internal/app/service.go",
-			Line:                    42,
-			Severity:                "nitpick",
-			Author:                  "coderabbitai[bot]",
-			Body:                    "Use the existing helper instead of duplicating logic.",
-			ReviewHash:              "hash-returned",
-			SourceReviewID:          "4001",
-			SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+			wantTotal: 1,
 		},
-		true,
-	)
-
-	restore := defaultProviderRegistry
-	defaultProviderRegistry = func() *provider.Registry {
-		registry := provider.NewRegistry()
-		registry.Register(stubReviewProvider{
-			name: "stub",
-			items: []provider.ReviewItem{
+		{
+			name: "re-import resolved nitpicks when the fetched review has a newer timestamp",
+			historicalItem: provider.ReviewItem{
+				Title:                   "Keep helper reuse consistent",
+				File:                    "internal/app/service.go",
+				Line:                    42,
+				Severity:                "nitpick",
+				Author:                  "coderabbitai[bot]",
+				Body:                    "Use the existing helper instead of duplicating logic.",
+				ReviewHash:              "hash-returned",
+				SourceReviewID:          "4001",
+				SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+			},
+			historicalState: "resolved",
+			fetchedItems: []provider.ReviewItem{
 				{
 					Title:                   "Keep helper reuse consistent",
 					File:                    "internal/app/service.go",
@@ -285,22 +215,87 @@ func TestFetchReviewsReimportsResolvedNitpickWhenProviderReviewIsNewer(t *testin
 					SourceReviewSubmittedAt: "2026-04-10T10:30:00Z",
 				},
 			},
+			wantTotal: 1,
+		},
+		{
+			name: "re-import resolved nitpicks when the fetched review has the same timestamp but a newer review id",
+			historicalItem: provider.ReviewItem{
+				Title:                   "Keep helper reuse consistent",
+				File:                    "internal/app/service.go",
+				Line:                    42,
+				Severity:                "nitpick",
+				Author:                  "coderabbitai[bot]",
+				Body:                    "Use the existing helper instead of duplicating logic.",
+				ReviewHash:              "hash-same-second",
+				SourceReviewID:          "4001",
+				SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+			},
+			historicalState: "resolved",
+			fetchedItems: []provider.ReviewItem{
+				{
+					Title:                   "Keep helper reuse consistent",
+					File:                    "internal/app/service.go",
+					Line:                    42,
+					Severity:                "nitpick",
+					Author:                  "coderabbitai[bot]",
+					Body:                    "Use the existing helper instead of duplicating logic.",
+					ReviewHash:              "hash-same-second",
+					SourceReviewID:          "4002",
+					SourceReviewSubmittedAt: "2026-04-10T10:00:00Z",
+				},
+			},
+			wantTotal: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run("Should "+tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			prdDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
+			if err := os.MkdirAll(prdDir, 0o755); err != nil {
+				t.Fatalf("mkdir prd dir: %v", err)
+			}
+			writeHistoricalNitpickRound(t, prdDir, 1, tc.historicalItem, tc.historicalState == "resolved")
+			installStubReviewProviderRegistry(t, tc.fetchedItems)
+
+			result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
+				Name:          "demo",
+				Provider:      "stub",
+				PR:            "259",
+				WorkspaceRoot: tmpDir,
+			})
+			if err != nil {
+				t.Fatalf("fetch reviews: %v", err)
+			}
+			if result.Total != tc.wantTotal {
+				t.Fatalf("unexpected fetched total: got %d, want %d", result.Total, tc.wantTotal)
+			}
+		})
+	}
+}
+
+func installStubReviewProviderRegistry(t *testing.T, items []provider.ReviewItem) {
+	t.Helper()
+
+	fetchReviewProviderRegistryMu.Lock()
+
+	restore := defaultProviderRegistry
+	defaultProviderRegistry = func() *provider.Registry {
+		registry := provider.NewRegistry()
+		registry.Register(stubReviewProvider{
+			name:  "stub",
+			items: items,
 		})
 		return registry
 	}
-	t.Cleanup(func() { defaultProviderRegistry = restore })
 
-	result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
-		Name:     "demo",
-		Provider: "stub",
-		PR:       "259",
+	t.Cleanup(func() {
+		defaultProviderRegistry = restore
+		fetchReviewProviderRegistryMu.Unlock()
 	})
-	if err != nil {
-		t.Fatalf("fetch reviews: %v", err)
-	}
-	if result.Total != 1 {
-		t.Fatalf("expected newer nitpick to be re-imported, got total %d", result.Total)
-	}
 }
 
 func writeHistoricalNitpickRound(

--- a/internal/core/kernel/commands/commands_test.go
+++ b/internal/core/kernel/commands/commands_test.go
@@ -89,6 +89,9 @@ func TestReviewsFetchFromConfigMapsLegacyFields(t *testing.T) {
 	if cmd.PR != cfg.PR {
 		t.Fatalf("unexpected pr: %q", cmd.PR)
 	}
+	if cmd.Nitpicks != cfg.Nitpicks {
+		t.Fatalf("unexpected nitpicks: %t", cmd.Nitpicks)
+	}
 }
 
 func TestReviewsFetchCommandCoreConfigMapsFields(t *testing.T) {
@@ -100,11 +103,15 @@ func TestReviewsFetchCommandCoreConfigMapsFields(t *testing.T) {
 		Round:         3,
 		Provider:      "coderabbit",
 		PR:            "259",
+		Nitpicks:      true,
 	}
 	cfg := cmd.CoreConfig()
 
 	if cfg.WorkspaceRoot != cmd.WorkspaceRoot || cfg.Name != cmd.Name || cfg.Round != cmd.Round {
 		t.Fatalf("unexpected fetch config: %#v", cfg)
+	}
+	if cfg.Nitpicks != cmd.Nitpicks {
+		t.Fatalf("unexpected fetch nitpicks flag: %t", cfg.Nitpicks)
 	}
 }
 
@@ -315,6 +322,9 @@ func assertRuntimeConfig(t *testing.T, got *model.RuntimeConfig, want core.Confi
 	if got.PR != want.PR {
 		t.Fatalf("unexpected pr: %q", got.PR)
 	}
+	if got.Nitpicks != want.Nitpicks {
+		t.Fatalf("unexpected nitpicks: %t", got.Nitpicks)
+	}
 	if got.ReviewsDir != want.ReviewsDir {
 		t.Fatalf("unexpected reviews dir: %q", got.ReviewsDir)
 	}
@@ -410,6 +420,7 @@ func testCoreConfig() core.Config {
 		Round:                  7,
 		Provider:               "coderabbit",
 		PR:                     "259",
+		Nitpicks:               true,
 		ReviewsDir:             "/workspace/.compozy/tasks/demo/reviews-007",
 		TasksDir:               "/workspace/.compozy/tasks/demo",
 		DryRun:                 true,

--- a/internal/core/kernel/commands/reviews_fetch.go
+++ b/internal/core/kernel/commands/reviews_fetch.go
@@ -12,6 +12,7 @@ type ReviewsFetchCommand struct {
 	Round         int
 	Provider      string
 	PR            string
+	Nitpicks      bool
 }
 
 // ReviewsFetchResult wraps the existing review fetch result contract.
@@ -27,6 +28,7 @@ func ReviewsFetchFromConfig(cfg core.Config) ReviewsFetchCommand {
 		Round:         cfg.Round,
 		Provider:      cfg.Provider,
 		PR:            cfg.PR,
+		Nitpicks:      cfg.Nitpicks,
 	}
 }
 
@@ -38,5 +40,6 @@ func (c ReviewsFetchCommand) CoreConfig() core.Config {
 		Round:         c.Round,
 		Provider:      c.Provider,
 		PR:            c.PR,
+		Nitpicks:      c.Nitpicks,
 	}
 }

--- a/internal/core/model/runtime_config.go
+++ b/internal/core/model/runtime_config.go
@@ -8,6 +8,7 @@ type RuntimeConfig struct {
 	Round                  int
 	Provider               string
 	PR                     string
+	Nitpicks               bool
 	ReviewsDir             string
 	TasksDir               string
 	DryRun                 bool

--- a/internal/core/model/task_review.go
+++ b/internal/core/model/task_review.go
@@ -16,6 +16,10 @@ type ReviewContext struct {
 	Severity    string
 	Author      string
 	ProviderRef string
+	ReviewHash  string
+
+	SourceReviewID          string
+	SourceReviewSubmittedAt string
 }
 
 type RoundMeta struct {
@@ -60,4 +64,8 @@ type ReviewFileMeta struct {
 	Severity    string `yaml:"severity,omitempty"`
 	Author      string `yaml:"author,omitempty"`
 	ProviderRef string `yaml:"provider_ref,omitempty"`
+	ReviewHash  string `yaml:"review_hash,omitempty"`
+
+	SourceReviewID          string `yaml:"source_review_id,omitempty"`
+	SourceReviewSubmittedAt string `yaml:"source_review_submitted_at,omitempty"`
 }

--- a/internal/core/provider/coderabbit/coderabbit.go
+++ b/internal/core/provider/coderabbit/coderabbit.go
@@ -62,8 +62,8 @@ func (p *Provider) Name() string {
 	return name
 }
 
-func (p *Provider) FetchReviews(ctx context.Context, pr string) ([]provider.ReviewItem, error) {
-	if strings.TrimSpace(pr) == "" {
+func (p *Provider) FetchReviews(ctx context.Context, req provider.FetchRequest) ([]provider.ReviewItem, error) {
+	if strings.TrimSpace(req.PR) == "" {
 		return nil, errors.New("pull request number is required")
 	}
 
@@ -72,11 +72,11 @@ func (p *Provider) FetchReviews(ctx context.Context, pr string) ([]provider.Revi
 		return nil, err
 	}
 
-	comments, err := p.fetchReviewComments(ctx, owner, repo, pr)
+	comments, err := p.fetchReviewComments(ctx, owner, repo, req.PR)
 	if err != nil {
 		return nil, err
 	}
-	threads, err := p.fetchReviewThreads(ctx, owner, repo, pr)
+	threads, err := p.fetchReviewThreads(ctx, owner, repo, req.PR)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +112,19 @@ func (p *Provider) FetchReviews(ctx context.Context, pr string) ([]provider.Revi
 		})
 	}
 
+	if req.IncludeNitpicks {
+		reviews, err := p.fetchPullRequestReviews(ctx, owner, repo, req.PR)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, parseNitpickReviewItems(reviews, p.botLogin)...)
+	}
+
+	sortReviewItems(items)
+	return items, nil
+}
+
+func sortReviewItems(items []provider.ReviewItem) {
 	sort.SliceStable(items, func(i, j int) bool {
 		if items[i].File != items[j].File {
 			return items[i].File < items[j].File
@@ -122,10 +135,11 @@ func (p *Provider) FetchReviews(ctx context.Context, pr string) ([]provider.Revi
 		if items[i].Title != items[j].Title {
 			return items[i].Title < items[j].Title
 		}
+		if items[i].ReviewHash != items[j].ReviewHash {
+			return items[i].ReviewHash < items[j].ReviewHash
+		}
 		return items[i].ProviderRef < items[j].ProviderRef
 	})
-
-	return items, nil
 }
 
 func (p *Provider) ResolveIssues(ctx context.Context, _ string, issues []provider.ResolvedIssue) error {

--- a/internal/core/provider/coderabbit/coderabbit_test.go
+++ b/internal/core/provider/coderabbit/coderabbit_test.go
@@ -43,7 +43,7 @@ func TestFetchReviewsFiltersResolvedThreadsAndNonBotComments(t *testing.T) {
 		}
 	}
 
-	items, err := New(WithCommandRunner(run)).FetchReviews(context.Background(), "259")
+	items, err := New(WithCommandRunner(run)).FetchReviews(context.Background(), provider.FetchRequest{PR: "259"})
 	if err != nil {
 		t.Fatalf("fetch reviews: %v", err)
 	}

--- a/internal/core/provider/coderabbit/nitpicks.go
+++ b/internal/core/provider/coderabbit/nitpicks.go
@@ -153,7 +153,7 @@ func parseNitpicksForFile(review pullRequestReview, filePath string, body string
 		}
 
 		reviewID := strconv.Itoa(review.ID)
-		reviewHash := buildNitpickHash(filePath, title, nitpickBody)
+		reviewHash := buildNitpickHash(filePath, lineRange, title, nitpickBody)
 		items = append(items, provider.ReviewItem{
 			Title:                   title,
 			File:                    filePath,
@@ -343,10 +343,11 @@ func normalizeNitpickBody(body string) string {
 	return strings.TrimSpace(strings.Join(normalized, "\n"))
 }
 
-func buildNitpickHash(filePath string, title string, body string) string {
+func buildNitpickHash(filePath string, location string, title string, body string) string {
 	canonical := strings.Join([]string{
 		"provider:" + name,
 		"file:" + canonicalHashValue(filePath),
+		"location:" + canonicalHashValue(location),
 		"title:" + canonicalHashValue(title),
 		"body:" + canonicalHashValue(firstParagraph(body)),
 	}, "\n")

--- a/internal/core/provider/coderabbit/nitpicks.go
+++ b/internal/core/provider/coderabbit/nitpicks.go
@@ -1,0 +1,417 @@
+package coderabbit
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/compozy/compozy/internal/core/provider"
+)
+
+const (
+	nitpickSeverity   = "nitpick"
+	nitpickHashLength = 12
+)
+
+var (
+	nitpickHeaderRe     = regexp.MustCompile("(?m)^`([^`]+)`:\\s*\\*\\*(.+?)\\*\\*\\s*$")
+	reviewFileSummaryRe = regexp.MustCompile(`^(.+?)\s+\(\d+\)$`)
+)
+
+type pullRequestReview struct {
+	ID          int    `json:"id"`
+	Body        string `json:"body"`
+	SubmittedAt string `json:"submitted_at"`
+	User        struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+type detailsBlock struct {
+	start   int
+	end     int
+	summary string
+	body    string
+}
+
+func (p *Provider) fetchPullRequestReviews(
+	ctx context.Context,
+	owner string,
+	repo string,
+	pr string,
+) ([]pullRequestReview, error) {
+	reviews := make([]pullRequestReview, 0, 16)
+	for page := 1; ; page++ {
+		endpoint := fmt.Sprintf("repos/%s/%s/pulls/%s/reviews?per_page=100&page=%d", owner, repo, pr, page)
+		output, err := p.run(ctx, "api", endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("fetch pull request reviews page %d: %w", page, err)
+		}
+
+		var pageReviews []pullRequestReview
+		if err := json.Unmarshal(output, &pageReviews); err != nil {
+			return nil, fmt.Errorf("decode pull request reviews page %d: %w", page, err)
+		}
+
+		reviews = append(reviews, pageReviews...)
+		if len(pageReviews) < 100 {
+			break
+		}
+	}
+	return reviews, nil
+}
+
+func parseNitpickReviewItems(reviews []pullRequestReview, botLogin string) []provider.ReviewItem {
+	if len(reviews) == 0 {
+		return nil
+	}
+
+	latestByHash := make(map[string]*provider.ReviewItem)
+	for _, review := range reviews {
+		if review.User.Login != botLogin || strings.TrimSpace(review.Body) == "" {
+			continue
+		}
+
+		parsedItems := parseNitpickReview(review)
+		for idx := range parsedItems {
+			item := parsedItems[idx]
+			if item.ReviewHash == "" {
+				continue
+			}
+
+			current, ok := latestByHash[item.ReviewHash]
+			if !ok || nitpickItemIsNewer(item, *current) {
+				next := item
+				latestByHash[item.ReviewHash] = &next
+			}
+		}
+	}
+
+	items := make([]provider.ReviewItem, 0, len(latestByHash))
+	for _, item := range latestByHash {
+		items = append(items, *item)
+	}
+	return items
+}
+
+func parseNitpickReview(review pullRequestReview) []provider.ReviewItem {
+	nitpickBlock, ok := findDetailsBlock(review.Body, func(summary string) bool {
+		return strings.Contains(strings.ToLower(summary), "nitpick comments")
+	})
+	if !ok {
+		return nil
+	}
+
+	fileBlocks := extractTopLevelDetailsBlocks(trimEnclosingTag(nitpickBlock.body, "blockquote"))
+	items := make([]provider.ReviewItem, 0, len(fileBlocks))
+	for _, fileBlock := range fileBlocks {
+		filePath := parseNitpickFilePath(fileBlock.summary)
+		if filePath == "" {
+			continue
+		}
+
+		items = append(items, parseNitpicksForFile(
+			review,
+			filePath,
+			trimEnclosingTag(fileBlock.body, "blockquote"),
+		)...)
+	}
+	return items
+}
+
+func parseNitpicksForFile(review pullRequestReview, filePath string, body string) []provider.ReviewItem {
+	trimmed := strings.TrimSpace(stripTopLevelDetailsBlocks(body))
+	if trimmed == "" {
+		return nil
+	}
+
+	matches := nitpickHeaderRe.FindAllStringSubmatchIndex(trimmed, -1)
+	items := make([]provider.ReviewItem, 0, len(matches))
+	for idx, match := range matches {
+		lineRange := strings.TrimSpace(trimmed[match[2]:match[3]])
+		title := normalizeNitpickText(trimmed[match[4]:match[5]])
+		if title == "" {
+			continue
+		}
+
+		bodyStart := match[1]
+		bodyEnd := len(trimmed)
+		if idx+1 < len(matches) {
+			bodyEnd = matches[idx+1][0]
+		}
+
+		nitpickBody := normalizeNitpickBody(trimmed[bodyStart:bodyEnd])
+		if nitpickBody == "" {
+			nitpickBody = title
+		}
+
+		reviewID := strconv.Itoa(review.ID)
+		reviewHash := buildNitpickHash(filePath, title, nitpickBody)
+		items = append(items, provider.ReviewItem{
+			Title:                   title,
+			File:                    filePath,
+			Line:                    parseNitpickLine(lineRange),
+			Severity:                nitpickSeverity,
+			Author:                  review.User.Login,
+			Body:                    nitpickBody,
+			ProviderRef:             buildNitpickProviderRef(reviewID, reviewHash),
+			ReviewHash:              reviewHash,
+			SourceReviewID:          reviewID,
+			SourceReviewSubmittedAt: strings.TrimSpace(review.SubmittedAt),
+		})
+	}
+
+	return items
+}
+
+func findDetailsBlock(text string, match func(string) bool) (detailsBlock, bool) {
+	for _, block := range extractTopLevelDetailsBlocks(text) {
+		if match(block.summary) {
+			return block, true
+		}
+	}
+	return detailsBlock{}, false
+}
+
+func extractTopLevelDetailsBlocks(text string) []detailsBlock {
+	blocks := make([]detailsBlock, 0, 8)
+	cursor := 0
+	for {
+		relativeStart := strings.Index(text[cursor:], "<details>")
+		if relativeStart < 0 {
+			break
+		}
+
+		start := cursor + relativeStart
+		end := matchingDetailsEnd(text, start)
+		if end < 0 {
+			break
+		}
+
+		block := parseDetailsBlock(start, end, text[start:end])
+		blocks = append(blocks, block)
+		cursor = end
+	}
+	return blocks
+}
+
+func matchingDetailsEnd(text string, start int) int {
+	cursor := start
+	depth := 0
+	for cursor < len(text) {
+		nextOpen := strings.Index(text[cursor:], "<details>")
+		if nextOpen >= 0 {
+			nextOpen += cursor
+		}
+		nextClose := strings.Index(text[cursor:], "</details>")
+		if nextClose >= 0 {
+			nextClose += cursor
+		}
+
+		switch {
+		case nextOpen >= 0 && (nextClose < 0 || nextOpen < nextClose):
+			depth++
+			cursor = nextOpen + len("<details>")
+		case nextClose >= 0:
+			depth--
+			cursor = nextClose + len("</details>")
+			if depth == 0 {
+				return cursor
+			}
+		default:
+			return -1
+		}
+	}
+	return -1
+}
+
+func parseDetailsBlock(start int, end int, raw string) detailsBlock {
+	inside := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(raw, "<details>"), "</details>"))
+	summaryStart := strings.Index(inside, "<summary>")
+	summaryEnd := strings.Index(inside, "</summary>")
+	if summaryStart < 0 || summaryEnd < 0 || summaryEnd < summaryStart {
+		return detailsBlock{
+			start: start,
+			end:   end,
+			body:  strings.TrimSpace(inside),
+		}
+	}
+
+	summary := html.UnescapeString(strings.TrimSpace(inside[summaryStart+len("<summary>") : summaryEnd]))
+	body := strings.TrimSpace(inside[summaryEnd+len("</summary>"):])
+	return detailsBlock{
+		start:   start,
+		end:     end,
+		summary: summary,
+		body:    body,
+	}
+}
+
+func stripTopLevelDetailsBlocks(text string) string {
+	blocks := extractTopLevelDetailsBlocks(text)
+	if len(blocks) == 0 {
+		return strings.TrimSpace(text)
+	}
+
+	var builder strings.Builder
+	cursor := 0
+	for _, block := range blocks {
+		if block.start > cursor {
+			builder.WriteString(text[cursor:block.start])
+		}
+		cursor = block.end
+	}
+	if cursor < len(text) {
+		builder.WriteString(text[cursor:])
+	}
+	return strings.TrimSpace(builder.String())
+}
+
+func trimEnclosingTag(text string, tag string) string {
+	openTag := "<" + tag + ">"
+	closeTag := "</" + tag + ">"
+
+	trimmed := strings.TrimSpace(text)
+	for strings.HasPrefix(trimmed, openTag) && strings.HasSuffix(trimmed, closeTag) {
+		trimmed = strings.TrimSpace(strings.TrimPrefix(trimmed, openTag))
+		trimmed = strings.TrimSpace(strings.TrimSuffix(trimmed, closeTag))
+	}
+	return trimmed
+}
+
+func parseNitpickFilePath(summary string) string {
+	trimmed := strings.TrimSpace(summary)
+	matches := reviewFileSummaryRe.FindStringSubmatch(trimmed)
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(matches[1])
+}
+
+func parseNitpickLine(lineRange string) int {
+	trimmed := strings.TrimSpace(lineRange)
+	if trimmed == "" {
+		return 0
+	}
+
+	for idx, r := range trimmed {
+		if r < '0' || r > '9' {
+			trimmed = trimmed[:idx]
+			break
+		}
+	}
+
+	line, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0
+	}
+	return line
+}
+
+func normalizeNitpickText(value string) string {
+	trimmed := html.UnescapeString(strings.TrimSpace(value))
+	trimmed = strings.ReplaceAll(trimmed, "`", "")
+	return strings.Join(strings.Fields(trimmed), " ")
+}
+
+func normalizeNitpickBody(body string) string {
+	lines := strings.Split(html.UnescapeString(body), "\n")
+	normalized := make([]string, 0, len(lines))
+	previousBlank := true
+
+	for _, rawLine := range lines {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			if !previousBlank {
+				normalized = append(normalized, "")
+			}
+			previousBlank = true
+			continue
+		}
+
+		normalized = append(normalized, strings.Join(strings.Fields(line), " "))
+		previousBlank = false
+	}
+
+	return strings.TrimSpace(strings.Join(normalized, "\n"))
+}
+
+func buildNitpickHash(filePath string, title string, body string) string {
+	canonical := strings.Join([]string{
+		"provider:" + name,
+		"file:" + canonicalHashValue(filePath),
+		"title:" + canonicalHashValue(title),
+		"body:" + canonicalHashValue(firstParagraph(body)),
+	}, "\n")
+
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:])[:nitpickHashLength]
+}
+
+func canonicalHashValue(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), " "))
+}
+
+func firstParagraph(body string) string {
+	for _, paragraph := range strings.Split(body, "\n\n") {
+		if trimmed := strings.TrimSpace(paragraph); trimmed != "" {
+			return trimmed
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+func buildNitpickProviderRef(reviewID string, reviewHash string) string {
+	parts := make([]string, 0, 2)
+	if strings.TrimSpace(reviewID) != "" {
+		parts = append(parts, "review:"+strings.TrimSpace(reviewID))
+	}
+	if strings.TrimSpace(reviewHash) != "" {
+		parts = append(parts, "nitpick_hash:"+strings.TrimSpace(reviewHash))
+	}
+	return strings.Join(parts, ",")
+}
+
+func nitpickItemIsNewer(candidate provider.ReviewItem, current provider.ReviewItem) bool {
+	candidateTime := parseNitpickSubmittedAt(candidate.SourceReviewSubmittedAt)
+	currentTime := parseNitpickSubmittedAt(current.SourceReviewSubmittedAt)
+	if candidateTime.After(currentTime) {
+		return true
+	}
+	if currentTime.After(candidateTime) {
+		return false
+	}
+	return compareReviewIDs(candidate.SourceReviewID, current.SourceReviewID) > 0
+}
+
+func parseNitpickSubmittedAt(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func compareReviewIDs(left string, right string) int {
+	leftID, leftErr := strconv.ParseInt(strings.TrimSpace(left), 10, 64)
+	rightID, rightErr := strconv.ParseInt(strings.TrimSpace(right), 10, 64)
+	if leftErr == nil && rightErr == nil {
+		switch {
+		case leftID > rightID:
+			return 1
+		case leftID < rightID:
+			return -1
+		default:
+			return 0
+		}
+	}
+
+	return strings.Compare(strings.TrimSpace(left), strings.TrimSpace(right))
+}

--- a/internal/core/provider/coderabbit/nitpicks_test.go
+++ b/internal/core/provider/coderabbit/nitpicks_test.go
@@ -65,7 +65,7 @@ func TestParseNitpickReviewItemsDeduplicatesHashesAndKeepsNewestReview(t *testin
 		t.Fatalf("expected 2 deduped nitpicks, got %d (%#v)", len(items), items)
 	}
 
-	hash := buildNitpickHash("internal/session/query.go", sharedTitle, sharedBody)
+	hash := buildNitpickHash("internal/session/query.go", "213-216", sharedTitle, sharedBody)
 	itemByHash := make(map[string]provider.ReviewItem, len(items))
 	for _, item := range items {
 		itemByHash[item.ReviewHash] = item
@@ -84,6 +84,52 @@ func TestParseNitpickReviewItemsDeduplicatesHashesAndKeepsNewestReview(t *testin
 	if queryItem.Line != 213 || queryItem.Severity != nitpickSeverity {
 		t.Fatalf("unexpected query nitpick metadata: %#v", queryItem)
 	}
+}
+
+func TestParseNitpickReviewItemsKeepsLocationsDistinct(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should keep identical nitpicks at different locations as separate items", func(t *testing.T) {
+		t.Parallel()
+
+		sharedTitle := "Prefer reusing existing stop-reason helper to avoid duplicated normalization."
+		sharedBody := "This block duplicates logic already present in the same package (`sessionMetaStopReason`). Reusing the helper keeps stop normalization behavior centralized."
+		reviews := []pullRequestReview{
+			{
+				ID: 4090314487,
+				Body: testNitpickReviewBody(
+					testNitpickFileSection("internal/session/query.go", "213-216", sharedTitle, sharedBody),
+					testNitpickFileSection("internal/session/query.go", "240-243", sharedTitle, sharedBody),
+				),
+				SubmittedAt: "2026-04-10T14:24:56Z",
+				User: struct {
+					Login string `json:"login"`
+				}{Login: defaultBotLogin},
+			},
+		}
+
+		items := parseNitpickReviewItems(reviews, defaultBotLogin)
+		if len(items) != 2 {
+			t.Fatalf("expected 2 nitpick items, got %d (%#v)", len(items), items)
+		}
+
+		firstHash := buildNitpickHash("internal/session/query.go", "213-216", sharedTitle, sharedBody)
+		secondHash := buildNitpickHash("internal/session/query.go", "240-243", sharedTitle, sharedBody)
+		if firstHash == secondHash {
+			t.Fatalf("expected distinct hashes for distinct locations, got %q", firstHash)
+		}
+
+		itemByHash := make(map[string]provider.ReviewItem, len(items))
+		for _, item := range items {
+			itemByHash[item.ReviewHash] = item
+		}
+		if _, ok := itemByHash[firstHash]; !ok {
+			t.Fatalf("expected first nitpick hash %q, got %#v", firstHash, itemByHash)
+		}
+		if _, ok := itemByHash[secondHash]; !ok {
+			t.Fatalf("expected second nitpick hash %q, got %#v", secondHash, itemByHash)
+		}
+	})
 }
 
 func TestFetchReviewsSkipsPullRequestReviewsWhenNitpicksDisabled(t *testing.T) {

--- a/internal/core/provider/coderabbit/nitpicks_test.go
+++ b/internal/core/provider/coderabbit/nitpicks_test.go
@@ -1,0 +1,212 @@
+package coderabbit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/compozy/compozy/internal/core/provider"
+)
+
+func TestParseNitpickReviewItemsDeduplicatesHashesAndKeepsNewestReview(t *testing.T) {
+	t.Parallel()
+
+	sharedTitle := "Prefer reusing existing stop-reason helper to avoid duplicated normalization."
+	sharedBody := "This block duplicates logic already present in the same package (`sessionMetaStopReason`). Reusing the helper keeps stop normalization behavior centralized."
+	reviews := []pullRequestReview{
+		{
+			ID: 4089982130,
+			Body: testNitpickReviewBody(
+				testNitpickFileSection("internal/session/query.go", "213-216", sharedTitle, sharedBody),
+			),
+			SubmittedAt: "2026-04-10T13:33:25Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: defaultBotLogin},
+		},
+		{
+			ID:          4090227334,
+			Body:        "",
+			SubmittedAt: "2026-04-10T14:10:44Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: defaultBotLogin},
+		},
+		{
+			ID: 4090314487,
+			Body: testNitpickReviewBody(
+				testNitpickFileSection("internal/session/query.go", "213-216", sharedTitle, sharedBody),
+				testNitpickFileSection(
+					"internal/session/query_test.go",
+					"358-371",
+					"Split the legacy-path assertions into an explicit subtest.",
+					"This introduces a second scenario in the same test body; isolating it in `t.Run(\"Should ...\")` keeps failures scoped and aligns with the test conventions.",
+				),
+			),
+			SubmittedAt: "2026-04-10T14:24:56Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: defaultBotLogin},
+		},
+		{
+			ID:          4090314499,
+			Body:        testNitpickReviewBody("internal/session/query.go", "213-216", sharedTitle, sharedBody),
+			SubmittedAt: "2026-04-10T14:25:00Z",
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "pedro"},
+		},
+	}
+
+	items := parseNitpickReviewItems(reviews, defaultBotLogin)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 deduped nitpicks, got %d (%#v)", len(items), items)
+	}
+
+	hash := buildNitpickHash("internal/session/query.go", sharedTitle, sharedBody)
+	itemByHash := make(map[string]provider.ReviewItem, len(items))
+	for _, item := range items {
+		itemByHash[item.ReviewHash] = item
+	}
+
+	queryItem, ok := itemByHash[hash]
+	if !ok {
+		t.Fatalf("expected query.go nitpick hash %q, got %#v", hash, itemByHash)
+	}
+	if queryItem.SourceReviewID != "4090314487" {
+		t.Fatalf("expected newest review id to win, got %q", queryItem.SourceReviewID)
+	}
+	if queryItem.ProviderRef != "review:4090314487,nitpick_hash:"+hash {
+		t.Fatalf("unexpected provider ref: %q", queryItem.ProviderRef)
+	}
+	if queryItem.Line != 213 || queryItem.Severity != nitpickSeverity {
+		t.Fatalf("unexpected query nitpick metadata: %#v", queryItem)
+	}
+}
+
+func TestFetchReviewsSkipsPullRequestReviewsWhenNitpicksDisabled(t *testing.T) {
+	t.Parallel()
+
+	reviewsEndpointCalled := false
+	run := func(_ context.Context, args ...string) ([]byte, error) {
+		switch {
+		case len(args) >= 4 && args[0] == "repo" && args[1] == "view":
+			return []byte(`{"owner":{"login":"acme"},"name":"compozy"}`), nil
+		case len(args) >= 2 && args[0] == "api" && strings.HasPrefix(args[1], "repos/acme/compozy/pulls/259/comments"):
+			return []byte(`[]`), nil
+		case len(args) >= 2 && args[0] == "api" && args[1] == "graphql":
+			return []byte(
+				`{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[]}}}}}`,
+			), nil
+		case len(args) >= 2 && args[0] == "api" && strings.HasPrefix(args[1], "repos/acme/compozy/pulls/259/reviews"):
+			reviewsEndpointCalled = true
+			return []byte(`[]`), nil
+		default:
+			return nil, errors.New("unexpected gh invocation: " + strings.Join(args, " "))
+		}
+	}
+
+	items, err := New(WithCommandRunner(run)).FetchReviews(context.Background(), provider.FetchRequest{PR: "259"})
+	if err != nil {
+		t.Fatalf("fetch reviews: %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected no items, got %#v", items)
+	}
+	if reviewsEndpointCalled {
+		t.Fatal("expected pull request reviews endpoint to be skipped without --nitpicks")
+	}
+}
+
+func TestFetchReviewsIncludesNitpicksWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	reviewsEndpointCalled := false
+	run := func(_ context.Context, args ...string) ([]byte, error) {
+		switch {
+		case len(args) >= 4 && args[0] == "repo" && args[1] == "view":
+			return []byte(`{"owner":{"login":"acme"},"name":"compozy"}`), nil
+		case len(args) >= 2 && args[0] == "api" && strings.HasPrefix(args[1], "repos/acme/compozy/pulls/259/comments"):
+			return []byte(`[]`), nil
+		case len(args) >= 2 && args[0] == "api" && args[1] == "graphql":
+			return []byte(
+				`{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[]}}}}}`,
+			), nil
+		case len(args) >= 2 && args[0] == "api" && strings.HasPrefix(args[1], "repos/acme/compozy/pulls/259/reviews"):
+			reviewsEndpointCalled = true
+			return []byte(fmt.Sprintf(`[
+				{"id":4089982130,"submitted_at":"2026-04-10T13:33:25Z","body":%q,"user":{"login":"%s"}}
+			]`, testNitpickReviewBody(
+				testNitpickFileSection(
+					"internal/session/query.go",
+					"213-216",
+					"Prefer reusing existing stop-reason helper to avoid duplicated normalization.",
+					"This block duplicates logic already present in the same package (`sessionMetaStopReason`). Reusing the helper keeps stop normalization behavior centralized.",
+				),
+			), defaultBotLogin)), nil
+		default:
+			return nil, errors.New("unexpected gh invocation: " + strings.Join(args, " "))
+		}
+	}
+
+	items, err := New(WithCommandRunner(run)).FetchReviews(context.Background(), provider.FetchRequest{
+		PR:              "259",
+		IncludeNitpicks: true,
+	})
+	if err != nil {
+		t.Fatalf("fetch reviews: %v", err)
+	}
+	if !reviewsEndpointCalled {
+		t.Fatal("expected pull request reviews endpoint to be used when nitpicks are enabled")
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 nitpick item, got %#v", items)
+	}
+	if items[0].Severity != nitpickSeverity || items[0].ReviewHash == "" {
+		t.Fatalf("unexpected nitpick item metadata: %#v", items[0])
+	}
+}
+
+func testNitpickReviewBody(fileSections ...string) string {
+	joinedSections := strings.Join(fileSections, "\n\n")
+	return strings.Join([]string{
+		"<details>",
+		fmt.Sprintf("<summary>🧹 Nitpick comments (%d)</summary><blockquote>", len(fileSections)),
+		"",
+		joinedSections,
+		"",
+		"</blockquote></details>",
+		"",
+	}, "\n")
+}
+
+func testNitpickFileSection(filePath string, lineRange string, title string, body string) string {
+	return strings.Join([]string{
+		"<details>",
+		fmt.Sprintf("<summary>%s (1)</summary><blockquote>", filePath),
+		"",
+		fmt.Sprintf("`%s`: **%s**", lineRange, title),
+		"",
+		body,
+		"",
+		"<details>",
+		"<summary>♻️ Proposed refactor</summary>",
+		"",
+		"```diff",
+		"+ ignored nested details",
+		"```",
+		"</details>",
+		"",
+		"<details>",
+		"<summary>🤖 Prompt for AI Agents</summary>",
+		"",
+		"```",
+		"ignored prompt details",
+		"```",
+		"</details>",
+		"",
+		"</blockquote></details>",
+	}, "\n")
+}

--- a/internal/core/provider/provider.go
+++ b/internal/core/provider/provider.go
@@ -2,6 +2,11 @@ package provider
 
 import "context"
 
+type FetchRequest struct {
+	PR              string
+	IncludeNitpicks bool
+}
+
 // ReviewItem is the normalized output of a provider fetch operation.
 type ReviewItem struct {
 	Title       string
@@ -11,6 +16,10 @@ type ReviewItem struct {
 	Author      string
 	Body        string
 	ProviderRef string
+
+	ReviewHash              string
+	SourceReviewID          string
+	SourceReviewSubmittedAt string
 }
 
 // ResolvedIssue identifies an issue file that the agent marked as resolved.
@@ -22,6 +31,6 @@ type ResolvedIssue struct {
 // Provider abstracts review fetching and thread resolution for a specific source.
 type Provider interface {
 	Name() string
-	FetchReviews(ctx context.Context, pr string) ([]ReviewItem, error)
+	FetchReviews(ctx context.Context, req FetchRequest) ([]ReviewItem, error)
 	ResolveIssues(ctx context.Context, pr string, issues []ResolvedIssue) error
 }

--- a/internal/core/provider/registry_test.go
+++ b/internal/core/provider/registry_test.go
@@ -11,7 +11,7 @@ type stubProvider struct {
 
 func (s stubProvider) Name() string { return s.name }
 
-func (s stubProvider) FetchReviews(context.Context, string) ([]ReviewItem, error) {
+func (s stubProvider) FetchReviews(context.Context, FetchRequest) ([]ReviewItem, error) {
 	return nil, nil
 }
 

--- a/internal/core/reviews/parser.go
+++ b/internal/core/reviews/parser.go
@@ -43,6 +43,10 @@ func ParseReviewContext(content string) (model.ReviewContext, error) {
 		Severity:    strings.TrimSpace(meta.Severity),
 		Author:      strings.TrimSpace(meta.Author),
 		ProviderRef: strings.TrimSpace(meta.ProviderRef),
+		ReviewHash:  strings.TrimSpace(meta.ReviewHash),
+
+		SourceReviewID:          strings.TrimSpace(meta.SourceReviewID),
+		SourceReviewSubmittedAt: strings.TrimSpace(meta.SourceReviewSubmittedAt),
 	}
 	if ctx.Status == "" {
 		return model.ReviewContext{}, errors.New("review front matter missing status")

--- a/internal/core/reviews/parser_test.go
+++ b/internal/core/reviews/parser_test.go
@@ -16,6 +16,9 @@ line: 42
 severity: high
 author: review-bot
 provider_ref: thread:1
+review_hash: abc123def456
+source_review_id: 4089982130
+source_review_submitted_at: 2026-04-10T13:33:25Z
 ---
 
 Review body.
@@ -52,6 +55,15 @@ Review body.
 				}
 				if ctx.Status != "resolved" || ctx.File != "internal/app/service.go" || ctx.Line != 42 {
 					t.Fatalf("unexpected review context: %#v", ctx)
+				}
+				if ctx.ReviewHash != "abc123def456" {
+					t.Fatalf("unexpected review hash: %q", ctx.ReviewHash)
+				}
+				if ctx.SourceReviewID != "4089982130" {
+					t.Fatalf("unexpected source review id: %q", ctx.SourceReviewID)
+				}
+				if ctx.SourceReviewSubmittedAt != "2026-04-10T13:33:25Z" {
+					t.Fatalf("unexpected source review submitted_at: %q", ctx.SourceReviewSubmittedAt)
 				}
 			},
 		},

--- a/internal/core/reviews/store.go
+++ b/internal/core/reviews/store.go
@@ -164,8 +164,8 @@ func WriteRound(reviewDir string, meta model.RoundMeta, items []provider.ReviewI
 	if err := WriteRoundMeta(reviewDir, meta); err != nil {
 		return err
 	}
-	for index, item := range items {
-		if err := writeIssueFile(reviewDir, index+1, item); err != nil {
+	for index := range items {
+		if err := writeIssueFile(reviewDir, index+1, items[index]); err != nil {
 			return err
 		}
 	}
@@ -298,6 +298,10 @@ func writeIssueFile(reviewDir string, number int, item provider.ReviewItem) erro
 		Severity:    strings.TrimSpace(item.Severity),
 		Author:      fallback(item.Author, "unknown"),
 		ProviderRef: strings.TrimSpace(item.ProviderRef),
+		ReviewHash:  strings.TrimSpace(item.ReviewHash),
+
+		SourceReviewID:          strings.TrimSpace(item.SourceReviewID),
+		SourceReviewSubmittedAt: strings.TrimSpace(item.SourceReviewSubmittedAt),
 	}
 
 	title := strings.TrimSpace(item.Title)

--- a/internal/core/reviews/store_test.go
+++ b/internal/core/reviews/store_test.go
@@ -99,12 +99,15 @@ func TestWriteRoundAndReadBackEntries(t *testing.T) {
 	}
 	items := []provider.ReviewItem{
 		{
-			Title:       "Add nil check",
-			File:        "internal/app/service.go",
-			Line:        42,
-			Author:      "coderabbitai[bot]",
-			ProviderRef: "thread:PRT_1,comment:RC_1",
-			Body:        "Please add a nil check before dereferencing the pointer.",
+			Title:                   "Add nil check",
+			File:                    "internal/app/service.go",
+			Line:                    42,
+			Author:                  "coderabbitai[bot]",
+			ProviderRef:             "thread:PRT_1,comment:RC_1",
+			Body:                    "Please add a nil check before dereferencing the pointer.",
+			ReviewHash:              "abc123def456",
+			SourceReviewID:          "4089982130",
+			SourceReviewSubmittedAt: "2026-04-10T13:33:25Z",
 		},
 	}
 
@@ -140,6 +143,15 @@ func TestWriteRoundAndReadBackEntries(t *testing.T) {
 	}
 	if ctx.ProviderRef != "thread:PRT_1,comment:RC_1" {
 		t.Fatalf("unexpected provider ref: %q", ctx.ProviderRef)
+	}
+	if ctx.ReviewHash != "abc123def456" {
+		t.Fatalf("unexpected review hash: %q", ctx.ReviewHash)
+	}
+	if ctx.SourceReviewID != "4089982130" {
+		t.Fatalf("unexpected source review id: %q", ctx.SourceReviewID)
+	}
+	if ctx.SourceReviewSubmittedAt != "2026-04-10T13:33:25Z" {
+		t.Fatalf("unexpected source review submitted_at: %q", ctx.SourceReviewSubmittedAt)
 	}
 }
 

--- a/internal/core/run/executor/execution_test.go
+++ b/internal/core/run/executor/execution_test.go
@@ -25,7 +25,7 @@ type stubResolverProvider struct {
 
 func (s *stubResolverProvider) Name() string { return s.name }
 
-func (s *stubResolverProvider) FetchReviews(context.Context, string) ([]provider.ReviewItem, error) {
+func (s *stubResolverProvider) FetchReviews(context.Context, provider.FetchRequest) ([]provider.ReviewItem, error) {
 	return nil, nil
 }
 

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -131,6 +131,7 @@ include_resolved = false
 
 [fetch_reviews]
 provider = "coderabbit"
+nitpicks = true
 
 [exec]
 model = "gpt-5.4"
@@ -171,6 +172,9 @@ output_format = "json"
 	}
 	if cfg.FetchReviews.Provider == nil || *cfg.FetchReviews.Provider != "coderabbit" {
 		t.Fatalf("unexpected fetch_reviews.provider: %#v", cfg.FetchReviews.Provider)
+	}
+	if cfg.FetchReviews.Nitpicks == nil || !*cfg.FetchReviews.Nitpicks {
+		t.Fatalf("unexpected fetch_reviews.nitpicks: %#v", cfg.FetchReviews.Nitpicks)
 	}
 	if cfg.Exec.Model == nil || *cfg.Exec.Model != "gpt-5.4" {
 		t.Fatalf("unexpected exec.model: %#v", cfg.Exec.Model)

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -48,6 +48,7 @@ type FixReviewsConfig struct {
 
 type FetchReviewsConfig struct {
 	Provider *string `toml:"provider"`
+	Nitpicks *bool   `toml:"nitpicks"`
 }
 
 type ExecConfig struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --nitpicks option to fetch-reviews to optionally include CodeRabbit nitpick comments.
  * Import now deduplicates and tracks nitpicks across review rounds to avoid re-importing unchanged/resolved nitpicks.

* **Improvements**
  * More robust nitpick parsing and deterministic ordering for consistent import results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->