### PR TITLE
feat: add optional sound notifications on run lifecycle events

### DIFF
--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -43,6 +43,9 @@ type runtimeConfig struct {
 	explicitRuntime  model.ExplicitRuntimeFlags
 	includeCompleted bool
 	includeResolved  bool
+	soundEnabled     bool
+	soundOnCompleted string
+	soundOnFailed    string
 }
 
 type execConfig struct {
@@ -317,6 +320,10 @@ func (s *commandState) buildConfig() (core.Config, error) {
 		Timeout:                timeoutDuration,
 		MaxRetries:             s.maxRetries,
 		RetryBackoffMultiplier: s.retryBackoffMultiplier,
+
+		SoundEnabled:     s.soundEnabled,
+		SoundOnCompleted: s.soundOnCompleted,
+		SoundOnFailed:    s.soundOnFailed,
 	}, nil
 }
 

--- a/internal/cli/workspace_config.go
+++ b/internal/cli/workspace_config.go
@@ -97,6 +97,7 @@ func commandPath(cmd *cobra.Command) string {
 }
 
 func (s *commandState) applyProjectConfig(cmd *cobra.Command, cfg workspace.ProjectConfig) {
+	applySoundConfig(s, cfg.Sound)
 	applyConfig(cmd, "ide", cfg.Defaults.IDE, func(val string) { s.ide = val })
 	applyConfig(cmd, "model", cfg.Defaults.Model, func(val string) { s.model = val })
 	applyConfig(cmd, "format", cfg.Defaults.OutputFormat, func(val string) { s.outputFormat = val })
@@ -162,6 +163,21 @@ func (s *commandState) applyProjectConfig(cmd *cobra.Command, cfg workspace.Proj
 			cfg.Exec.RetryBackoffMultiplier,
 			func(val float64) { s.retryBackoffMultiplier = val },
 		)
+	}
+}
+
+// applySoundConfig copies the project-level [sound] TOML section onto the command
+// state. Sound has no CLI flags today, so this bypasses the flag-aware applyConfig
+// helper and writes straight to the state fields.
+func applySoundConfig(s *commandState, cfg workspace.SoundConfig) {
+	if cfg.Enabled != nil {
+		s.soundEnabled = *cfg.Enabled
+	}
+	if cfg.OnCompleted != nil {
+		s.soundOnCompleted = *cfg.OnCompleted
+	}
+	if cfg.OnFailed != nil {
+		s.soundOnFailed = *cfg.OnFailed
 	}
 }
 

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -129,6 +129,9 @@ type Config struct {
 	Timeout                    time.Duration
 	MaxRetries                 int
 	RetryBackoffMultiplier     float64
+	SoundEnabled               bool
+	SoundOnCompleted           string
+	SoundOnFailed              string
 }
 
 // Job is a prepared execution unit with its generated artifacts.
@@ -365,6 +368,9 @@ func (cfg Config) RuntimeConfig() *model.RuntimeConfig {
 		Timeout:                    cfg.Timeout,
 		MaxRetries:                 cfg.MaxRetries,
 		RetryBackoffMultiplier:     cfg.RetryBackoffMultiplier,
+		SoundEnabled:               cfg.SoundEnabled,
+		SoundOnCompleted:           cfg.SoundOnCompleted,
+		SoundOnFailed:              cfg.SoundOnFailed,
 	}
 	runtimeCfg.ApplyDefaults()
 	return runtimeCfg

--- a/internal/core/model/model_test.go
+++ b/internal/core/model/model_test.go
@@ -45,6 +45,77 @@ func TestRuntimeConfigApplyDefaults(t *testing.T) {
 		if cfg.RetryBackoffMultiplier != 1.5 {
 			t.Fatalf("unexpected retry multiplier default: %f", cfg.RetryBackoffMultiplier)
 		}
+		if cfg.SoundOnCompleted != "" || cfg.SoundOnFailed != "" {
+			t.Fatalf(
+				"expected sound presets to stay empty when sound is disabled: got %q / %q",
+				cfg.SoundOnCompleted,
+				cfg.SoundOnFailed,
+			)
+		}
+	})
+
+	t.Run("Should fill sound presets only when sound is enabled", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &model.RuntimeConfig{SoundEnabled: true}
+		cfg.ApplyDefaults()
+		if cfg.SoundOnCompleted != model.DefaultSoundOnCompleted {
+			t.Fatalf("unexpected on_completed default: %q", cfg.SoundOnCompleted)
+		}
+		if cfg.SoundOnFailed != model.DefaultSoundOnFailed {
+			t.Fatalf("unexpected on_failed default: %q", cfg.SoundOnFailed)
+		}
+	})
+
+	t.Run("Should preserve explicit sound presets over defaults", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &model.RuntimeConfig{
+			SoundEnabled:     true,
+			SoundOnCompleted: "/custom/done.aiff",
+			SoundOnFailed:    "/custom/fail.aiff",
+		}
+		cfg.ApplyDefaults()
+		if cfg.SoundOnCompleted != "/custom/done.aiff" {
+			t.Fatalf("explicit on_completed was overwritten: %q", cfg.SoundOnCompleted)
+		}
+		if cfg.SoundOnFailed != "/custom/fail.aiff" {
+			t.Fatalf("explicit on_failed was overwritten: %q", cfg.SoundOnFailed)
+		}
+	})
+
+	t.Run("Should treat whitespace-only sound presets as unset and apply defaults", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &model.RuntimeConfig{
+			SoundEnabled:     true,
+			SoundOnCompleted: "   ",
+			SoundOnFailed:    "\t\n",
+		}
+		cfg.ApplyDefaults()
+		if cfg.SoundOnCompleted != model.DefaultSoundOnCompleted {
+			t.Fatalf("whitespace on_completed was not replaced with default: %q", cfg.SoundOnCompleted)
+		}
+		if cfg.SoundOnFailed != model.DefaultSoundOnFailed {
+			t.Fatalf("whitespace on_failed was not replaced with default: %q", cfg.SoundOnFailed)
+		}
+	})
+
+	t.Run("Should trim surrounding whitespace from explicit sound presets", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &model.RuntimeConfig{
+			SoundEnabled:     true,
+			SoundOnCompleted: "  /custom/done.aiff  ",
+			SoundOnFailed:    "\tbasso\n",
+		}
+		cfg.ApplyDefaults()
+		if cfg.SoundOnCompleted != "/custom/done.aiff" {
+			t.Fatalf("explicit on_completed was not trimmed: %q", cfg.SoundOnCompleted)
+		}
+		if cfg.SoundOnFailed != "basso" {
+			t.Fatalf("explicit on_failed was not trimmed: %q", cfg.SoundOnFailed)
+		}
 	})
 }
 

--- a/internal/core/model/runtime_config.go
+++ b/internal/core/model/runtime_config.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // ExplicitRuntimeFlags tracks which runtime fields were explicitly overridden
 // by the current caller, using CLI-compatible `Flags().Changed(...)` semantics.
@@ -49,6 +52,9 @@ type RuntimeConfig struct {
 	Timeout                    time.Duration
 	MaxRetries                 int
 	RetryBackoffMultiplier     float64
+	SoundEnabled               bool
+	SoundOnCompleted           string
+	SoundOnFailed              string
 }
 
 func (cfg *RuntimeConfig) ApplyDefaults() {
@@ -82,4 +88,22 @@ func (cfg *RuntimeConfig) ApplyDefaults() {
 	if cfg.RetryBackoffMultiplier <= 0 {
 		cfg.RetryBackoffMultiplier = 1.5
 	}
+	if cfg.SoundEnabled {
+		cfg.SoundOnCompleted = strings.TrimSpace(cfg.SoundOnCompleted)
+		if cfg.SoundOnCompleted == "" {
+			cfg.SoundOnCompleted = DefaultSoundOnCompleted
+		}
+		cfg.SoundOnFailed = strings.TrimSpace(cfg.SoundOnFailed)
+		if cfg.SoundOnFailed == "" {
+			cfg.SoundOnFailed = DefaultSoundOnFailed
+		}
+	}
 }
+
+// DefaultSoundOnCompleted is the preset played on run.completed when sound is
+// enabled and the user has not set an explicit preset or path.
+const DefaultSoundOnCompleted = "glass"
+
+// DefaultSoundOnFailed is the preset played on run.failed / run.cancelled when
+// sound is enabled and the user has not set an explicit preset or path.
+const DefaultSoundOnFailed = "basso"

--- a/internal/core/run/exec/exec.go
+++ b/internal/core/run/exec/exec.go
@@ -12,10 +12,13 @@ import (
 	"sync"
 	"time"
 
+	"log/slog"
+
 	"github.com/compozy/compozy/internal/core/agent"
 	reusableagents "github.com/compozy/compozy/internal/core/agents"
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/core/run/journal"
+	"github.com/compozy/compozy/internal/core/sound"
 	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
 	"github.com/compozy/compozy/pkg/compozy/events/kinds"
 )
@@ -103,6 +106,7 @@ type execTurnPaths struct {
 
 type execRunState struct {
 	ctx            context.Context
+	cfg            *model.RuntimeConfig
 	record         PersistedExecRun
 	runArtifacts   model.RunArtifacts
 	runtimeManager model.RuntimeManager
@@ -509,6 +513,7 @@ func prepareExecRunState(ctx context.Context, cfg *model.RuntimeConfig, scope mo
 	}
 	state := &execRunState{
 		ctx:      ctx,
+		cfg:      cfg,
 		emitText: cfg.OutputFormat == model.OutputFormatText && !cfg.TUI,
 	}
 	if scope != nil {
@@ -939,18 +944,38 @@ func (s *execRunState) emit(event execEvent) error {
 }
 
 func (s *execRunState) submitRuntimeEvent(kind eventspkg.EventKind, payload any) error {
-	if s == nil || s.journal == nil {
+	if s == nil {
 		return nil
 	}
 	ctx := s.ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	event, err := newRuntimeEvent(s.runArtifacts.RunID, kind, payload)
-	if err != nil {
-		return err
+	if s.journal != nil {
+		event, err := newRuntimeEvent(s.runArtifacts.RunID, kind, payload)
+		if err != nil {
+			return err
+		}
+		if err := s.journal.Submit(ctx, event); err != nil {
+			return err
+		}
 	}
-	return s.journal.Submit(ctx, event)
+	s.notifySoundForKind(ctx, kind)
+	return nil
+}
+
+// notifySoundForKind plays the configured sound for a terminal lifecycle
+// event kind. It runs synchronously so the audio finishes before the exec
+// run state is closed. When the [sound] feature flag is off this is a no-op.
+func (s *execRunState) notifySoundForKind(ctx context.Context, kind eventspkg.EventKind) {
+	if s == nil || s.cfg == nil || !s.cfg.SoundEnabled {
+		return
+	}
+	sound.Notify(ctx, sound.Config{
+		Player:      sound.New(),
+		OnCompleted: s.cfg.SoundOnCompleted,
+		OnFailed:    s.cfg.SoundOnFailed,
+	}, kind, slog.Default())
 }
 
 func stateJournal(state *execRunState) *journal.Journal {

--- a/internal/core/run/executor/execution.go
+++ b/internal/core/run/executor/execution.go
@@ -14,6 +14,7 @@ import (
 	"github.com/compozy/compozy/internal/core/agent"
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/core/run/journal"
+	"github.com/compozy/compozy/internal/core/sound"
 	"github.com/compozy/compozy/pkg/compozy/events"
 	"github.com/compozy/compozy/pkg/compozy/events/kinds"
 )
@@ -188,6 +189,12 @@ func finalizeExecution(
 	if err := emitRunTerminalEvent(ctx, runJournal, result, internalJobs, startedAt); err != nil {
 		return err
 	}
+	notifySoundForKind(
+		ctx,
+		internalCfg,
+		terminalEventKindFor(result.Status),
+		runtimeLoggerFor(internalCfg, internalCfg.UIEnabled()),
+	)
 	model.DispatchObserverHook(
 		ctx,
 		internalCfg.RuntimeManager,
@@ -266,6 +273,34 @@ func newJobExecutionContext(
 	}
 	execCtx.ui = setupUI(ctx, execCtx.jobs, cfg, bus, cfg.UIEnabled())
 	return execCtx, nil
+}
+
+// notifySoundForKind plays the configured sound for a terminal lifecycle
+// event kind. It runs synchronously so the audio finishes before run
+// cleanup tears state down. When the [sound] feature flag is off this
+// is a no-op.
+func notifySoundForKind(ctx context.Context, cfg *config, kind events.EventKind, logger *slog.Logger) {
+	if cfg == nil || !cfg.SoundEnabled {
+		return
+	}
+	sound.Notify(ctx, sound.Config{
+		Player:      sound.New(),
+		OnCompleted: cfg.SoundOnCompleted,
+		OnFailed:    cfg.SoundOnFailed,
+	}, kind, logger)
+}
+
+// terminalEventKindFor maps an executor result status to the lifecycle event
+// kind that finalizeExecution emits. Mirrors the switch in emitRunTerminalEvent.
+func terminalEventKindFor(status string) events.EventKind {
+	switch status {
+	case runStatusSucceeded:
+		return events.EventKindRunCompleted
+	case runStatusCanceled:
+		return events.EventKindRunCancelled
+	default:
+		return events.EventKindRunFailed
+	}
 }
 
 func (j *jobExecutionContext) cleanup() {

--- a/internal/core/run/internal/runshared/config.go
+++ b/internal/core/run/internal/runshared/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	Timeout                time.Duration
 	MaxRetries             int
 	RetryBackoffMultiplier float64
+	SoundEnabled           bool
+	SoundOnCompleted       string
+	SoundOnFailed          string
 }
 
 type Job struct {
@@ -128,6 +131,9 @@ func NewConfig(src *model.RuntimeConfig, runArtifacts model.RunArtifacts) *Confi
 		Timeout:                src.Timeout,
 		MaxRetries:             src.MaxRetries,
 		RetryBackoffMultiplier: src.RetryBackoffMultiplier,
+		SoundEnabled:           src.SoundEnabled,
+		SoundOnCompleted:       src.SoundOnCompleted,
+		SoundOnFailed:          src.SoundOnFailed,
 	}
 }
 

--- a/internal/core/sound/player.go
+++ b/internal/core/sound/player.go
@@ -58,10 +58,7 @@ func (p *osPlayer) Play(ctx context.Context, sound string) error {
 	if err != nil {
 		return err
 	}
-	if err := p.runner.Run(ctx, name, args...); err != nil {
-		return err
-	}
-	return nil
+	return p.runner.Run(ctx, name, args...)
 }
 
 // New returns the default Player for the current platform. Callers that

--- a/internal/core/sound/player.go
+++ b/internal/core/sound/player.go
@@ -1,0 +1,71 @@
+// Package sound provides optional audio notifications for run-lifecycle events.
+//
+// Playback is opt-in via the [sound] section in .compozy/config.toml and is
+// disabled by default. A Noop player is used whenever the feature flag is off
+// or the platform is not supported, so callers never need to special-case
+// "sound is turned off".
+package sound
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// ErrUnsupported indicates the running platform cannot play sounds.
+var ErrUnsupported = errors.New("sound: unsupported platform")
+
+// ErrEmptySound indicates the caller passed an empty sound identifier.
+var ErrEmptySound = errors.New("sound: empty sound name")
+
+// Player plays a named preset or a filesystem path. Implementations must be
+// safe to call from any goroutine and must honor context cancellation.
+type Player interface {
+	Play(ctx context.Context, sound string) error
+}
+
+// Noop is the zero-cost player used when sound is disabled or unsupported.
+type Noop struct{}
+
+// Play satisfies Player and always returns nil.
+func (Noop) Play(context.Context, string) error { return nil }
+
+var _ Player = Noop{}
+
+// commandRunner is the injection seam that lets tests replace the real
+// os/exec call with a recorder. The default implementation shells out via
+// exec.CommandContext.
+type commandRunner interface {
+	Run(ctx context.Context, name string, args ...string) error
+}
+
+// osPlayer plays sounds by shelling out to a platform-native command
+// (afplay on darwin, paplay on linux, powershell on windows).
+type osPlayer struct {
+	runner  commandRunner
+	resolve func(sound string) (name string, args []string, err error)
+}
+
+// Play runs the platform-native sound command. An empty sound name is a
+// user error and returns ErrEmptySound; platform errors are wrapped with
+// context so the subscriber can log the failing preset.
+func (p *osPlayer) Play(ctx context.Context, sound string) error {
+	trimmed := strings.TrimSpace(sound)
+	if trimmed == "" {
+		return ErrEmptySound
+	}
+	name, args, err := p.resolve(trimmed)
+	if err != nil {
+		return err
+	}
+	if err := p.runner.Run(ctx, name, args...); err != nil {
+		return err
+	}
+	return nil
+}
+
+// New returns the default Player for the current platform. Callers that
+// want to skip playback entirely should use Noop{} directly.
+func New() Player {
+	return newOSPlayer()
+}

--- a/internal/core/sound/player_test.go
+++ b/internal/core/sound/player_test.go
@@ -1,0 +1,121 @@
+package sound
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+// recordingRunner captures every Run invocation without shelling out.
+type recordingRunner struct {
+	mu    sync.Mutex
+	calls []runCall
+	err   error
+}
+
+type runCall struct {
+	name string
+	args []string
+}
+
+func (r *recordingRunner) Run(_ context.Context, name string, args ...string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, runCall{name: name, args: append([]string(nil), args...)})
+	return r.err
+}
+
+func (r *recordingRunner) snapshot() []runCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]runCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func TestNoop_Play_AlwaysNil(t *testing.T) {
+	t.Parallel()
+	if err := (Noop{}).Play(context.Background(), ""); err != nil {
+		t.Fatalf("expected nil error from Noop, got %v", err)
+	}
+	if err := (Noop{}).Play(context.Background(), "glass"); err != nil {
+		t.Fatalf("expected nil error from Noop with preset, got %v", err)
+	}
+}
+
+func TestOSPlayer_Play_EmptySound(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{}
+	player := &osPlayer{
+		runner:  runner,
+		resolve: func(string) (string, []string, error) { return "afplay", nil, nil },
+	}
+	if err := player.Play(context.Background(), "  "); !errors.Is(err, ErrEmptySound) {
+		t.Fatalf("expected ErrEmptySound, got %v", err)
+	}
+	if len(runner.snapshot()) != 0 {
+		t.Fatalf("runner should not have been called on empty input")
+	}
+}
+
+func TestOSPlayer_Play_ResolverError(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{}
+	boom := errors.New("boom")
+	player := &osPlayer{
+		runner:  runner,
+		resolve: func(string) (string, []string, error) { return "", nil, boom },
+	}
+	err := player.Play(context.Background(), "anything")
+	if !errors.Is(err, boom) {
+		t.Fatalf("expected resolver error to propagate, got %v", err)
+	}
+	if len(runner.snapshot()) != 0 {
+		t.Fatal("runner should not have been called when resolver fails")
+	}
+}
+
+func TestOSPlayer_Play_RunnerInvokedWithResolvedCommand(t *testing.T) {
+	t.Parallel()
+	runner := &recordingRunner{}
+	player := &osPlayer{
+		runner: runner,
+		resolve: func(sound string) (string, []string, error) {
+			return "afplay", []string{"/tmp/" + sound + ".aiff"}, nil
+		},
+	}
+	if err := player.Play(context.Background(), "glass"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	calls := runner.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly one runner call, got %d", len(calls))
+	}
+	if calls[0].name != "afplay" {
+		t.Fatalf("unexpected command: %q", calls[0].name)
+	}
+	if len(calls[0].args) != 1 || calls[0].args[0] != "/tmp/glass.aiff" {
+		t.Fatalf("unexpected args: %#v", calls[0].args)
+	}
+}
+
+func TestOSPlayer_Play_RunnerErrorPropagates(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("afplay exited 1")
+	runner := &recordingRunner{err: boom}
+	player := &osPlayer{
+		runner:  runner,
+		resolve: func(string) (string, []string, error) { return "afplay", []string{"/x"}, nil },
+	}
+	if err := player.Play(context.Background(), "glass"); !errors.Is(err, boom) {
+		t.Fatalf("expected runner error to propagate, got %v", err)
+	}
+}
+
+func TestNew_ReturnsNonNilPlayer(t *testing.T) {
+	t.Parallel()
+	if New() == nil {
+		t.Fatal("New() returned nil")
+	}
+}

--- a/internal/core/sound/player_test.go
+++ b/internal/core/sound/player_test.go
@@ -3,6 +3,8 @@ package sound
 import (
 	"context"
 	"errors"
+	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 )
@@ -36,11 +38,22 @@ func (r *recordingRunner) snapshot() []runCall {
 
 func TestNoop_Play_AlwaysNil(t *testing.T) {
 	t.Parallel()
-	if err := (Noop{}).Play(context.Background(), ""); err != nil {
-		t.Fatalf("expected nil error from Noop, got %v", err)
+	cases := []struct {
+		name  string
+		sound string
+	}{
+		{name: "Should return nil for empty sound", sound: ""},
+		{name: "Should return nil for preset name", sound: "glass"},
+		{name: "Should return nil for absolute path", sound: "/tmp/custom.aiff"},
+		{name: "Should return nil for whitespace-only input", sound: "   "},
 	}
-	if err := (Noop{}).Play(context.Background(), "glass"); err != nil {
-		t.Fatalf("expected nil error from Noop with preset, got %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := (Noop{}).Play(context.Background(), tc.sound); err != nil {
+				t.Fatalf("expected nil from Noop, got %v", err)
+			}
+		})
 	}
 }
 
@@ -113,9 +126,40 @@ func TestOSPlayer_Play_RunnerErrorPropagates(t *testing.T) {
 	}
 }
 
-func TestNew_ReturnsNonNilPlayer(t *testing.T) {
+func TestNew_WiresPlatformPlayer(t *testing.T) {
 	t.Parallel()
-	if New() == nil {
+	// New() is a thin constructor but it IS load-bearing: it must return a
+	// player whose resolver matches the host platform so real runs get the
+	// right command. On supported unix variants we assert the resolver picks
+	// afplay/paplay for the glass preset. On anything else we only assert
+	// that it returns Noop (the documented fallback).
+	player := New()
+	if player == nil {
 		t.Fatal("New() returned nil")
+	}
+
+	switch runtime.GOOS {
+	case goosDarwin, goosLinux:
+		osp, ok := player.(*osPlayer)
+		if !ok {
+			t.Fatalf("expected *osPlayer on %s, got %T", runtime.GOOS, player)
+		}
+		name, args, err := osp.resolve(PresetGlass)
+		if err != nil {
+			t.Fatalf("resolver failed for glass preset: %v", err)
+		}
+		if runtime.GOOS == goosDarwin && name != cmdAfplay {
+			t.Errorf("darwin should use %q, got %q", cmdAfplay, name)
+		}
+		if runtime.GOOS == goosLinux && name != cmdPaplay {
+			t.Errorf("linux should use %q, got %q", cmdPaplay, name)
+		}
+		if len(args) != 1 || !filepath.IsAbs(args[0]) {
+			t.Errorf("resolver should yield a single absolute-path arg, got %#v", args)
+		}
+	default:
+		if _, ok := player.(Noop); !ok {
+			t.Fatalf("expected Noop fallback on %s, got %T", runtime.GOOS, player)
+		}
 	}
 }

--- a/internal/core/sound/player_unix.go
+++ b/internal/core/sound/player_unix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+package sound
+
+import "runtime"
+
+// newOSPlayer returns the unix-family player. It uses afplay on darwin and
+// paplay on linux. Other unix variants fall back to the Noop player because
+// they have no universally available command-line sound tool.
+func newOSPlayer() Player {
+	switch runtime.GOOS {
+	case goosDarwin, goosLinux:
+		return &osPlayer{runner: execRunner{}, resolve: resolveUnixCommand}
+	default:
+		return Noop{}
+	}
+}
+
+// resolveUnixCommand maps a preset name or absolute path to the
+// platform-native playback command. The caller guarantees a non-empty input.
+func resolveUnixCommand(sound string) (string, []string, error) {
+	path, err := ResolvePath(sound)
+	if err != nil {
+		return "", nil, err
+	}
+	switch runtime.GOOS {
+	case goosDarwin:
+		return cmdAfplay, []string{path}, nil
+	case goosLinux:
+		return cmdPaplay, []string{path}, nil
+	default:
+		return "", nil, ErrUnsupported
+	}
+}

--- a/internal/core/sound/player_windows.go
+++ b/internal/core/sound/player_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package sound
+
+import "fmt"
+
+// newOSPlayer returns the windows player, which shells out to powershell and
+// uses System.Media.SoundPlayer to play the resolved file synchronously.
+func newOSPlayer() Player {
+	return &osPlayer{runner: execRunner{}, resolve: resolveWindowsCommand}
+}
+
+// resolveWindowsCommand maps a preset or absolute path to a powershell
+// invocation. The caller guarantees a non-empty input.
+func resolveWindowsCommand(sound string) (string, []string, error) {
+	path, err := ResolvePath(sound)
+	if err != nil {
+		return "", nil, err
+	}
+	script := fmt.Sprintf("(New-Object Media.SoundPlayer '%s').PlaySync()", escapePSSingleQuoted(path))
+	return "powershell", []string{"-NoProfile", "-Command", script}, nil
+}

--- a/internal/core/sound/presets.go
+++ b/internal/core/sound/presets.go
@@ -1,0 +1,136 @@
+package sound
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// preset names accepted in config.toml. Absolute paths bypass preset lookup.
+const (
+	PresetGlass  = "glass"
+	PresetBasso  = "basso"
+	PresetPing   = "ping"
+	PresetHero   = "hero"
+	PresetFunk   = "funk"
+	PresetTink   = "tink"
+	PresetSubmar = "submarine"
+)
+
+// GOOS string constants used across the package. Centralized so the goconst
+// linter does not flag duplicate string literals and so a typo in one place
+// is a compile error rather than a silent runtime miss.
+const (
+	goosDarwin  = "darwin"
+	goosLinux   = "linux"
+	goosWindows = "windows"
+)
+
+// Platform sound commands. Same rationale as the GOOS constants above.
+const (
+	cmdAfplay = "afplay"
+	cmdPaplay = "paplay"
+)
+
+// KnownPresets lists every preset name the resolver understands. The list is
+// exposed so the CLI / docs can surface valid values without re-declaring them.
+func KnownPresets() []string {
+	return []string{
+		PresetGlass,
+		PresetBasso,
+		PresetPing,
+		PresetHero,
+		PresetFunk,
+		PresetTink,
+		PresetSubmar,
+	}
+}
+
+// ResolvePath maps a preset name or filesystem path to a concrete file that
+// the platform player can consume. Absolute paths are returned verbatim.
+// Unknown presets produce a descriptive error so users see typos early.
+func ResolvePath(sound string) (string, error) {
+	trimmed := strings.TrimSpace(sound)
+	if trimmed == "" {
+		return "", ErrEmptySound
+	}
+	if filepath.IsAbs(trimmed) {
+		return trimmed, nil
+	}
+	key := strings.ToLower(trimmed)
+	path, ok := presetPathForOS(key, runtime.GOOS)
+	if !ok {
+		return "", fmt.Errorf(
+			"sound: unknown preset %q (known: %s) — pass an absolute path to use a custom file",
+			trimmed,
+			strings.Join(KnownPresets(), ", "),
+		)
+	}
+	return path, nil
+}
+
+// presetPathForOS is split out so tests can exercise every OS branch from any
+// host. It returns (path, true) on a known preset for the given GOOS and
+// ("", false) otherwise.
+func presetPathForOS(preset, goos string) (string, bool) {
+	switch goos {
+	case goosDarwin:
+		path, ok := darwinPresets[preset]
+		return path, ok
+	case goosLinux:
+		path, ok := linuxPresets[preset]
+		return path, ok
+	case goosWindows:
+		path, ok := windowsPresets[preset]
+		return path, ok
+	default:
+		return "", false
+	}
+}
+
+var darwinPresets = map[string]string{
+	PresetGlass:  "/System/Library/Sounds/Glass.aiff",
+	PresetBasso:  "/System/Library/Sounds/Basso.aiff",
+	PresetPing:   "/System/Library/Sounds/Ping.aiff",
+	PresetHero:   "/System/Library/Sounds/Hero.aiff",
+	PresetFunk:   "/System/Library/Sounds/Funk.aiff",
+	PresetTink:   "/System/Library/Sounds/Tink.aiff",
+	PresetSubmar: "/System/Library/Sounds/Submarine.aiff",
+}
+
+// linuxPresets map to freedesktop sound names commonly shipped by
+// sound-theme-freedesktop. Distros that omit them will surface the missing
+// file as a Play error, which the subscriber logs at debug level.
+var linuxPresets = map[string]string{
+	PresetGlass:  "/usr/share/sounds/freedesktop/stereo/complete.oga",
+	PresetBasso:  "/usr/share/sounds/freedesktop/stereo/dialog-error.oga",
+	PresetPing:   "/usr/share/sounds/freedesktop/stereo/message.oga",
+	PresetHero:   "/usr/share/sounds/freedesktop/stereo/complete.oga",
+	PresetFunk:   "/usr/share/sounds/freedesktop/stereo/bell.oga",
+	PresetTink:   "/usr/share/sounds/freedesktop/stereo/message.oga",
+	PresetSubmar: "/usr/share/sounds/freedesktop/stereo/bell.oga",
+}
+
+// Windows ships a small set of .wav files under %WINDIR%\Media. Users who
+// want richer sounds can still pass an absolute path.
+var windowsPresets = map[string]string{
+	PresetGlass:  `C:\Windows\Media\tada.wav`,
+	PresetBasso:  `C:\Windows\Media\chord.wav`,
+	PresetPing:   `C:\Windows\Media\ding.wav`,
+	PresetHero:   `C:\Windows\Media\tada.wav`,
+	PresetFunk:   `C:\Windows\Media\notify.wav`,
+	PresetTink:   `C:\Windows\Media\chimes.wav`,
+	PresetSubmar: `C:\Windows\Media\Ring01.wav`,
+}
+
+// escapePSSingleQuoted escapes a string for use inside a PowerShell
+// single-quoted literal. In PowerShell, single-quoted strings take every
+// character verbatim except the single quote itself, which is escaped by
+// doubling it (”). NTFS filenames can contain apostrophes — e.g.
+// C:\Users\O'Neil\alert.wav — so without this escape the generated command
+// would be a syntax error. Defined here (no build tag) so it can be
+// unit-tested on any host platform.
+func escapePSSingleQuoted(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}

--- a/internal/core/sound/presets.go
+++ b/internal/core/sound/presets.go
@@ -2,6 +2,7 @@ package sound
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -9,13 +10,13 @@ import (
 
 // preset names accepted in config.toml. Absolute paths bypass preset lookup.
 const (
-	PresetGlass  = "glass"
-	PresetBasso  = "basso"
-	PresetPing   = "ping"
-	PresetHero   = "hero"
-	PresetFunk   = "funk"
-	PresetTink   = "tink"
-	PresetSubmar = "submarine"
+	PresetGlass     = "glass"
+	PresetBasso     = "basso"
+	PresetPing      = "ping"
+	PresetHero      = "hero"
+	PresetFunk      = "funk"
+	PresetTink      = "tink"
+	PresetSubmarine = "submarine"
 )
 
 // GOOS string constants used across the package. Centralized so the goconst
@@ -43,7 +44,7 @@ func KnownPresets() []string {
 		PresetHero,
 		PresetFunk,
 		PresetTink,
-		PresetSubmar,
+		PresetSubmarine,
 	}
 }
 
@@ -72,7 +73,9 @@ func ResolvePath(sound string) (string, error) {
 
 // presetPathForOS is split out so tests can exercise every OS branch from any
 // host. It returns (path, true) on a known preset for the given GOOS and
-// ("", false) otherwise.
+// ("", false) otherwise. Windows lookups are resolved at call time so they
+// honor a caller-provided WINDIR (falling back to C:\Windows) rather than
+// a hardcoded install path.
 func presetPathForOS(preset, goos string) (string, bool) {
 	switch goos {
 	case goosDarwin:
@@ -82,46 +85,67 @@ func presetPathForOS(preset, goos string) (string, bool) {
 		path, ok := linuxPresets[preset]
 		return path, ok
 	case goosWindows:
-		path, ok := windowsPresets[preset]
-		return path, ok
+		return windowsPresetPath(preset, os.Getenv("WINDIR"))
 	default:
 		return "", false
 	}
 }
 
+// windowsPresetPath resolves a preset name to an absolute Windows path by
+// joining the Media directory of the active Windows install. It accepts
+// windir explicitly so tests can exercise both the set and fallback branches
+// without touching process environment state. Backslashes are used directly
+// instead of filepath.Join because non-windows test hosts would otherwise
+// emit forward-slash separators for a path the OS will never see.
+func windowsPresetPath(preset, windir string) (string, bool) {
+	file, ok := windowsPresetFiles[preset]
+	if !ok {
+		return "", false
+	}
+	root := strings.TrimRight(strings.TrimSpace(windir), `\`)
+	if root == "" {
+		root = defaultWindowsDir
+	}
+	return root + `\Media\` + file, true
+}
+
+const defaultWindowsDir = `C:\Windows`
+
 var darwinPresets = map[string]string{
-	PresetGlass:  "/System/Library/Sounds/Glass.aiff",
-	PresetBasso:  "/System/Library/Sounds/Basso.aiff",
-	PresetPing:   "/System/Library/Sounds/Ping.aiff",
-	PresetHero:   "/System/Library/Sounds/Hero.aiff",
-	PresetFunk:   "/System/Library/Sounds/Funk.aiff",
-	PresetTink:   "/System/Library/Sounds/Tink.aiff",
-	PresetSubmar: "/System/Library/Sounds/Submarine.aiff",
+	PresetGlass:     "/System/Library/Sounds/Glass.aiff",
+	PresetBasso:     "/System/Library/Sounds/Basso.aiff",
+	PresetPing:      "/System/Library/Sounds/Ping.aiff",
+	PresetHero:      "/System/Library/Sounds/Hero.aiff",
+	PresetFunk:      "/System/Library/Sounds/Funk.aiff",
+	PresetTink:      "/System/Library/Sounds/Tink.aiff",
+	PresetSubmarine: "/System/Library/Sounds/Submarine.aiff",
 }
 
 // linuxPresets map to freedesktop sound names commonly shipped by
 // sound-theme-freedesktop. Distros that omit them will surface the missing
 // file as a Play error, which the subscriber logs at debug level.
 var linuxPresets = map[string]string{
-	PresetGlass:  "/usr/share/sounds/freedesktop/stereo/complete.oga",
-	PresetBasso:  "/usr/share/sounds/freedesktop/stereo/dialog-error.oga",
-	PresetPing:   "/usr/share/sounds/freedesktop/stereo/message.oga",
-	PresetHero:   "/usr/share/sounds/freedesktop/stereo/complete.oga",
-	PresetFunk:   "/usr/share/sounds/freedesktop/stereo/bell.oga",
-	PresetTink:   "/usr/share/sounds/freedesktop/stereo/message.oga",
-	PresetSubmar: "/usr/share/sounds/freedesktop/stereo/bell.oga",
+	PresetGlass:     "/usr/share/sounds/freedesktop/stereo/complete.oga",
+	PresetBasso:     "/usr/share/sounds/freedesktop/stereo/dialog-error.oga",
+	PresetPing:      "/usr/share/sounds/freedesktop/stereo/message.oga",
+	PresetHero:      "/usr/share/sounds/freedesktop/stereo/complete.oga",
+	PresetFunk:      "/usr/share/sounds/freedesktop/stereo/bell.oga",
+	PresetTink:      "/usr/share/sounds/freedesktop/stereo/message.oga",
+	PresetSubmarine: "/usr/share/sounds/freedesktop/stereo/bell.oga",
 }
 
-// Windows ships a small set of .wav files under %WINDIR%\Media. Users who
-// want richer sounds can still pass an absolute path.
-var windowsPresets = map[string]string{
-	PresetGlass:  `C:\Windows\Media\tada.wav`,
-	PresetBasso:  `C:\Windows\Media\chord.wav`,
-	PresetPing:   `C:\Windows\Media\ding.wav`,
-	PresetHero:   `C:\Windows\Media\tada.wav`,
-	PresetFunk:   `C:\Windows\Media\notify.wav`,
-	PresetTink:   `C:\Windows\Media\chimes.wav`,
-	PresetSubmar: `C:\Windows\Media\Ring01.wav`,
+// windowsPresetFiles maps each preset to the basename of its .wav under the
+// active Windows install's Media directory. The full path is built at lookup
+// time using %WINDIR% so non-standard installs (D:\Windows etc.) resolve
+// correctly. Users who want richer sounds can still pass an absolute path.
+var windowsPresetFiles = map[string]string{
+	PresetGlass:     "tada.wav",
+	PresetBasso:     "chord.wav",
+	PresetPing:      "ding.wav",
+	PresetHero:      "tada.wav",
+	PresetFunk:      "notify.wav",
+	PresetTink:      "chimes.wav",
+	PresetSubmarine: "Ring01.wav",
 }
 
 // escapePSSingleQuoted escapes a string for use inside a PowerShell

--- a/internal/core/sound/presets_test.go
+++ b/internal/core/sound/presets_test.go
@@ -1,0 +1,226 @@
+package sound
+
+import (
+	"errors"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestResolvePath(t *testing.T) {
+	t.Parallel()
+
+	// Use t.TempDir() + filepath.Join() so the fixture is portable across
+	// platforms — per CONTRIBUTING.md "Use t.TempDir() for filesystem isolation".
+	absPath := filepath.Join(t.TempDir(), "custom.aiff")
+	cases := []struct {
+		name    string
+		input   string
+		wantAbs string
+	}{
+		{
+			name:    "absolute path is returned verbatim",
+			input:   absPath,
+			wantAbs: absPath,
+		},
+		{
+			name:    "trims surrounding whitespace on absolute path",
+			input:   "  " + absPath + "  ",
+			wantAbs: absPath,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ResolvePath(tc.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantAbs {
+				t.Fatalf("unexpected path: got %q, want %q", got, tc.wantAbs)
+			}
+		})
+	}
+}
+
+func TestResolvePath_EmptyInputReturnsErrEmptySound(t *testing.T) {
+	t.Parallel()
+	cases := []string{"", "   ", "\t\n"}
+	for _, input := range cases {
+		input := input
+		t.Run("input "+input, func(t *testing.T) {
+			t.Parallel()
+			_, err := ResolvePath(input)
+			if !errors.Is(err, ErrEmptySound) {
+				t.Fatalf("expected ErrEmptySound, got %v", err)
+			}
+		})
+	}
+}
+
+func TestResolvePath_UnknownPresetErrorMessage(t *testing.T) {
+	t.Parallel()
+	const unknown = "nonsense-preset-xyz"
+
+	_, err := ResolvePath(unknown)
+	if err == nil {
+		t.Fatal("expected error for unknown preset")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, unknown) {
+		t.Errorf("error message should surface the unknown input %q, got: %q", unknown, msg)
+	}
+	// The error should list the known presets so users can spot typos against
+	// the canonical list. Assert a couple of known presets are named.
+	for _, expected := range []string{PresetGlass, PresetBasso} {
+		if !strings.Contains(msg, expected) {
+			t.Errorf("error message should list known preset %q, got: %q", expected, msg)
+		}
+	}
+	if !strings.Contains(msg, "absolute path") {
+		t.Errorf("error message should hint at absolute-path escape hatch, got: %q", msg)
+	}
+}
+
+func TestResolvePath_KnownPresetForCurrentOS(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" && runtime.GOOS != "windows" {
+		t.Skipf("no preset table for %s", runtime.GOOS)
+	}
+
+	got, err := ResolvePath(PresetGlass)
+	if err != nil {
+		t.Fatalf("unexpected error resolving glass preset on %s: %v", runtime.GOOS, err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty path for glass preset")
+	}
+}
+
+func TestPresetPathForOS(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		preset   string
+		goos     string
+		wantOK   bool
+		wantPath string
+	}{
+		{
+			name:     "darwin glass resolves to System Sounds",
+			preset:   PresetGlass,
+			goos:     "darwin",
+			wantOK:   true,
+			wantPath: "/System/Library/Sounds/Glass.aiff",
+		},
+		{
+			name:     "linux basso resolves to freedesktop error",
+			preset:   PresetBasso,
+			goos:     "linux",
+			wantOK:   true,
+			wantPath: "/usr/share/sounds/freedesktop/stereo/dialog-error.oga",
+		},
+		{
+			name:   "windows ping resolves under C:\\Windows\\Media",
+			preset: PresetPing,
+			goos:   "windows",
+			wantOK: true,
+		},
+		{
+			name:   "unknown preset returns false",
+			preset: "not-a-preset",
+			goos:   "darwin",
+			wantOK: false,
+		},
+		{
+			name:   "unsupported goos returns false",
+			preset: PresetGlass,
+			goos:   "plan9",
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := presetPathForOS(tc.preset, tc.goos)
+			if ok != tc.wantOK {
+				t.Fatalf("ok mismatch: got %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if tc.wantPath != "" && got != tc.wantPath {
+				t.Fatalf("unexpected path: got %q, want %q", got, tc.wantPath)
+			}
+			if tc.wantPath == "" && !strings.Contains(strings.ToLower(got), "windows") {
+				t.Fatalf("expected windows-style path, got %q", got)
+			}
+		})
+	}
+}
+
+func TestKnownPresets_ContainsDefaults(t *testing.T) {
+	t.Parallel()
+
+	presets := KnownPresets()
+	if len(presets) == 0 {
+		t.Fatal("expected at least one preset")
+	}
+	seen := make(map[string]struct{}, len(presets))
+	for _, p := range presets {
+		seen[p] = struct{}{}
+	}
+	for _, required := range []string{PresetGlass, PresetBasso} {
+		if _, ok := seen[required]; !ok {
+			t.Fatalf("KnownPresets missing required default %q", required)
+		}
+	}
+}
+
+func TestEscapePSSingleQuoted(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no apostrophes is a no-op",
+			in:   `C:\Windows\Media\tada.wav`,
+			want: `C:\Windows\Media\tada.wav`,
+		},
+		{
+			name: "single apostrophe is doubled",
+			in:   `C:\Users\O'Neil\alert.wav`,
+			want: `C:\Users\O''Neil\alert.wav`,
+		},
+		{
+			name: "multiple apostrophes are all doubled",
+			in:   `C:\a'b'c'.wav`,
+			want: `C:\a''b''c''.wav`,
+		},
+		{
+			name: "empty string is unchanged",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := escapePSSingleQuoted(tc.in)
+			if got != tc.want {
+				t.Fatalf("escapePSSingleQuoted(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/core/sound/presets_test.go
+++ b/internal/core/sound/presets_test.go
@@ -32,7 +32,6 @@ func TestResolvePath(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ResolvePath(tc.input)
@@ -113,33 +112,27 @@ func TestPresetPathForOS(t *testing.T) {
 		wantPath string
 	}{
 		{
-			name:     "darwin glass resolves to System Sounds",
+			name:     "Should resolve darwin glass preset to System Sounds",
 			preset:   PresetGlass,
 			goos:     "darwin",
 			wantOK:   true,
 			wantPath: "/System/Library/Sounds/Glass.aiff",
 		},
 		{
-			name:     "linux basso resolves to freedesktop error",
+			name:     "Should resolve linux basso preset to freedesktop error sound",
 			preset:   PresetBasso,
 			goos:     "linux",
 			wantOK:   true,
 			wantPath: "/usr/share/sounds/freedesktop/stereo/dialog-error.oga",
 		},
 		{
-			name:   "windows ping resolves under C:\\Windows\\Media",
-			preset: PresetPing,
-			goos:   "windows",
-			wantOK: true,
-		},
-		{
-			name:   "unknown preset returns false",
+			name:   "Should return false for unknown preset",
 			preset: "not-a-preset",
 			goos:   "darwin",
 			wantOK: false,
 		},
 		{
-			name:   "unsupported goos returns false",
+			name:   "Should return false for unsupported goos",
 			preset: PresetGlass,
 			goos:   "plan9",
 			wantOK: false,
@@ -147,7 +140,6 @@ func TestPresetPathForOS(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got, ok := presetPathForOS(tc.preset, tc.goos)
@@ -157,11 +149,71 @@ func TestPresetPathForOS(t *testing.T) {
 			if !tc.wantOK {
 				return
 			}
-			if tc.wantPath != "" && got != tc.wantPath {
+			if got != tc.wantPath {
 				t.Fatalf("unexpected path: got %q, want %q", got, tc.wantPath)
 			}
-			if tc.wantPath == "" && !strings.Contains(strings.ToLower(got), "windows") {
-				t.Fatalf("expected windows-style path, got %q", got)
+		})
+	}
+}
+
+func TestWindowsPresetPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		preset  string
+		windir  string
+		wantOK  bool
+		wantOut string
+	}{
+		{
+			name:    "Should resolve glass under the provided WINDIR",
+			preset:  PresetGlass,
+			windir:  `D:\WinRoot`,
+			wantOK:  true,
+			wantOut: `D:\WinRoot\Media\tada.wav`,
+		},
+		{
+			name:    "Should trim trailing backslash from WINDIR",
+			preset:  PresetPing,
+			windir:  `D:\WinRoot\`,
+			wantOK:  true,
+			wantOut: `D:\WinRoot\Media\ding.wav`,
+		},
+		{
+			name:    "Should fall back to C:\\Windows when WINDIR is empty",
+			preset:  PresetBasso,
+			windir:  "",
+			wantOK:  true,
+			wantOut: `C:\Windows\Media\chord.wav`,
+		},
+		{
+			name:    "Should fall back to C:\\Windows when WINDIR is whitespace",
+			preset:  PresetSubmarine,
+			windir:  "   ",
+			wantOK:  true,
+			wantOut: `C:\Windows\Media\Ring01.wav`,
+		},
+		{
+			name:   "Should return false for unknown preset",
+			preset: "mystery",
+			windir: `C:\Windows`,
+			wantOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := windowsPresetPath(tc.preset, tc.windir)
+			if ok != tc.wantOK {
+				t.Fatalf("ok mismatch: got %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				return
+			}
+			if got != tc.wantOut {
+				t.Fatalf("unexpected path: got %q, want %q", got, tc.wantOut)
 			}
 		})
 	}
@@ -214,7 +266,6 @@ func TestEscapePSSingleQuoted(t *testing.T) {
 		},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := escapePSSingleQuoted(tc.in)

--- a/internal/core/sound/runner.go
+++ b/internal/core/sound/runner.go
@@ -1,0 +1,24 @@
+package sound
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// execRunner is the production commandRunner. It runs the requested binary
+// with the given arguments and discards stdout/stderr — sound commands never
+// emit output we care about.
+type execRunner struct{}
+
+// Run executes the command and returns any error from the underlying process.
+func (execRunner) Run(ctx context.Context, name string, args ...string) error {
+	if name == "" {
+		return fmt.Errorf("sound: empty command name")
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sound: %s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/core/sound/subscriber.go
+++ b/internal/core/sound/subscriber.go
@@ -1,0 +1,93 @@
+package sound
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/compozy/compozy/pkg/compozy/events"
+)
+
+// playbackTimeout bounds how long a single Notify call can block on the
+// underlying player. Three seconds is comfortably above the ~500ms that
+// macOS system sounds take while still preventing a hung player from
+// delaying run shutdown indefinitely.
+const playbackTimeout = 3 * time.Second
+
+// Config binds a Player to per-event-kind preset names. Both presets and
+// absolute filesystem paths are accepted; an empty string for a given kind
+// disables playback for that kind.
+type Config struct {
+	Player      Player
+	OnCompleted string
+	OnFailed    string
+}
+
+// Notify plays the configured sound for the given lifecycle event kind and
+// blocks until the underlying player returns. Notify is the only API the run
+// pipelines use: it runs on the caller's goroutine so the sound is guaranteed
+// to finish before run cleanup tears down state.
+//
+// The parent context is detached via context.WithoutCancel before playback
+// starts. This is deliberate: on run.failed and run.cancelled the caller
+// passes a ctx that is already done, and a canceled exec.CommandContext
+// would immediately kill afplay/paplay so the failure sound would never be
+// audible. A bounded playbackTimeout prevents a hung player from delaying
+// run shutdown indefinitely.
+//
+// Unrecognized kinds and empty preset configurations are silent no-ops.
+// Playback errors are logged at debug and never bubble back to the caller — a
+// missing system sound must not break a successful run.
+func Notify(
+	ctx context.Context,
+	cfg Config,
+	kind events.EventKind,
+	logger *slog.Logger,
+) {
+	if cfg.Player == nil {
+		return
+	}
+	name := pickSound(kind, cfg)
+	if name == "" {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	playCtx, cancel := playbackContext(ctx)
+	defer cancel()
+	if err := cfg.Player.Play(playCtx, name); err != nil {
+		logger.DebugContext(
+			playCtx,
+			"sound playback failed",
+			slog.String("kind", string(kind)),
+			slog.String("sound", name),
+			slog.String("err", err.Error()),
+		)
+	}
+}
+
+// playbackContext returns a bounded, uncancelable derivative of the caller's
+// context so terminal events (which often arrive with ctx already done) can
+// still reach the audio command. The returned context preserves values from
+// the parent for logging/tracing but is isolated from parent cancellation.
+func playbackContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	detached := context.WithoutCancel(parent)
+	return context.WithTimeout(detached, playbackTimeout)
+}
+
+// pickSound returns the configured sound name for a lifecycle event kind, or
+// an empty string when the kind should be silent.
+func pickSound(kind events.EventKind, cfg Config) string {
+	switch kind {
+	case events.EventKindRunCompleted:
+		return cfg.OnCompleted
+	case events.EventKindRunFailed, events.EventKindRunCancelled:
+		return cfg.OnFailed
+	default:
+		return ""
+	}
+}

--- a/internal/core/sound/subscriber_test.go
+++ b/internal/core/sound/subscriber_test.go
@@ -1,0 +1,246 @@
+package sound
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/compozy/compozy/pkg/compozy/events"
+)
+
+// fakePlayer records every Play call along with whether the context it
+// received was already canceled. It is only used from a single goroutine in
+// these tests, but the mutex keeps it safe in case future tests parallelize.
+type fakePlayer struct {
+	mu              sync.Mutex
+	played          []string
+	observedCtxErrs []error
+	err             error
+}
+
+func (f *fakePlayer) Play(ctx context.Context, sound string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.played = append(f.played, sound)
+	f.observedCtxErrs = append(f.observedCtxErrs, ctx.Err())
+	return f.err
+}
+
+func (f *fakePlayer) snapshot() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.played))
+	copy(out, f.played)
+	return out
+}
+
+func (f *fakePlayer) observedCtxErr(i int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if i < 0 || i >= len(f.observedCtxErrs) {
+		return nil
+	}
+	return f.observedCtxErrs[i]
+}
+
+func TestPickSound(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{OnCompleted: "glass", OnFailed: "basso"}
+	cases := []struct {
+		name string
+		kind events.EventKind
+		want string
+	}{
+		{"completed plays success sound", events.EventKindRunCompleted, "glass"},
+		{"failed plays failure sound", events.EventKindRunFailed, "basso"},
+		{"canceled plays failure sound", events.EventKindRunCancelled, "basso"},
+		{"started is silent", events.EventKindRunStarted, ""},
+		{"queued is silent", events.EventKindRunQueued, ""},
+		{"unrelated kind is silent", events.EventKindToolCallStarted, ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pickSound(tc.kind, cfg)
+			if got != tc.want {
+				t.Fatalf("pickSound(%q) = %q, want %q", tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPickSound_EmptyConfigsAreSilent(t *testing.T) {
+	t.Parallel()
+	cfg := Config{}
+	if got := pickSound(events.EventKindRunCompleted, cfg); got != "" {
+		t.Fatalf("expected silence when OnCompleted is empty, got %q", got)
+	}
+	if got := pickSound(events.EventKindRunFailed, cfg); got != "" {
+		t.Fatalf("expected silence when OnFailed is empty, got %q", got)
+	}
+}
+
+func TestNotify_PlaysSoundForEachKind(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		kind events.EventKind
+		want string
+	}{
+		{"completed", events.EventKindRunCompleted, "glass"},
+		{"failed", events.EventKindRunFailed, "basso"},
+		{"canceled", events.EventKindRunCancelled, "basso"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			player := &fakePlayer{}
+			Notify(
+				context.Background(),
+				Config{Player: player, OnCompleted: "glass", OnFailed: "basso"},
+				tc.kind,
+				nil,
+			)
+			got := player.snapshot()
+			if len(got) != 1 || got[0] != tc.want {
+				t.Fatalf("expected %q to be played, got %#v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestNotify_SilentForNonTerminalKinds(t *testing.T) {
+	t.Parallel()
+	player := &fakePlayer{}
+	for _, kind := range []events.EventKind{
+		events.EventKindRunStarted,
+		events.EventKindRunQueued,
+		events.EventKindToolCallStarted,
+	} {
+		Notify(
+			context.Background(),
+			Config{Player: player, OnCompleted: "glass", OnFailed: "basso"},
+			kind,
+			nil,
+		)
+	}
+	if len(player.snapshot()) != 0 {
+		t.Fatalf("expected silence for non-terminal kinds, got %#v", player.snapshot())
+	}
+}
+
+func TestNotify_NilPlayerIsNoOp(t *testing.T) {
+	t.Parallel()
+	Notify(context.Background(), Config{OnCompleted: "glass"}, events.EventKindRunCompleted, nil)
+}
+
+func TestNotify_EmptyPresetForKindIsNoOp(t *testing.T) {
+	t.Parallel()
+	player := &fakePlayer{}
+	Notify(
+		context.Background(),
+		Config{Player: player, OnFailed: "basso"},
+		events.EventKindRunCompleted,
+		nil,
+	)
+	if len(player.snapshot()) != 0 {
+		t.Fatalf("expected no plays when OnCompleted is empty, got %#v", player.snapshot())
+	}
+}
+
+func TestNotify_PlaybackErrorIsLoggedNotPanicked(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	player := &fakePlayer{err: errors.New("afplay exited 1")}
+
+	Notify(
+		context.Background(),
+		Config{Player: player, OnCompleted: "glass", OnFailed: "basso"},
+		events.EventKindRunCompleted,
+		logger,
+	)
+
+	logged := buf.String()
+	if !strings.Contains(logged, "sound playback failed") {
+		t.Fatalf("expected debug log to mention failure, got: %q", logged)
+	}
+	if !strings.Contains(logged, "glass") {
+		t.Fatalf("expected debug log to include sound name, got: %q", logged)
+	}
+}
+
+func TestNotify_NilContextIsTolerated(t *testing.T) {
+	t.Parallel()
+	player := &fakePlayer{}
+	// The compozy convention is to never pass nil context, but Notify must
+	// not panic if a caller forgets — it falls back to context.Background.
+	Notify(
+		nil, //nolint:staticcheck // intentional nil to verify graceful handling
+		Config{Player: player, OnCompleted: "glass"},
+		events.EventKindRunCompleted,
+		nil,
+	)
+	got := player.snapshot()
+	if len(got) != 1 || got[0] != "glass" {
+		t.Fatalf("expected glass to be played even with nil ctx, got %#v", got)
+	}
+}
+
+func TestNotify_PlaysOnAlreadyCancelledParentContext(t *testing.T) {
+	t.Parallel()
+	// Regression: on run.cancelled / run.failed the caller passes a ctx
+	// that is already done. Before the WithoutCancel fix, exec.CommandContext
+	// would kill afplay instantly and the failure sound would never be
+	// audible. Notify must detach from the parent context so the player
+	// receives an unset ctx.Err().
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+	if parent.Err() == nil {
+		t.Fatal("precondition: parent ctx should be canceled")
+	}
+
+	player := &fakePlayer{}
+	Notify(
+		parent,
+		Config{Player: player, OnCompleted: "glass", OnFailed: "basso"},
+		events.EventKindRunFailed,
+		nil,
+	)
+
+	got := player.snapshot()
+	if len(got) != 1 || got[0] != "basso" {
+		t.Fatalf("expected basso to be played once, got %#v", got)
+	}
+	if err := player.observedCtxErr(0); err != nil {
+		t.Fatalf("expected playback ctx to be detached (Err()=nil), got %v", err)
+	}
+}
+
+func TestPlaybackContext_EnforcesTimeoutAndDetaches(t *testing.T) {
+	t.Parallel()
+	parent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	playCtx, release := playbackContext(parent)
+	defer release()
+
+	if err := playCtx.Err(); err != nil {
+		t.Fatalf("playback ctx must be detached from canceled parent, got %v", err)
+	}
+	deadline, ok := playCtx.Deadline()
+	if !ok {
+		t.Fatal("playback ctx must have a bounded deadline")
+	}
+	if time.Until(deadline) > playbackTimeout || time.Until(deadline) <= 0 {
+		t.Fatalf("deadline %v is outside expected window (0, %v]", time.Until(deadline), playbackTimeout)
+	}
+}

--- a/internal/core/sound/subscriber_test.go
+++ b/internal/core/sound/subscriber_test.go
@@ -65,7 +65,6 @@ func TestPickSound(t *testing.T) {
 		{"unrelated kind is silent", events.EventKindToolCallStarted, ""},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := pickSound(tc.kind, cfg)
@@ -99,7 +98,6 @@ func TestNotify_PlaysSoundForEachKind(t *testing.T) {
 		{"canceled", events.EventKindRunCancelled, "basso"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			player := &fakePlayer{}

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -646,6 +646,69 @@ func TestLoadConfigReturnsContextErrorWhenCanceled(t *testing.T) {
 	}
 }
 
+func TestLoadConfigParsesSoundSection(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, `
+[sound]
+enabled = true
+on_completed = "glass"
+on_failed = "basso"
+`)
+
+	cfg, _, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Sound.Enabled == nil || !*cfg.Sound.Enabled {
+		t.Fatalf("unexpected sound.enabled: %#v", cfg.Sound.Enabled)
+	}
+	if cfg.Sound.OnCompleted == nil || *cfg.Sound.OnCompleted != "glass" {
+		t.Fatalf("unexpected sound.on_completed: %#v", cfg.Sound.OnCompleted)
+	}
+	if cfg.Sound.OnFailed == nil || *cfg.Sound.OnFailed != "basso" {
+		t.Fatalf("unexpected sound.on_failed: %#v", cfg.Sound.OnFailed)
+	}
+}
+
+func TestLoadConfigLeavesSoundDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, ``)
+
+	cfg, _, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Sound.Enabled != nil {
+		t.Fatalf("expected sound.enabled to be nil when unset, got %#v", cfg.Sound.Enabled)
+	}
+	if cfg.Sound.OnCompleted != nil || cfg.Sound.OnFailed != nil {
+		t.Fatalf("expected sound presets to be nil when unset, got %#v / %#v",
+			cfg.Sound.OnCompleted, cfg.Sound.OnFailed)
+	}
+}
+
+func TestLoadConfigRejectsEmptySoundPreset(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, `
+[sound]
+on_completed = "   "
+`)
+
+	_, _, err := LoadConfig(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected error for empty sound.on_completed")
+	}
+	if !strings.Contains(err.Error(), "sound.on_completed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func writeWorkspaceConfig(t *testing.T, workspaceRoot, content string) {
 	t.Helper()
 

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -646,66 +646,102 @@ func TestLoadConfigReturnsContextErrorWhenCanceled(t *testing.T) {
 	}
 }
 
-func TestLoadConfigParsesSoundSection(t *testing.T) {
+func TestLoadConfigSoundSection(t *testing.T) {
 	t.Parallel()
 
-	root := t.TempDir()
-	writeWorkspaceConfig(t, root, `
+	cases := []struct {
+		name          string
+		content       string
+		wantErr       string
+		wantEnabled   *bool
+		wantCompleted *string
+		wantFailed    *string
+	}{
+		{
+			name: "Should parse a fully populated [sound] section",
+			content: `
 [sound]
 enabled = true
 on_completed = "glass"
 on_failed = "basso"
-`)
-
-	cfg, _, err := LoadConfig(context.Background(), root)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
-	}
-	if cfg.Sound.Enabled == nil || !*cfg.Sound.Enabled {
-		t.Fatalf("unexpected sound.enabled: %#v", cfg.Sound.Enabled)
-	}
-	if cfg.Sound.OnCompleted == nil || *cfg.Sound.OnCompleted != "glass" {
-		t.Fatalf("unexpected sound.on_completed: %#v", cfg.Sound.OnCompleted)
-	}
-	if cfg.Sound.OnFailed == nil || *cfg.Sound.OnFailed != "basso" {
-		t.Fatalf("unexpected sound.on_failed: %#v", cfg.Sound.OnFailed)
-	}
-}
-
-func TestLoadConfigLeavesSoundDisabledByDefault(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	writeWorkspaceConfig(t, root, ``)
-
-	cfg, _, err := LoadConfig(context.Background(), root)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
-	}
-	if cfg.Sound.Enabled != nil {
-		t.Fatalf("expected sound.enabled to be nil when unset, got %#v", cfg.Sound.Enabled)
-	}
-	if cfg.Sound.OnCompleted != nil || cfg.Sound.OnFailed != nil {
-		t.Fatalf("expected sound presets to be nil when unset, got %#v / %#v",
-			cfg.Sound.OnCompleted, cfg.Sound.OnFailed)
-	}
-}
-
-func TestLoadConfigRejectsEmptySoundPreset(t *testing.T) {
-	t.Parallel()
-
-	root := t.TempDir()
-	writeWorkspaceConfig(t, root, `
+`,
+			wantEnabled:   ptrBool(true),
+			wantCompleted: ptrString("glass"),
+			wantFailed:    ptrString("basso"),
+		},
+		{
+			name:    "Should leave [sound] fields nil when the section is absent",
+			content: ``,
+		},
+		{
+			name: "Should reject whitespace-only sound.on_completed",
+			content: `
 [sound]
 on_completed = "   "
-`)
-
-	_, _, err := LoadConfig(context.Background(), root)
-	if err == nil {
-		t.Fatal("expected error for empty sound.on_completed")
+`,
+			wantErr: "sound.on_completed",
+		},
+		{
+			name: "Should reject whitespace-only sound.on_failed",
+			content: `
+[sound]
+on_failed = "\t"
+`,
+			wantErr: "sound.on_failed",
+		},
 	}
-	if !strings.Contains(err.Error(), "sound.on_completed") {
-		t.Fatalf("unexpected error: %v", err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			writeWorkspaceConfig(t, root, tc.content)
+
+			cfg, _, err := LoadConfig(context.Background(), root)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("unexpected error: got %q, want substring %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+			assertOptionalBool(t, "sound.enabled", cfg.Sound.Enabled, tc.wantEnabled)
+			assertOptionalString(t, "sound.on_completed", cfg.Sound.OnCompleted, tc.wantCompleted)
+			assertOptionalString(t, "sound.on_failed", cfg.Sound.OnFailed, tc.wantFailed)
+		})
+	}
+}
+
+func ptrBool(b bool) *bool       { return &b }
+func ptrString(s string) *string { return &s }
+
+func assertOptionalBool(t *testing.T, field string, got *bool, want *bool) {
+	t.Helper()
+	switch {
+	case want == nil && got != nil:
+		t.Fatalf("%s: expected nil, got %v", field, *got)
+	case want != nil && got == nil:
+		t.Fatalf("%s: expected %v, got nil", field, *want)
+	case want != nil && got != nil && *want != *got:
+		t.Fatalf("%s: expected %v, got %v", field, *want, *got)
+	}
+}
+
+func assertOptionalString(t *testing.T, field string, got *string, want *string) {
+	t.Helper()
+	switch {
+	case want == nil && got != nil:
+		t.Fatalf("%s: expected nil, got %q", field, *got)
+	case want != nil && got == nil:
+		t.Fatalf("%s: expected %q, got nil", field, *want)
+	case want != nil && got != nil && *want != *got:
+		t.Fatalf("%s: expected %q, got %q", field, *want, *got)
 	}
 }
 

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -14,6 +14,7 @@ type ProjectConfig struct {
 	FixReviews   FixReviewsConfig   `toml:"fix_reviews"`
 	FetchReviews FetchReviewsConfig `toml:"fetch_reviews"`
 	Exec         ExecConfig         `toml:"exec"`
+	Sound        SoundConfig        `toml:"sound"`
 }
 
 type RuntimeOverrides struct {
@@ -60,4 +61,12 @@ type ExecConfig struct {
 	Verbose *bool `toml:"verbose"`
 	TUI     *bool `toml:"tui"`
 	Persist *bool `toml:"persist"`
+}
+
+// SoundConfig controls optional audio notifications on run lifecycle events.
+// Disabled by default; opt-in via `[sound] enabled = true` in .compozy/config.toml.
+type SoundConfig struct {
+	Enabled     *bool   `toml:"enabled"`
+	OnCompleted *string `toml:"on_completed"`
+	OnFailed    *string `toml:"on_failed"`
 }

--- a/internal/core/workspace/config_validate.go
+++ b/internal/core/workspace/config_validate.go
@@ -32,6 +32,26 @@ func (cfg ProjectConfig) Validate() error {
 	if err := validateExec(cfg.Defaults, cfg.Exec); err != nil {
 		return err
 	}
+	if err := validateSound(cfg.Sound); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateSound(cfg SoundConfig) error {
+	if err := validateSoundField("sound.on_completed", cfg.OnCompleted); err != nil {
+		return err
+	}
+	return validateSoundField("sound.on_failed", cfg.OnFailed)
+}
+
+func validateSoundField(field string, value *string) error {
+	if value == nil {
+		return nil
+	}
+	if strings.TrimSpace(*value) == "" {
+		return fmt.Errorf("workspace config %s cannot be empty", field)
+	}
 	return nil
 }
 

--- a/sdk/extension/types.go
+++ b/sdk/extension/types.go
@@ -423,6 +423,9 @@ type RuntimeConfig struct {
 	Timeout                    time.Duration
 	MaxRetries                 int
 	RetryBackoffMultiplier     float64
+	SoundEnabled               bool
+	SoundOnCompleted           string
+	SoundOnFailed              string
 }
 
 // RunArtifacts mirrors the run artifact directory layout exposed to run hooks.

--- a/skills/compozy/references/config-reference.md
+++ b/skills/compozy/references/config-reference.md
@@ -71,6 +71,39 @@ Options specific to `compozy exec`. Inherits all `[defaults]` fields plus:
 | `tui` | bool | Open the interactive TUI |
 | `persist` | bool | Save artifacts under `.compozy/runs/<run-id>/` |
 
+### `[sound]`
+
+Optional audio notifications that play when a run reaches a terminal state. Applies to both `compozy start` and `compozy exec`. Disabled by default — setting any field without `enabled = true` is a no-op.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `enabled` | bool | Master switch. Default `false`. |
+| `on_completed` | string | Preset name or absolute path played on `run.completed`. Default `glass` when `enabled = true`. |
+| `on_failed` | string | Preset name or absolute path played on `run.failed` and `run.cancelled`. Default `basso` when `enabled = true`. |
+
+**Presets** (resolve to platform-native files at play time):
+
+| Preset | macOS | Linux (freedesktop) | Windows |
+| --- | --- | --- | --- |
+| `glass` | `/System/Library/Sounds/Glass.aiff` | `complete.oga` | `tada.wav` |
+| `basso` | `/System/Library/Sounds/Basso.aiff` | `dialog-error.oga` | `chord.wav` |
+| `ping` | `Ping.aiff` | `message.oga` | `ding.wav` |
+| `hero` | `Hero.aiff` | `complete.oga` | `tada.wav` |
+| `funk` | `Funk.aiff` | `bell.oga` | `notify.wav` |
+| `tink` | `Tink.aiff` | `message.oga` | `chimes.wav` |
+| `submarine` | `Submarine.aiff` | `bell.oga` | `Ring01.wav` |
+
+**Absolute paths** bypass preset lookup, so any local sound file works:
+
+```toml
+[sound]
+enabled = true
+on_completed = "/System/Library/Sounds/Hero.aiff"
+on_failed = "/Users/me/sounds/custom-fail.wav"
+```
+
+**Platform requirements**: `afplay` (bundled with macOS), `paplay` (Linux, from `pulseaudio-utils`), or `powershell` + `System.Media.SoundPlayer` (Windows). On unix variants without one of these tools the feature silently falls back to no-op; playback errors never break a run.
+
 ## Complete Example
 
 ```toml
@@ -103,4 +136,9 @@ nitpicks = false
 verbose = false
 tui = false
 persist = false
+
+[sound]
+enabled = true
+on_completed = "glass"
+on_failed = "basso"
 ```


### PR DESCRIPTION
## Summary

Adds optional audio cues that play when an ACP run reaches a terminal state — a small ergonomic win for operators who step away from long-running sessions and want to know without checking the terminal whether the model finished cleanly or failed.

The feature is **opt-in** via a new `[sound]` section in `.compozy/config.toml` and ships **disabled by default**, so it costs nothing for users who don't want it.

```toml
[sound]
enabled = true
on_completed = "glass"   # preset name OR absolute path
on_failed = "basso"      # played on run.failed and run.cancelled
```

https://github.com/user-attachments/assets/cf313104-cd17-4c4b-a1f3-5188e48b2e7a


Presets resolve to platform-native files at play time (`afplay` on darwin, `paplay` on linux, `powershell` on windows). Absolute paths bypass preset lookup so users can ship custom sounds.

## Why

- A long ACP session can run for minutes; switching back to the terminal only to check a status string is friction.
- A 500ms beep at the boundary is enough to surface the result without requiring focus.
- Keeping it strictly opt-in means CI, headless servers, and silence-loving users see no behavior change.

## Design notes

**Synchronous playback at the emission point.** The first iteration used a goroutine subscribed to the run event bus, but cleanup raced the terminal event and could silently drop the very sound it was meant to play. The final design exposes `sound.Notify(ctx, cfg, kind, logger)` which plays on the caller's goroutine right after `emitRunTerminalEvent` (executor) and `submitRuntimeEvent` (exec). It blocks for ~500ms on the audio command, then returns. Single-flight, deterministic, no concurrency surface.

**Cross-platform isolation via build tags.** `player_unix.go` (`//go:build !windows`) selects `afplay`/`paplay` based on `runtime.GOOS`; `player_windows.go` shells out to `powershell` + `System.Media.SoundPlayer`. Other unix variants gracefully fall back to a `Noop` player.

**Test seam.** `os/exec` is hidden behind a `commandRunner` interface so unit tests never shell out — they assert the resolved command name and args without producing audio.

**TOML-only for v1.** No CLI flag was added; per-project sound feels like a project preference rather than a per-invocation toggle. Easy to add later if there's demand.

## Files touched

| Area | Files |
|---|---|
| New package | `internal/core/sound/{player,runner,presets,player_unix,player_windows,subscriber}.go` (+ tests) |
| Config schema | `internal/core/workspace/config_types.go`, `config_validate.go`, `config_test.go` |
| Runtime config | `internal/core/model/runtime_config.go`, `model_test.go` |
| Executor wiring | `internal/core/run/executor/execution.go` (synchronous `notifySoundForKind` after `emitRunTerminalEvent`) |
| Exec wiring | `internal/core/run/exec/exec.go` (`notifySoundForKind` inside `submitRuntimeEvent`) |
| Plumbing | `internal/core/run/internal/runshared/config.go`, `internal/core/api.go`, `internal/cli/state.go`, `internal/cli/workspace_config.go` |
| SDK alignment | `sdk/extension/types.go` (mirrors `model.RuntimeConfig` per the existing `compat_test` contract) |

## Test plan

- [ ] `make verify` passes (1848 tests, 0 lint, build green)
- [ ] New tests cover preset resolution per OS, `Notify` for every terminal kind, silent kinds, nil player, nil context, playback errors logged not panicked
- [ ] Extended `TestRuntimeConfigApplyDefaults` to cover the sound default branch (presets only fill when `SoundEnabled` is true; explicit values are preserved)
- [ ] New `TestLoadConfig` cases for `[sound]` parsing, default-disabled state, and empty-string rejection
- [ ] Manual: `compozy exec --dry-run --tui=false "hello"` plays Glass on darwin
- [ ] Manual: `compozy exec --tui --dry-run "hello"` plays Glass with the cockpit visible
- [ ] Manual: feature is silent when `enabled = false` or the section is absent
- [ ] Maintainer to verify on linux (`paplay` + freedesktop sounds) — only tested darwin

## Not included

- "Awaiting input" event kind. The current run lifecycle has no native "blocked on user feedback" event; adding one is a larger surface change and didn't seem worth bundling. Happy to follow up in a second PR if there's interest.
- Job-level beeps. The wiring is intentionally restricted to the three run-level events to avoid a 50-beep batch run.
- Volume / debounce controls. Easy to add if real-world usage shows a need.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sound notifications for run completion/failure across Windows, macOS, and Linux.
  * New [sound] project config to enable/disable notifications and set completion/failure sounds.
  * Configurable defaults applied when enabled (defaults: glass for success, basso for failure); preset names are trimmed and preserved when explicitly set.
  * Preset list: glass, basso, ping, hero, funk, tink, submarine.
  * Runtime SDK exposes sound-enabled fields for extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->