### PR TITLE
feat: global config defaults

### DIFF
--- a/.codex/ledger/2026-04-15-MEMORY-config-path-errors.md
+++ b/.codex/ledger/2026-04-15-MEMORY-config-path-errors.md
@@ -1,0 +1,58 @@
+## Goal (incl. success criteria):
+
+- Verify the inline review finding about `resolveConfigPaths` swallowing global config path resolution errors, and fix it only if the current code still does that.
+- Success criteria:
+- Confirm current behavior from source and tests.
+- Propagate `osUserHomeDir` and `resolveConfigBaseDir` failures through `resolveConfigPaths` and `loadEffectiveConfig`.
+- Keep the change scoped to `internal/core/workspace`.
+- Full verification passes via `make verify`.
+
+## Constraints/Assumptions:
+
+- Follow Go bug-fix workflow with `golang-pro`, `systematic-debugging`, and `no-workarounds`.
+- Use `testing-anti-patterns` for test updates.
+- Do not touch unrelated worktree changes or use destructive git commands.
+- Only fix the finding if the current code still exhibits it.
+
+## Key decisions:
+
+- The finding is real in current `internal/core/workspace/config.go`: `resolveConfigPaths` returns `configPaths` only and silently drops `osUserHomeDir` / `resolveConfigBaseDir` failures by returning partial paths.
+- Existing test `TestLoadConfigDoesNotRequireGlobalConfigWhenHomeLookupFails` codifies the buggy behavior and must be updated rather than preserved.
+
+## State:
+
+- Completed.
+
+## Done:
+
+- Read repository and workspace instructions.
+- Loaded `golang-pro`, `systematic-debugging`, `no-workarounds`, and `testing-anti-patterns`.
+- Read current `internal/core/workspace/config.go`, related helpers, and current tests.
+- Verified the reported bug still exists in the current code.
+- Updated `resolveConfigPaths` to return `(configPaths, error)` and propagate `osUserHomeDir` / `resolveConfigBaseDir` failures with context.
+- Updated `loadEffectiveConfig` to wrap path resolution failures as `resolve config paths: %w`.
+- Replaced the old optional-home behavior test with explicit error-propagation coverage for both failure branches.
+- Fixed two environment-coupled workspace config tests so they isolate `HOME` instead of depending on the developer machine's real global config.
+- Ran `go test ./internal/core/workspace -count=1` successfully.
+- Ran `make verify` successfully.
+
+## Now:
+
+- None.
+
+## Next:
+
+- None.
+
+## Open questions (UNCONFIRMED if needed):
+
+- None.
+
+## Working set (files/ids/commands):
+
+- `.codex/ledger/2026-04-15-MEMORY-config-path-errors.md`
+- `internal/core/workspace/config.go`
+- `internal/core/workspace/config_test.go`
+- `internal/core/workspace/config_merge.go`
+- `go test ./internal/core/workspace -count=1`
+- `make verify`

--- a/.codex/ledger/2026-04-15-MEMORY-global-config-defaults.md
+++ b/.codex/ledger/2026-04-15-MEMORY-global-config-defaults.md
@@ -1,0 +1,95 @@
+## Goal (incl. success criteria):
+
+- Implement support for `~/.compozy/config.toml` as global defaults merged with workspace `.compozy/config.toml`.
+- Success criteria:
+- Global config uses the same schema as workspace config.
+- Effective precedence is centralized and consistent across CLI and non-CLI consumers.
+- Existing workspace-only behavior remains unchanged when no global config exists.
+- Full verification passes via `make verify`.
+
+## Constraints/Assumptions:
+
+- Accepted implementation plan must be persisted under `.codex/plans/`.
+- Use the existing `internal/core/workspace` package as the single source of truth for config loading.
+- No destructive git commands; do not touch unrelated worktree changes.
+- v1 path is exactly `~/.compozy/config.toml`; no XDG support in this change.
+- Global config scope matches the full current schema: `defaults`, `exec`, `start`, `fix_reviews`, `fetch_reviews`, `tasks`, `sound`.
+
+## Key decisions:
+
+- Merge config centrally in `internal/core/workspace` instead of adding a second loader in CLI.
+- Keep per-field precedence; list fields are replaced by the more specific scope rather than concatenated.
+- Resolve config-owned relative `add_dirs` against the owning config root: workspace root for workspace config, home dir for global config.
+- Preserve reusable-agent runtime precedence above config for exec runtime fields already controlled by `AGENT.md`.
+
+## State:
+
+- Completed.
+
+## Done:
+
+- Re-read repository instructions and mandatory skills for Go/tests/verification.
+- Reconstructed the existing workspace config architecture and confirmed the root cause: only workspace config is loaded today.
+- Mapped all current config sections, validation rules, CLI application points, and non-CLI consumers of `workspace.LoadConfig(...)`.
+- Confirmed user decisions from planning:
+- Full schema support in global config.
+- Official path is `~/.compozy/config.toml` only.
+- Produced a decision-complete implementation plan.
+- Implemented central global+workspace config loading in `internal/core/workspace`.
+- Added per-field config merge, source-aware validation labels, and config-owned `add_dirs` path normalization.
+- Extended workspace context metadata to expose workspace/global config paths.
+- Verified existing non-CLI consumers inherit merged config through `workspace.LoadConfig(...)` without bespoke changes.
+- Added regression tests for:
+- global fallback with no workspace config
+- workspace-over-global field precedence
+- cross-scope merged validation failures
+- config-relative `add_dirs` resolution
+- CLI application of global defaults and workspace overrides
+- Updated CLI help text, README, reusable-agent docs, and start help golden fixture.
+- Ran targeted verification:
+- `go test ./internal/core/workspace`
+- `go test ./internal/cli`
+- `go test ./internal/core/...`
+- Ran full verification: `make verify` (pass).
+- Reviewed the landed change set against the documented precedence and identified two real defects:
+- effective config composition let `global` command sections override `workspace` defaults
+- optional global config loading failed when the home directory could not be resolved
+- Refactored effective config composition to preserve precedence per command field:
+- `workspace` command override > `workspace` defaults > `global` command override > `global` defaults
+- command-only fields still merge `global` -> `workspace`
+- Made global config discovery optional when `HOME` cannot be resolved; workspace config loading now continues.
+- Added regression tests in `internal/core/workspace` and `internal/cli` for both precedence and optional-home behavior.
+- Re-ran targeted verification:
+- `go test ./internal/core/workspace -count=1`
+- `go test ./internal/cli -count=1`
+- Re-ran the full repository gate successfully:
+- `make verify`
+- Result: `0 issues`, `DONE 1905 tests in 14.215s`, successful build, final line `All verification checks passed`
+
+## Now:
+
+- None.
+
+## Next:
+
+- None.
+
+## Open questions (UNCONFIRMED if needed):
+
+- None.
+
+## Working set (files/ids/commands):
+
+- `.codex/plans/2026-04-15-global-config-defaults.md`
+- `.codex/ledger/2026-04-15-MEMORY-global-config-defaults.md`
+- `internal/core/workspace/config.go`
+- `internal/core/workspace/config_merge.go`
+- `internal/core/workspace/config_types.go`
+- `internal/core/workspace/config_validate.go`
+- `internal/cli/workspace_config.go`
+- `internal/cli/workspace_config_test.go`
+- `internal/cli/commands.go`
+- `internal/cli/root.go`
+- `README.md`
+- `internal/core/migration/migrate.go`
+- `internal/core/extension/host_helpers.go`

--- a/.codex/ledger/2026-04-15-MEMORY-review-current-changes.md
+++ b/.codex/ledger/2026-04-15-MEMORY-review-current-changes.md
@@ -1,0 +1,52 @@
+## Goal (incl. success criteria):
+
+- Review current staged, unstaged, and untracked code changes and report prioritized actionable findings.
+- Success criteria:
+- Inspect the full diff (excluding reviewer-created artifacts).
+- Identify only discrete bugs introduced by the patch.
+- Return findings in the required JSON schema.
+
+## Constraints/Assumptions:
+
+- Do not run destructive git commands.
+- Review-only task; do not modify product code.
+- Ignore reviewer-created ledger artifact during diff analysis.
+
+## Key decisions:
+
+- Focus review on the global config defaults change set in workspace/CLI/docs.
+- Treat documented plan decisions as intentional unless the implementation still breaks stated precedence or optionality.
+
+## State:
+
+- Completed.
+
+## Done:
+
+- Read repository instructions and scanned existing ledgers.
+- Identified modified files via git status.
+- Inspected workspace config loading/merge/validation changes, CLI application order, tests, and docs.
+- Identified two actionable issues: precedence inversion between workspace defaults and global command sections; optional global config now hard-fails when home resolution fails.
+
+## Now:
+
+- Preparing final review JSON.
+
+## Next:
+
+- None.
+
+## Open questions (UNCONFIRMED if needed):
+
+- None.
+
+## Working set (files/ids/commands):
+
+- `.codex/ledger/2026-04-15-MEMORY-review-current-changes.md`
+- `.codex/plans/2026-04-15-global-config-defaults.md`
+- `internal/core/workspace/config.go`
+- `internal/core/workspace/config_merge.go`
+- `internal/core/workspace/config_validate.go`
+- `internal/cli/workspace_config.go`
+- `git status --short --branch`
+- `git diff -- <files>`

--- a/README.md
+++ b/README.md
@@ -130,19 +130,20 @@ dependencies:
 
 Validate task files at any time with `compozy validate-tasks --name <feature>`. `compozy start` runs the same preflight automatically; use `--skip-validation` only when tasks were validated elsewhere, or `--force` to continue after validation failures in non-interactive runs.
 
-## ⚙️ Workspace Config
+## ⚙️ Config Files
 
-Compozy can load project defaults from `.compozy/config.toml`.
+Compozy can load global defaults from `~/.compozy/config.toml` and override them per workspace with `.compozy/config.toml`.
 
 - The CLI discovers the nearest `.compozy/` directory by walking upward from the current working directory.
-- If `.compozy/config.toml` exists, Compozy loads it once at command startup.
+- If `~/.compozy/config.toml` exists, Compozy loads it once at command startup.
+- If `.compozy/config.toml` exists in the resolved workspace, it overrides the global config field by field.
 - Interactive forms for `compozy start`, `compozy fix-reviews`, and `compozy fetch-reviews` are prefilled from the resolved config.
 - Explicit CLI flags always win over config values.
 
 Precedence is:
 
 ```text
-explicit flags > command section > [defaults] > built-in defaults
+explicit flags > workspace command section > workspace [defaults] > global command section > global [defaults] > built-in defaults
 ```
 
 Example:
@@ -187,12 +188,14 @@ Supported sections:
 - `[tasks]` for the allowed task `type` list used by `cy-create-tasks` and `compozy validate-tasks`
 - `[fix_reviews]` for `concurrent`, `batch_size`, and `include_resolved`
 - `[fetch_reviews]` for `provider` and `nitpicks` (controls CodeRabbit review-body comments; default is enabled when unset)
+- `[sound]` for optional run-completion audio presets or absolute file paths
 
 Notes:
 
-- `.compozy/config.toml` is optional. If it is absent, Compozy keeps the current built-in defaults.
+- Both `~/.compozy/config.toml` and `.compozy/config.toml` are optional. If both are absent, Compozy keeps the current built-in defaults.
 - `.compozy/tasks` remains the fixed workflow root in this version; the config file does not change the workflow root path.
 - Unknown keys and invalid value types are rejected during config loading.
+- Relative `add_dirs` are resolved against the owning config scope: the user home directory for `~/.compozy/config.toml` and the workspace root for `.compozy/config.toml`.
 - `max_retries` applies to execution-stage ACP failures and inactivity timeouts for `compozy exec`, `compozy start`, and `compozy fix-reviews`.
 - `retry_backoff_multiplier` only increases the next attempt timeout; retries restart immediately and do not add a sleep delay.
 
@@ -223,7 +226,7 @@ compozy exec --agent reviewer "Review the staged changes"
 Runtime precedence for `compozy exec --agent ...` is:
 
 ```text
-explicit CLI flags > AGENT.md runtime defaults > .compozy/config.toml > built-in defaults
+explicit CLI flags > AGENT.md runtime defaults > workspace/global config > built-in defaults
 ```
 
 `mcp.json` is only for agent-local MCP servers. The reserved Compozy MCP server is also named `compozy`, but it is injected by the host and must not appear in `mcp.json`. That reserved server exists only to expose host-owned tools such as `run_agent`. Child agent runs receive the reserved `compozy` server plus the child agent's own `mcp.json`; they do not inherit the parent agent's local MCP servers.
@@ -320,7 +323,7 @@ Persisted `exec` runs use this layout:
 .compozy/runs/<run-id>/turns/0001/result.json
 ```
 
-`compozy exec` uses the same config merge rule as the rest of the CLI: `flags > [exec] > [defaults] > built-in defaults`.
+`compozy exec` uses the same config merge rule as the rest of the CLI: `flags > workspace [exec] > workspace [defaults] > global [exec] > global [defaults] > built-in defaults`.
 
 ## 🚀 Quick Start
 
@@ -566,7 +569,7 @@ compozy archive [flags]
 compozy exec [prompt] [flags]
 ```
 
-Provide exactly one prompt source: a positional prompt, `--prompt-file`, or `stdin`. When present, `.compozy/config.toml` can provide exec defaults through `[exec]` and shared runtime defaults through `[defaults]`.
+Provide exactly one prompt source: a positional prompt, `--prompt-file`, or `stdin`. When present, `~/.compozy/config.toml` and `.compozy/config.toml` can provide exec defaults through `[exec]` and shared runtime defaults through `[defaults]`.
 
 `compozy exec` is headless and ephemeral by default. Use `--agent <name>` to execute a reusable agent from `.compozy/agents/` or `~/.compozy/agents/`, `--persist` to create `.compozy/runs/<run-id>/` for resumable sessions, `--run-id` to continue a persisted session, `--format json` for lean JSONL, `--format raw-json` for the full raw event stream, and `--tui` to opt back into the interactive UI.
 
@@ -640,7 +643,7 @@ compozy start [flags]
 ```
 
 Running `compozy start` with no flags opens the interactive form automatically.
-When present, `.compozy/config.toml` can provide defaults for runtime flags such as
+When present, `~/.compozy/config.toml` and `.compozy/config.toml` can provide defaults for runtime flags such as
 `--ide`, `--model`, `--reasoning-effort`, `--access-mode`, `--timeout`, `--add-dir`, and `--auto-commit`.
 
 | Flag                         | Default     | Description                                                                                |
@@ -670,7 +673,7 @@ compozy fetch-reviews [flags]
 ```
 
 Running `compozy fetch-reviews` with no flags opens the interactive form automatically.
-When present, `.compozy/config.toml` can provide defaults such as `provider` and `nitpicks`.
+When present, `~/.compozy/config.toml` and `.compozy/config.toml` can provide defaults such as `provider` and `nitpicks`.
 
 | Flag         | Default | Description                               |
 | ------------ | ------- | ----------------------------------------- |
@@ -680,7 +683,7 @@ When present, `.compozy/config.toml` can provide defaults such as `provider` and
 | `--round`    | `0`     | Round number (auto-increments if omitted) |
 
 By default, `fetch-reviews` imports CodeRabbit review-body comments for `nitpick`, `minor`, and `major`.
-Use `[fetch_reviews].nitpicks = false` in `.compozy/config.toml` to disable that import.
+Use `[fetch_reviews].nitpicks = false` in either config file to disable that import.
 
 </details>
 
@@ -692,7 +695,7 @@ compozy fix-reviews [flags]
 ```
 
 Running `compozy fix-reviews` with no flags opens the interactive form automatically.
-When present, `.compozy/config.toml` can provide runtime defaults as well as review workflow
+When present, `~/.compozy/config.toml` and `.compozy/config.toml` can provide runtime defaults as well as review workflow
 defaults such as `--concurrent`, `--batch-size`, and `--include-resolved`.
 
 | Flag                         | Default     | Description                                                                                |

--- a/docs/reusable-agents.md
+++ b/docs/reusable-agents.md
@@ -162,4 +162,4 @@ Execute an agent through the normal `exec` pipeline:
 compozy exec --agent reviewer "Review the staged changes"
 ```
 
-You can still combine `--agent` with normal exec controls such as `--model`, `--reasoning-effort`, `--format`, `--persist`, and `--run-id`. Explicit CLI flags win over `AGENT.md` defaults. When an inspected agent is invalid, `compozy agents inspect <name>` prints the validation report and exits non-zero so you can fix the definition before running it.
+You can still combine `--agent` with normal exec controls such as `--model`, `--reasoning-effort`, `--format`, `--persist`, and `--run-id`. Explicit CLI flags win over `AGENT.md` defaults, and `AGENT.md` runtime defaults still win over workspace/global config files. When an inspected agent is invalid, `compozy agents inspect <name>` prints the validation report and exits non-zero so you can fix the definition before running it.

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -18,7 +18,7 @@ func newFetchReviewsCommandWithDefaults(dispatcher *kernel.Dispatcher, defaults 
 		Short:        "Fetch provider review comments into a PRD review round",
 		SilenceUsage: true,
 		Long: "Fetch review comments from a provider and write them into .compozy/tasks/<name>/reviews-NNN/.\n\n" +
-			"When --provider is omitted, Compozy can load its default from .compozy/config.toml.",
+			"When --provider is omitted, Compozy can load its default from ~/.compozy/config.toml or .compozy/config.toml.",
 		Example: `  compozy fetch-reviews --provider coderabbit --pr 259 --name my-feature
   compozy fetch-reviews --provider coderabbit --pr 259 --name my-feature --round 2
   compozy fetch-reviews`,
@@ -51,7 +51,8 @@ func newFixReviewsCommandWithDefaults(dispatcher *kernel.Dispatcher, defaults co
 		Long: `Process review issue markdown files from .compozy/tasks/<name>/reviews-NNN/ and run the configured AI agent
 to remediate review feedback.
 
-Most runtime defaults can be supplied by .compozy/config.toml. In interactive terminals the command
+Most runtime defaults can be supplied by ~/.compozy/config.toml and overridden by
+.compozy/config.toml. In interactive terminals the command
 opens the run cockpit by default; in non-TTY environments it falls back to headless streaming.`,
 		Example: `  compozy fix-reviews --name my-feature --ide codex --concurrent 2 --batch-size 3
   compozy fix-reviews --name my-feature --round 2
@@ -92,7 +93,8 @@ func newStartCommandWithDefaults(dispatcher *kernel.Dispatcher, defaults command
 		Long: `Execute task markdown files from a PRD workflow directory and dispatch them to the configured
 AI agent one task at a time.
 
-Most runtime defaults can be supplied by .compozy/config.toml. In interactive terminals the command
+Most runtime defaults can be supplied by ~/.compozy/config.toml and overridden by
+.compozy/config.toml. In interactive terminals the command
 opens the run cockpit by default; in non-TTY environments it falls back to headless streaming.`,
 		Example: `  compozy start --name multi-repo --tasks-dir .compozy/tasks/multi-repo --ide claude
   compozy start --format json --name multi-repo --tasks-dir .compozy/tasks/multi-repo

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -67,8 +67,8 @@ func newRootCommandWithDefaults(dispatcher *kernel.Dispatcher, defaults commandS
 		SilenceUsage: true,
 		Long: `Compozy manages review rounds and PRD execution workflows.
 
-Project-level defaults can be stored in .compozy/config.toml. Explicit CLI flags
-always override values loaded from the workspace config.
+Defaults can be stored in ~/.compozy/config.toml and overridden per workspace in
+.compozy/config.toml. Explicit CLI flags always override values loaded from config files.
 
 Use explicit workflow subcommands:
   compozy setup         Install bundled public skills for supported agents

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -432,7 +432,7 @@ func TestREADMEExecDocumentationMatchesCurrentContract(t *testing.T) {
 		".compozy/runs/<run-id>/events.jsonl",
 		".compozy/runs/<run-id>/turns/0001/prompt.md",
 		".compozy/runs/<run-id>/turns/0001/result.json",
-		"flags > [exec] > [defaults] > built-in defaults",
+		"flags > workspace [exec] > workspace [defaults] > global [exec] > global [defaults] > built-in defaults",
 		"[exec]",
 		"`copilot`",
 		"`cursor-agent`",

--- a/internal/cli/testdata/start_help.golden
+++ b/internal/cli/testdata/start_help.golden
@@ -1,7 +1,8 @@
 Execute task markdown files from a PRD workflow directory and dispatch them to the configured
 AI agent one task at a time.
 
-Most runtime defaults can be supplied by .compozy/config.toml. In interactive terminals the command
+Most runtime defaults can be supplied by ~/.compozy/config.toml and overridden by
+.compozy/config.toml. In interactive terminals the command
 opens the run cockpit by default; in non-TTY environments it falls back to headless streaming.
 
 Usage:

--- a/internal/cli/workspace_config_test.go
+++ b/internal/cli/workspace_config_test.go
@@ -22,6 +22,7 @@ var cliWorkingDirMu sync.Mutex
 
 func TestApplyWorkspaceDefaultsLoadsNearestWorkspaceConfig(t *testing.T) {
 	root := t.TempDir()
+	homeDir := isolateCLIConfigHome(t)
 	startDir := filepath.Join(root, "pkg", "feature")
 	if err := os.MkdirAll(startDir, 0o755); err != nil {
 		t.Fatalf("mkdir start dir: %v", err)
@@ -62,13 +63,23 @@ include_completed = true
 	if !state.includeCompleted {
 		t.Fatalf("expected includeCompleted=true")
 	}
-	wantDirs := []string{"../shared", "../docs"}
+	resolvedRoot := mustEvalSymlinksCLITest(t, root)
+	wantDirs := []string{
+		filepath.Join(filepath.Dir(resolvedRoot), "shared"),
+		filepath.Join(filepath.Dir(resolvedRoot), "docs"),
+	}
 	if !reflect.DeepEqual(state.addDirs, wantDirs) {
 		t.Fatalf("unexpected addDirs\nwant: %#v\ngot:  %#v", wantDirs, state.addDirs)
+	}
+
+	globalConfigPath := filepath.Join(homeDir, ".compozy", "config.toml")
+	if _, err := os.Stat(globalConfigPath); !os.IsNotExist(err) {
+		t.Fatalf("expected isolated global config to be absent, got stat err=%v", err)
 	}
 }
 
 func TestApplyWorkspaceDefaultsDoesNotOverrideChangedFlags(t *testing.T) {
+	isolateCLIConfigHome(t)
 	root := t.TempDir()
 	startDir := filepath.Join(root, "pkg", "feature")
 	if err := os.MkdirAll(startDir, 0o755); err != nil {
@@ -429,6 +440,165 @@ func TestNewFormInputsFromStatePreservesResolvedDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyWorkspaceDefaultsLoadsGlobalConfigWhenWorkspaceConfigIsMissing(t *testing.T) {
+	root := t.TempDir()
+	homeDir := isolateCLIConfigHome(t)
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIGlobalConfig(t, homeDir, `
+[defaults]
+ide = "claude"
+model = "sonnet"
+
+[start]
+include_completed = true
+`)
+
+	state := newCommandState(commandKindStart, core.ModePRDTasks)
+	cmd := newTestCommand(state)
+	cmd.Flags().Bool("include-completed", false, "include completed")
+
+	chdirCLITest(t, startDir)
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if state.ide != "claude" {
+		t.Fatalf("expected global ide to apply, got %q", state.ide)
+	}
+	if state.model != "sonnet" {
+		t.Fatalf("expected global model to apply, got %q", state.model)
+	}
+	if !state.includeCompleted {
+		t.Fatal("expected global start.include_completed to apply")
+	}
+}
+
+func TestApplyWorkspaceDefaultsMergesWorkspaceOverGlobal(t *testing.T) {
+	root := t.TempDir()
+	homeDir := isolateCLIConfigHome(t)
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIGlobalConfig(t, homeDir, `
+[defaults]
+ide = "claude"
+model = "sonnet"
+access_mode = "default"
+
+[start]
+include_completed = false
+`)
+	writeCLIWorkspaceConfig(t, root, `
+[defaults]
+model = "gpt-5.4"
+
+[start]
+include_completed = true
+`)
+
+	state := newCommandState(commandKindStart, core.ModePRDTasks)
+	cmd := newTestCommand(state)
+	cmd.Flags().Bool("include-completed", false, "include completed")
+
+	chdirCLITest(t, startDir)
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if state.ide != "claude" {
+		t.Fatalf("expected global defaults.ide fallback, got %q", state.ide)
+	}
+	if state.model != "gpt-5.4" {
+		t.Fatalf("expected workspace defaults.model to override global, got %q", state.model)
+	}
+	if state.accessMode != "default" {
+		t.Fatalf("expected global access_mode fallback, got %q", state.accessMode)
+	}
+	if !state.includeCompleted {
+		t.Fatal("expected workspace start.include_completed to override global")
+	}
+}
+
+func TestApplyWorkspaceDefaultsKeepsWorkspaceDefaultsAheadOfGlobalStartOverrides(t *testing.T) {
+	root := t.TempDir()
+	homeDir := isolateCLIConfigHome(t)
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIGlobalConfig(t, homeDir, `
+[defaults]
+output_format = "json"
+
+[start]
+output_format = "raw-json"
+tui = false
+`)
+	writeCLIWorkspaceConfig(t, root, `
+[defaults]
+output_format = "text"
+`)
+
+	state := newCommandState(commandKindStart, core.ModePRDTasks)
+	cmd := newTestCommand(state)
+
+	chdirCLITest(t, startDir)
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if state.outputFormat != "text" {
+		t.Fatalf(
+			"expected workspace defaults.output_format to beat global start.output_format, got %q",
+			state.outputFormat,
+		)
+	}
+	if state.tui {
+		t.Fatal("expected global start.tui to remain applied")
+	}
+}
+
+func TestApplyWorkspaceDefaultsKeepsWorkspaceDefaultsAheadOfGlobalExecOverrides(t *testing.T) {
+	root := t.TempDir()
+	homeDir := isolateCLIConfigHome(t)
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIGlobalConfig(t, homeDir, `
+[defaults]
+model = "sonnet"
+
+[exec]
+model = "gpt-5.4"
+verbose = true
+`)
+	writeCLIWorkspaceConfig(t, root, `
+[defaults]
+model = "o4-mini"
+`)
+
+	state := newCommandState(commandKindExec, core.ModeExec)
+	cmd := newTestCommand(state)
+	cmd.Flags().Bool("verbose", false, "verbose logging")
+
+	chdirCLITest(t, startDir)
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if state.model != "o4-mini" {
+		t.Fatalf("expected workspace defaults.model to beat global exec.model, got %q", state.model)
+	}
+	if !state.verbose {
+		t.Fatal("expected global exec.verbose to remain applied")
+	}
+}
+
 func TestNewFormInputsFromStateQuotesAddDirsContainingCommas(t *testing.T) {
 	t.Parallel()
 
@@ -742,6 +912,26 @@ func writeCLIWorkspaceConfig(t *testing.T, workspaceRoot, content string) {
 	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
+}
+
+func writeCLIGlobalConfig(t *testing.T, homeDir, content string) {
+	t.Helper()
+
+	configDir := filepath.Join(homeDir, ".compozy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir global .compozy: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+}
+
+func isolateCLIConfigHome(t *testing.T) string {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	return homeDir
 }
 
 func mustEvalSymlinksCLITest(t *testing.T, path string) string {

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -105,7 +105,10 @@ func loadEffectiveConfig(ctx context.Context, workspaceRoot string) (ProjectConf
 		return ProjectConfig{}, configPaths{}, fmt.Errorf("load workspace config: %w", err)
 	}
 
-	paths := resolveConfigPaths(workspaceRoot)
+	paths, err := resolveConfigPaths(workspaceRoot)
+	if err != nil {
+		return ProjectConfig{}, configPaths{}, fmt.Errorf("resolve config paths: %w", err)
+	}
 
 	globalCfg, globalSeen, err := loadConfigFile(ctx, paths.globalPath, globalConfigScope, paths.globalRoot)
 	if err != nil {
@@ -131,7 +134,7 @@ func loadEffectiveConfig(ctx context.Context, workspaceRoot string) (ProjectConf
 	return cfg, paths, nil
 }
 
-func resolveConfigPaths(workspaceRoot string) configPaths {
+func resolveConfigPaths(workspaceRoot string) (configPaths, error) {
 	paths := configPaths{
 		workspaceRoot: workspaceRoot,
 		workspacePath: model.ConfigPathForWorkspace(workspaceRoot),
@@ -139,16 +142,16 @@ func resolveConfigPaths(workspaceRoot string) configPaths {
 
 	homeDir, err := osUserHomeDir()
 	if err != nil {
-		return paths
+		return configPaths{}, fmt.Errorf("lookup user home directory: %w", err)
 	}
 	resolvedHomeDir, err := resolveConfigBaseDir(homeDir)
 	if err != nil {
-		return paths
+		return configPaths{}, fmt.Errorf("resolve global config base dir: %w", err)
 	}
 
 	paths.globalRoot = resolvedHomeDir
 	paths.globalPath = filepath.Join(resolvedHomeDir, model.WorkflowRootDirName, model.WorkflowConfigFileName)
-	return paths
+	return paths, nil
 }
 
 func loadConfigFile(

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -13,22 +13,35 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 )
 
+var osUserHomeDir = os.UserHomeDir
+
+type configPaths struct {
+	workspaceRoot string
+	globalRoot    string
+	workspacePath string
+	globalPath    string
+	workspaceSeen bool
+	globalSeen    bool
+}
+
 func Resolve(ctx context.Context, startDir string) (Context, error) {
 	root, err := Discover(ctx, startDir)
 	if err != nil {
 		return Context{}, err
 	}
 
-	cfg, configPath, err := LoadConfig(ctx, root)
+	cfg, paths, err := loadEffectiveConfig(ctx, root)
 	if err != nil {
 		return Context{}, err
 	}
 
 	return Context{
-		Root:       root,
-		CompozyDir: model.CompozyDir(root),
-		ConfigPath: configPath,
-		Config:     cfg,
+		Root:                root,
+		CompozyDir:          model.CompozyDir(root),
+		ConfigPath:          paths.effectivePath(),
+		WorkspaceConfigPath: paths.workspacePath,
+		GlobalConfigPath:    paths.globalPath,
+		Config:              cfg,
 	}, nil
 }
 
@@ -80,27 +93,107 @@ func Discover(ctx context.Context, startDir string) (string, error) {
 }
 
 func LoadConfig(ctx context.Context, workspaceRoot string) (ProjectConfig, string, error) {
+	cfg, paths, err := loadEffectiveConfig(ctx, workspaceRoot)
+	if err != nil {
+		return ProjectConfig{}, "", err
+	}
+	return cfg, paths.effectivePath(), nil
+}
+
+func loadEffectiveConfig(ctx context.Context, workspaceRoot string) (ProjectConfig, configPaths, error) {
 	if err := context.Cause(ctx); err != nil {
-		return ProjectConfig{}, "", fmt.Errorf("load workspace config: %w", err)
+		return ProjectConfig{}, configPaths{}, fmt.Errorf("load workspace config: %w", err)
 	}
 
-	configPath := model.ConfigPathForWorkspace(workspaceRoot)
+	paths := resolveConfigPaths(workspaceRoot)
+
+	globalCfg, globalSeen, err := loadConfigFile(ctx, paths.globalPath, globalConfigScope, paths.globalRoot)
+	if err != nil {
+		return ProjectConfig{}, configPaths{}, err
+	}
+	workspaceCfg, workspaceSeen, err := loadConfigFile(
+		ctx,
+		paths.workspacePath,
+		workspaceConfigScope,
+		paths.workspaceRoot,
+	)
+	if err != nil {
+		return ProjectConfig{}, configPaths{}, err
+	}
+
+	paths.globalSeen = globalSeen
+	paths.workspaceSeen = workspaceSeen
+
+	cfg := buildEffectiveProjectConfig(globalCfg, workspaceCfg)
+	if err := cfg.validate(effectiveConfigScope); err != nil {
+		return ProjectConfig{}, configPaths{}, err
+	}
+	return cfg, paths, nil
+}
+
+func resolveConfigPaths(workspaceRoot string) configPaths {
+	paths := configPaths{
+		workspaceRoot: workspaceRoot,
+		workspacePath: model.ConfigPathForWorkspace(workspaceRoot),
+	}
+
+	homeDir, err := osUserHomeDir()
+	if err != nil {
+		return paths
+	}
+	resolvedHomeDir, err := resolveConfigBaseDir(homeDir)
+	if err != nil {
+		return paths
+	}
+
+	paths.globalRoot = resolvedHomeDir
+	paths.globalPath = filepath.Join(resolvedHomeDir, model.WorkflowRootDirName, model.WorkflowConfigFileName)
+	return paths
+}
+
+func loadConfigFile(
+	ctx context.Context,
+	configPath string,
+	scope string,
+	baseDir string,
+) (ProjectConfig, bool, error) {
+	if err := context.Cause(ctx); err != nil {
+		return ProjectConfig{}, false, fmt.Errorf("load %s: %w", scope, err)
+	}
+	if strings.TrimSpace(configPath) == "" {
+		return ProjectConfig{}, false, nil
+	}
+
 	content, err := os.ReadFile(configPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return ProjectConfig{}, configPath, nil
+			return ProjectConfig{}, false, nil
 		}
-		return ProjectConfig{}, configPath, fmt.Errorf("read workspace config: %w", err)
+		return ProjectConfig{}, false, fmt.Errorf("read %s: %w", scope, err)
 	}
 
 	var cfg ProjectConfig
 	decoder := toml.NewDecoder(bytes.NewReader(content)).DisallowUnknownFields()
 	if err := decoder.Decode(&cfg); err != nil {
-		return ProjectConfig{}, configPath, fmt.Errorf("decode workspace config: %w", err)
-	}
-	if err := cfg.Validate(); err != nil {
-		return ProjectConfig{}, configPath, err
+		return ProjectConfig{}, true, fmt.Errorf("decode %s: %w", scope, err)
 	}
 
-	return cfg, configPath, nil
+	cfg, err = normalizeProjectConfigPaths(cfg, baseDir)
+	if err != nil {
+		return ProjectConfig{}, true, fmt.Errorf("normalize %s: %w", scope, err)
+	}
+	if err := cfg.validate(scope); err != nil {
+		return ProjectConfig{}, true, err
+	}
+	return cfg, true, nil
+}
+
+func (p configPaths) effectivePath() string {
+	if p.workspaceSeen {
+		return p.workspacePath
+	}
+	if p.globalSeen {
+		return p.globalPath
+	}
+	return p.workspacePath
 }

--- a/internal/core/workspace/config_merge.go
+++ b/internal/core/workspace/config_merge.go
@@ -1,0 +1,306 @@
+package workspace
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func buildEffectiveProjectConfig(global, workspace ProjectConfig) ProjectConfig {
+	defaults := mergeDefaultsConfig(global.Defaults, workspace.Defaults)
+	return ProjectConfig{
+		Defaults: defaults,
+		Start:    buildEffectiveStartConfig(global.Defaults, global.Start, workspace.Defaults, workspace.Start),
+		Tasks:    mergeTasksConfig(global.Tasks, workspace.Tasks),
+		FixReviews: buildEffectiveFixReviewsConfig(
+			global.Defaults,
+			global.FixReviews,
+			workspace.Defaults,
+			workspace.FixReviews,
+		),
+		FetchReviews: mergeFetchReviewsConfig(global.FetchReviews, workspace.FetchReviews),
+		Exec:         buildEffectiveExecConfig(global.Defaults, global.Exec, workspace.Defaults, workspace.Exec),
+		Sound:        mergeSoundConfig(global.Sound, workspace.Sound),
+	}
+}
+
+func mergeDefaultsConfig(base, overlay DefaultsConfig) DefaultsConfig {
+	return DefaultsConfig(mergeRuntimeOverrides(RuntimeOverrides(base), RuntimeOverrides(overlay)))
+}
+
+func mergeTasksConfig(base, overlay TasksConfig) TasksConfig {
+	return TasksConfig{Types: cloneStringSlicePointer(preferOverlay(base.Types, overlay.Types))}
+}
+
+func mergeFetchReviewsConfig(base, overlay FetchReviewsConfig) FetchReviewsConfig {
+	return FetchReviewsConfig{
+		Provider: cloneOptionalValue(preferOverlay(base.Provider, overlay.Provider)),
+		Nitpicks: cloneOptionalValue(preferOverlay(base.Nitpicks, overlay.Nitpicks)),
+	}
+}
+
+func buildEffectiveStartConfig(
+	globalDefaults DefaultsConfig,
+	global StartConfig,
+	workspaceDefaults DefaultsConfig,
+	workspace StartConfig,
+) StartConfig {
+	return StartConfig{
+		IncludeCompleted: cloneOptionalValue(preferOverlay(global.IncludeCompleted, workspace.IncludeCompleted)),
+		OutputFormat: effectiveCommandOverride(
+			globalDefaults.OutputFormat,
+			global.OutputFormat,
+			workspaceDefaults.OutputFormat,
+			workspace.OutputFormat,
+		),
+		TUI: cloneOptionalValue(preferOverlay(global.TUI, workspace.TUI)),
+	}
+}
+
+func buildEffectiveFixReviewsConfig(
+	globalDefaults DefaultsConfig,
+	global FixReviewsConfig,
+	workspaceDefaults DefaultsConfig,
+	workspace FixReviewsConfig,
+) FixReviewsConfig {
+	return FixReviewsConfig{
+		Concurrent:      cloneOptionalValue(preferOverlay(global.Concurrent, workspace.Concurrent)),
+		BatchSize:       cloneOptionalValue(preferOverlay(global.BatchSize, workspace.BatchSize)),
+		IncludeResolved: cloneOptionalValue(preferOverlay(global.IncludeResolved, workspace.IncludeResolved)),
+		OutputFormat: effectiveCommandOverride(
+			globalDefaults.OutputFormat,
+			global.OutputFormat,
+			workspaceDefaults.OutputFormat,
+			workspace.OutputFormat,
+		),
+		TUI: cloneOptionalValue(preferOverlay(global.TUI, workspace.TUI)),
+	}
+}
+
+func buildEffectiveExecConfig(
+	globalDefaults DefaultsConfig,
+	global ExecConfig,
+	workspaceDefaults DefaultsConfig,
+	workspace ExecConfig,
+) ExecConfig {
+	return ExecConfig{
+		RuntimeOverrides: RuntimeOverrides{
+			IDE: effectiveCommandOverride(
+				globalDefaults.IDE,
+				global.IDE,
+				workspaceDefaults.IDE,
+				workspace.IDE,
+			),
+			Model: effectiveCommandOverride(
+				globalDefaults.Model,
+				global.Model,
+				workspaceDefaults.Model,
+				workspace.Model,
+			),
+			OutputFormat: effectiveCommandOverride(
+				globalDefaults.OutputFormat,
+				global.OutputFormat,
+				workspaceDefaults.OutputFormat,
+				workspace.OutputFormat,
+			),
+			ReasoningEffort: effectiveCommandOverride(
+				globalDefaults.ReasoningEffort,
+				global.ReasoningEffort,
+				workspaceDefaults.ReasoningEffort,
+				workspace.ReasoningEffort,
+			),
+			AccessMode: effectiveCommandOverride(
+				globalDefaults.AccessMode,
+				global.AccessMode,
+				workspaceDefaults.AccessMode,
+				workspace.AccessMode,
+			),
+			Timeout: effectiveCommandOverride(
+				globalDefaults.Timeout,
+				global.Timeout,
+				workspaceDefaults.Timeout,
+				workspace.Timeout,
+			),
+			TailLines: effectiveCommandOverride(
+				globalDefaults.TailLines,
+				global.TailLines,
+				workspaceDefaults.TailLines,
+				workspace.TailLines,
+			),
+			AddDirs: effectiveCommandSliceOverride(
+				globalDefaults.AddDirs,
+				global.AddDirs,
+				workspaceDefaults.AddDirs,
+				workspace.AddDirs,
+			),
+			AutoCommit: effectiveCommandOverride(
+				globalDefaults.AutoCommit,
+				global.AutoCommit,
+				workspaceDefaults.AutoCommit,
+				workspace.AutoCommit,
+			),
+			MaxRetries: effectiveCommandOverride(
+				globalDefaults.MaxRetries,
+				global.MaxRetries,
+				workspaceDefaults.MaxRetries,
+				workspace.MaxRetries,
+			),
+			RetryBackoffMultiplier: effectiveCommandOverride(
+				globalDefaults.RetryBackoffMultiplier,
+				global.RetryBackoffMultiplier,
+				workspaceDefaults.RetryBackoffMultiplier,
+				workspace.RetryBackoffMultiplier,
+			),
+		},
+		Verbose: cloneOptionalValue(preferOverlay(global.Verbose, workspace.Verbose)),
+		TUI:     cloneOptionalValue(preferOverlay(global.TUI, workspace.TUI)),
+		Persist: cloneOptionalValue(preferOverlay(global.Persist, workspace.Persist)),
+	}
+}
+
+func mergeSoundConfig(base, overlay SoundConfig) SoundConfig {
+	return SoundConfig{
+		Enabled:     cloneOptionalValue(preferOverlay(base.Enabled, overlay.Enabled)),
+		OnCompleted: cloneOptionalValue(preferOverlay(base.OnCompleted, overlay.OnCompleted)),
+		OnFailed:    cloneOptionalValue(preferOverlay(base.OnFailed, overlay.OnFailed)),
+	}
+}
+
+func mergeRuntimeOverrides(base, overlay RuntimeOverrides) RuntimeOverrides {
+	return RuntimeOverrides{
+		IDE:             cloneOptionalValue(preferOverlay(base.IDE, overlay.IDE)),
+		Model:           cloneOptionalValue(preferOverlay(base.Model, overlay.Model)),
+		OutputFormat:    cloneOptionalValue(preferOverlay(base.OutputFormat, overlay.OutputFormat)),
+		ReasoningEffort: cloneOptionalValue(preferOverlay(base.ReasoningEffort, overlay.ReasoningEffort)),
+		AccessMode:      cloneOptionalValue(preferOverlay(base.AccessMode, overlay.AccessMode)),
+		Timeout:         cloneOptionalValue(preferOverlay(base.Timeout, overlay.Timeout)),
+		TailLines:       cloneOptionalValue(preferOverlay(base.TailLines, overlay.TailLines)),
+		AddDirs:         cloneStringSlicePointer(preferOverlay(base.AddDirs, overlay.AddDirs)),
+		AutoCommit:      cloneOptionalValue(preferOverlay(base.AutoCommit, overlay.AutoCommit)),
+		MaxRetries:      cloneOptionalValue(preferOverlay(base.MaxRetries, overlay.MaxRetries)),
+		RetryBackoffMultiplier: cloneOptionalValue(
+			preferOverlay(base.RetryBackoffMultiplier, overlay.RetryBackoffMultiplier),
+		),
+	}
+}
+
+func normalizeProjectConfigPaths(cfg ProjectConfig, baseDir string) (ProjectConfig, error) {
+	defaultsAddDirs, err := resolveConfigAddDirs(cfg.Defaults.AddDirs, baseDir)
+	if err != nil {
+		return ProjectConfig{}, fmt.Errorf("resolve defaults.add_dirs: %w", err)
+	}
+	execAddDirs, err := resolveConfigAddDirs(cfg.Exec.AddDirs, baseDir)
+	if err != nil {
+		return ProjectConfig{}, fmt.Errorf("resolve exec.add_dirs: %w", err)
+	}
+
+	cfg.Defaults.AddDirs = defaultsAddDirs
+	cfg.Exec.AddDirs = execAddDirs
+	return cfg, nil
+}
+
+func resolveConfigAddDirs(addDirs *[]string, baseDir string) (*[]string, error) {
+	if addDirs == nil {
+		return nil, nil
+	}
+
+	resolvedBaseDir, err := resolveConfigBaseDir(baseDir)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := make([]string, 0, len(*addDirs))
+	for _, dir := range *addDirs {
+		trimmed := strings.TrimSpace(dir)
+		if trimmed == "" {
+			resolved = append(resolved, "")
+			continue
+		}
+		if filepath.IsAbs(trimmed) {
+			resolved = append(resolved, filepath.Clean(trimmed))
+			continue
+		}
+		resolved = append(resolved, filepath.Join(resolvedBaseDir, trimmed))
+	}
+	return &resolved, nil
+}
+
+func resolveConfigBaseDir(baseDir string) (string, error) {
+	trimmed := strings.TrimSpace(baseDir)
+	if trimmed == "" {
+		return "", fmt.Errorf("base directory is empty")
+	}
+	if filepath.IsAbs(trimmed) {
+		return filepath.Clean(trimmed), nil
+	}
+	absBaseDir, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve base directory %q: %w", trimmed, err)
+	}
+	return absBaseDir, nil
+}
+
+func effectiveCommandOverride[T any](
+	globalDefault *T,
+	globalCommand *T,
+	workspaceDefault *T,
+	workspaceCommand *T,
+) *T {
+	if workspaceCommand != nil {
+		return cloneOptionalValue(workspaceCommand)
+	}
+	if workspaceDefault != nil {
+		return nil
+	}
+	if globalCommand != nil {
+		return cloneOptionalValue(globalCommand)
+	}
+	if globalDefault != nil {
+		return nil
+	}
+	return nil
+}
+
+func effectiveCommandSliceOverride(
+	globalDefault *[]string,
+	globalCommand *[]string,
+	workspaceDefault *[]string,
+	workspaceCommand *[]string,
+) *[]string {
+	if workspaceCommand != nil {
+		return cloneStringSlicePointer(workspaceCommand)
+	}
+	if workspaceDefault != nil {
+		return nil
+	}
+	if globalCommand != nil {
+		return cloneStringSlicePointer(globalCommand)
+	}
+	if globalDefault != nil {
+		return nil
+	}
+	return nil
+}
+
+func preferOverlay[T any](base, overlay *T) *T {
+	if overlay != nil {
+		return overlay
+	}
+	return base
+}
+
+func cloneOptionalValue[T any](value *T) *T {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneStringSlicePointer(value *[]string) *[]string {
+	if value == nil {
+		return nil
+	}
+	cloned := append([]string(nil), (*value)...)
+	return &cloned
+}

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -48,8 +48,7 @@ func TestDiscoverFallsBackToStartDirectoryWhenWorkspaceIsMissing(t *testing.T) {
 }
 
 func TestLoadConfigReturnsZeroConfigWhenFileIsMissing(t *testing.T) {
-	t.Parallel()
-
+	isolateWorkspaceConfigHome(t)
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".compozy"), 0o755); err != nil {
 		t.Fatalf("mkdir .compozy: %v", err)
@@ -677,8 +676,6 @@ func TestLoadConfigReturnsContextErrorWhenCanceled(t *testing.T) {
 }
 
 func TestLoadConfigSoundSection(t *testing.T) {
-	t.Parallel()
-
 	cases := []struct {
 		name          string
 		content       string
@@ -723,8 +720,7 @@ on_failed = "\t"
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
+			isolateWorkspaceConfigHome(t)
 			root := t.TempDir()
 			writeWorkspaceConfig(t, root, tc.content)
 
@@ -881,25 +877,48 @@ add_dirs = ["shared", "/opt/tools"]
 	}
 }
 
-func TestLoadConfigDoesNotRequireGlobalConfigWhenHomeLookupFails(t *testing.T) {
+func TestLoadConfigReturnsErrorWhenHomeLookupFails(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, `
+[defaults]
+ide = "claude"
+`)
+	homeErr := errors.New("home unavailable")
+	stubWorkspaceUserHomeDir(t, func() (string, error) {
+		return "", homeErr
+	})
+
+	_, _, err := LoadConfig(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected load config error")
+	}
+	if !errors.Is(err, homeErr) {
+		t.Fatalf("expected home lookup error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "resolve config paths: lookup user home directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigReturnsErrorWhenGlobalBaseDirCannotBeResolved(t *testing.T) {
 	root := t.TempDir()
 	writeWorkspaceConfig(t, root, `
 [defaults]
 ide = "claude"
 `)
 	stubWorkspaceUserHomeDir(t, func() (string, error) {
-		return "", errors.New("home unavailable")
+		return " ", nil
 	})
 
-	cfg, path, err := LoadConfig(context.Background(), root)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
+	_, _, err := LoadConfig(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected load config error")
 	}
-	if path != filepath.Join(root, ".compozy", "config.toml") {
-		t.Fatalf("unexpected effective config path: %q", path)
+	if !strings.Contains(err.Error(), "resolve config paths: resolve global config base dir") {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Defaults.IDE == nil || *cfg.Defaults.IDE != "claude" {
-		t.Fatalf("expected workspace config to load without global path, got %#v", cfg.Defaults.IDE)
+	if !strings.Contains(err.Error(), "base directory is empty") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -67,6 +67,36 @@ func TestLoadConfigReturnsZeroConfigWhenFileIsMissing(t *testing.T) {
 	}
 }
 
+func TestLoadConfigReturnsGlobalConfigWhenWorkspaceFileIsMissing(t *testing.T) {
+	homeDir := isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".compozy"), 0o755); err != nil {
+		t.Fatalf("mkdir .compozy: %v", err)
+	}
+	writeGlobalConfig(t, homeDir, `
+[defaults]
+ide = "claude"
+model = "sonnet"
+
+[tasks]
+types = ["mobile", "api"]
+`)
+
+	cfg, path, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if path != filepath.Join(homeDir, ".compozy", "config.toml") {
+		t.Fatalf("unexpected effective config path: %q", path)
+	}
+	if cfg.Defaults.IDE == nil || *cfg.Defaults.IDE != "claude" {
+		t.Fatalf("unexpected defaults.ide: %#v", cfg.Defaults.IDE)
+	}
+	if cfg.Tasks.Types == nil || !equalStrings(*cfg.Tasks.Types, []string{"mobile", "api"}) {
+		t.Fatalf("unexpected tasks.types: %#v", cfg.Tasks.Types)
+	}
+}
+
 func TestLoadConfigRejectsUnknownFields(t *testing.T) {
 	t.Parallel()
 
@@ -718,6 +748,161 @@ on_failed = "\t"
 	}
 }
 
+func TestLoadConfigMergesWorkspaceOverGlobalConfig(t *testing.T) {
+	homeDir := isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	writeGlobalConfig(t, homeDir, `
+[defaults]
+ide = "claude"
+model = "sonnet"
+access_mode = "default"
+
+[start]
+include_completed = false
+`)
+	writeWorkspaceConfig(t, root, `
+[defaults]
+model = "gpt-5.4"
+
+[start]
+include_completed = true
+`)
+
+	cfg, path, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if path != filepath.Join(root, ".compozy", "config.toml") {
+		t.Fatalf("unexpected effective config path: %q", path)
+	}
+	if cfg.Defaults.IDE == nil || *cfg.Defaults.IDE != "claude" {
+		t.Fatalf("expected global defaults.ide fallback, got %#v", cfg.Defaults.IDE)
+	}
+	if cfg.Defaults.Model == nil || *cfg.Defaults.Model != "gpt-5.4" {
+		t.Fatalf("expected workspace defaults.model override, got %#v", cfg.Defaults.Model)
+	}
+	if cfg.Start.IncludeCompleted == nil || !*cfg.Start.IncludeCompleted {
+		t.Fatalf("expected workspace start.include_completed override, got %#v", cfg.Start.IncludeCompleted)
+	}
+}
+
+func TestLoadConfigKeepsWorkspaceDefaultsAheadOfGlobalCommandOverrides(t *testing.T) {
+	homeDir := isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	writeGlobalConfig(t, homeDir, `
+[defaults]
+model = "sonnet"
+output_format = "json"
+
+[start]
+output_format = "raw-json"
+tui = false
+
+[exec]
+model = "gpt-5.4"
+output_format = "raw-json"
+verbose = true
+`)
+	writeWorkspaceConfig(t, root, `
+[defaults]
+model = "o4-mini"
+output_format = "text"
+`)
+
+	cfg, _, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Defaults.Model == nil || *cfg.Defaults.Model != "o4-mini" {
+		t.Fatalf("expected workspace defaults.model to win, got %#v", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.OutputFormat == nil || *cfg.Defaults.OutputFormat != "text" {
+		t.Fatalf("expected workspace defaults.output_format to win, got %#v", cfg.Defaults.OutputFormat)
+	}
+	if cfg.Start.OutputFormat != nil {
+		t.Fatalf("expected global start.output_format to stay shadowed, got %#v", cfg.Start.OutputFormat)
+	}
+	if cfg.Start.TUI == nil || *cfg.Start.TUI {
+		t.Fatalf("expected global start.tui to remain available, got %#v", cfg.Start.TUI)
+	}
+	if cfg.Exec.Model != nil {
+		t.Fatalf("expected global exec.model to stay shadowed, got %#v", cfg.Exec.Model)
+	}
+	if cfg.Exec.OutputFormat != nil {
+		t.Fatalf("expected global exec.output_format to stay shadowed, got %#v", cfg.Exec.OutputFormat)
+	}
+	if cfg.Exec.Verbose == nil || !*cfg.Exec.Verbose {
+		t.Fatalf("expected global exec.verbose to remain available, got %#v", cfg.Exec.Verbose)
+	}
+}
+
+func TestLoadConfigRejectsInvalidMergedCrossScopeCombination(t *testing.T) {
+	homeDir := isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	writeGlobalConfig(t, homeDir, `
+[defaults]
+output_format = "json"
+`)
+	writeWorkspaceConfig(t, root, `
+[start]
+tui = true
+`)
+
+	_, _, err := LoadConfig(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected merged config validation error")
+	}
+	if !strings.Contains(err.Error(), "effective config start.tui cannot be true") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigResolvesGlobalAddDirsRelativeToHome(t *testing.T) {
+	homeDir := isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	writeGlobalConfig(t, homeDir, `
+[defaults]
+add_dirs = ["shared", "/opt/tools"]
+`)
+
+	cfg, _, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Defaults.AddDirs == nil {
+		t.Fatal("expected defaults.add_dirs to be populated")
+	}
+	want := []string{
+		filepath.Join(homeDir, "shared"),
+		"/opt/tools",
+	}
+	if !equalStrings(*cfg.Defaults.AddDirs, want) {
+		t.Fatalf("unexpected defaults.add_dirs\nwant: %#v\ngot:  %#v", want, *cfg.Defaults.AddDirs)
+	}
+}
+
+func TestLoadConfigDoesNotRequireGlobalConfigWhenHomeLookupFails(t *testing.T) {
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, `
+[defaults]
+ide = "claude"
+`)
+	stubWorkspaceUserHomeDir(t, func() (string, error) {
+		return "", errors.New("home unavailable")
+	})
+
+	cfg, path, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if path != filepath.Join(root, ".compozy", "config.toml") {
+		t.Fatalf("unexpected effective config path: %q", path)
+	}
+	if cfg.Defaults.IDE == nil || *cfg.Defaults.IDE != "claude" {
+		t.Fatalf("expected workspace config to load without global path, got %#v", cfg.Defaults.IDE)
+	}
+}
+
 func ptrBool(b bool) *bool       { return &b }
 func ptrString(s string) *string { return &s }
 
@@ -756,6 +941,37 @@ func writeWorkspaceConfig(t *testing.T, workspaceRoot, content string) {
 	if err := os.WriteFile(configPath, []byte(strings.TrimLeft(content, "\n")), 0o600); err != nil {
 		t.Fatalf("write config: %v", err)
 	}
+}
+
+func writeGlobalConfig(t *testing.T, homeDir, content string) {
+	t.Helper()
+
+	configDir := filepath.Join(homeDir, ".compozy")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir global config dir: %v", err)
+	}
+	configPath := filepath.Join(configDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte(strings.TrimLeft(content, "\n")), 0o600); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+}
+
+func isolateWorkspaceConfigHome(t *testing.T) string {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	return homeDir
+}
+
+func stubWorkspaceUserHomeDir(t *testing.T, fn func() (string, error)) {
+	t.Helper()
+
+	original := osUserHomeDir
+	osUserHomeDir = fn
+	t.Cleanup(func() {
+		osUserHomeDir = original
+	})
 }
 
 func mustEvalSymlinksWorkspaceTest(t *testing.T, path string) string {

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -1,10 +1,12 @@
 package workspace
 
 type Context struct {
-	Root       string
-	CompozyDir string
-	ConfigPath string
-	Config     ProjectConfig
+	Root                string
+	CompozyDir          string
+	ConfigPath          string
+	WorkspaceConfigPath string
+	GlobalConfigPath    string
+	Config              ProjectConfig
 }
 
 type ProjectConfig struct {

--- a/internal/core/workspace/config_validate.go
+++ b/internal/core/workspace/config_validate.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -13,36 +12,46 @@ import (
 	"github.com/compozy/compozy/internal/core/tasks"
 )
 
+const (
+	workspaceConfigScope = "workspace config"
+	globalConfigScope    = "global config"
+	effectiveConfigScope = "effective config"
+)
+
 func (cfg ProjectConfig) Validate() error {
-	if err := validateDefaults(cfg.Defaults); err != nil {
+	return cfg.validate(workspaceConfigScope)
+}
+
+func (cfg ProjectConfig) validate(scope string) error {
+	if err := validateDefaults(scope, cfg.Defaults); err != nil {
 		return err
 	}
-	if err := validateStart(cfg.Defaults, cfg.Start); err != nil {
+	if err := validateStart(scope, cfg.Defaults, cfg.Start); err != nil {
 		return err
 	}
-	if err := validateTasks(cfg.Tasks); err != nil {
+	if err := validateTasks(scope, cfg.Tasks); err != nil {
 		return err
 	}
-	if err := validateFixReviews(cfg.Defaults, cfg.FixReviews); err != nil {
+	if err := validateFixReviews(scope, cfg.Defaults, cfg.FixReviews); err != nil {
 		return err
 	}
-	if err := validateFetchReviews(cfg.FetchReviews); err != nil {
+	if err := validateFetchReviews(scope, cfg.FetchReviews); err != nil {
 		return err
 	}
-	if err := validateExec(cfg.Defaults, cfg.Exec); err != nil {
+	if err := validateExec(scope, cfg.Defaults, cfg.Exec); err != nil {
 		return err
 	}
-	if err := validateSound(cfg.Sound); err != nil {
+	if err := validateSound(scope, cfg.Sound); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validateSound(cfg SoundConfig) error {
-	if err := validateSoundField("sound.on_completed", cfg.OnCompleted); err != nil {
+func validateSound(scope string, cfg SoundConfig) error {
+	if err := validateSoundField(configFieldName(scope, "sound.on_completed"), cfg.OnCompleted); err != nil {
 		return err
 	}
-	return validateSoundField("sound.on_failed", cfg.OnFailed)
+	return validateSoundField(configFieldName(scope, "sound.on_failed"), cfg.OnFailed)
 }
 
 func validateSoundField(field string, value *string) error {
@@ -50,71 +59,85 @@ func validateSoundField(field string, value *string) error {
 		return nil
 	}
 	if strings.TrimSpace(*value) == "" {
-		return fmt.Errorf("workspace config %s cannot be empty", field)
+		return fmt.Errorf("%s cannot be empty", field)
 	}
 	return nil
 }
 
-func validateDefaults(cfg DefaultsConfig) error {
+func validateDefaults(scope string, cfg DefaultsConfig) error {
 	overrides := RuntimeOverrides(cfg)
-	if err := validateRuntimeOverrides("defaults", overrides); err != nil {
+	if err := validateRuntimeOverrides(scope, "defaults", overrides); err != nil {
 		return err
 	}
-	return validateRuntimeAddDirs("defaults", overrides, nil)
+	return validateRuntimeAddDirs(scope, "defaults", overrides, nil)
 }
 
-func validateStart(defaults DefaultsConfig, cfg StartConfig) error {
-	if err := validateOutputFormatValue("start.output_format", cfg.OutputFormat); err != nil {
+func validateStart(scope string, defaults DefaultsConfig, cfg StartConfig) error {
+	if err := validateOutputFormatValue(configFieldName(scope, "start.output_format"), cfg.OutputFormat); err != nil {
 		return err
 	}
-	return validateWorkflowTUI("start", defaults, cfg.OutputFormat, cfg.TUI)
+	return validateWorkflowTUI(scope, "start", defaults, cfg.OutputFormat, cfg.TUI)
 }
 
-func validateTasks(cfg TasksConfig) error {
+func validateTasks(scope string, cfg TasksConfig) error {
 	if cfg.Types == nil {
 		return nil
 	}
 	if len(*cfg.Types) == 0 {
-		return errors.New("workspace config tasks.types cannot be empty; omit tasks.types to use built-in defaults")
+		return fmt.Errorf(
+			"%s cannot be empty; omit tasks.types to use built-in defaults",
+			configFieldName(scope, "tasks.types"),
+		)
 	}
 	if _, err := tasks.NewRegistry(*cfg.Types); err != nil {
-		return fmt.Errorf("workspace config tasks.types: %w", err)
+		return fmt.Errorf("%s: %w", configFieldName(scope, "tasks.types"), err)
 	}
 	return nil
 }
 
-func validateFixReviews(defaults DefaultsConfig, cfg FixReviewsConfig) error {
+func validateFixReviews(scope string, defaults DefaultsConfig, cfg FixReviewsConfig) error {
 	if cfg.Concurrent != nil && *cfg.Concurrent <= 0 {
-		return fmt.Errorf("workspace config fix_reviews.concurrent must be greater than zero (got %d)", *cfg.Concurrent)
+		return fmt.Errorf(
+			"%s must be greater than zero (got %d)",
+			configFieldName(scope, "fix_reviews.concurrent"),
+			*cfg.Concurrent,
+		)
 	}
 	if cfg.BatchSize != nil && *cfg.BatchSize <= 0 {
-		return fmt.Errorf("workspace config fix_reviews.batch_size must be greater than zero (got %d)", *cfg.BatchSize)
+		return fmt.Errorf(
+			"%s must be greater than zero (got %d)",
+			configFieldName(scope, "fix_reviews.batch_size"),
+			*cfg.BatchSize,
+		)
 	}
-	if err := validateOutputFormatValue("fix_reviews.output_format", cfg.OutputFormat); err != nil {
+	if err := validateOutputFormatValue(
+		configFieldName(scope, "fix_reviews.output_format"),
+		cfg.OutputFormat,
+	); err != nil {
 		return err
 	}
-	return validateWorkflowTUI("fix_reviews", defaults, cfg.OutputFormat, cfg.TUI)
+	return validateWorkflowTUI(scope, "fix_reviews", defaults, cfg.OutputFormat, cfg.TUI)
 }
 
-func validateFetchReviews(cfg FetchReviewsConfig) error {
+func validateFetchReviews(scope string, cfg FetchReviewsConfig) error {
 	if cfg.Provider == nil {
 		return nil
 	}
 	name := strings.TrimSpace(*cfg.Provider)
 	if name == "" {
-		return errors.New("workspace config fetch_reviews.provider cannot be empty")
+		return fmt.Errorf("%s cannot be empty", configFieldName(scope, "fetch_reviews.provider"))
 	}
 	if _, err := provider.ResolveRegistry(providerdefaults.DefaultRegistry()).Get(name); err != nil {
-		return fmt.Errorf("workspace config fetch_reviews.provider: %w", err)
+		return fmt.Errorf("%s: %w", configFieldName(scope, "fetch_reviews.provider"), err)
 	}
 	return nil
 }
 
-func validateExec(defaults DefaultsConfig, cfg ExecConfig) error {
-	if err := validateRuntimeOverrides("exec", cfg.RuntimeOverrides); err != nil {
+func validateExec(scope string, defaults DefaultsConfig, cfg ExecConfig) error {
+	if err := validateRuntimeOverrides(scope, "exec", cfg.RuntimeOverrides); err != nil {
 		return err
 	}
-	if err := validateRuntimeAddDirs("exec", cfg.RuntimeOverrides, &defaults); err != nil {
+	if err := validateRuntimeAddDirs(scope, "exec", cfg.RuntimeOverrides, &defaults); err != nil {
 		return err
 	}
 
@@ -125,7 +148,9 @@ func validateExec(defaults DefaultsConfig, cfg ExecConfig) error {
 	if cfg.TUI != nil && effectiveOutputFormat != nil && *cfg.TUI &&
 		isExecJSONOutputFormat(*effectiveOutputFormat) {
 		return fmt.Errorf(
-			"workspace config exec.tui cannot be true when exec.output_format is %q or %q",
+			"%s cannot be true when %s is %q or %q",
+			configFieldName(scope, "exec.tui"),
+			configFieldName(scope, "exec.output_format"),
 			model.OutputFormatJSONValue,
 			model.OutputFormatRawJSONValue,
 		)
@@ -133,17 +158,17 @@ func validateExec(defaults DefaultsConfig, cfg ExecConfig) error {
 	return nil
 }
 
-func validateWorkflowTUI(section string, defaults DefaultsConfig, outputFormat *string, tui *bool) error {
+func validateWorkflowTUI(scope, section string, defaults DefaultsConfig, outputFormat *string, tui *bool) error {
 	effectiveOutputFormat := outputFormat
-	outputField := fmt.Sprintf("%s.output_format", section)
+	outputField := configFieldName(scope, fmt.Sprintf("%s.output_format", section))
 	if effectiveOutputFormat == nil {
 		effectiveOutputFormat = defaults.OutputFormat
-		outputField = "defaults.output_format"
+		outputField = configFieldName(scope, "defaults.output_format")
 	}
 	if tui != nil && effectiveOutputFormat != nil && *tui && isExecJSONOutputFormat(*effectiveOutputFormat) {
 		return fmt.Errorf(
-			"workspace config %s.tui cannot be true when workspace config %s is %q or %q",
-			section,
+			"%s cannot be true when %s is %q or %q",
+			configFieldName(scope, fmt.Sprintf("%s.tui", section)),
 			outputField,
 			model.OutputFormatJSONValue,
 			model.OutputFormatRawJSONValue,
@@ -152,8 +177,8 @@ func validateWorkflowTUI(section string, defaults DefaultsConfig, outputFormat *
 	return nil
 }
 
-func validateRuntimeOverrides(section string, cfg RuntimeOverrides) error {
-	validators := []func(string, RuntimeOverrides) error{
+func validateRuntimeOverrides(scope, section string, cfg RuntimeOverrides) error {
+	validators := []func(string, string, RuntimeOverrides) error{
 		validateRuntimeIDE,
 		validateRuntimeOutputFormat,
 		validateRuntimeReasoningEffort,
@@ -164,31 +189,31 @@ func validateRuntimeOverrides(section string, cfg RuntimeOverrides) error {
 		validateRuntimeRetryBackoffMultiplier,
 	}
 	for _, validate := range validators {
-		if err := validate(section, cfg); err != nil {
+		if err := validate(scope, section, cfg); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateRuntimeIDE(section string, cfg RuntimeOverrides) error {
+func validateRuntimeIDE(scope, section string, cfg RuntimeOverrides) error {
 	if cfg.IDE == nil {
 		return nil
 	}
 	if strings.TrimSpace(*cfg.IDE) == "" {
-		return fmt.Errorf("workspace config %s.ide cannot be empty", section)
+		return fmt.Errorf("%s cannot be empty", runtimeFieldName(scope, section, "ide"))
 	}
 	if _, err := agent.DriverCatalogEntryForIDE(strings.TrimSpace(*cfg.IDE)); err != nil {
-		return fmt.Errorf("workspace config %s.ide: %w", section, err)
+		return fmt.Errorf("%s: %w", runtimeFieldName(scope, section, "ide"), err)
 	}
 	return nil
 }
 
-func validateRuntimeOutputFormat(section string, cfg RuntimeOverrides) error {
-	return validateOutputFormatValue(runtimeFieldName(section, "output_format"), cfg.OutputFormat)
+func validateRuntimeOutputFormat(scope, section string, cfg RuntimeOverrides) error {
+	return validateOutputFormatValue(runtimeFieldName(scope, section, "output_format"), cfg.OutputFormat)
 }
 
-func validateRuntimeReasoningEffort(section string, cfg RuntimeOverrides) error {
+func validateRuntimeReasoningEffort(scope, section string, cfg RuntimeOverrides) error {
 	if cfg.ReasoningEffort == nil {
 		return nil
 	}
@@ -198,13 +223,13 @@ func validateRuntimeReasoningEffort(section string, cfg RuntimeOverrides) error 
 	default:
 		return fmt.Errorf(
 			"%s must be one of low, medium, high, xhigh (got %q)",
-			runtimeFieldName(section, "reasoning_effort"),
+			runtimeFieldName(scope, section, "reasoning_effort"),
 			strings.TrimSpace(*cfg.ReasoningEffort),
 		)
 	}
 }
 
-func validateRuntimeAccessMode(section string, cfg RuntimeOverrides) error {
+func validateRuntimeAccessMode(scope, section string, cfg RuntimeOverrides) error {
 	if cfg.AccessMode == nil {
 		return nil
 	}
@@ -214,7 +239,7 @@ func validateRuntimeAccessMode(section string, cfg RuntimeOverrides) error {
 	default:
 		return fmt.Errorf(
 			"%s must be %q or %q (got %q)",
-			runtimeFieldName(section, "access_mode"),
+			runtimeFieldName(scope, section, "access_mode"),
 			model.AccessModeDefault,
 			model.AccessModeFull,
 			strings.TrimSpace(*cfg.AccessMode),
@@ -222,27 +247,27 @@ func validateRuntimeAccessMode(section string, cfg RuntimeOverrides) error {
 	}
 }
 
-func validateRuntimeTimeout(section string, cfg RuntimeOverrides) error {
+func validateRuntimeTimeout(scope, section string, cfg RuntimeOverrides) error {
 	if cfg.Timeout == nil {
 		return nil
 	}
 
 	timeout := strings.TrimSpace(*cfg.Timeout)
 	if timeout == "" {
-		return fmt.Errorf("%s cannot be empty", runtimeFieldName(section, "timeout"))
+		return fmt.Errorf("%s cannot be empty", runtimeFieldName(scope, section, "timeout"))
 	}
 	duration, err := time.ParseDuration(timeout)
 	if err != nil {
-		return fmt.Errorf("%s: %w", runtimeFieldName(section, "timeout"), err)
+		return fmt.Errorf("%s: %w", runtimeFieldName(scope, section, "timeout"), err)
 	}
 	if duration <= 0 {
-		return fmt.Errorf("%s must be greater than zero (got %s)", runtimeFieldName(section, "timeout"), timeout)
+		return fmt.Errorf("%s must be greater than zero (got %s)", runtimeFieldName(scope, section, "timeout"), timeout)
 	}
 	return nil
 }
 
-func validateRuntimeAddDirs(section string, cfg RuntimeOverrides, defaults *DefaultsConfig) error {
-	addDirs, fieldName := effectiveAddDirs(section, cfg, defaults)
+func validateRuntimeAddDirs(scope, section string, cfg RuntimeOverrides, defaults *DefaultsConfig) error {
+	addDirs, fieldName := effectiveAddDirs(scope, section, cfg, defaults)
 	if len(addDirs) == 0 {
 		return nil
 	}
@@ -260,35 +285,43 @@ func effectiveIDE(cfg RuntimeOverrides, defaults *DefaultsConfig) string {
 	return model.IDECodex
 }
 
-func effectiveAddDirs(section string, cfg RuntimeOverrides, defaults *DefaultsConfig) ([]string, string) {
+func effectiveAddDirs(scope, section string, cfg RuntimeOverrides, defaults *DefaultsConfig) ([]string, string) {
 	if cfg.AddDirs != nil {
-		return *cfg.AddDirs, runtimeFieldName(section, "add_dirs")
+		return *cfg.AddDirs, runtimeFieldName(scope, section, "add_dirs")
 	}
 	if defaults != nil && defaults.AddDirs != nil {
-		return *defaults.AddDirs, runtimeFieldName("defaults", "add_dirs")
+		return *defaults.AddDirs, runtimeFieldName(scope, "defaults", "add_dirs")
 	}
 	return nil, ""
 }
 
-func validateRuntimeTailLines(section string, cfg RuntimeOverrides) error {
+func validateRuntimeTailLines(scope, section string, cfg RuntimeOverrides) error {
 	if cfg.TailLines != nil && *cfg.TailLines < 0 {
-		return fmt.Errorf("%s must be 0 or greater (got %d)", runtimeFieldName(section, "tail_lines"), *cfg.TailLines)
+		return fmt.Errorf(
+			"%s must be 0 or greater (got %d)",
+			runtimeFieldName(scope, section, "tail_lines"),
+			*cfg.TailLines,
+		)
 	}
 	return nil
 }
 
-func validateRuntimeMaxRetries(section string, cfg RuntimeOverrides) error {
+func validateRuntimeMaxRetries(scope, section string, cfg RuntimeOverrides) error {
 	if cfg.MaxRetries != nil && *cfg.MaxRetries < 0 {
-		return fmt.Errorf("%s cannot be negative (got %d)", runtimeFieldName(section, "max_retries"), *cfg.MaxRetries)
+		return fmt.Errorf(
+			"%s cannot be negative (got %d)",
+			runtimeFieldName(scope, section, "max_retries"),
+			*cfg.MaxRetries,
+		)
 	}
 	return nil
 }
 
-func validateRuntimeRetryBackoffMultiplier(section string, cfg RuntimeOverrides) error {
+func validateRuntimeRetryBackoffMultiplier(scope, section string, cfg RuntimeOverrides) error {
 	if cfg.RetryBackoffMultiplier != nil && *cfg.RetryBackoffMultiplier <= 0 {
 		return fmt.Errorf(
 			"%s must be positive (got %.2f)",
-			runtimeFieldName(section, "retry_backoff_multiplier"),
+			runtimeFieldName(scope, section, "retry_backoff_multiplier"),
 			*cfg.RetryBackoffMultiplier,
 		)
 	}
@@ -325,6 +358,10 @@ func isExecJSONOutputFormat(value string) bool {
 	}
 }
 
-func runtimeFieldName(section, field string) string {
-	return fmt.Sprintf("workspace config %s.%s", section, field)
+func configFieldName(scope, field string) string {
+	return fmt.Sprintf("%s %s", scope, field)
+}
+
+func runtimeFieldName(scope, section, field string) string {
+	return configFieldName(scope, fmt.Sprintf("%s.%s", section, field))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configs are now resolved from both a global file (~/.compozy/config.toml) and a workspace file (.compozy/config.toml); workspace settings override global ones when present.

* **Documentation**
  * Updated CLI help and README wording to reflect the global → workspace → flags precedence.

* **Tests**
  * Expanded tests to cover global config loading, merge precedence, and related error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->