### PR TITLE
ci(release): Release v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+### ♻️  Refactoring
+
+- Improve packages (#70)- Add nitpicks for coderabbit (#75)
+### 🎉 Features
+
+- Kernel refactoring (#68)
+### 🐛 Bug Fixes
+
+- Stop rewriting all _meta.md files when listing workflows (#73)
+## 0.1.9 - 2026-04-06
+
 ### 🎉 Features
 
 - Exec command (#60)
@@ -15,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 📚 Documentation
 
 - Context7 and exa skills
+### 🔧 CI/CD
+
+- *(release)* Prepare release v0.1.9 (#67)
+
 ## 0.1.8 - 2026-04-05
 
 ### ♻️  Refactoring
@@ -179,7 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
-[unreleased]: https://github.com///compare/v0.1.8...HEAD
+[unreleased]: https://github.com///compare/v0.1.9...HEAD
+[0.1.9]: https://github.com///compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com///compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com///compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com///compare/v0.1.5...v0.1.6

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   "scripts": {
     "prepare": "husky"
   },
-  "version": "0.1.9"
+  "version": "0.1.10"
 }


### PR DESCRIPTION

## Release v0.1.10

This PR prepares the release of version v0.1.10.

### Changelog

# Changelog

All notable changes to this project will be documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
## Unreleased

### ♻️  Refactoring

- Improve packages (#70)- Add nitpicks for coderabbit (#75)
### 🎉 Features

- Kernel refactoring (#68)
### 🐛 Bug Fixes

- Stop rewriting all _meta.md files when listing workflows (#73)
[unreleased]: https://github.com///compare/v0.1.9...HEAD
---
*Generated by [git-cliff](https://git-cliff.org)*
