### PR TITLE
feat: add shared layout package for run artifact filenames

### DIFF
--- a/internal/core/model/artifacts.go
+++ b/internal/core/model/artifacts.go
@@ -3,6 +3,8 @@ package model
 import (
 	"path/filepath"
 	"strings"
+
+	"github.com/compozy/compozy/pkg/compozy/runs/layout"
 )
 
 const defaultRunID = "run"
@@ -29,11 +31,11 @@ func NewRunArtifacts(workspaceRoot, runID string) RunArtifacts {
 	return RunArtifacts{
 		RunID:       safeRunID,
 		RunDir:      runDir,
-		RunMetaPath: filepath.Join(runDir, "run.json"),
-		EventsPath:  filepath.Join(runDir, "events.jsonl"),
-		TurnsDir:    filepath.Join(runDir, "turns"),
-		JobsDir:     filepath.Join(runDir, "jobs"),
-		ResultPath:  filepath.Join(runDir, "result.json"),
+		RunMetaPath: layout.RunMetaPath(runDir),
+		EventsPath:  layout.EventsLogPath(runDir),
+		TurnsDir:    layout.TurnsDir(runDir),
+		JobsDir:     layout.JobsDir(runDir),
+		ResultPath:  layout.ResultPath(runDir),
 	}
 }
 

--- a/pkg/compozy/runs/layout/layout.go
+++ b/pkg/compozy/runs/layout/layout.go
@@ -1,0 +1,33 @@
+// Package layout exports the on-disk layout for one persisted Compozy run.
+//
+// Both the internal writer ([github.com/compozy/compozy/internal/core/model])
+// and the public reader ([github.com/compozy/compozy/pkg/compozy/runs])
+// depend on these constants so that renaming a run artifact is a single-place
+// change visible to the type checker, not an agree-by-string contract.
+package layout
+
+import "path/filepath"
+
+// File and directory names that live under one run directory.
+const (
+	RunMetaFileName   = "run.json"
+	EventsLogFileName = "events.jsonl"
+	RunResultFileName = "result.json"
+	JobsDirName       = "jobs"
+	TurnsDirName      = "turns"
+)
+
+// RunMetaPath returns the absolute path to the run metadata file inside runDir.
+func RunMetaPath(runDir string) string { return filepath.Join(runDir, RunMetaFileName) }
+
+// EventsLogPath returns the absolute path to the events log inside runDir.
+func EventsLogPath(runDir string) string { return filepath.Join(runDir, EventsLogFileName) }
+
+// ResultPath returns the absolute path to the result file inside runDir.
+func ResultPath(runDir string) string { return filepath.Join(runDir, RunResultFileName) }
+
+// JobsDir returns the absolute path to the jobs subdirectory inside runDir.
+func JobsDir(runDir string) string { return filepath.Join(runDir, JobsDirName) }
+
+// TurnsDir returns the absolute path to the turns subdirectory inside runDir.
+func TurnsDir(runDir string) string { return filepath.Join(runDir, TurnsDirName) }

--- a/pkg/compozy/runs/layout/layout.go
+++ b/pkg/compozy/runs/layout/layout.go
@@ -10,11 +10,20 @@ import "path/filepath"
 
 // File and directory names that live under one run directory.
 const (
-	RunMetaFileName   = "run.json"
+	// RunMetaFileName is the basename of the per-run metadata file written by
+	// the journal and read by the public reader.
+	RunMetaFileName = "run.json"
+	// EventsLogFileName is the basename of the append-only event log inside
+	// the run directory.
 	EventsLogFileName = "events.jsonl"
+	// RunResultFileName is the basename of the terminal run result document.
 	RunResultFileName = "result.json"
-	JobsDirName       = "jobs"
-	TurnsDirName      = "turns"
+	// JobsDirName is the basename of the subdirectory that holds per-job
+	// artifacts (prompt, stdout, stderr).
+	JobsDirName = "jobs"
+	// TurnsDirName is the basename of the subdirectory that holds per-turn
+	// transcript artifacts.
+	TurnsDirName = "turns"
 )
 
 // RunMetaPath returns the absolute path to the run metadata file inside runDir.

--- a/pkg/compozy/runs/layout/layout_test.go
+++ b/pkg/compozy/runs/layout/layout_test.go
@@ -1,0 +1,57 @@
+package layout
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestConstantsAreStable guards against silent renames. Changing any of these
+// strings is a breaking change to the public pkg/compozy/runs API and to the
+// internal writer in internal/core/model; if a constant must change, update
+// this test deliberately and call out the rename in the PR description.
+func TestConstantsAreStable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"RunMetaFileName", RunMetaFileName, "run.json"},
+		{"EventsLogFileName", EventsLogFileName, "events.jsonl"},
+		{"RunResultFileName", RunResultFileName, "result.json"},
+		{"JobsDirName", JobsDirName, "jobs"},
+		{"TurnsDirName", TurnsDirName, "turns"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHelpersJoinUnderRunDir(t *testing.T) {
+	t.Parallel()
+	runDir := filepath.Join("ws", ".compozy", "runs", "run-1")
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"RunMetaPath", RunMetaPath(runDir), filepath.Join(runDir, RunMetaFileName)},
+		{"EventsLogPath", EventsLogPath(runDir), filepath.Join(runDir, EventsLogFileName)},
+		{"ResultPath", ResultPath(runDir), filepath.Join(runDir, RunResultFileName)},
+		{"JobsDir", JobsDir(runDir), filepath.Join(runDir, JobsDirName)},
+		{"TurnsDir", TurnsDir(runDir), filepath.Join(runDir, TurnsDirName)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.got != tc.want {
+				t.Errorf("%s = %q, want %q", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/compozy/runs/run.go
+++ b/pkg/compozy/runs/run.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/compozy/compozy/pkg/compozy/runs/layout"
 )
 
 var (
@@ -151,11 +153,11 @@ func defaultRunPaths(workspaceRoot, runID string) runPaths {
 	runDir := filepath.Join(runsDirForWorkspace(workspaceRoot), runID)
 	return runPaths{
 		runDir:      runDir,
-		runMetaPath: filepath.Join(runDir, "run.json"),
-		eventsPath:  filepath.Join(runDir, "events.jsonl"),
-		resultPath:  filepath.Join(runDir, "result.json"),
-		jobsDir:     filepath.Join(runDir, "jobs"),
-		turnsDir:    filepath.Join(runDir, "turns"),
+		runMetaPath: layout.RunMetaPath(runDir),
+		eventsPath:  layout.EventsLogPath(runDir),
+		resultPath:  layout.ResultPath(runDir),
+		jobsDir:     layout.JobsDir(runDir),
+		turnsDir:    layout.TurnsDir(runDir),
 	}
 }
 

--- a/pkg/compozy/runs/summary.go
+++ b/pkg/compozy/runs/summary.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/compozy/compozy/pkg/compozy/runs/layout"
 )
 
 // RunSummary is the public metadata view for one persisted run.
@@ -54,7 +56,7 @@ func List(workspaceRoot string, opts ListOptions) ([]RunSummary, error) {
 		}
 
 		runID := entry.Name()
-		runMetaPath := filepath.Join(runsDir, runID, "run.json")
+		runMetaPath := layout.RunMetaPath(filepath.Join(runsDir, runID))
 		run, err := loadRun(cleanRoot, runID)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {

--- a/pkg/compozy/runs/watch.go
+++ b/pkg/compozy/runs/watch.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/compozy/compozy/pkg/compozy/runs/layout"
 )
 
 // RunEventKind identifies the type of workspace run event.
@@ -578,7 +580,7 @@ func classifyWorkspacePath(runsDir, target string) (string, workspacePathKind) {
 	switch {
 	case len(parts) == 1 && parts[0] != "":
 		return parts[0], workspacePathRunDir
-	case len(parts) == 2 && parts[0] != "" && parts[1] == "run.json":
+	case len(parts) == 2 && parts[0] != "" && parts[1] == layout.RunMetaFileName:
 		return parts[0], workspacePathRunMeta
 	default:
 		return "", workspacePathUnknown

--- a/test/public_api_test.go
+++ b/test/public_api_test.go
@@ -237,8 +237,11 @@ func TestRunsLayoutAgreesAcrossWriterAndReader(t *testing.T) {
 		{"turns dir", artifacts.TurnsDir, layout.TurnsDir(artifacts.RunDir)},
 	}
 	for _, tc := range cases {
-		if tc.writer != tc.reader {
-			t.Errorf("%s: writer=%q reader=%q (writer/reader disagree on layout)", tc.name, tc.writer, tc.reader)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.writer != tc.reader {
+				t.Errorf("writer=%q reader=%q (writer/reader disagree on layout)", tc.writer, tc.reader)
+			}
+		})
 	}
 }

--- a/test/public_api_test.go
+++ b/test/public_api_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/compozy/compozy"
+	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/pkg/compozy/runs"
+	"github.com/compozy/compozy/pkg/compozy/runs/layout"
 )
 
 func TestPrepareAndRunExposePublicAPI(t *testing.T) {
@@ -188,5 +191,54 @@ func TestArchiveExposePublicAPI(t *testing.T) {
 	}
 	if _, err := os.Stat(result.ArchivedPaths[0]); err != nil {
 		t.Fatalf("expected archived path to exist: %v", err)
+	}
+}
+
+// TestRunsLayoutAgreesAcrossWriterAndReader proves that the canonical writer
+// (model.NewRunArtifacts) and the public reader (runs.Open) agree on the
+// on-disk layout via the shared pkg/compozy/runs/layout constants. If anyone
+// changes a literal on only one side, this test fails before the change is
+// merged.
+func TestRunsLayoutAgreesAcrossWriterAndReader(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	const runID = "agree-test"
+
+	artifacts := model.NewRunArtifacts(workspaceRoot, runID)
+	if err := os.MkdirAll(artifacts.RunDir, 0o755); err != nil {
+		t.Fatalf("mkdir run dir: %v", err)
+	}
+
+	meta := []byte(
+		`{"version":1,"run_id":"agree-test","status":"completed","mode":"exec","created_at":"2026-04-13T12:00:00Z","updated_at":"2026-04-13T12:00:00Z"}`,
+	)
+	if err := os.WriteFile(artifacts.RunMetaPath, meta, 0o600); err != nil {
+		t.Fatalf("write run meta: %v", err)
+	}
+
+	run, err := runs.Open(workspaceRoot, runID)
+	if err != nil {
+		t.Fatalf("runs.Open after model.NewRunArtifacts: %v", err)
+	}
+	if got := run.Summary().RunID; got != runID {
+		t.Fatalf("Summary.RunID = %q, want %q", got, runID)
+	}
+
+	cases := []struct {
+		name   string
+		writer string
+		reader string
+	}{
+		{"run meta", artifacts.RunMetaPath, layout.RunMetaPath(artifacts.RunDir)},
+		{"events log", artifacts.EventsPath, layout.EventsLogPath(artifacts.RunDir)},
+		{"result", artifacts.ResultPath, layout.ResultPath(artifacts.RunDir)},
+		{"jobs dir", artifacts.JobsDir, layout.JobsDir(artifacts.RunDir)},
+		{"turns dir", artifacts.TurnsDir, layout.TurnsDir(artifacts.RunDir)},
+	}
+	for _, tc := range cases {
+		if tc.writer != tc.reader {
+			t.Errorf("%s: writer=%q reader=%q (writer/reader disagree on layout)", tc.name, tc.writer, tc.reader)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Both the public Go reader (`pkg/compozy/runs`) and the internal writer (`internal/core/model.NewRunArtifacts`) hardcode the same five run artifact filenames as private string literals (`run.json`, `events.jsonl`, `result.json`, `jobs/`, `turns/`), agreeing only by convention with no compile-time link. Renaming a file on one side would silently break `runs.Open()` at runtime without any test or build failure.

This change introduces `pkg/compozy/runs/layout` owning the constants and a small set of `RunMetaPath(runDir)`-style helpers, then routes both the writer (`internal/core/model/artifacts.go`) and the reader (`pkg/compozy/runs/{run,summary,watch}.go`) through it.

The dependency direction `internal/core/model -> pkg/compozy/runs/layout` follows the existing precedent set by `internal/core/model/{preparation,run_scope}.go` importing `pkg/compozy/events`.

## Why this matters to SDK users

I noticed this while reading both sides of the `pkg/compozy/runs` boundary. The reader is documented as the public Go API for replay/list/watch flows, but if anyone renames a file in `model/artifacts.go` the public reader silently returns "no such file or directory" at runtime — there is no type-system signal. After this change a layout rename is a one-place edit that's visible to the type checker, and the new end-to-end test fails if writer and reader paths drift.

## What changed

- New `pkg/compozy/runs/layout` package: 5 constants (`RunMetaFileName`, `EventsLogFileName`, `RunResultFileName`, `JobsDirName`, `TurnsDirName`) and 5 helpers (`RunMetaPath`, `EventsLogPath`, `ResultPath`, `JobsDir`, `TurnsDir`).
- `internal/core/model/artifacts.go::NewRunArtifacts` now uses `layout.*` instead of literals.
- `pkg/compozy/runs/{run,summary,watch}.go` now use `layout.*` instead of literals.
- `test/public_api_test.go`: new `TestRunsLayoutAgreesAcrossWriterAndReader` writes a run via the writer constructor and reads it back via `runs.Open`, asserting every writer path matches the reader's expected path.
- `pkg/compozy/runs/layout/layout_test.go`: snapshot guard that catches any constant rename in PR diffs.

162 insertions, 12 deletions across 7 files.

## Out of scope (follow-ups)

- The `.compozy` and `runs` directory names are still split between `model.WorkflowRootDirName` / `WorkflowRunsDirName` and inline literals in `pkg/compozy/runs/{summary,watch}.go::runsDirForWorkspace` and the inline `compozyDir` build. Migrating those would touch ~30 files across the repo and is best as a separate PR.
- Pre-existing string literals inside `pkg/compozy/runs/*_test.go` and `internal/core/run/journal/journal_test.go` still use the literals. Migrating tests is noise that does not change the production guarantee.

## Test plan

- [x] `make verify` (fmt + lint + test + build) passes locally — 1857 tests green
- [x] `TestRunsLayoutAgreesAcrossWriterAndReader` in `test/public_api_test.go` — writes via `model.NewRunArtifacts`, reads via `runs.Open`, asserts the 5 paths match
- [x] `TestConstantsAreStable` in `pkg/compozy/runs/layout` — snapshot guard for the 5 constants
- [x] `TestHelpersJoinUnderRunDir` in `pkg/compozy/runs/layout` — verifies the helper joins
- [x] `go test -race` clean across `pkg/compozy/runs/...`, `internal/core/model/...`, and `test/...`
- [x] Production grep confirms no `"run.json"` / `"events.jsonl"` / `"result.json"` literals remain in non-test files under `pkg/compozy/runs/` and `internal/core/model/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated path definitions for run artifacts into a centralized layout module, eliminating hardcoded path construction across the codebase and improving maintainability.

* **Tests**
  * Added test coverage to ensure consistency of artifact path generation across different run operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->