### PR TITLE
feat: add repo-level default override setup

### DIFF
--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -89,6 +89,7 @@ func TestNewExecCommandRegistersExtensionsFlag(t *testing.T) {
 	flag := cmd.Flags().Lookup("extensions")
 	if flag == nil {
 		t.Fatal("expected exec command to register --extensions")
+		return
 	}
 	if flag.DefValue != "false" {
 		t.Fatalf("expected --extensions default false, got %q", flag.DefValue)
@@ -102,6 +103,7 @@ func TestNewTasksRunCommandDefaultsAttachModeToAuto(t *testing.T) {
 	flag := cmd.Flags().Lookup("attach")
 	if flag == nil {
 		t.Fatal("expected --attach flag")
+		return
 	}
 	if flag.DefValue != attachModeAuto {
 		t.Fatalf("expected --attach default %q, got %q", attachModeAuto, flag.DefValue)
@@ -133,6 +135,7 @@ func TestNewTasksCommandDoesNotRegisterRunMultiple(t *testing.T) {
 		flag := run.Flags().Lookup("attach")
 		if flag == nil {
 			t.Fatal("expected run --attach flag")
+			return
 		}
 		if flag.DefValue != attachModeAuto {
 			t.Fatalf("expected --attach default %q, got %q", attachModeAuto, flag.DefValue)
@@ -147,6 +150,7 @@ func TestNewTasksRunCommandRegistersRecursiveFlag(t *testing.T) {
 	flag := cmd.Flags().Lookup("recursive")
 	if flag == nil {
 		t.Fatal("expected --recursive flag on tasks run")
+		return
 	}
 	if flag.Shorthand != "r" {
 		t.Fatalf("expected --recursive shorthand %q, got %q", "r", flag.Shorthand)
@@ -166,6 +170,7 @@ func TestReviewsFixCommandDefaultsTUIToTrue(t *testing.T) {
 	flag := cmd.Flags().Lookup("tui")
 	if flag == nil {
 		t.Fatal("expected --tui flag")
+		return
 	}
 	if flag.DefValue != "true" {
 		t.Fatalf("expected --tui default true, got %q", flag.DefValue)

--- a/internal/cli/form_test.go
+++ b/internal/cli/form_test.go
@@ -404,6 +404,7 @@ func TestTaskRunRuntimeFormPreseedsConfiguredTypeRules(t *testing.T) {
 		}
 		if form == nil {
 			t.Fatal("expected task runtime form")
+			return
 		}
 		if !slices.Contains(form.selectedTypes, "demo::backend") {
 			t.Fatalf("expected backend type to be preselected, got %#v", form.selectedTypes)
@@ -411,6 +412,7 @@ func TestTaskRunRuntimeFormPreseedsConfiguredTypeRules(t *testing.T) {
 		editor := form.typeEditors["demo::backend"]
 		if editor == nil {
 			t.Fatal("expected backend editor to be created")
+			return
 		}
 		if editor.IDE != "claude" || editor.Model != "sonnet" || editor.ReasoningEffort != "high" {
 			t.Fatalf("unexpected preseeded editor: %#v", editor)
@@ -449,6 +451,7 @@ func TestTaskRuntimeFormUsesRecursiveWalkerWhenEnabled(t *testing.T) {
 	}
 	if form == nil {
 		t.Fatal("expected task runtime form")
+		return
 	}
 	if len(form.taskOptions) != 2 {
 		t.Fatalf("expected recursive form to discover 2 tasks, got %d: %#v", len(form.taskOptions), form.taskOptions)
@@ -486,6 +489,7 @@ func TestTaskRuntimeFormUsesFlatWalkerByDefault(t *testing.T) {
 	}
 	if form == nil {
 		t.Fatal("expected task runtime form")
+		return
 	}
 	if len(form.taskOptions) != 1 {
 		t.Fatalf("expected flat form to discover 1 task, got %d: %#v", len(form.taskOptions), form.taskOptions)
@@ -585,6 +589,7 @@ func TestTaskRunRuntimeFormScopesDuplicateTaskIDsByWorkflow(t *testing.T) {
 		}
 		if form == nil {
 			t.Fatal("expected multi-workflow task runtime form")
+			return
 		}
 		if len(form.taskOptions) != 2 {
 			t.Fatalf("expected two task options, got %#v", form.taskOptions)
@@ -652,6 +657,7 @@ func TestTaskRunRuntimeFormPreservesSingleWorkflowScopedRules(t *testing.T) {
 		}
 		if form == nil {
 			t.Fatal("expected single-workflow task runtime form")
+			return
 		}
 		if !slices.Equal(form.selectedTypes, []string{"alpha::backend"}) {
 			t.Fatalf("selected types = %#v, want alpha-scoped backend", form.selectedTypes)

--- a/internal/cli/kernel_dispatch_test.go
+++ b/internal/cli/kernel_dispatch_test.go
@@ -126,6 +126,7 @@ func TestNewRunWorkflowDispatchesStartCommand(t *testing.T) {
 	runtime := handler.got.RuntimeConfig()
 	if runtime == nil {
 		t.Fatal("expected runtime config")
+		return
 	}
 	if runtime.WorkspaceRoot != "/workspace" {
 		t.Fatalf("unexpected workspace root: %q", runtime.WorkspaceRoot)
@@ -181,6 +182,7 @@ func TestNewRunWorkflowPassesRecursiveFlagThroughKernel(t *testing.T) {
 	runtime := handler.got.RuntimeConfig()
 	if runtime == nil {
 		t.Fatal("expected runtime config")
+		return
 	}
 	if !runtime.Recursive {
 		t.Fatalf("expected runtime.Recursive=true, got %#v", runtime)
@@ -218,6 +220,7 @@ func TestNewRunWorkflowUsesPRReviewModeForFixReviews(t *testing.T) {
 	runtime := handler.got.RuntimeConfig()
 	if runtime == nil {
 		t.Fatal("expected runtime config")
+		return
 	}
 	if runtime.Mode != model.ExecutionModePRReview {
 		t.Fatalf("unexpected mode: %q", runtime.Mode)
@@ -299,6 +302,7 @@ func TestNewRunWorkflowDispatchesExecPromptSources(t *testing.T) {
 			runtime := handler.got.RuntimeConfig()
 			if runtime == nil {
 				t.Fatal("expected runtime config")
+				return
 			}
 			if runtime.Mode != model.ExecutionModeExec {
 				t.Fatalf("unexpected mode: %q", runtime.Mode)

--- a/internal/cli/migrate_command_test.go
+++ b/internal/cli/migrate_command_test.go
@@ -70,6 +70,11 @@ func committedACPFixtureDir(repoRoot string) (string, error) {
 		return activePath, nil
 	}
 
+	testdataPath := filepath.Join(repoRoot, "internal", "cli", "testdata", "acp-integration")
+	if info, err := os.Stat(testdataPath); err == nil && info.IsDir() {
+		return testdataPath, nil
+	}
+
 	matches, err := filepath.Glob(filepath.Join(repoRoot, ".compozy", "tasks", "_archived", "*-acp-integration"))
 	if err != nil {
 		return "", err

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -931,6 +931,7 @@ func TestAddCommonFlagsUseOptInRetryDefaults(t *testing.T) {
 		flag := cmd.Flags().Lookup("max-retries")
 		if flag == nil {
 			t.Fatal("expected max-retries flag to be registered")
+			return
 		}
 		if got, want := flag.DefValue, strconv.Itoa(defaultMaxRetries); got != want {
 			t.Fatalf("unexpected max-retries flag default: got %q want %q", got, want)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -11,10 +11,20 @@ import (
 
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
+	coreagent "github.com/compozy/compozy/internal/core/agent"
 	"github.com/compozy/compozy/internal/core/kernel"
+	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/core/workspace"
 	"github.com/compozy/compozy/internal/setup"
 	"github.com/spf13/cobra"
 )
+
+type runtimeDefaultsPlan struct {
+	Enabled    bool
+	ConfigPath string
+	Existing   bool
+	Defaults   workspace.DefaultsConfig
+}
 
 type setupCommandState struct {
 	agentNames []string
@@ -33,6 +43,10 @@ type setupCommandState struct {
 	installSkills         setupSkillInstallFunc
 	installReusableAgents setupReusableAgentInstallFunc
 	cleanupLegacyAssets   func(setup.LegacyAssetCleanupConfig) (setup.LegacyAssetCleanupResult, error)
+	resolveWorkspace      func(context.Context) (workspace.Context, error)
+	loadConfigFile        func(context.Context, string) (workspace.ProjectConfig, bool, error)
+	writeConfig           func(context.Context, string, workspace.ProjectConfig) error
+	promptRuntimeDefaults func(string) (bool, error)
 	isInteractive         func() bool
 }
 
@@ -62,6 +76,7 @@ type setupInstallPlan struct {
 	ReusableAgents       []setup.ReusableAgent
 	Previews             []setup.PreviewItem
 	ReusableAgentPreview []setup.ReusableAgentPreviewItem
+	RuntimePlan          runtimeDefaultsPlan
 }
 
 func newSetupCommand(_ *kernel.Dispatcher) *cobra.Command {
@@ -104,6 +119,10 @@ func newSetupCommandState() *setupCommandState {
 		installSkills:         setup.InstallSelectedSkills,
 		installReusableAgents: setup.InstallReusableAgents,
 		cleanupLegacyAssets:   setup.CleanupLegacyTransferredAssets,
+		resolveWorkspace:      resolveSetupWorkspaceContext,
+		loadConfigFile:        workspace.LoadConfigFile,
+		writeConfig:           workspace.WriteConfig,
+		promptRuntimeDefaults: promptRuntimeDefaultsOptIn,
 		isInteractive:         isInteractiveTerminal,
 	}
 }
@@ -112,7 +131,10 @@ func (s *setupCommandState) run(cmd *cobra.Command, _ []string) error {
 	ctx, stop := signalCommandContext(cmd)
 	defer stop()
 
-	resolver := s.resolverOptions()
+	resolver, err := s.resolverOptions(ctx)
+	if err != nil {
+		return err
+	}
 	catalog, err := s.loadCatalog(ctx, resolver)
 	if err != nil {
 		return err
@@ -135,7 +157,8 @@ func (s *setupCommandState) run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	cfg, previews, reusableAgentPreviews, err := s.buildInstallPlan(
+	cfg, previews, reusableAgentPreviews, runtimePlan, err := s.buildInstallPlan(
+		ctx,
 		cmd,
 		catalog,
 		resolver,
@@ -146,16 +169,17 @@ func (s *setupCommandState) run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	printSetupWarnings(cmd, catalog.Conflicts)
-	if err := s.confirmPlan(cmd, previews, reusableAgentPreviews, cfg.Global, cfg.Mode); err != nil {
+	if err := s.confirmPlan(cmd, previews, reusableAgentPreviews, runtimePlan, cfg.Global, cfg.Mode); err != nil {
 		return err
 	}
 
-	return s.executeInstall(cmd, setupInstallPlan{
+	return s.executeInstall(ctx, cmd, setupInstallPlan{
 		Config:               cfg,
 		Skills:               previewsToSkills(previews),
 		ReusableAgents:       append([]setup.ReusableAgent(nil), catalog.ReusableAgents...),
 		Previews:             previews,
 		ReusableAgentPreview: reusableAgentPreviews,
+		RuntimePlan:          runtimePlan,
 	})
 }
 
@@ -169,12 +193,31 @@ func (s *setupCommandState) prepareRunMode() error {
 	return nil
 }
 
-func (s *setupCommandState) resolverOptions() setup.ResolverOptions {
-	return currentResolverOptions()
+func (s *setupCommandState) resolverOptions(ctx context.Context) (setup.ResolverOptions, error) {
+	workspaceCtx, err := s.resolveWorkspace(ctx)
+	if err != nil {
+		return setup.ResolverOptions{}, err
+	}
+	return currentResolverOptions(workspaceCtx.Root), nil
 }
 
-func currentResolverOptions() setup.ResolverOptions {
+func resolveSetupWorkspaceContext(ctx context.Context) (workspace.Context, error) {
+	root, err := discoverWorkspaceRoot(ctx)
+	if err != nil {
+		return workspace.Context{}, err
+	}
+	configPath := model.ConfigPathForWorkspace(root)
+	return workspace.Context{
+		Root:                root,
+		CompozyDir:          model.CompozyDir(root),
+		ConfigPath:          configPath,
+		WorkspaceConfigPath: configPath,
+	}, nil
+}
+
+func currentResolverOptions(cwd string) setup.ResolverOptions {
 	return setup.ResolverOptions{
+		CWD:             strings.TrimSpace(cwd),
 		CodeXHome:       strings.TrimSpace(os.Getenv("CODEX_HOME")),
 		ClaudeConfigDir: strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")),
 		XDGConfigHome:   strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")),
@@ -195,34 +238,40 @@ func (s *setupCommandState) loadAgents(resolver setup.ResolverOptions) ([]setup.
 }
 
 func (s *setupCommandState) buildInstallPlan(
+	ctx context.Context,
 	cmd *cobra.Command,
 	catalog setup.EffectiveCatalog,
 	resolver setup.ResolverOptions,
 	supportedAgents []setup.Agent,
 	detectedAgents []setup.Agent,
-) (setup.InstallConfig, []setup.PreviewItem, []setup.ReusableAgentPreviewItem, error) {
+) (setup.InstallConfig, []setup.PreviewItem, []setup.ReusableAgentPreviewItem, runtimeDefaultsPlan, error) {
 	selectedSkillNames, err := s.resolveSkillSelection(catalog.Skills)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 	selectedSkills, err := setup.SelectSkills(catalog.Skills, selectedSkillNames)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	selectedAgents, err := s.resolveAgentSelection(supportedAgents, detectedAgents)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	globalScope, err := s.resolveScope(cmd, selectedAgents)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	mode, err := s.resolveInstallMode(cmd, supportedAgents, selectedAgents, globalScope)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
+	}
+
+	runtimePlan, err := s.resolveRuntimeDefaultsPlan(ctx, globalScope, selectedAgents)
+	if err != nil {
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	cfg := setup.InstallConfig{
@@ -234,7 +283,7 @@ func (s *setupCommandState) buildInstallPlan(
 	}
 	previews, err := s.previewSkills(resolver, selectedSkills, selectedAgents, globalScope, mode)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 	reusableAgentPreviews, err := s.previewReusableAgents(setup.ReusableAgentInstallConfig{
 		ResolverOptions: resolver,
@@ -242,15 +291,16 @@ func (s *setupCommandState) buildInstallPlan(
 		Global:          globalScope,
 	})
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
-	return cfg, previews, reusableAgentPreviews, nil
+	return cfg, previews, reusableAgentPreviews, runtimePlan, nil
 }
 
 func (s *setupCommandState) confirmPlan(
 	cmd *cobra.Command,
 	previews []setup.PreviewItem,
 	reusableAgentPreviews []setup.ReusableAgentPreviewItem,
+	runtimePlan runtimeDefaultsPlan,
 	global bool,
 	mode setup.InstallMode,
 ) error {
@@ -258,7 +308,7 @@ func (s *setupCommandState) confirmPlan(
 		return nil
 	}
 
-	printPreviewSummary(cmd, previews, reusableAgentPreviews, global, mode)
+	printPreviewSummary(cmd, previews, reusableAgentPreviews, runtimePlan, global, mode)
 	confirmed, err := confirmSetup()
 	if err != nil {
 		return err
@@ -269,7 +319,11 @@ func (s *setupCommandState) confirmPlan(
 	return nil
 }
 
-func (s *setupCommandState) executeInstall(cmd *cobra.Command, plan setupInstallPlan) error {
+func (s *setupCommandState) executeInstall(
+	ctx context.Context,
+	cmd *cobra.Command,
+	plan setupInstallPlan,
+) error {
 	result, err := s.installPlan(plan)
 	printInstallResult(cmd, result)
 	if err != nil {
@@ -278,6 +332,9 @@ func (s *setupCommandState) executeInstall(cmd *cobra.Command, plan setupInstall
 	failureCount := len(result.Failed) + len(result.ReusableAgentsFailed)
 	if failureCount > 0 {
 		return fmt.Errorf("setup completed with %d failure(s)", failureCount)
+	}
+	if err := s.persistRuntimeDefaults(ctx, plan.RuntimePlan); err != nil {
+		return err
 	}
 	return nil
 }
@@ -321,6 +378,222 @@ func (s *setupCommandState) installPlan(plan setupInstallPlan) (*setup.Result, e
 	result.ReusableAgentsSuccessful = successfulReusableAgents
 	result.ReusableAgentsFailed = failedReusableAgents
 	return result, nil
+}
+
+func (s *setupCommandState) resolveRuntimeDefaultsPlan(
+	ctx context.Context,
+	global bool,
+	selectedAgents []string,
+) (runtimeDefaultsPlan, error) {
+	if s.yes || global {
+		return runtimeDefaultsPlan{}, nil
+	}
+
+	configPath, err := s.runtimeDefaultsPath(ctx)
+	if err != nil {
+		return runtimeDefaultsPlan{}, err
+	}
+	enabled, err := s.promptRuntimeDefaults(configPath)
+	if err != nil {
+		return runtimeDefaultsPlan{}, err
+	}
+	if !enabled {
+		return runtimeDefaultsPlan{}, nil
+	}
+
+	currentConfig, exists, err := s.loadConfigFile(ctx, configPath)
+	if err != nil {
+		return runtimeDefaultsPlan{}, fmt.Errorf("load workspace runtime defaults: %w", err)
+	}
+	hasExistingDefaults :=
+		(currentConfig.Defaults.IDE != nil && strings.TrimSpace(*currentConfig.Defaults.IDE) != "") ||
+			(currentConfig.Defaults.Model != nil && strings.TrimSpace(*currentConfig.Defaults.Model) != "") ||
+			(currentConfig.Defaults.ReasoningEffort != nil && strings.TrimSpace(*currentConfig.Defaults.ReasoningEffort) != "")
+	selectedIDE := preferredRuntimeIDE(currentConfig.Defaults, selectedAgents)
+	defaults, err := editRuntimeDefaultsSelection(
+		selectedIDE,
+		preferredRuntimeModel(currentConfig.Defaults, selectedIDE),
+		preferredRuntimeReasoningEffort(currentConfig.Defaults),
+		defaultModelForIDE(selectedIDE),
+	)
+	if err != nil {
+		return runtimeDefaultsPlan{}, err
+	}
+
+	return runtimeDefaultsPlan{
+		Enabled:    true,
+		ConfigPath: configPath,
+		Existing:   exists && hasExistingDefaults,
+		Defaults:   defaults,
+	}, nil
+}
+
+func promptRuntimeDefaultsOptIn(configPath string) (bool, error) {
+	writeDefaults := false
+	field := huh.NewConfirm().
+		Key("runtime-defaults").
+		Title("Write repo-level default runtime overrides?").
+		Description(fmt.Sprintf("Save workspace defaults to %s.", configPath)).
+		Value(&writeDefaults)
+	if err := runPromptField(field); err != nil {
+		return false, fmt.Errorf("select runtime defaults behavior: %w", err)
+	}
+	if !writeDefaults {
+		return false, nil
+	}
+	return true, nil
+}
+
+func editRuntimeDefaultsSelection(
+	selectedIDE string,
+	selectedModel string,
+	selectedReasoning string,
+	originalRecommendedModel string,
+) (workspace.DefaultsConfig, error) {
+	ideField := huh.NewSelect[string]().
+		Key("defaults-ide").
+		Title("Default IDE").
+		Description("Recommended workspace default from the README example.").
+		Options(runtimeIDEOptions()...).
+		Value(&selectedIDE)
+	if err := runPromptField(ideField); err != nil {
+		return workspace.DefaultsConfig{}, fmt.Errorf("select default ide: %w", err)
+	}
+	recommendedModel := defaultModelForIDE(selectedIDE)
+	if strings.TrimSpace(selectedModel) == "" || strings.TrimSpace(selectedModel) == originalRecommendedModel {
+		selectedModel = recommendedModel
+	}
+	modelField := huh.NewInput().
+		Key("defaults-model").
+		Title("Default Model").
+		Description(fmt.Sprintf("Recommended for %s: %s.", selectedIDE, recommendedModel)).
+		Value(&selectedModel).
+		Validate(func(value string) error {
+			if strings.TrimSpace(value) == "" {
+				return errors.New("model is required")
+			}
+			return nil
+		})
+	if err := runPromptField(modelField); err != nil {
+		return workspace.DefaultsConfig{}, fmt.Errorf("select default model: %w", err)
+	}
+	reasoningField := huh.NewSelect[string]().
+		Key("defaults-reasoning-effort").
+		Title("Default Reasoning Effort").
+		Description("Recommended workspace default from the README example.").
+		Options(
+			huh.NewOption("Low", "low"),
+			huh.NewOption("Medium", "medium"),
+			huh.NewOption("High", "high"),
+			huh.NewOption("Extra High", "xhigh"),
+		).
+		Value(&selectedReasoning)
+	if err := runPromptField(reasoningField); err != nil {
+		return workspace.DefaultsConfig{}, fmt.Errorf("select default reasoning effort: %w", err)
+	}
+
+	return workspace.DefaultsConfig{
+		IDE:             stringPtr(strings.TrimSpace(selectedIDE)),
+		Model:           stringPtr(strings.TrimSpace(selectedModel)),
+		ReasoningEffort: stringPtr(strings.TrimSpace(selectedReasoning)),
+	}, nil
+}
+
+func (s *setupCommandState) runtimeDefaultsPath(ctx context.Context) (string, error) {
+	workspaceCtx, err := s.resolveWorkspace(ctx)
+	if err != nil {
+		return "", err
+	}
+	return workspaceCtx.ConfigPath, nil
+}
+
+func (s *setupCommandState) persistRuntimeDefaults(ctx context.Context, plan runtimeDefaultsPlan) error {
+	if !plan.Enabled {
+		return nil
+	}
+
+	currentConfig, _, err := s.loadConfigFile(ctx, plan.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("reload runtime defaults config: %w", err)
+	}
+	currentConfig.Defaults.IDE = plan.Defaults.IDE
+	currentConfig.Defaults.Model = plan.Defaults.Model
+	currentConfig.Defaults.ReasoningEffort = plan.Defaults.ReasoningEffort
+	if err := s.writeConfig(ctx, plan.ConfigPath, currentConfig); err != nil {
+		return err
+	}
+	return nil
+}
+
+func preferredRuntimeIDE(defaults workspace.DefaultsConfig, selectedAgents []string) string {
+	if defaults.IDE != nil && strings.TrimSpace(*defaults.IDE) != "" {
+		return strings.TrimSpace(*defaults.IDE)
+	}
+	if inferredIDE := runtimeIDEFromSelectedAgents(selectedAgents); inferredIDE != "" {
+		return inferredIDE
+	}
+	return model.IDECodex
+}
+
+func preferredRuntimeModel(defaults workspace.DefaultsConfig, selectedIDE string) string {
+	if defaults.Model != nil && strings.TrimSpace(*defaults.Model) != "" {
+		return strings.TrimSpace(*defaults.Model)
+	}
+	return defaultModelForIDE(selectedIDE)
+}
+
+func preferredRuntimeReasoningEffort(defaults workspace.DefaultsConfig) string {
+	if defaults.ReasoningEffort != nil && strings.TrimSpace(*defaults.ReasoningEffort) != "" {
+		return strings.TrimSpace(*defaults.ReasoningEffort)
+	}
+	return model.DefaultReasoningEffort
+}
+
+func runtimeIDEOptions() []huh.Option[string] {
+	entries := coreagent.DriverCatalog()
+	options := make([]huh.Option[string], 0, len(entries))
+	for i := range entries {
+		entry := &entries[i]
+		label := entry.DisplayName
+		if entry.IDE == model.IDECodex {
+			label += " (recommended)"
+		}
+		options = append(options, huh.NewOption(label, entry.IDE))
+	}
+	return options
+}
+
+func defaultModelForIDE(ide string) string {
+	resolved := strings.TrimSpace(coreagent.DefaultModel(ide))
+	if resolved != "" {
+		return resolved
+	}
+	return model.DefaultCodexModel
+}
+
+func runtimeIDEFromSelectedAgents(selectedAgents []string) string {
+	entries := coreagent.DriverCatalog()
+	for _, selectedAgent := range selectedAgents {
+		normalizedAgent := strings.TrimSpace(strings.ToLower(selectedAgent))
+		if normalizedAgent == "" {
+			continue
+		}
+		for i := range entries {
+			setupAgentName, err := coreagent.SetupAgentName(entries[i].IDE)
+			if err != nil {
+				continue
+			}
+			if normalizedAgent == strings.TrimSpace(strings.ToLower(setupAgentName)) {
+				return entries[i].IDE
+			}
+		}
+	}
+	return ""
+}
+
+func stringPtr(value string) *string {
+	resolved := value
+	return &resolved
 }
 
 func (s *setupCommandState) resolveSkillSelection(skills []setup.Skill) ([]string, error) {
@@ -580,10 +853,11 @@ func printPreviewSummary(
 	cmd *cobra.Command,
 	previews []setup.PreviewItem,
 	reusableAgentPreviews []setup.ReusableAgentPreviewItem,
+	runtimePlan runtimeDefaultsPlan,
 	global bool,
 	mode setup.InstallMode,
 ) {
-	if len(previews) == 0 && len(reusableAgentPreviews) == 0 {
+	if len(previews) == 0 && len(reusableAgentPreviews) == 0 && !runtimePlan.Enabled {
 		return
 	}
 	styles := newCLIChromeStyles()
@@ -596,6 +870,7 @@ func printPreviewSummary(
 
 	lipgloss.Fprintf(w, "  %s  %s\n", styles.label.Render("Scope "), styles.value.Render(scopeLabel(global)))
 	lipgloss.Fprintf(w, "  %s  %s\n", styles.label.Render("Method"), styles.value.Render(string(mode)))
+	printRuntimeDefaultsSummary(w, styles, runtimePlan, cwd, homeDir)
 	fmt.Fprintln(w)
 	lipgloss.Fprintln(w, styles.separator.Render("  "+strings.Repeat("─", 50)))
 	fmt.Fprintln(w)
@@ -611,6 +886,57 @@ func printPreviewSummary(
 		}
 	}
 
+	printSkillPreviewItems(w, styles, previews, mode, cwd, homeDir, maxSkillLen, maxAgentLen)
+	printReusableAgentPreviewItems(w, styles, reusableAgentPreviews, global, cwd, homeDir)
+	fmt.Fprintln(w)
+}
+
+func printRuntimeDefaultsSummary(
+	w io.Writer,
+	styles cliChromeStyles,
+	runtimePlan runtimeDefaultsPlan,
+	cwd, homeDir string,
+) {
+	if !runtimePlan.Enabled {
+		return
+	}
+
+	configPath := shortenPath(runtimePlan.ConfigPath, cwd, homeDir)
+	ide := ""
+	modelName := ""
+	reasoningEffort := ""
+	if runtimePlan.Defaults.IDE != nil {
+		ide = *runtimePlan.Defaults.IDE
+	}
+	if runtimePlan.Defaults.Model != nil {
+		modelName = *runtimePlan.Defaults.Model
+	}
+	if runtimePlan.Defaults.ReasoningEffort != nil {
+		reasoningEffort = *runtimePlan.Defaults.ReasoningEffort
+	}
+	status := "new"
+	if runtimePlan.Existing {
+		status = "update"
+	}
+	lipgloss.Fprintf(w, "  %s  %s\n", styles.label.Render("Config "), styles.value.Render(configPath+" ["+status+"]"))
+	lipgloss.Fprintf(
+		w,
+		"  %s  %s / %s / %s\n",
+		styles.label.Render("Defaults"),
+		styles.value.Render(ide),
+		styles.value.Render(modelName),
+		styles.value.Render(reasoningEffort),
+	)
+}
+
+func printSkillPreviewItems(
+	w io.Writer,
+	styles cliChromeStyles,
+	previews []setup.PreviewItem,
+	mode setup.InstallMode,
+	cwd, homeDir string,
+	maxSkillLen, maxAgentLen int,
+) {
 	for i := range previews {
 		preview := &previews[i]
 		name := styles.skill.Render(padRight(preview.Skill.Name, maxSkillLen))
@@ -619,7 +945,6 @@ func printPreviewSummary(
 		path := styles.path.Render(shortenPath(preview.TargetPath, cwd, homeDir))
 
 		line := fmt.Sprintf("    %s  %s  %s  %s", name, arrow, agent, path)
-
 		if mode == setup.InstallModeSymlink && !sameInstallPath(preview.CanonicalPath, preview.TargetPath) {
 			via := styles.path.Render("via " + shortenPath(preview.CanonicalPath, cwd, homeDir))
 			line += "  " + via
@@ -629,32 +954,41 @@ func printPreviewSummary(
 		}
 		lipgloss.Fprintln(w, line)
 	}
+}
 
-	if len(reusableAgentPreviews) > 0 {
-		fmt.Fprintln(w)
-		lipgloss.Fprintln(w, styles.sectionTitle.Render(reusableAgentSectionTitle(global)))
-		fmt.Fprintln(w)
+func printReusableAgentPreviewItems(
+	w io.Writer,
+	styles cliChromeStyles,
+	reusableAgentPreviews []setup.ReusableAgentPreviewItem,
+	global bool,
+	cwd, homeDir string,
+) {
+	if len(reusableAgentPreviews) == 0 {
+		return
+	}
 
-		maxReusableAgentLen := 0
-		for i := range reusableAgentPreviews {
-			if len(reusableAgentPreviews[i].ReusableAgent.Name) > maxReusableAgentLen {
-				maxReusableAgentLen = len(reusableAgentPreviews[i].ReusableAgent.Name)
-			}
-		}
+	fmt.Fprintln(w)
+	lipgloss.Fprintln(w, styles.sectionTitle.Render(reusableAgentSectionTitle(global)))
+	fmt.Fprintln(w)
 
-		for i := range reusableAgentPreviews {
-			preview := &reusableAgentPreviews[i]
-			name := styles.agent.Render(padRight(preview.ReusableAgent.Name, maxReusableAgentLen))
-			path := styles.path.Render(shortenPath(preview.TargetPath, cwd, homeDir))
-
-			line := fmt.Sprintf("    %s  %s", name, path)
-			if preview.WillOverwrite {
-				line += "  " + styles.warn.Render("[overwrite]")
-			}
-			lipgloss.Fprintln(w, line)
+	maxReusableAgentLen := 0
+	for i := range reusableAgentPreviews {
+		if len(reusableAgentPreviews[i].ReusableAgent.Name) > maxReusableAgentLen {
+			maxReusableAgentLen = len(reusableAgentPreviews[i].ReusableAgent.Name)
 		}
 	}
-	fmt.Fprintln(w)
+
+	for i := range reusableAgentPreviews {
+		preview := &reusableAgentPreviews[i]
+		name := styles.agent.Render(padRight(preview.ReusableAgent.Name, maxReusableAgentLen))
+		path := styles.path.Render(shortenPath(preview.TargetPath, cwd, homeDir))
+
+		line := fmt.Sprintf("    %s  %s", name, path)
+		if preview.WillOverwrite {
+			line += "  " + styles.warn.Render("[overwrite]")
+		}
+		lipgloss.Fprintln(w, line)
+	}
 }
 
 func printInstallResult(cmd *cobra.Command, result *setup.Result) {

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -11,10 +11,20 @@ import (
 
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
+	coreagent "github.com/compozy/compozy/internal/core/agent"
 	"github.com/compozy/compozy/internal/core/kernel"
+	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/core/workspace"
 	"github.com/compozy/compozy/internal/setup"
 	"github.com/spf13/cobra"
 )
+
+type runtimeDefaultsPlan struct {
+	Enabled    bool
+	ConfigPath string
+	Existing   bool
+	Defaults   workspace.DefaultsConfig
+}
 
 type setupCommandState struct {
 	agentNames []string
@@ -33,6 +43,11 @@ type setupCommandState struct {
 	installSkills         setupSkillInstallFunc
 	installReusableAgents setupReusableAgentInstallFunc
 	cleanupLegacyAssets   func(setup.LegacyAssetCleanupConfig) (setup.LegacyAssetCleanupResult, error)
+	resolveWorkspace      func(context.Context) (workspace.Context, error)
+	loadConfigFile        func(context.Context, string) (workspace.ProjectConfig, bool, error)
+	writeConfig           func(context.Context, string, workspace.ProjectConfig) error
+	promptRuntimeDefaults func(string) (bool, error)
+	editRuntimeDefaults   func(string, string, string, string) (workspace.DefaultsConfig, error)
 	isInteractive         func() bool
 }
 
@@ -62,6 +77,7 @@ type setupInstallPlan struct {
 	ReusableAgents       []setup.ReusableAgent
 	Previews             []setup.PreviewItem
 	ReusableAgentPreview []setup.ReusableAgentPreviewItem
+	RuntimePlan          runtimeDefaultsPlan
 }
 
 func newSetupCommand(_ *kernel.Dispatcher) *cobra.Command {
@@ -104,6 +120,11 @@ func newSetupCommandState() *setupCommandState {
 		installSkills:         setup.InstallSelectedSkills,
 		installReusableAgents: setup.InstallReusableAgents,
 		cleanupLegacyAssets:   setup.CleanupLegacyTransferredAssets,
+		resolveWorkspace:      resolveSetupWorkspaceContext,
+		loadConfigFile:        workspace.LoadConfigFile,
+		writeConfig:           workspace.WriteConfig,
+		promptRuntimeDefaults: promptRuntimeDefaultsOptIn,
+		editRuntimeDefaults:   editRuntimeDefaultsSelection,
 		isInteractive:         isInteractiveTerminal,
 	}
 }
@@ -112,7 +133,10 @@ func (s *setupCommandState) run(cmd *cobra.Command, _ []string) error {
 	ctx, stop := signalCommandContext(cmd)
 	defer stop()
 
-	resolver := s.resolverOptions()
+	resolver, workspaceCtx, err := s.resolverOptions(ctx)
+	if err != nil {
+		return err
+	}
 	catalog, err := s.loadCatalog(ctx, resolver)
 	if err != nil {
 		return err
@@ -135,10 +159,12 @@ func (s *setupCommandState) run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	cfg, previews, reusableAgentPreviews, err := s.buildInstallPlan(
+	cfg, previews, reusableAgentPreviews, runtimePlan, err := s.buildInstallPlan(
+		ctx,
 		cmd,
 		catalog,
 		resolver,
+		workspaceCtx,
 		supportedAgents,
 		detectedAgents,
 	)
@@ -146,16 +172,17 @@ func (s *setupCommandState) run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	printSetupWarnings(cmd, catalog.Conflicts)
-	if err := s.confirmPlan(cmd, previews, reusableAgentPreviews, cfg.Global, cfg.Mode); err != nil {
+	if err := s.confirmPlan(cmd, previews, reusableAgentPreviews, runtimePlan, cfg.Global, cfg.Mode); err != nil {
 		return err
 	}
 
-	return s.executeInstall(cmd, setupInstallPlan{
+	return s.executeInstall(ctx, cmd, setupInstallPlan{
 		Config:               cfg,
 		Skills:               previewsToSkills(previews),
 		ReusableAgents:       append([]setup.ReusableAgent(nil), catalog.ReusableAgents...),
 		Previews:             previews,
 		ReusableAgentPreview: reusableAgentPreviews,
+		RuntimePlan:          runtimePlan,
 	})
 }
 
@@ -169,12 +196,31 @@ func (s *setupCommandState) prepareRunMode() error {
 	return nil
 }
 
-func (s *setupCommandState) resolverOptions() setup.ResolverOptions {
-	return currentResolverOptions()
+func (s *setupCommandState) resolverOptions(ctx context.Context) (setup.ResolverOptions, workspace.Context, error) {
+	workspaceCtx, err := s.resolveWorkspace(ctx)
+	if err != nil {
+		return setup.ResolverOptions{}, workspace.Context{}, err
+	}
+	return currentResolverOptions(workspaceCtx.Root), workspaceCtx, nil
 }
 
-func currentResolverOptions() setup.ResolverOptions {
+func resolveSetupWorkspaceContext(ctx context.Context) (workspace.Context, error) {
+	root, err := discoverWorkspaceRoot(ctx)
+	if err != nil {
+		return workspace.Context{}, err
+	}
+	configPath := model.ConfigPathForWorkspace(root)
+	return workspace.Context{
+		Root:                root,
+		CompozyDir:          model.CompozyDir(root),
+		ConfigPath:          configPath,
+		WorkspaceConfigPath: configPath,
+	}, nil
+}
+
+func currentResolverOptions(cwd string) setup.ResolverOptions {
 	return setup.ResolverOptions{
+		CWD:             strings.TrimSpace(cwd),
 		CodeXHome:       strings.TrimSpace(os.Getenv("CODEX_HOME")),
 		ClaudeConfigDir: strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")),
 		XDGConfigHome:   strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")),
@@ -195,34 +241,41 @@ func (s *setupCommandState) loadAgents(resolver setup.ResolverOptions) ([]setup.
 }
 
 func (s *setupCommandState) buildInstallPlan(
+	ctx context.Context,
 	cmd *cobra.Command,
 	catalog setup.EffectiveCatalog,
 	resolver setup.ResolverOptions,
+	workspaceCtx workspace.Context,
 	supportedAgents []setup.Agent,
 	detectedAgents []setup.Agent,
-) (setup.InstallConfig, []setup.PreviewItem, []setup.ReusableAgentPreviewItem, error) {
+) (setup.InstallConfig, []setup.PreviewItem, []setup.ReusableAgentPreviewItem, runtimeDefaultsPlan, error) {
 	selectedSkillNames, err := s.resolveSkillSelection(catalog.Skills)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 	selectedSkills, err := setup.SelectSkills(catalog.Skills, selectedSkillNames)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	selectedAgents, err := s.resolveAgentSelection(supportedAgents, detectedAgents)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	globalScope, err := s.resolveScope(cmd, selectedAgents)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	mode, err := s.resolveInstallMode(cmd, supportedAgents, selectedAgents, globalScope)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
+	}
+
+	runtimePlan, err := s.resolveRuntimeDefaultsPlan(ctx, globalScope, selectedAgents, workspaceCtx.ConfigPath)
+	if err != nil {
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 
 	cfg := setup.InstallConfig{
@@ -234,7 +287,7 @@ func (s *setupCommandState) buildInstallPlan(
 	}
 	previews, err := s.previewSkills(resolver, selectedSkills, selectedAgents, globalScope, mode)
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
 	reusableAgentPreviews, err := s.previewReusableAgents(setup.ReusableAgentInstallConfig{
 		ResolverOptions: resolver,
@@ -242,15 +295,16 @@ func (s *setupCommandState) buildInstallPlan(
 		Global:          globalScope,
 	})
 	if err != nil {
-		return setup.InstallConfig{}, nil, nil, err
+		return setup.InstallConfig{}, nil, nil, runtimeDefaultsPlan{}, err
 	}
-	return cfg, previews, reusableAgentPreviews, nil
+	return cfg, previews, reusableAgentPreviews, runtimePlan, nil
 }
 
 func (s *setupCommandState) confirmPlan(
 	cmd *cobra.Command,
 	previews []setup.PreviewItem,
 	reusableAgentPreviews []setup.ReusableAgentPreviewItem,
+	runtimePlan runtimeDefaultsPlan,
 	global bool,
 	mode setup.InstallMode,
 ) error {
@@ -258,7 +312,7 @@ func (s *setupCommandState) confirmPlan(
 		return nil
 	}
 
-	printPreviewSummary(cmd, previews, reusableAgentPreviews, global, mode)
+	printPreviewSummary(cmd, previews, reusableAgentPreviews, runtimePlan, global, mode)
 	confirmed, err := confirmSetup()
 	if err != nil {
 		return err
@@ -269,7 +323,11 @@ func (s *setupCommandState) confirmPlan(
 	return nil
 }
 
-func (s *setupCommandState) executeInstall(cmd *cobra.Command, plan setupInstallPlan) error {
+func (s *setupCommandState) executeInstall(
+	ctx context.Context,
+	cmd *cobra.Command,
+	plan setupInstallPlan,
+) error {
 	result, err := s.installPlan(plan)
 	printInstallResult(cmd, result)
 	if err != nil {
@@ -278,6 +336,9 @@ func (s *setupCommandState) executeInstall(cmd *cobra.Command, plan setupInstall
 	failureCount := len(result.Failed) + len(result.ReusableAgentsFailed)
 	if failureCount > 0 {
 		return fmt.Errorf("setup completed with %d failure(s)", failureCount)
+	}
+	if err := s.persistRuntimeDefaults(ctx, plan.RuntimePlan); err != nil {
+		return err
 	}
 	return nil
 }
@@ -321,6 +382,214 @@ func (s *setupCommandState) installPlan(plan setupInstallPlan) (*setup.Result, e
 	result.ReusableAgentsSuccessful = successfulReusableAgents
 	result.ReusableAgentsFailed = failedReusableAgents
 	return result, nil
+}
+
+func (s *setupCommandState) resolveRuntimeDefaultsPlan(
+	ctx context.Context,
+	global bool,
+	selectedAgents []string,
+	configPath string,
+) (runtimeDefaultsPlan, error) {
+	if s.yes || global {
+		return runtimeDefaultsPlan{}, nil
+	}
+
+	if strings.TrimSpace(configPath) == "" {
+		return runtimeDefaultsPlan{}, errors.New("resolve runtime defaults config path: empty workspace config path")
+	}
+	enabled, err := s.promptRuntimeDefaults(configPath)
+	if err != nil {
+		return runtimeDefaultsPlan{}, err
+	}
+	if !enabled {
+		return runtimeDefaultsPlan{}, nil
+	}
+
+	currentConfig, exists, err := s.loadConfigFile(ctx, configPath)
+	if err != nil {
+		return runtimeDefaultsPlan{}, fmt.Errorf("load workspace runtime defaults: %w", err)
+	}
+	hasExistingDefaults :=
+		(currentConfig.Defaults.IDE != nil && strings.TrimSpace(*currentConfig.Defaults.IDE) != "") ||
+			(currentConfig.Defaults.Model != nil && strings.TrimSpace(*currentConfig.Defaults.Model) != "") ||
+			(currentConfig.Defaults.ReasoningEffort != nil && strings.TrimSpace(*currentConfig.Defaults.ReasoningEffort) != "")
+	selectedIDE := preferredRuntimeIDE(currentConfig.Defaults, selectedAgents)
+	defaults, err := s.editRuntimeDefaults(
+		selectedIDE,
+		preferredRuntimeModel(currentConfig.Defaults, selectedIDE),
+		preferredRuntimeReasoningEffort(currentConfig.Defaults),
+		defaultModelForIDE(selectedIDE),
+	)
+	if err != nil {
+		return runtimeDefaultsPlan{}, err
+	}
+
+	return runtimeDefaultsPlan{
+		Enabled:    true,
+		ConfigPath: configPath,
+		Existing:   exists && hasExistingDefaults,
+		Defaults:   defaults,
+	}, nil
+}
+
+func promptRuntimeDefaultsOptIn(configPath string) (bool, error) {
+	writeDefaults := false
+	field := huh.NewConfirm().
+		Key("runtime-defaults").
+		Title("Write repo-level default runtime overrides?").
+		Description(fmt.Sprintf("Save workspace defaults to %s.", configPath)).
+		Value(&writeDefaults)
+	if err := runPromptField(field); err != nil {
+		return false, fmt.Errorf("select runtime defaults behavior: %w", err)
+	}
+	if !writeDefaults {
+		return false, nil
+	}
+	return true, nil
+}
+
+func editRuntimeDefaultsSelection(
+	selectedIDE string,
+	selectedModel string,
+	selectedReasoning string,
+	originalRecommendedModel string,
+) (workspace.DefaultsConfig, error) {
+	ideField := huh.NewSelect[string]().
+		Key("defaults-ide").
+		Title("Default IDE").
+		Description("Recommended workspace default from the README example.").
+		Options(runtimeIDEOptions()...).
+		Value(&selectedIDE)
+	if err := runPromptField(ideField); err != nil {
+		return workspace.DefaultsConfig{}, fmt.Errorf("select default ide: %w", err)
+	}
+	recommendedModel := defaultModelForIDE(selectedIDE)
+	if strings.TrimSpace(selectedModel) == "" || strings.TrimSpace(selectedModel) == originalRecommendedModel {
+		selectedModel = recommendedModel
+	}
+	modelField := huh.NewInput().
+		Key("defaults-model").
+		Title("Default Model").
+		Description(fmt.Sprintf("Recommended for %s: %s.", selectedIDE, recommendedModel)).
+		Value(&selectedModel).
+		Validate(func(value string) error {
+			if strings.TrimSpace(value) == "" {
+				return errors.New("model is required")
+			}
+			return nil
+		})
+	if err := runPromptField(modelField); err != nil {
+		return workspace.DefaultsConfig{}, fmt.Errorf("select default model: %w", err)
+	}
+	reasoningField := huh.NewSelect[string]().
+		Key("defaults-reasoning-effort").
+		Title("Default Reasoning Effort").
+		Description("Recommended workspace default from the README example.").
+		Options(
+			huh.NewOption("Low", "low"),
+			huh.NewOption("Medium", "medium"),
+			huh.NewOption("High", "high"),
+			huh.NewOption("Extra High", "xhigh"),
+		).
+		Value(&selectedReasoning)
+	if err := runPromptField(reasoningField); err != nil {
+		return workspace.DefaultsConfig{}, fmt.Errorf("select default reasoning effort: %w", err)
+	}
+
+	return workspace.DefaultsConfig{
+		IDE:             stringPtr(strings.TrimSpace(selectedIDE)),
+		Model:           stringPtr(strings.TrimSpace(selectedModel)),
+		ReasoningEffort: stringPtr(strings.TrimSpace(selectedReasoning)),
+	}, nil
+}
+
+func (s *setupCommandState) persistRuntimeDefaults(ctx context.Context, plan runtimeDefaultsPlan) error {
+	if !plan.Enabled {
+		return nil
+	}
+
+	currentConfig, _, err := s.loadConfigFile(ctx, plan.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("reload runtime defaults config: %w", err)
+	}
+	currentConfig.Defaults.IDE = plan.Defaults.IDE
+	currentConfig.Defaults.Model = plan.Defaults.Model
+	currentConfig.Defaults.ReasoningEffort = plan.Defaults.ReasoningEffort
+	if err := s.writeConfig(ctx, plan.ConfigPath, currentConfig); err != nil {
+		return fmt.Errorf("persist runtime defaults: %w", err)
+	}
+	return nil
+}
+
+func preferredRuntimeIDE(defaults workspace.DefaultsConfig, selectedAgents []string) string {
+	if defaults.IDE != nil && strings.TrimSpace(*defaults.IDE) != "" {
+		return strings.TrimSpace(*defaults.IDE)
+	}
+	if inferredIDE := runtimeIDEFromSelectedAgents(selectedAgents); inferredIDE != "" {
+		return inferredIDE
+	}
+	return model.IDECodex
+}
+
+func preferredRuntimeModel(defaults workspace.DefaultsConfig, selectedIDE string) string {
+	if defaults.Model != nil && strings.TrimSpace(*defaults.Model) != "" {
+		return strings.TrimSpace(*defaults.Model)
+	}
+	return defaultModelForIDE(selectedIDE)
+}
+
+func preferredRuntimeReasoningEffort(defaults workspace.DefaultsConfig) string {
+	if defaults.ReasoningEffort != nil && strings.TrimSpace(*defaults.ReasoningEffort) != "" {
+		return strings.TrimSpace(*defaults.ReasoningEffort)
+	}
+	return model.DefaultReasoningEffort
+}
+
+func runtimeIDEOptions() []huh.Option[string] {
+	entries := coreagent.DriverCatalog()
+	options := make([]huh.Option[string], 0, len(entries))
+	for i := range entries {
+		entry := &entries[i]
+		label := entry.DisplayName
+		if entry.IDE == model.IDECodex {
+			label += " (recommended)"
+		}
+		options = append(options, huh.NewOption(label, entry.IDE))
+	}
+	return options
+}
+
+func defaultModelForIDE(ide string) string {
+	resolved := strings.TrimSpace(coreagent.DefaultModel(ide))
+	if resolved != "" {
+		return resolved
+	}
+	return model.DefaultCodexModel
+}
+
+func runtimeIDEFromSelectedAgents(selectedAgents []string) string {
+	entries := coreagent.DriverCatalog()
+	for _, selectedAgent := range selectedAgents {
+		normalizedAgent := strings.TrimSpace(strings.ToLower(selectedAgent))
+		if normalizedAgent == "" {
+			continue
+		}
+		for i := range entries {
+			setupAgentName, err := coreagent.SetupAgentName(entries[i].IDE)
+			if err != nil {
+				continue
+			}
+			if normalizedAgent == strings.TrimSpace(strings.ToLower(setupAgentName)) {
+				return entries[i].IDE
+			}
+		}
+	}
+	return ""
+}
+
+func stringPtr(value string) *string {
+	resolved := value
+	return &resolved
 }
 
 func (s *setupCommandState) resolveSkillSelection(skills []setup.Skill) ([]string, error) {
@@ -580,10 +849,11 @@ func printPreviewSummary(
 	cmd *cobra.Command,
 	previews []setup.PreviewItem,
 	reusableAgentPreviews []setup.ReusableAgentPreviewItem,
+	runtimePlan runtimeDefaultsPlan,
 	global bool,
 	mode setup.InstallMode,
 ) {
-	if len(previews) == 0 && len(reusableAgentPreviews) == 0 {
+	if len(previews) == 0 && len(reusableAgentPreviews) == 0 && !runtimePlan.Enabled {
 		return
 	}
 	styles := newCLIChromeStyles()
@@ -596,6 +866,7 @@ func printPreviewSummary(
 
 	lipgloss.Fprintf(w, "  %s  %s\n", styles.label.Render("Scope "), styles.value.Render(scopeLabel(global)))
 	lipgloss.Fprintf(w, "  %s  %s\n", styles.label.Render("Method"), styles.value.Render(string(mode)))
+	printRuntimeDefaultsSummary(w, styles, runtimePlan, cwd, homeDir)
 	fmt.Fprintln(w)
 	lipgloss.Fprintln(w, styles.separator.Render("  "+strings.Repeat("─", 50)))
 	fmt.Fprintln(w)
@@ -611,6 +882,57 @@ func printPreviewSummary(
 		}
 	}
 
+	printSkillPreviewItems(w, styles, previews, mode, cwd, homeDir, maxSkillLen, maxAgentLen)
+	printReusableAgentPreviewItems(w, styles, reusableAgentPreviews, global, cwd, homeDir)
+	fmt.Fprintln(w)
+}
+
+func printRuntimeDefaultsSummary(
+	w io.Writer,
+	styles cliChromeStyles,
+	runtimePlan runtimeDefaultsPlan,
+	cwd, homeDir string,
+) {
+	if !runtimePlan.Enabled {
+		return
+	}
+
+	configPath := shortenPath(runtimePlan.ConfigPath, cwd, homeDir)
+	ide := ""
+	modelName := ""
+	reasoningEffort := ""
+	if runtimePlan.Defaults.IDE != nil {
+		ide = *runtimePlan.Defaults.IDE
+	}
+	if runtimePlan.Defaults.Model != nil {
+		modelName = *runtimePlan.Defaults.Model
+	}
+	if runtimePlan.Defaults.ReasoningEffort != nil {
+		reasoningEffort = *runtimePlan.Defaults.ReasoningEffort
+	}
+	status := "new"
+	if runtimePlan.Existing {
+		status = "update"
+	}
+	lipgloss.Fprintf(w, "  %s  %s\n", styles.label.Render("Config "), styles.value.Render(configPath+" ["+status+"]"))
+	lipgloss.Fprintf(
+		w,
+		"  %s  %s / %s / %s\n",
+		styles.label.Render("Defaults"),
+		styles.value.Render(ide),
+		styles.value.Render(modelName),
+		styles.value.Render(reasoningEffort),
+	)
+}
+
+func printSkillPreviewItems(
+	w io.Writer,
+	styles cliChromeStyles,
+	previews []setup.PreviewItem,
+	mode setup.InstallMode,
+	cwd, homeDir string,
+	maxSkillLen, maxAgentLen int,
+) {
 	for i := range previews {
 		preview := &previews[i]
 		name := styles.skill.Render(padRight(preview.Skill.Name, maxSkillLen))
@@ -619,7 +941,6 @@ func printPreviewSummary(
 		path := styles.path.Render(shortenPath(preview.TargetPath, cwd, homeDir))
 
 		line := fmt.Sprintf("    %s  %s  %s  %s", name, arrow, agent, path)
-
 		if mode == setup.InstallModeSymlink && !sameInstallPath(preview.CanonicalPath, preview.TargetPath) {
 			via := styles.path.Render("via " + shortenPath(preview.CanonicalPath, cwd, homeDir))
 			line += "  " + via
@@ -629,32 +950,41 @@ func printPreviewSummary(
 		}
 		lipgloss.Fprintln(w, line)
 	}
+}
 
-	if len(reusableAgentPreviews) > 0 {
-		fmt.Fprintln(w)
-		lipgloss.Fprintln(w, styles.sectionTitle.Render(reusableAgentSectionTitle(global)))
-		fmt.Fprintln(w)
+func printReusableAgentPreviewItems(
+	w io.Writer,
+	styles cliChromeStyles,
+	reusableAgentPreviews []setup.ReusableAgentPreviewItem,
+	global bool,
+	cwd, homeDir string,
+) {
+	if len(reusableAgentPreviews) == 0 {
+		return
+	}
 
-		maxReusableAgentLen := 0
-		for i := range reusableAgentPreviews {
-			if len(reusableAgentPreviews[i].ReusableAgent.Name) > maxReusableAgentLen {
-				maxReusableAgentLen = len(reusableAgentPreviews[i].ReusableAgent.Name)
-			}
-		}
+	fmt.Fprintln(w)
+	lipgloss.Fprintln(w, styles.sectionTitle.Render(reusableAgentSectionTitle(global)))
+	fmt.Fprintln(w)
 
-		for i := range reusableAgentPreviews {
-			preview := &reusableAgentPreviews[i]
-			name := styles.agent.Render(padRight(preview.ReusableAgent.Name, maxReusableAgentLen))
-			path := styles.path.Render(shortenPath(preview.TargetPath, cwd, homeDir))
-
-			line := fmt.Sprintf("    %s  %s", name, path)
-			if preview.WillOverwrite {
-				line += "  " + styles.warn.Render("[overwrite]")
-			}
-			lipgloss.Fprintln(w, line)
+	maxReusableAgentLen := 0
+	for i := range reusableAgentPreviews {
+		if len(reusableAgentPreviews[i].ReusableAgent.Name) > maxReusableAgentLen {
+			maxReusableAgentLen = len(reusableAgentPreviews[i].ReusableAgent.Name)
 		}
 	}
-	fmt.Fprintln(w)
+
+	for i := range reusableAgentPreviews {
+		preview := &reusableAgentPreviews[i]
+		name := styles.agent.Render(padRight(preview.ReusableAgent.Name, maxReusableAgentLen))
+		path := styles.path.Render(shortenPath(preview.TargetPath, cwd, homeDir))
+
+		line := fmt.Sprintf("    %s  %s", name, path)
+		if preview.WillOverwrite {
+			line += "  " + styles.warn.Render("[overwrite]")
+		}
+		lipgloss.Fprintln(w, line)
+	}
 }
 
 func printInstallResult(cmd *cobra.Command, result *setup.Result) {

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -3,9 +3,13 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/core/workspace"
 	"github.com/compozy/compozy/internal/setup"
 	"github.com/spf13/cobra"
 )
@@ -373,5 +377,372 @@ func TestSetupRunYesCleansLegacyTransferredAssetsBeforeInstall(t *testing.T) {
 	}
 	if got, want := strings.Join(callOrder, ","), "cleanup,skills,agents"; got != want {
 		t.Fatalf("unexpected setup install order\nwant: %s\ngot:  %s", want, got)
+	}
+}
+
+func TestPreferredRuntimeDefaultsUseReadmeExamples(t *testing.T) {
+	t.Parallel()
+
+	defaults := workspace.DefaultsConfig{}
+	if got := preferredRuntimeIDE(defaults, nil); got != "codex" {
+		t.Fatalf("unexpected ide default: %q", got)
+	}
+	if got := preferredRuntimeModel(defaults, model.IDECodex); got != model.DefaultCodexModel {
+		t.Fatalf("unexpected model default: %q", got)
+	}
+	if got := preferredRuntimeReasoningEffort(defaults); got != "medium" {
+		t.Fatalf("unexpected reasoning effort default: %q", got)
+	}
+}
+
+func TestPreferredRuntimeIDEUsesSelectedAgentsWhenConfigUnset(t *testing.T) {
+	t.Parallel()
+
+	defaults := workspace.DefaultsConfig{}
+	if got := preferredRuntimeIDE(defaults, []string{"claude-code"}); got != model.IDEClaude {
+		t.Fatalf("unexpected claude ide default: %q", got)
+	}
+	if got := preferredRuntimeIDE(defaults, []string{"cursor"}); got != model.IDECursor {
+		t.Fatalf("unexpected cursor ide default: %q", got)
+	}
+}
+
+func TestPreferredRuntimeModelFollowsConfiguredIDE(t *testing.T) {
+	t.Parallel()
+
+	defaults := workspace.DefaultsConfig{IDE: stringPtr(model.IDECursor)}
+	if got := preferredRuntimeModel(defaults, model.IDECursor); got != model.DefaultCursorModel {
+		t.Fatalf("unexpected cursor model default: %q", got)
+	}
+}
+
+func TestSetupResolverOptionsUseDiscoveredWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.resolveWorkspace = func(context.Context) (workspace.Context, error) {
+		return workspace.Context{Root: "/tmp/workspace-root"}, nil
+	}
+
+	resolver, err := state.resolverOptions(context.Background())
+	if err != nil {
+		t.Fatalf("resolver options: %v", err)
+	}
+	if resolver.CWD != "/tmp/workspace-root" {
+		t.Fatalf("unexpected resolver cwd: %q", resolver.CWD)
+	}
+}
+
+func TestDefaultModelForIDEResolvesRegistryDefault(t *testing.T) {
+	t.Parallel()
+
+	if got := defaultModelForIDE(model.IDECursor); got != model.DefaultCursorModel {
+		t.Fatalf("unexpected cursor default model: %q", got)
+	}
+}
+
+func TestPersistRuntimeDefaultsPreservesOtherConfigSections(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".compozy", "config.toml")
+	provider := "coderabbit"
+	accessMode := "full"
+	if err := workspace.WriteConfig(context.Background(), configPath, workspace.ProjectConfig{
+		Defaults:     workspace.DefaultsConfig{AccessMode: &accessMode},
+		FetchReviews: workspace.FetchReviewsConfig{Provider: &provider},
+	}); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	state := newSetupCommandState()
+	plan := runtimeDefaultsPlan{
+		Enabled:    true,
+		ConfigPath: configPath,
+		Defaults: workspace.DefaultsConfig{
+			IDE:             stringPtr("codex"),
+			Model:           stringPtr("gpt-5.4"),
+			ReasoningEffort: stringPtr("medium"),
+		},
+	}
+
+	if err := state.persistRuntimeDefaults(context.Background(), plan); err != nil {
+		t.Fatalf("persist runtime defaults: %v", err)
+	}
+
+	loaded, exists, err := workspace.LoadConfigFile(context.Background(), configPath)
+	if err != nil {
+		t.Fatalf("load updated config: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected config file to exist")
+	}
+	if loaded.Defaults.IDE == nil || *loaded.Defaults.IDE != "codex" {
+		t.Fatalf("unexpected defaults.ide: %#v", loaded.Defaults.IDE)
+	}
+	if loaded.Defaults.Model == nil || *loaded.Defaults.Model != "gpt-5.4" {
+		t.Fatalf("unexpected defaults.model: %#v", loaded.Defaults.Model)
+	}
+	if loaded.Defaults.ReasoningEffort == nil || *loaded.Defaults.ReasoningEffort != "medium" {
+		t.Fatalf("unexpected defaults.reasoning_effort: %#v", loaded.Defaults.ReasoningEffort)
+	}
+	if loaded.Defaults.AccessMode == nil || *loaded.Defaults.AccessMode != "full" {
+		t.Fatalf("unexpected defaults.access_mode: %#v", loaded.Defaults.AccessMode)
+	}
+	if loaded.FetchReviews.Provider == nil || *loaded.FetchReviews.Provider != "coderabbit" {
+		t.Fatalf("unexpected fetch_reviews.provider: %#v", loaded.FetchReviews.Provider)
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanUsesProvidedContextForConfigLoad(t *testing.T) {
+	t.Parallel()
+
+	type contextKey string
+	const key contextKey = "source"
+	loadErr := context.Canceled
+
+	state := newSetupCommandState()
+	state.resolveWorkspace = func(ctx context.Context) (workspace.Context, error) {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach workspace resolution, got %#v", got)
+		}
+		configPath := filepath.Join(t.TempDir(), ".compozy", "config.toml")
+		return workspace.Context{Root: filepath.Dir(filepath.Dir(configPath)), ConfigPath: configPath}, nil
+	}
+	state.promptRuntimeDefaults = func(string) (bool, error) {
+		return true, nil
+	}
+	state.loadConfigFile = func(ctx context.Context, _ string) (workspace.ProjectConfig, bool, error) {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach config load, got %#v", got)
+		}
+		return workspace.ProjectConfig{}, false, loadErr
+	}
+
+	ctx := context.WithValue(context.Background(), key, "cmd-context")
+	_, err := state.resolveRuntimeDefaultsPlan(ctx, false, []string{"codex"})
+	if err == nil {
+		t.Fatal("expected runtime defaults plan to return load error")
+	}
+	if !strings.Contains(err.Error(), loadErr.Error()) {
+		t.Fatalf("expected load error to be wrapped, got %v", err)
+	}
+}
+
+func TestPersistRuntimeDefaultsUsesProvidedContextForLoadAndWrite(t *testing.T) {
+	t.Parallel()
+
+	type contextKey string
+	const key contextKey = "source"
+
+	state := newSetupCommandState()
+	state.loadConfigFile = func(ctx context.Context, _ string) (workspace.ProjectConfig, bool, error) {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach config load, got %#v", got)
+		}
+		return workspace.ProjectConfig{}, true, nil
+	}
+	state.writeConfig = func(ctx context.Context, _ string, cfg workspace.ProjectConfig) error {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach config write, got %#v", got)
+		}
+		if cfg.Defaults.IDE == nil || *cfg.Defaults.IDE != "codex" {
+			t.Fatalf("unexpected defaults.ide: %#v", cfg.Defaults.IDE)
+		}
+		return nil
+	}
+
+	ctx := context.WithValue(context.Background(), key, "cmd-context")
+	err := state.persistRuntimeDefaults(ctx, runtimeDefaultsPlan{
+		Enabled:    true,
+		ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
+		Defaults: workspace.DefaultsConfig{
+			IDE:             stringPtr("codex"),
+			Model:           stringPtr("gpt-5.4"),
+			ReasoningEffort: stringPtr("medium"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("persist runtime defaults: %v", err)
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanSkipsWorkspacePromptForGlobalInstall(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+		t.Fatal("expected global setup to skip workspace config loading")
+		return workspace.ProjectConfig{}, false, nil
+	}
+
+	plan, err := state.resolveRuntimeDefaultsPlan(context.Background(), true, []string{"codex"})
+	if err != nil {
+		t.Fatalf("resolve runtime defaults plan: %v", err)
+	}
+	if plan.Enabled {
+		t.Fatal("expected global setup to skip runtime defaults plan")
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanSkipsConfigLoadWhenPromptDeclined(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.promptRuntimeDefaults = func(string) (bool, error) {
+		return false, nil
+	}
+	state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+		t.Fatal("expected declining runtime defaults prompt to skip workspace config loading")
+		return workspace.ProjectConfig{}, false, nil
+	}
+
+	plan, err := state.resolveRuntimeDefaultsPlan(context.Background(), false, []string{"codex"})
+	if err != nil {
+		t.Fatalf("resolve runtime defaults plan: %v", err)
+	}
+	if plan.Enabled {
+		t.Fatal("expected declined runtime defaults prompt to skip runtime defaults plan")
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanDoesNotParseConfigBeforeOptIn(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	configPath := filepath.Join(workspaceRoot, ".compozy", "config.toml")
+	if err := workspace.WriteConfig(context.Background(), configPath, workspace.ProjectConfig{}); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("[defaults]\nide = ["), 0o600); err != nil {
+		t.Fatalf("write malformed config: %v", err)
+	}
+
+	state := newSetupCommandState()
+	state.resolveWorkspace = func(context.Context) (workspace.Context, error) {
+		return workspace.Context{Root: workspaceRoot, ConfigPath: configPath}, nil
+	}
+	state.promptRuntimeDefaults = func(string) (bool, error) {
+		return false, nil
+	}
+	state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+		t.Fatal("expected config parsing to be skipped before opt-in")
+		return workspace.ProjectConfig{}, false, nil
+	}
+
+	plan, err := state.resolveRuntimeDefaultsPlan(context.Background(), false, []string{"claude-code"})
+	if err != nil {
+		t.Fatalf("resolve runtime defaults plan: %v", err)
+	}
+	if plan.Enabled {
+		t.Fatal("expected declined runtime defaults prompt to skip runtime defaults plan")
+	}
+}
+
+func TestRuntimeDefaultsExistingTracksManagedFields(t *testing.T) {
+	t.Parallel()
+
+	blank := "   "
+	modelName := "gpt-5.4"
+	accessMode := "full"
+
+	tests := []struct {
+		name   string
+		exists bool
+		config workspace.ProjectConfig
+		want   bool
+	}{
+		{
+			name:   "missing file",
+			exists: false,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{Model: &modelName},
+			},
+			want: false,
+		},
+		{
+			name:   "blank managed field",
+			exists: true,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{IDE: &blank},
+			},
+			want: false,
+		},
+		{
+			name:   "unmanaged defaults field ignored",
+			exists: true,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{AccessMode: &accessMode},
+			},
+			want: false,
+		},
+		{
+			name:   "managed defaults field present",
+			exists: true,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{Model: &modelName},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			hasExistingDefaults :=
+				(tc.config.Defaults.IDE != nil && strings.TrimSpace(*tc.config.Defaults.IDE) != "") ||
+					(tc.config.Defaults.Model != nil && strings.TrimSpace(*tc.config.Defaults.Model) != "") ||
+					(tc.config.Defaults.ReasoningEffort != nil && strings.TrimSpace(*tc.config.Defaults.ReasoningEffort) != "")
+			if got := tc.exists && hasExistingDefaults; got != tc.want {
+				t.Fatalf("existing runtime defaults = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteInstallDoesNotPersistDefaultsWhenInstallFails(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.installSkills = func(
+		_ setup.ResolverOptions,
+		_ []setup.Skill,
+		_ []string,
+		_ bool,
+		_ setup.InstallMode,
+	) ([]setup.SuccessItem, []setup.FailureItem, error) {
+		return nil, []setup.FailureItem{{Error: "boom"}}, nil
+	}
+	state.installReusableAgents = func(
+		_ setup.ReusableAgentInstallConfig,
+	) ([]setup.ReusableAgentSuccessItem, []setup.ReusableAgentFailureItem, error) {
+		return nil, nil, nil
+	}
+	state.writeConfig = func(context.Context, string, workspace.ProjectConfig) error {
+		t.Fatal("expected failed setup to skip config persistence")
+		return nil
+	}
+
+	cmd := &cobra.Command{Use: "setup"}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := state.executeInstall(context.Background(), cmd, setupInstallPlan{
+		Config: setup.InstallConfig{},
+		RuntimePlan: runtimeDefaultsPlan{
+			Enabled:    true,
+			ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
+			Defaults: workspace.DefaultsConfig{
+				IDE:             stringPtr("codex"),
+				Model:           stringPtr("gpt-5.4"),
+				ReasoningEffort: stringPtr("medium"),
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected setup failure")
+	}
+	if !strings.Contains(err.Error(), "1 failure") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -3,9 +3,14 @@ package cli
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/core/workspace"
 	"github.com/compozy/compozy/internal/setup"
 	"github.com/spf13/cobra"
 )
@@ -153,6 +158,13 @@ func TestSetupRunYesUsesProjectScopeForReusableAgentsWhenGlobalFlagIsFalse(t *te
 	t.Parallel()
 
 	state := newSetupCommandState()
+	resolveWorkspaceCalls := 0
+	state.resolveWorkspace = func(context.Context) (workspace.Context, error) {
+		resolveWorkspaceCalls++
+		root := t.TempDir()
+		configPath := filepath.Join(root, ".compozy", "config.toml")
+		return workspace.Context{Root: root, ConfigPath: configPath}, nil
+	}
 	state.yes = true
 	state.loadCatalog = func(_ context.Context, _ setup.ResolverOptions) (setup.EffectiveCatalog, error) {
 		return setup.EffectiveCatalog{
@@ -273,6 +285,9 @@ func TestSetupRunYesUsesProjectScopeForReusableAgentsWhenGlobalFlagIsFalse(t *te
 	if len(installCfg.ReusableAgents) != 1 || installCfg.ReusableAgents[0].Name != "architect-advisor" {
 		t.Fatalf("unexpected reusable-agent install config: %#v", installCfg)
 	}
+	if resolveWorkspaceCalls != 1 {
+		t.Fatalf("expected setup run to resolve workspace once, got %d", resolveWorkspaceCalls)
+	}
 }
 
 func TestSetupRunYesCleansLegacyTransferredAssetsBeforeInstall(t *testing.T) {
@@ -373,5 +388,435 @@ func TestSetupRunYesCleansLegacyTransferredAssetsBeforeInstall(t *testing.T) {
 	}
 	if got, want := strings.Join(callOrder, ","), "cleanup,skills,agents"; got != want {
 		t.Fatalf("unexpected setup install order\nwant: %s\ngot:  %s", want, got)
+	}
+}
+
+func TestPreferredRuntimeDefaultsUseReadmeExamples(t *testing.T) {
+	t.Parallel()
+
+	defaults := workspace.DefaultsConfig{}
+	if got := preferredRuntimeIDE(defaults, nil); got != "codex" {
+		t.Fatalf("unexpected ide default: %q", got)
+	}
+	if got := preferredRuntimeModel(defaults, model.IDECodex); got != model.DefaultCodexModel {
+		t.Fatalf("unexpected model default: %q", got)
+	}
+	if got := preferredRuntimeReasoningEffort(defaults); got != "medium" {
+		t.Fatalf("unexpected reasoning effort default: %q", got)
+	}
+}
+
+func TestPreferredRuntimeIDEUsesSelectedAgentsWhenConfigUnset(t *testing.T) {
+	t.Parallel()
+
+	defaults := workspace.DefaultsConfig{}
+	if got := preferredRuntimeIDE(defaults, []string{"claude-code"}); got != model.IDEClaude {
+		t.Fatalf("unexpected claude ide default: %q", got)
+	}
+	if got := preferredRuntimeIDE(defaults, []string{"cursor"}); got != model.IDECursor {
+		t.Fatalf("unexpected cursor ide default: %q", got)
+	}
+}
+
+func TestPreferredRuntimeModelFollowsConfiguredIDE(t *testing.T) {
+	t.Parallel()
+
+	defaults := workspace.DefaultsConfig{IDE: stringPtr(model.IDECursor)}
+	if got := preferredRuntimeModel(defaults, model.IDECursor); got != model.DefaultCursorModel {
+		t.Fatalf("unexpected cursor model default: %q", got)
+	}
+}
+
+func TestSetupResolverOptionsUseDiscoveredWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.resolveWorkspace = func(context.Context) (workspace.Context, error) {
+		return workspace.Context{Root: "/tmp/workspace-root"}, nil
+	}
+
+	resolver, workspaceCtx, err := state.resolverOptions(context.Background())
+	if err != nil {
+		t.Fatalf("resolver options: %v", err)
+	}
+	if resolver.CWD != "/tmp/workspace-root" {
+		t.Fatalf("unexpected resolver cwd: %q", resolver.CWD)
+	}
+	if workspaceCtx.Root != "/tmp/workspace-root" {
+		t.Fatalf("unexpected workspace root: %q", workspaceCtx.Root)
+	}
+}
+
+func TestDefaultModelForIDEResolvesRegistryDefault(t *testing.T) {
+	t.Parallel()
+
+	if got := defaultModelForIDE(model.IDECursor); got != model.DefaultCursorModel {
+		t.Fatalf("unexpected cursor default model: %q", got)
+	}
+}
+
+func TestPersistRuntimeDefaultsPreservesOtherConfigSections(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".compozy", "config.toml")
+	provider := "coderabbit"
+	accessMode := "full"
+	if err := workspace.WriteConfig(context.Background(), configPath, workspace.ProjectConfig{
+		Defaults:     workspace.DefaultsConfig{AccessMode: &accessMode},
+		FetchReviews: workspace.FetchReviewsConfig{Provider: &provider},
+	}); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	state := newSetupCommandState()
+	plan := runtimeDefaultsPlan{
+		Enabled:    true,
+		ConfigPath: configPath,
+		Defaults: workspace.DefaultsConfig{
+			IDE:             stringPtr("codex"),
+			Model:           stringPtr("gpt-5.4"),
+			ReasoningEffort: stringPtr("medium"),
+		},
+	}
+
+	if err := state.persistRuntimeDefaults(context.Background(), plan); err != nil {
+		t.Fatalf("persist runtime defaults: %v", err)
+	}
+
+	loaded, exists, err := workspace.LoadConfigFile(context.Background(), configPath)
+	if err != nil {
+		t.Fatalf("load updated config: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected config file to exist")
+	}
+	if loaded.Defaults.IDE == nil || *loaded.Defaults.IDE != "codex" {
+		t.Fatalf("unexpected defaults.ide: %#v", loaded.Defaults.IDE)
+	}
+	if loaded.Defaults.Model == nil || *loaded.Defaults.Model != "gpt-5.4" {
+		t.Fatalf("unexpected defaults.model: %#v", loaded.Defaults.Model)
+	}
+	if loaded.Defaults.ReasoningEffort == nil || *loaded.Defaults.ReasoningEffort != "medium" {
+		t.Fatalf("unexpected defaults.reasoning_effort: %#v", loaded.Defaults.ReasoningEffort)
+	}
+	if loaded.Defaults.AccessMode == nil || *loaded.Defaults.AccessMode != "full" {
+		t.Fatalf("unexpected defaults.access_mode: %#v", loaded.Defaults.AccessMode)
+	}
+	if loaded.FetchReviews.Provider == nil || *loaded.FetchReviews.Provider != "coderabbit" {
+		t.Fatalf("unexpected fetch_reviews.provider: %#v", loaded.FetchReviews.Provider)
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanUsesProvidedContextForConfigLoad(t *testing.T) {
+	t.Parallel()
+
+	type contextKey string
+	const key contextKey = "source"
+	loadErr := context.Canceled
+
+	state := newSetupCommandState()
+	state.resolveWorkspace = func(ctx context.Context) (workspace.Context, error) {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach workspace resolution, got %#v", got)
+		}
+		configPath := filepath.Join(t.TempDir(), ".compozy", "config.toml")
+		return workspace.Context{Root: filepath.Dir(filepath.Dir(configPath)), ConfigPath: configPath}, nil
+	}
+	state.promptRuntimeDefaults = func(string) (bool, error) {
+		return true, nil
+	}
+	state.loadConfigFile = func(ctx context.Context, _ string) (workspace.ProjectConfig, bool, error) {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach config load, got %#v", got)
+		}
+		return workspace.ProjectConfig{}, false, loadErr
+	}
+
+	ctx := context.WithValue(context.Background(), key, "cmd-context")
+	configPath := filepath.Join(t.TempDir(), ".compozy", "config.toml")
+	_, err := state.resolveRuntimeDefaultsPlan(ctx, false, []string{"codex"}, configPath)
+	if err == nil {
+		t.Fatal("expected runtime defaults plan to return load error")
+	}
+	if !strings.Contains(err.Error(), loadErr.Error()) {
+		t.Fatalf("expected load error to be wrapped, got %v", err)
+	}
+}
+
+func TestPersistRuntimeDefaultsUsesProvidedContextForLoadAndWrite(t *testing.T) {
+	t.Parallel()
+
+	type contextKey string
+	const key contextKey = "source"
+
+	state := newSetupCommandState()
+	state.loadConfigFile = func(ctx context.Context, _ string) (workspace.ProjectConfig, bool, error) {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach config load, got %#v", got)
+		}
+		return workspace.ProjectConfig{}, true, nil
+	}
+	state.writeConfig = func(ctx context.Context, _ string, cfg workspace.ProjectConfig) error {
+		if got := ctx.Value(key); got != "cmd-context" {
+			t.Fatalf("expected command context to reach config write, got %#v", got)
+		}
+		if cfg.Defaults.IDE == nil || *cfg.Defaults.IDE != "codex" {
+			t.Fatalf("unexpected defaults.ide: %#v", cfg.Defaults.IDE)
+		}
+		return nil
+	}
+
+	ctx := context.WithValue(context.Background(), key, "cmd-context")
+	err := state.persistRuntimeDefaults(ctx, runtimeDefaultsPlan{
+		Enabled:    true,
+		ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
+		Defaults: workspace.DefaultsConfig{
+			IDE:             stringPtr("codex"),
+			Model:           stringPtr("gpt-5.4"),
+			ReasoningEffort: stringPtr("medium"),
+		},
+	})
+	if err != nil {
+		t.Fatalf("persist runtime defaults: %v", err)
+	}
+}
+
+func TestPersistRuntimeDefaultsWrapsWriteErrors(t *testing.T) {
+	t.Parallel()
+
+	writeErr := errors.New("disk full")
+	state := newSetupCommandState()
+	state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+		return workspace.ProjectConfig{}, true, nil
+	}
+	state.writeConfig = func(context.Context, string, workspace.ProjectConfig) error {
+		return writeErr
+	}
+
+	err := state.persistRuntimeDefaults(context.Background(), runtimeDefaultsPlan{
+		Enabled:    true,
+		ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
+		Defaults: workspace.DefaultsConfig{
+			IDE:             stringPtr("codex"),
+			Model:           stringPtr("gpt-5.4"),
+			ReasoningEffort: stringPtr("medium"),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected write error")
+	}
+	if !strings.Contains(err.Error(), "persist runtime defaults") || !errors.Is(err, writeErr) {
+		t.Fatalf("expected wrapped write error, got %v", err)
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanSkipsWorkspacePromptForGlobalInstall(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+		t.Fatal("expected global setup to skip workspace config loading")
+		return workspace.ProjectConfig{}, false, nil
+	}
+
+	plan, err := state.resolveRuntimeDefaultsPlan(context.Background(), true, []string{"codex"}, "")
+	if err != nil {
+		t.Fatalf("resolve runtime defaults plan: %v", err)
+	}
+	if plan.Enabled {
+		t.Fatal("expected global setup to skip runtime defaults plan")
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanSkipsConfigLoadWhenPromptDeclined(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.promptRuntimeDefaults = func(string) (bool, error) {
+		return false, nil
+	}
+	state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+		t.Fatal("expected declining runtime defaults prompt to skip workspace config loading")
+		return workspace.ProjectConfig{}, false, nil
+	}
+
+	plan, err := state.resolveRuntimeDefaultsPlan(
+		context.Background(),
+		false,
+		[]string{"codex"},
+		filepath.Join(t.TempDir(), ".compozy", "config.toml"),
+	)
+	if err != nil {
+		t.Fatalf("resolve runtime defaults plan: %v", err)
+	}
+	if plan.Enabled {
+		t.Fatal("expected declined runtime defaults prompt to skip runtime defaults plan")
+	}
+}
+
+func TestResolveRuntimeDefaultsPlanDoesNotParseConfigBeforeOptIn(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	configPath := filepath.Join(workspaceRoot, ".compozy", "config.toml")
+	if err := workspace.WriteConfig(context.Background(), configPath, workspace.ProjectConfig{}); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte("[defaults]\nide = ["), 0o600); err != nil {
+		t.Fatalf("write malformed config: %v", err)
+	}
+
+	state := newSetupCommandState()
+	state.resolveWorkspace = func(context.Context) (workspace.Context, error) {
+		t.Fatal("expected runtime defaults plan to use provided config path")
+		return workspace.Context{}, nil
+	}
+	state.promptRuntimeDefaults = func(string) (bool, error) {
+		return false, nil
+	}
+	state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+		t.Fatal("expected config parsing to be skipped before opt-in")
+		return workspace.ProjectConfig{}, false, nil
+	}
+
+	plan, err := state.resolveRuntimeDefaultsPlan(context.Background(), false, []string{"claude-code"}, configPath)
+	if err != nil {
+		t.Fatalf("resolve runtime defaults plan: %v", err)
+	}
+	if plan.Enabled {
+		t.Fatal("expected declined runtime defaults prompt to skip runtime defaults plan")
+	}
+}
+
+func TestRuntimeDefaultsExistingTracksManagedFields(t *testing.T) {
+	t.Parallel()
+
+	blank := "   "
+	modelName := "gpt-5.4"
+	accessMode := "full"
+
+	tests := []struct {
+		name   string
+		exists bool
+		config workspace.ProjectConfig
+		want   bool
+	}{
+		{
+			name:   "missing file",
+			exists: false,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{Model: &modelName},
+			},
+			want: false,
+		},
+		{
+			name:   "blank managed field",
+			exists: true,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{IDE: &blank},
+			},
+			want: false,
+		},
+		{
+			name:   "unmanaged defaults field ignored",
+			exists: true,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{AccessMode: &accessMode},
+			},
+			want: false,
+		},
+		{
+			name:   "managed defaults field present",
+			exists: true,
+			config: workspace.ProjectConfig{
+				Defaults: workspace.DefaultsConfig{Model: &modelName},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newSetupCommandState()
+			state.promptRuntimeDefaults = func(string) (bool, error) {
+				return true, nil
+			}
+			state.loadConfigFile = func(context.Context, string) (workspace.ProjectConfig, bool, error) {
+				return tc.config, tc.exists, nil
+			}
+			state.editRuntimeDefaults = func(string, string, string, string) (workspace.DefaultsConfig, error) {
+				return workspace.DefaultsConfig{
+					IDE:             stringPtr("codex"),
+					Model:           stringPtr("gpt-5.4"),
+					ReasoningEffort: stringPtr("medium"),
+				}, nil
+			}
+
+			plan, err := state.resolveRuntimeDefaultsPlan(
+				context.Background(),
+				false,
+				[]string{"codex"},
+				filepath.Join(t.TempDir(), ".compozy", "config.toml"),
+			)
+			if err != nil {
+				t.Fatalf("resolve runtime defaults plan: %v", err)
+			}
+			if !plan.Enabled {
+				t.Fatal("expected enabled runtime defaults plan")
+			}
+			if plan.Existing != tc.want {
+				t.Fatalf("existing runtime defaults = %v, want %v", plan.Existing, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteInstallDoesNotPersistDefaultsWhenInstallFails(t *testing.T) {
+	t.Parallel()
+
+	state := newSetupCommandState()
+	state.installSkills = func(
+		_ setup.ResolverOptions,
+		_ []setup.Skill,
+		_ []string,
+		_ bool,
+		_ setup.InstallMode,
+	) ([]setup.SuccessItem, []setup.FailureItem, error) {
+		return nil, []setup.FailureItem{{Error: "boom"}}, nil
+	}
+	state.installReusableAgents = func(
+		_ setup.ReusableAgentInstallConfig,
+	) ([]setup.ReusableAgentSuccessItem, []setup.ReusableAgentFailureItem, error) {
+		return nil, nil, nil
+	}
+	state.writeConfig = func(context.Context, string, workspace.ProjectConfig) error {
+		t.Fatal("expected failed setup to skip config persistence")
+		return nil
+	}
+
+	cmd := &cobra.Command{Use: "setup"}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := state.executeInstall(context.Background(), cmd, setupInstallPlan{
+		Config: setup.InstallConfig{},
+		RuntimePlan: runtimeDefaultsPlan{
+			Enabled:    true,
+			ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
+			Defaults: workspace.DefaultsConfig{
+				IDE:             stringPtr("codex"),
+				Model:           stringPtr("gpt-5.4"),
+				ReasoningEffort: stringPtr("medium"),
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected setup failure")
+	}
+	if !strings.Contains(err.Error(), "1 failure") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/cli/skills_preflight.go
+++ b/internal/cli/skills_preflight.go
@@ -21,6 +21,7 @@ type skillRefreshPrompt struct {
 }
 
 type requiredSkillState struct {
+	ResolverOptions   setup.ResolverOptions
 	AgentName         string
 	BundledSkillNames []string
 	ExtensionPacks    []setup.SkillPackSource
@@ -74,9 +75,10 @@ func (s *commandState) verifyRequiredSkillState(
 	if verifyBundledSkills == nil {
 		verifyBundledSkills = setup.VerifyBundledSkills
 	}
+	resolver := preflightResolverOptions(setup.ResolverOptions{}, s.workspaceRoot)
 
 	bundledResult, err := verifyBundledSkills(setup.VerifyConfig{
-		ResolverOptions: currentResolverOptions(),
+		ResolverOptions: resolver,
 		AgentName:       agentName,
 		SkillNames:      bundledSkillNames,
 	})
@@ -89,7 +91,7 @@ func (s *commandState) verifyRequiredSkillState(
 		verifyExtensionSkills = setup.VerifyExtensionSkillPacks
 	}
 	extensionResult, err := verifyExtensionSkills(setup.ExtensionVerifyConfig{
-		ResolverOptions: currentResolverOptions(),
+		ResolverOptions: resolver,
 		AgentName:       agentName,
 		Packs:           extensionPacks,
 		ScopeHint:       bundledResult.Scope,
@@ -99,6 +101,7 @@ func (s *commandState) verifyRequiredSkillState(
 	}
 
 	return requiredSkillState{
+		ResolverOptions:   resolver,
 		AgentName:         agentName,
 		BundledSkillNames: bundledSkillNames,
 		ExtensionPacks:    append([]setup.SkillPackSource(nil), extensionPacks...),
@@ -174,8 +177,10 @@ func (s *commandState) refreshBundledSkills(verifyState requiredSkillState) erro
 	global := verifyState.Scope() == setup.InstallScopeGlobal
 	mode := verifyState.Mode()
 
+	resolver := preflightResolverOptions(verifyState.ResolverOptions, s.workspaceRoot)
+
 	installResult, err := installBundledSkills(setup.InstallConfig{
-		ResolverOptions: currentResolverOptions(),
+		ResolverOptions: resolver,
 		SkillNames:      verifyState.BundledSkillNames,
 		AgentNames:      []string{verifyState.AgentName},
 		Global:          global,
@@ -197,7 +202,7 @@ func (s *commandState) refreshBundledSkills(verifyState requiredSkillState) erro
 		installExtensionSkills = setup.InstallExtensionSkillPacks
 	}
 	extensionResult, err := installExtensionSkills(setup.ExtensionInstallConfig{
-		ResolverOptions: currentResolverOptions(),
+		ResolverOptions: resolver,
 		Packs:           verifyState.ExtensionPacks,
 		AgentNames:      []string{verifyState.AgentName},
 		Global:          global,
@@ -224,8 +229,10 @@ func ensureBundledSkillsCurrent(
 		verifyExtensionSkills = setup.VerifyExtensionSkillPacks
 	}
 
+	resolver := preflightResolverOptions(verifyState.ResolverOptions, "")
+
 	reverifiedBundled, err := verifyBundledSkills(setup.VerifyConfig{
-		ResolverOptions: currentResolverOptions(),
+		ResolverOptions: resolver,
 		AgentName:       verifyState.AgentName,
 		SkillNames:      verifyState.BundledSkillNames,
 	})
@@ -233,7 +240,7 @@ func ensureBundledSkillsCurrent(
 		return fmt.Errorf("re-verify bundled skills: %w", err)
 	}
 	reverifiedExtensions, err := verifyExtensionSkills(setup.ExtensionVerifyConfig{
-		ResolverOptions: currentResolverOptions(),
+		ResolverOptions: resolver,
 		AgentName:       verifyState.AgentName,
 		Packs:           verifyState.ExtensionPacks,
 		ScopeHint:       verifyState.Scope(),
@@ -243,6 +250,7 @@ func ensureBundledSkillsCurrent(
 	}
 
 	reverified := requiredSkillState{
+		ResolverOptions:   verifyState.ResolverOptions,
 		AgentName:         verifyState.AgentName,
 		BundledSkillNames: verifyState.BundledSkillNames,
 		ExtensionPacks:    verifyState.ExtensionPacks,
@@ -264,6 +272,26 @@ func ensureBundledSkillsCurrent(
 		)
 	}
 	return nil
+}
+
+func preflightResolverOptions(provided setup.ResolverOptions, workspaceRoot string) setup.ResolverOptions {
+	resolved := currentResolverOptions(workspaceRoot)
+	if trimmed := strings.TrimSpace(provided.CWD); trimmed != "" {
+		resolved.CWD = trimmed
+	}
+	if trimmed := strings.TrimSpace(provided.HomeDir); trimmed != "" {
+		resolved.HomeDir = trimmed
+	}
+	if trimmed := strings.TrimSpace(provided.XDGConfigHome); trimmed != "" {
+		resolved.XDGConfigHome = trimmed
+	}
+	if trimmed := strings.TrimSpace(provided.CodeXHome); trimmed != "" {
+		resolved.CodeXHome = trimmed
+	}
+	if trimmed := strings.TrimSpace(provided.ClaudeConfigDir); trimmed != "" {
+		resolved.ClaudeConfigDir = trimmed
+	}
+	return resolved
 }
 
 func (s *commandState) requiresBundledSkillPreflight() bool {

--- a/internal/cli/skills_preflight_test.go
+++ b/internal/cli/skills_preflight_test.go
@@ -228,10 +228,14 @@ func TestRefreshBundledSkillsInstallsBundledAndExtensionSkills(t *testing.T) {
 	t.Parallel()
 
 	state := &commandState{}
+	state.workspaceRoot = "/tmp/workspace-root"
 	var bundledCalled bool
 	var extensionCalled bool
 	state.installBundledSkills = func(cfg setup.InstallConfig) (*setup.Result, error) {
 		bundledCalled = true
+		if cfg.CWD != state.workspaceRoot {
+			t.Fatalf("unexpected bundled resolver cwd: %q", cfg.CWD)
+		}
 		if !cfg.Global {
 			t.Fatal("expected global bundled refresh")
 		}
@@ -245,6 +249,9 @@ func TestRefreshBundledSkillsInstallsBundledAndExtensionSkills(t *testing.T) {
 	}
 	state.installExtensionSkills = func(cfg setup.ExtensionInstallConfig) (*setup.ExtensionResult, error) {
 		extensionCalled = true
+		if cfg.CWD != state.workspaceRoot {
+			t.Fatalf("unexpected extension resolver cwd: %q", cfg.CWD)
+		}
 		if !cfg.Global {
 			t.Fatal("expected global extension refresh")
 		}
@@ -301,10 +308,14 @@ func TestVerifyRequiredSkillStateUsesSetupAgentNameAndExtensionScopeHint(t *test
 	t.Parallel()
 
 	state := newCommandState(commandKindStart, core.ModePRDTasks)
+	state.workspaceRoot = "/tmp/workspace-root"
 	state.listBundledSkills = func() ([]setup.Skill, error) {
 		return []setup.Skill{{Name: "cy-execute-task"}, {Name: "cy-final-verify"}}, nil
 	}
 	state.verifyBundledSkills = func(cfg setup.VerifyConfig) (setup.VerifyResult, error) {
+		if cfg.CWD != state.workspaceRoot {
+			t.Fatalf("unexpected bundled resolver cwd: %q", cfg.CWD)
+		}
 		if cfg.AgentName != "codex" {
 			t.Fatalf("unexpected setup agent name: %q", cfg.AgentName)
 		}
@@ -321,6 +332,9 @@ func TestVerifyRequiredSkillStateUsesSetupAgentNameAndExtensionScopeHint(t *test
 		}, nil
 	}
 	state.verifyExtensionSkills = func(cfg setup.ExtensionVerifyConfig) (setup.ExtensionVerifyResult, error) {
+		if cfg.CWD != state.workspaceRoot {
+			t.Fatalf("unexpected extension resolver cwd: %q", cfg.CWD)
+		}
 		if cfg.AgentName != "codex" {
 			t.Fatalf("unexpected extension setup agent name: %q", cfg.AgentName)
 		}

--- a/internal/cli/skills_preflight_test.go
+++ b/internal/cli/skills_preflight_test.go
@@ -228,10 +228,14 @@ func TestRefreshBundledSkillsInstallsBundledAndExtensionSkills(t *testing.T) {
 	t.Parallel()
 
 	state := &commandState{}
+	state.workspaceRoot = "/tmp/workspace-root"
 	var bundledCalled bool
 	var extensionCalled bool
 	state.installBundledSkills = func(cfg setup.InstallConfig) (*setup.Result, error) {
 		bundledCalled = true
+		if cfg.CWD != state.workspaceRoot {
+			t.Fatalf("unexpected bundled resolver cwd: %q", cfg.CWD)
+		}
 		if !cfg.Global {
 			t.Fatal("expected global bundled refresh")
 		}
@@ -245,6 +249,9 @@ func TestRefreshBundledSkillsInstallsBundledAndExtensionSkills(t *testing.T) {
 	}
 	state.installExtensionSkills = func(cfg setup.ExtensionInstallConfig) (*setup.ExtensionResult, error) {
 		extensionCalled = true
+		if cfg.CWD != state.workspaceRoot {
+			t.Fatalf("unexpected extension resolver cwd: %q", cfg.CWD)
+		}
 		if !cfg.Global {
 			t.Fatal("expected global extension refresh")
 		}
@@ -300,14 +307,18 @@ func TestScopeInstallFlagAndInstallScopeLabel(t *testing.T) {
 func TestVerifyRequiredSkillStateUsesSetupAgentNameAndExtensionScopeHint(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should use setup agent name and extension scope hint", func(t *testing.T) {
+	t.Run("Should use setup agent name, workspace cwd, and extension scope hint", func(t *testing.T) {
 		t.Parallel()
 
 		state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
+		state.workspaceRoot = "/tmp/workspace-root"
 		state.listBundledSkills = func() ([]setup.Skill, error) {
 			return []setup.Skill{{Name: "cy-execute-task"}, {Name: "cy-final-verify"}}, nil
 		}
 		state.verifyBundledSkills = func(cfg setup.VerifyConfig) (setup.VerifyResult, error) {
+			if cfg.CWD != state.workspaceRoot {
+				t.Fatalf("unexpected bundled resolver cwd: %q", cfg.CWD)
+			}
 			if cfg.AgentName != "codex" {
 				t.Fatalf("unexpected setup agent name: %q", cfg.AgentName)
 			}
@@ -324,6 +335,9 @@ func TestVerifyRequiredSkillStateUsesSetupAgentNameAndExtensionScopeHint(t *test
 			}, nil
 		}
 		state.verifyExtensionSkills = func(cfg setup.ExtensionVerifyConfig) (setup.ExtensionVerifyResult, error) {
+			if cfg.CWD != state.workspaceRoot {
+				t.Fatalf("unexpected extension resolver cwd: %q", cfg.CWD)
+			}
 			if cfg.AgentName != "codex" {
 				t.Fatalf("unexpected extension setup agent name: %q", cfg.AgentName)
 			}

--- a/internal/cli/tasks_run_wizard_test.go
+++ b/internal/cli/tasks_run_wizard_test.go
@@ -133,6 +133,7 @@ func TestTaskRunWizardModel(t *testing.T) {
 		editor := wizard.currentOverrideEditor()
 		if editor == nil {
 			t.Fatal("expected current override editor after selecting target")
+			return
 		}
 		editor.IDE = "claude"
 		editor.ReasoningEffort = "high"
@@ -183,6 +184,7 @@ func TestTaskRunWizardModel(t *testing.T) {
 		editor := wizard.currentOverrideEditor()
 		if editor == nil {
 			t.Fatal("expected current override editor after selecting target")
+			return
 		}
 		editor.IDE = "claude"
 
@@ -282,6 +284,7 @@ func TestTaskRunWizardModel(t *testing.T) {
 		editor := wizard.currentOverrideEditor()
 		if editor == nil {
 			t.Fatal("expected current override editor")
+			return
 		}
 		if editor.Model != "haiku" {
 			t.Fatalf("override model = %q, want haiku", editor.Model)

--- a/internal/cli/testdata/acp-integration/task_01.md
+++ b/internal/cli/testdata/acp-integration/task_01.md
@@ -1,0 +1,10 @@
+---
+status: pending
+title: ACP Agent Layer
+type: backend
+complexity: medium
+---
+
+# Task 1: ACP Agent Layer
+
+Validate a committed ACP workflow fixture without depending on sidecar-managed .compozy tasks.

--- a/internal/core/agent/registry_specs.go
+++ b/internal/core/agent/registry_specs.go
@@ -283,6 +283,15 @@ func DisplayName(ide string) string {
 	return spec.DisplayName
 }
 
+// DefaultModel returns the default model identifier for an agent runtime.
+func DefaultModel(ide string) string {
+	spec, err := lookupAgentSpec(ide)
+	if err != nil {
+		return ""
+	}
+	return spec.DefaultModel
+}
+
 // SetupAgentName returns the setup/install agent identifier for one ACP runtime.
 func SetupAgentName(ide string) (string, error) {
 	spec, err := lookupAgentSpec(ide)

--- a/internal/core/agent/registry_specs.go
+++ b/internal/core/agent/registry_specs.go
@@ -359,6 +359,15 @@ func RuntimeCommandName(ide string) string {
 	return firstNonEmpty(spec.Command, spec.ID)
 }
 
+// DefaultModel returns the default model identifier for an agent runtime.
+func DefaultModel(ide string) string {
+	spec, err := lookupAgentSpec(ide)
+	if err != nil {
+		return ""
+	}
+	return spec.DefaultModel
+}
+
 // SetupAgentName returns the setup/install agent identifier for one ACP runtime.
 func SetupAgentName(ide string) (string, error) {
 	spec, err := lookupAgentSpec(ide)

--- a/internal/core/agents/mcpserver/engine_test.go
+++ b/internal/core/agents/mcpserver/engine_test.go
@@ -355,6 +355,7 @@ func TestRunAgentHonorsWorkspaceOverrideDuringNestedResolution(t *testing.T) {
 			}
 			if agentExecution == nil {
 				t.Fatal("expected nested agent execution context")
+				return execpkg.PreparedPromptResult{}, nil
 			}
 			if agentExecution.Agent.Source.Scope != reusableagents.ScopeWorkspace {
 				t.Fatalf("expected workspace override source, got %#v", agentExecution.Agent.Source)

--- a/internal/core/kernel/commands/commands_test.go
+++ b/internal/core/kernel/commands/commands_test.go
@@ -314,6 +314,7 @@ func assertRuntimeConfig(t *testing.T, got *model.RuntimeConfig, want core.Confi
 
 	if got == nil {
 		t.Fatal("expected runtime config")
+		return
 	}
 	if got.WorkspaceRoot != want.WorkspaceRoot {
 		t.Fatalf("unexpected workspace root: %q", got.WorkspaceRoot)

--- a/internal/core/migration/migrate_test.go
+++ b/internal/core/migration/migrate_test.go
@@ -134,6 +134,7 @@ func TestMigrateV1ToV2RemapsTypesAndExtractsTitle(t *testing.T) {
 			}
 			if migrated == nil {
 				t.Fatal("expected migrated file")
+				return
 			}
 			if strings.Contains(migrated.content, "domain:") || strings.Contains(migrated.content, "scope:") {
 				t.Fatalf("expected migrated content to drop v1-only keys, got:\n%s", migrated.content)
@@ -736,6 +737,7 @@ func TestMigrateRejectsInvalidArtifactsWithoutWriting(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected migration result on error")
+		return
 	}
 	if result.FilesInvalid != 1 {
 		t.Fatalf("expected 1 invalid file, got %d", result.FilesInvalid)

--- a/internal/core/model/runtime_config.go
+++ b/internal/core/model/runtime_config.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const DefaultReasoningEffort = "medium"
+
 // ExplicitRuntimeFlags tracks which runtime fields were explicitly overridden
 // by the current caller, using CLI-compatible `Flags().Changed(...)` semantics.
 type ExplicitRuntimeFlags struct {
@@ -73,7 +75,7 @@ func (cfg *RuntimeConfig) ApplyDefaults() {
 		cfg.TailLines = 0
 	}
 	if cfg.ReasoningEffort == "" {
-		cfg.ReasoningEffort = "medium"
+		cfg.ReasoningEffort = DefaultReasoningEffort
 	}
 	if cfg.AccessMode == "" {
 		cfg.AccessMode = AccessModeFull

--- a/internal/core/model/runtime_config.go
+++ b/internal/core/model/runtime_config.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const DefaultReasoningEffort = "medium"
+
 // ExplicitRuntimeFlags tracks which runtime fields were explicitly overridden
 // by the current caller, using CLI-compatible `Flags().Changed(...)` semantics.
 type ExplicitRuntimeFlags struct {
@@ -78,7 +80,7 @@ func (cfg *RuntimeConfig) ApplyDefaults() {
 		cfg.TailLines = 0
 	}
 	if cfg.ReasoningEffort == "" {
-		cfg.ReasoningEffort = "medium"
+		cfg.ReasoningEffort = DefaultReasoningEffort
 	}
 	if cfg.AccessMode == "" {
 		cfg.AccessMode = AccessModeFull

--- a/internal/core/run/recovery/reader_integration_test.go
+++ b/internal/core/run/recovery/reader_integration_test.go
@@ -54,6 +54,7 @@ func TestReadRunOutcomeFromExecutorPersistedResult(t *testing.T) {
 		}
 		if outcome == nil {
 			t.Fatal("expected outcome")
+			return
 		}
 		if outcome.RunID != runArtifacts.RunID {
 			t.Fatalf("unexpected run ID: %q", outcome.RunID)

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -143,6 +143,32 @@ func LoadConfig(ctx context.Context, workspaceRoot string) (ProjectConfig, strin
 	return cfg, paths.effectivePath(), nil
 }
 
+func WriteConfig(ctx context.Context, configPath string, cfg ProjectConfig) error {
+	if err := context.Cause(ctx); err != nil {
+		return fmt.Errorf("write workspace config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	content, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode workspace config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir workspace config dir: %w", err)
+	}
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		return fmt.Errorf("write workspace config: %w", err)
+	}
+	return nil
+}
+
+func LoadConfigFile(ctx context.Context, configPath string) (ProjectConfig, bool, error) {
+	cfg, exists, err := loadConfigFile(ctx, configPath, workspaceConfigScope, configBaseDirForPath(configPath))
+	return cfg, exists, err
+}
+
 func LoadGlobalConfig(ctx context.Context) (ProjectConfig, string, error) {
 	if err := context.Cause(ctx); err != nil {
 		return ProjectConfig{}, "", fmt.Errorf("load global config: %w", err)
@@ -217,6 +243,14 @@ func resolveConfigPaths(workspaceRoot string) (configPaths, error) {
 	paths.globalRoot = resolvedHomeDir
 	paths.globalPath = homePaths.ConfigFile
 	return paths, nil
+}
+
+func configBaseDirForPath(configPath string) string {
+	configDir := filepath.Dir(strings.TrimSpace(configPath))
+	if filepath.Base(configDir) == model.WorkflowRootDirName {
+		return filepath.Dir(configDir)
+	}
+	return configDir
 }
 
 func loadConfigFile(

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -188,6 +188,32 @@ func LoadConfig(ctx context.Context, workspaceRoot string) (ProjectConfig, strin
 	return cfg, paths.effectivePath(), nil
 }
 
+func WriteConfig(ctx context.Context, configPath string, cfg ProjectConfig) error {
+	if err := context.Cause(ctx); err != nil {
+		return fmt.Errorf("write workspace config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	content, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode workspace config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir workspace config dir: %w", err)
+	}
+	if err := os.WriteFile(configPath, content, 0o600); err != nil {
+		return fmt.Errorf("write workspace config: %w", err)
+	}
+	return nil
+}
+
+func LoadConfigFile(ctx context.Context, configPath string) (ProjectConfig, bool, error) {
+	cfg, exists, err := loadConfigFile(ctx, configPath, workspaceConfigScope, configBaseDirForPath(configPath))
+	return cfg, exists, err
+}
+
 func LoadGlobalConfig(ctx context.Context) (ProjectConfig, string, error) {
 	if err := context.Cause(ctx); err != nil {
 		return ProjectConfig{}, "", fmt.Errorf("load global config: %w", err)
@@ -262,6 +288,14 @@ func resolveConfigPaths(workspaceRoot string) (configPaths, error) {
 	paths.globalRoot = resolvedHomeDir
 	paths.globalPath = homePaths.ConfigFile
 	return paths, nil
+}
+
+func configBaseDirForPath(configPath string) string {
+	configDir := filepath.Dir(strings.TrimSpace(configPath))
+	if filepath.Base(configDir) == model.WorkflowRootDirName {
+		return filepath.Dir(configDir)
+	}
+	return configDir
 }
 
 func loadConfigFile(

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -133,6 +133,53 @@ types = ["mobile", "api"]
 	}
 }
 
+func TestWriteConfigRoundTripsDefaultsWithoutEmptySections(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".compozy", "config.toml")
+	ide := "codex"
+	modelName := "gpt-5.4"
+	accessMode := "default"
+	cfg := ProjectConfig{
+		Defaults: DefaultsConfig{
+			IDE:        &ide,
+			Model:      &modelName,
+			AccessMode: &accessMode,
+		},
+	}
+
+	if err := WriteConfig(context.Background(), configPath, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	rendered := string(content)
+	if !strings.Contains(rendered, "[defaults]") || !strings.Contains(rendered, "ide = 'codex'") {
+		t.Fatalf("expected defaults section in rendered config, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "[start]") || strings.Contains(rendered, "[exec]") {
+		t.Fatalf("expected empty sections to be omitted, got:\n%s", rendered)
+	}
+
+	loaded, exists, err := LoadConfigFile(context.Background(), configPath)
+	if err != nil {
+		t.Fatalf("load config file: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected written config file to exist")
+	}
+	if loaded.Defaults.IDE == nil || *loaded.Defaults.IDE != "codex" {
+		t.Fatalf("unexpected loaded defaults.ide: %#v", loaded.Defaults.IDE)
+	}
+	if loaded.Defaults.Model == nil || *loaded.Defaults.Model != "gpt-5.4" {
+		t.Fatalf("unexpected loaded defaults.model: %#v", loaded.Defaults.Model)
+	}
+}
+
 func TestLoadConfigRejectsUnknownFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -194,6 +194,53 @@ types = ["mobile", "api"]
 	}
 }
 
+func TestWriteConfigRoundTripsDefaultsWithoutEmptySections(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	configPath := filepath.Join(root, ".compozy", "config.toml")
+	ide := "codex"
+	modelName := "gpt-5.4"
+	accessMode := "default"
+	cfg := ProjectConfig{
+		Defaults: DefaultsConfig{
+			IDE:        &ide,
+			Model:      &modelName,
+			AccessMode: &accessMode,
+		},
+	}
+
+	if err := WriteConfig(context.Background(), configPath, cfg); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	rendered := string(content)
+	if !strings.Contains(rendered, "[defaults]") || !strings.Contains(rendered, "ide = 'codex'") {
+		t.Fatalf("expected defaults section in rendered config, got:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "[start]") || strings.Contains(rendered, "[exec]") {
+		t.Fatalf("expected empty sections to be omitted, got:\n%s", rendered)
+	}
+
+	loaded, exists, err := LoadConfigFile(context.Background(), configPath)
+	if err != nil {
+		t.Fatalf("load config file: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected written config file to exist")
+	}
+	if loaded.Defaults.IDE == nil || *loaded.Defaults.IDE != "codex" {
+		t.Fatalf("unexpected loaded defaults.ide: %#v", loaded.Defaults.IDE)
+	}
+	if loaded.Defaults.Model == nil || *loaded.Defaults.Model != "gpt-5.4" {
+		t.Fatalf("unexpected loaded defaults.model: %#v", loaded.Defaults.Model)
+	}
+}
+
 func TestLoadConfigRejectsUnknownFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -12,28 +12,28 @@ type Context struct {
 }
 
 type ProjectConfig struct {
-	Defaults     DefaultsConfig     `toml:"defaults"`
-	Start        StartConfig        `toml:"start"`
-	Tasks        TasksConfig        `toml:"tasks"`
-	FixReviews   FixReviewsConfig   `toml:"fix_reviews"`
-	FetchReviews FetchReviewsConfig `toml:"fetch_reviews"`
-	Exec         ExecConfig         `toml:"exec"`
-	Runs         RunsConfig         `toml:"runs"`
-	Sound        SoundConfig        `toml:"sound"`
+	Defaults     DefaultsConfig     `toml:"defaults,omitempty"`
+	Start        StartConfig        `toml:"start,omitempty"`
+	Tasks        TasksConfig        `toml:"tasks,omitempty"`
+	FixReviews   FixReviewsConfig   `toml:"fix_reviews,omitempty"`
+	FetchReviews FetchReviewsConfig `toml:"fetch_reviews,omitempty"`
+	Exec         ExecConfig         `toml:"exec,omitempty"`
+	Runs         RunsConfig         `toml:"runs,omitempty"`
+	Sound        SoundConfig        `toml:"sound,omitempty"`
 }
 
 type RuntimeOverrides struct {
-	IDE                    *string   `toml:"ide"`
-	Model                  *string   `toml:"model"`
-	OutputFormat           *string   `toml:"output_format"`
-	ReasoningEffort        *string   `toml:"reasoning_effort"`
-	AccessMode             *string   `toml:"access_mode"`
-	Timeout                *string   `toml:"timeout"`
-	TailLines              *int      `toml:"tail_lines"`
-	AddDirs                *[]string `toml:"add_dirs"`
-	AutoCommit             *bool     `toml:"auto_commit"`
-	MaxRetries             *int      `toml:"max_retries"`
-	RetryBackoffMultiplier *float64  `toml:"retry_backoff_multiplier"`
+	IDE                    *string   `toml:"ide,omitempty"`
+	Model                  *string   `toml:"model,omitempty"`
+	OutputFormat           *string   `toml:"output_format,omitempty"`
+	ReasoningEffort        *string   `toml:"reasoning_effort,omitempty"`
+	AccessMode             *string   `toml:"access_mode,omitempty"`
+	Timeout                *string   `toml:"timeout,omitempty"`
+	TailLines              *int      `toml:"tail_lines,omitempty"`
+	AddDirs                *[]string `toml:"add_dirs,omitempty"`
+	AutoCommit             *bool     `toml:"auto_commit,omitempty"`
+	MaxRetries             *int      `toml:"max_retries,omitempty"`
+	RetryBackoffMultiplier *float64  `toml:"retry_backoff_multiplier,omitempty"`
 }
 
 type DefaultsConfig RuntimeOverrides
@@ -46,7 +46,7 @@ type StartConfig struct {
 }
 
 type TasksConfig struct {
-	Types *[]string `toml:"types"`
+	Types *[]string `toml:"types,omitempty"`
 }
 
 type FixReviewsConfig struct {
@@ -58,15 +58,15 @@ type FixReviewsConfig struct {
 }
 
 type FetchReviewsConfig struct {
-	Provider *string `toml:"provider"`
-	Nitpicks *bool   `toml:"nitpicks"`
+	Provider *string `toml:"provider,omitempty"`
+	Nitpicks *bool   `toml:"nitpicks,omitempty"`
 }
 
 type ExecConfig struct {
 	RuntimeOverrides
-	Verbose *bool `toml:"verbose"`
-	TUI     *bool `toml:"tui"`
-	Persist *bool `toml:"persist"`
+	Verbose *bool `toml:"verbose,omitempty"`
+	TUI     *bool `toml:"tui,omitempty"`
+	Persist *bool `toml:"persist,omitempty"`
 }
 
 type RunsConfig struct {

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -35,29 +35,29 @@ type Context struct {
 }
 
 type ProjectConfig struct {
-	Defaults     DefaultsConfig      `toml:"defaults"`
-	Tasks        TasksConfig         `toml:"tasks"`
-	FixReviews   FixReviewsConfig    `toml:"fix_reviews"`
-	FetchReviews FetchReviewsConfig  `toml:"fetch_reviews"`
-	WatchReviews WatchReviewsConfig  `toml:"watch_reviews"`
-	Exec         ExecConfig          `toml:"exec"`
-	Runs         RunsConfig          `toml:"runs"`
-	Recovery     AgentRecoveryConfig `toml:"recovery"`
-	Sound        SoundConfig         `toml:"sound"`
+	Defaults     DefaultsConfig      `toml:"defaults,omitempty"`
+	Tasks        TasksConfig         `toml:"tasks,omitempty"`
+	FixReviews   FixReviewsConfig    `toml:"fix_reviews,omitempty"`
+	FetchReviews FetchReviewsConfig  `toml:"fetch_reviews,omitempty"`
+	WatchReviews WatchReviewsConfig  `toml:"watch_reviews,omitempty"`
+	Exec         ExecConfig          `toml:"exec,omitempty"`
+	Runs         RunsConfig          `toml:"runs,omitempty"`
+	Recovery     AgentRecoveryConfig `toml:"recovery,omitempty"`
+	Sound        SoundConfig         `toml:"sound,omitempty"`
 }
 
 type RuntimeOverrides struct {
-	IDE                    *string   `toml:"ide"`
-	Model                  *string   `toml:"model"`
-	OutputFormat           *string   `toml:"output_format"`
-	ReasoningEffort        *string   `toml:"reasoning_effort"`
-	AccessMode             *string   `toml:"access_mode"`
-	Timeout                *string   `toml:"timeout"`
-	TailLines              *int      `toml:"tail_lines"`
-	AddDirs                *[]string `toml:"add_dirs"`
-	AutoCommit             *bool     `toml:"auto_commit"`
-	MaxRetries             *int      `toml:"max_retries"`
-	RetryBackoffMultiplier *float64  `toml:"retry_backoff_multiplier"`
+	IDE                    *string   `toml:"ide,omitempty"`
+	Model                  *string   `toml:"model,omitempty"`
+	OutputFormat           *string   `toml:"output_format,omitempty"`
+	ReasoningEffort        *string   `toml:"reasoning_effort,omitempty"`
+	AccessMode             *string   `toml:"access_mode,omitempty"`
+	Timeout                *string   `toml:"timeout,omitempty"`
+	TailLines              *int      `toml:"tail_lines,omitempty"`
+	AddDirs                *[]string `toml:"add_dirs,omitempty"`
+	AutoCommit             *bool     `toml:"auto_commit,omitempty"`
+	MaxRetries             *int      `toml:"max_retries,omitempty"`
+	RetryBackoffMultiplier *float64  `toml:"retry_backoff_multiplier,omitempty"`
 }
 
 type DefaultsConfig RuntimeOverrides
@@ -128,8 +128,8 @@ func (cfg ParallelTasksConfig) ApplyDefaults() ParallelTasksConfig {
 }
 
 type TasksConfig struct {
-	Types *[]string     `toml:"types"`
-	Run   TaskRunConfig `toml:"run"`
+	Types *[]string     `toml:"types,omitempty"`
+	Run   TaskRunConfig `toml:"run,omitempty"`
 }
 
 type FixReviewsConfig struct {
@@ -141,8 +141,8 @@ type FixReviewsConfig struct {
 }
 
 type FetchReviewsConfig struct {
-	Provider *string `toml:"provider"`
-	Nitpicks *bool   `toml:"nitpicks"`
+	Provider *string `toml:"provider,omitempty"`
+	Nitpicks *bool   `toml:"nitpicks,omitempty"`
 }
 
 type WatchReviewsConfig struct {
@@ -158,9 +158,9 @@ type WatchReviewsConfig struct {
 
 type ExecConfig struct {
 	RuntimeOverrides
-	Verbose *bool `toml:"verbose"`
-	TUI     *bool `toml:"tui"`
-	Persist *bool `toml:"persist"`
+	Verbose *bool `toml:"verbose,omitempty"`
+	TUI     *bool `toml:"tui,omitempty"`
+	Persist *bool `toml:"persist,omitempty"`
 }
 
 type RunsConfig struct {

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -121,6 +121,7 @@ func TestCheckForUpdateQueriesWhenCacheIsStale(t *testing.T) {
 	}
 	if state == nil {
 		t.Fatal("expected persisted state after cache miss")
+		return
 	}
 	if !state.CheckedForUpdateAt.Equal(now) {
 		t.Fatalf("unexpected checked time: want %s, got %s", now, state.CheckedForUpdateAt)
@@ -250,6 +251,7 @@ func TestSelfUpdaterClientDetectLatestReturnsReleaseInfo(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected release info, got nil")
+		return
 	}
 	if got.Version != "1.2.3" {
 		t.Fatalf("unexpected version: %q", got.Version)

--- a/internal/update/state_test.go
+++ b/internal/update/state_test.go
@@ -55,6 +55,7 @@ func TestReadStateWriteStateRoundTrip(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("expected state entry, got nil")
+		return
 	}
 	if !got.CheckedForUpdateAt.Equal(want.CheckedForUpdateAt) {
 		t.Fatalf("unexpected checked time: want %s, got %s", want.CheckedForUpdateAt, got.CheckedForUpdateAt)

--- a/test/public_api_test.go
+++ b/test/public_api_test.go
@@ -49,6 +49,7 @@ complexity: low
 	}
 	if prep == nil {
 		t.Fatal("expected preparation result")
+		return
 	}
 	if len(prep.Jobs) != 1 {
 		t.Fatalf("expected 1 job, got %d", len(prep.Jobs))
@@ -68,6 +69,7 @@ func TestNewCommandUsesCompozyRootCommand(t *testing.T) {
 	cmd := compozy.NewCommand()
 	if cmd == nil {
 		t.Fatal("expected command")
+		return
 	}
 	if cmd.Use != "compozy" {
 		t.Fatalf("expected use compozy, got %q", cmd.Use)
@@ -97,6 +99,7 @@ func TestMigrateExposePublicAPI(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected migration result")
+		return
 	}
 	if result.FilesMigrated != 1 {
 		t.Fatalf("expected 1 planned migration, got %d", result.FilesMigrated)
@@ -130,6 +133,7 @@ func TestSyncExposePublicAPI(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected sync result")
+		return
 	}
 	if result.WorkflowsScanned != 1 ||
 		result.TaskItemsUpserted != 1 ||
@@ -170,6 +174,7 @@ func TestArchiveExposePublicAPI(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected archive result")
+		return
 	}
 	if result.Archived != 1 || result.Skipped != 0 {
 		t.Fatalf("unexpected archive result: %#v", result)


### PR DESCRIPTION
## Summary

Add an optional repo-level config step to `compozy setup` so interactive setup can override built-in runtime defaults and save those overrides to `.compozy/config.toml`.

## Why

Compozy already works without a repo config file because it has built-in defaults. This change makes repo-level overrides easier to set.

The README already documents workspace config and shows recommended `[defaults]` values, but setup previously stopped at skill installation. This change closes that gap by letting users change and save repo-specific defaults from the setup flow instead of editing TOML manually.

## What Changed

- added an interactive repo-level defaults step to `compozy setup`
- defaulted the override prompt to `No`
- limited the config write to workspace scope only
- skipped the prompt entirely for `compozy setup --global`
- only persist defaults after setup completes with zero failures
- restored IDE selection as a dropdown of supported runtimes
- used the runtime registry's per-IDE default model as the recommendation source
- reused the shared built-in default reasoning effort instead of a setup-local hardcoded value
- preserved existing config sections when writing the selected defaults

## Config Written

When the user opts in, setup updates:

```toml
[defaults]
ide = "..."
model = "..."
reasoning_effort = "..."
```

## Behavior Notes

- repo config is written to `.compozy/config.toml`
- users who opt out keep the normal built-in defaults with no config change
- global setup does not prompt for repo defaults and does not modify workspace config
- if the current model matches the previous recommended model, changing IDE updates the model recommendation to the new IDE default
- if the repo already has a custom model, setup preserves it

## Testing

- added coverage for registry-backed IDE default model resolution
- added coverage for preserving unrelated config sections on write
- added coverage for skipping repo-default prompts in global mode
- added coverage for not persisting config when setup installation fails

## Verification

```text
make verify
```

Passed locally.

Closes #89 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive runtime defaults during setup (choose preferred IDE, model, reasoning effort) with preview and persistence to workspace config.
  * Added default reasoning level ("medium") and a lookup for IDE-specific default models.
  * Config read/write updated to omit empty sections when saving and to explicitly handle load/write semantics.

* **Tests**
  * Added tests covering runtime-default selection, persistence, config read/write, prompting flows, and context/error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->