### PR TITLE
ci(release): Release v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+### 🎉 Features
+
+- Agents spec (#78)
+### 📚 Documentation
+
+- New prds
+## 0.1.10 - 2026-04-10
+
 ### ♻️  Refactoring
 
 - Improve packages (#70)- Add nitpicks for coderabbit (#75)
@@ -15,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 🐛 Bug Fixes
 
 - Stop rewriting all _meta.md files when listing workflows (#73)
+### 🔧 CI/CD
+
+- *(release)* Prepare release v0.1.10 (#76)
+
 ## 0.1.9 - 2026-04-06
 
 ### 🎉 Features
@@ -194,7 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
-[unreleased]: https://github.com///compare/v0.1.9...HEAD
+[unreleased]: https://github.com///compare/v0.1.10...HEAD
+[0.1.10]: https://github.com///compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com///compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com///compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com///compare/v0.1.6...v0.1.7

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   "scripts": {
     "prepare": "husky"
   },
-  "version": "0.1.10"
+  "version": "0.1.11"
 }


### PR DESCRIPTION
## Release v0.1.11
This PR prepares the release of version v0.1.11.
### Changelog
# Changelog
All notable changes to this project will be documented in this file.
The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
## Unreleased
### 🎉 Features
- Agents spec (#78)