### PR TITLE
ci(release): Release v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
+### 🔧 CI/CD
+
+- Fix auto-docs
+## 0.1.12 - 2026-04-14
+
 ### 🎉 Features
 
 - Add shared layout package for run artifact filenames (#95)
 ### 🐛 Bug Fixes
 
 - Execution order- Fetch reviews parsing
+### 🔧 CI/CD
+
+- *(release)* Prepare release v0.1.12 (#100)
+
 ### 🧪 Testing
 
 - Fix suite
@@ -224,7 +233,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
-[unreleased]: https://github.com///compare/v0.1.11...HEAD
+[unreleased]: https://github.com///compare/v0.1.12...HEAD
+[0.1.12]: https://github.com///compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com///compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com///compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com///compare/v0.1.8...v0.1.9

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "bunx vitest run",
     "typecheck": "turbo run typecheck"
   },
-  "version": "0.1.12",
+  "version": "0.1.13",
   "workspaces": [
     "sdk/*"
   ]


### PR DESCRIPTION
## Release v0.1.13
This PR prepares the release of version v0.1.13.
### Changelog
# Changelog
All notable changes to this project will be documented in this file.
The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
## Unreleased