### PR TITLE
fix: workspace register

### DIFF
--- a/.codex/ledger/2026-05-04-MEMORY-workspace-discovery-home.md
+++ b/.codex/ledger/2026-05-04-MEMORY-workspace-discovery-home.md
@@ -1,0 +1,97 @@
+Goal (incl. success criteria):
+
+- Fix issue `#139`: `workspaces register` / `resolve` must not collapse project paths to `$HOME` because of the global `~/.compozy` directory.
+- Success means discovery ignores the global home-scoped `.compozy` marker during upward workspace lookup, real local workspace discovery still works, live daemon-backed relative-path commands resolve against the caller path instead of the daemon cwd, focused tests pass, and `make verify` passes.
+
+Constraints/Assumptions:
+
+- Follow repo instructions: no destructive git commands, use `apply_patch` for manual edits, run full verification before claiming completion.
+- Required skills in use: `systematic-debugging`, `no-workarounds`, `golang-pro`, `testing-anti-patterns`, `qa-execution`, `cy-final-verify`.
+- Accepted plan must be persisted under `.codex/plans/`.
+- API callers using raw relative paths are ambiguous by design; the supported fix surface is the internal client/CLI boundary where the caller cwd is known.
+
+Key decisions:
+
+- Treat `~/.compozy` as global runtime/config state, not a workspace marker for upward discovery.
+- Keep public CLI/API contracts unchanged; only path resolution behavior changes.
+- Prefer best-effort canonical path comparison so symlinks do not reintroduce the bug.
+- Normalize relative workspace register/resolve paths on the client side before they cross the daemon boundary so a detached daemon never resolves `.` against its own cwd.
+
+State:
+
+- Completed.
+
+Done:
+
+- Read issue `#139` and confirmed the reported symptom and reproduction.
+- Traced the path flow through `internal/cli/workspace_commands.go`, `internal/api/client/operator.go`, `internal/api/core/handlers.go`, `internal/store/globaldb/registry.go`, and `internal/core/workspace/config.go`.
+- Identified root cause candidate: `workspace.Discover()` walks upward on `.compozy`, which collides with the global `~/.compozy` home layout.
+- Confirmed current tests cover normal nested workspace discovery and fallback-to-start behavior, but not the case where only the global home `.compozy` exists.
+- Persisted the accepted implementation plan.
+- Patched workspace discovery to skip the global home-scoped `.compozy` marker during upward lookup while preserving the fallback-to-start behavior.
+- Added regression coverage in:
+- `internal/core/workspace/config_test.go`
+- `internal/store/globaldb/registry_test.go`
+- `internal/cli/operator_commands_integration_test.go`
+- Ran a dedicated `qa-execution` pass in `/tmp/codex-qa-issue-139`.
+- Reproduced a remaining live bug the earlier tests missed: after the daemon starts from one cwd, `workspaces register .` / `resolve .` still used the daemon cwd because the client forwarded relative paths unchanged.
+- Fixed the live relative-path bug in `internal/api/client/operator.go` by normalizing non-empty relative workspace paths to absolute client-side before API requests.
+- Added focused regression coverage in:
+- `internal/api/client/client_transport_test.go`
+- `internal/cli/operator_commands_integration_test.go`
+- Focused regression verification passed:
+- `go test ./internal/api/client ./internal/cli -run 'TestClientNormalizesRelativeWorkspacePaths|TestWorkspaceCommandsResolveRelativePathsAgainstRealDaemon|TestWorkspaceCommandsIgnoreGlobalHomeMarkerForProjectsWithoutLocalWorkspace' -count=1`
+- Rebuilt `bin/compozy` and reran a live CLI/API matrix against a fresh temp home with `COMPOZY_DAEMON_HTTP_PORT=0`.
+- Live QA matrix passed for:
+- explicit `workspaces register`
+- `workspaces register .` from a project root without local `.compozy`
+- `workspaces register .` from a nested subdir without local `.compozy`
+- explicit `workspaces resolve`
+- `workspaces resolve .` from inside a real local workspace
+- API `POST /api/workspaces`
+- API `POST /api/workspaces/resolve`
+- `workspaces list` / `show`
+- `sync --name complete`
+- `sync`
+- `archive --name complete`
+- Browser smoke passed with `agent-browser`: the daemon-served workspace chooser rendered all seven canonical root paths and reported no page errors; screenshot saved to `/tmp/codex-qa-issue-139/qa/screenshots/issue139-dashboard.png`.
+- Focused verification passed:
+- `go test ./internal/core/workspace ./internal/store/globaldb ./internal/cli -count=1`
+- First `make verify` run failed in lint on `internal/core/workspace/config.go` because `revive` flagged the intentional skip branch as an empty block.
+- Refactored the conditional to preserve behavior without the empty block and re-ran the full gate.
+- Final full verification passed after the QA follow-up fix: `make verify`
+- Evidence:
+- frontend lint/typecheck/test/build passed
+- `golangci-lint run --fix --allow-parallel-runners` reported `0 issues`
+- Go tests reported `DONE 3018 tests, 3 skipped in 37.866s`
+- Go build completed and Playwright e2e reported `5 passed`
+- final line: `All verification checks passed`
+- QA artifacts written:
+- `/tmp/codex-qa-issue-139/qa/verification-report.md`
+- `/tmp/codex-qa-issue-139/qa/bootstrap-manifest.json`
+- `/tmp/codex-qa-issue-139/qa/issues/BUG-001.md`
+
+Now:
+
+- None.
+
+Next:
+
+- None.
+
+Open questions (UNCONFIRMED if needed):
+
+- None.
+
+Working set (files/ids/commands):
+
+- `.codex/plans/2026-05-04-workspace-discovery-home-root.md`
+- `.codex/ledger/2026-05-04-MEMORY-workspace-discovery-home.md`
+- `/tmp/codex-qa-issue-139/qa/{verification-report.md,bootstrap-manifest.json,issues/BUG-001.md,screenshots/issue139-dashboard.png,outputs/*}`
+- `internal/api/client/operator.go`
+- `internal/api/client/client_transport_test.go`
+- `internal/core/workspace/config.go`
+- `internal/core/workspace/config_test.go`
+- `internal/store/globaldb/registry_test.go`
+- `internal/cli/operator_commands_integration_test.go`
+- Commands: `go test ./internal/core/workspace ./internal/store/globaldb ./internal/cli -count=1`, `go test ./internal/api/client ./internal/cli -run 'TestClientNormalizesRelativeWorkspacePaths|TestWorkspaceCommandsResolveRelativePathsAgainstRealDaemon|TestWorkspaceCommandsIgnoreGlobalHomeMarkerForProjectsWithoutLocalWorkspace' -count=1`, live CLI/API QA matrix under `/tmp/codex-qa-issue-139/lab/sequential-live`, `agent-browser --session issue139-qa open http://127.0.0.1:59433/`, `make verify`

--- a/internal/api/client/client_transport_test.go
+++ b/internal/api/client/client_transport_test.go
@@ -186,14 +186,8 @@ func TestClientNormalizesRelativeWorkspacePaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("os.Getwd() error = %v", err)
 	}
-	registerRelative, err := filepath.Rel(cwd, registerDir)
-	if err != nil {
-		t.Fatalf("filepath.Rel(registerDir) error = %v", err)
-	}
-	resolveRelative, err := filepath.Rel(cwd, resolveDir)
-	if err != nil {
-		t.Fatalf("filepath.Rel(resolveDir) error = %v", err)
-	}
+	registerInput := bestEffortRelativeOrAbsoluteClientPath(t, cwd, registerDir)
+	resolveInput := bestEffortRelativeOrAbsoluteClientPath(t, cwd, resolveDir)
 
 	workspace := contract.Workspace{
 		ID:      "ws-relative",
@@ -202,9 +196,6 @@ func TestClientNormalizesRelativeWorkspacePaths(t *testing.T) {
 	}
 	registerExpected := filepath.Clean(registerDir)
 	resolveExpected := filepath.Clean(resolveDir)
-	if filepath.IsAbs(registerRelative) || filepath.IsAbs(resolveRelative) {
-		t.Fatalf("relative paths unexpectedly absolute from cwd %q", cwd)
-	}
 
 	client := &Client{
 		baseURL: "http://daemon",
@@ -245,7 +236,7 @@ func TestClientNormalizesRelativeWorkspacePaths(t *testing.T) {
 
 	registered, err := client.RegisterWorkspace(
 		context.Background(),
-		" "+registerRelative+" ",
+		" "+registerInput+" ",
 		" Demo ",
 	)
 	if err != nil {
@@ -255,13 +246,35 @@ func TestClientNormalizesRelativeWorkspacePaths(t *testing.T) {
 		t.Fatalf("RegisterWorkspace(relative) = %#v, want created workspace at %q", registered, registerExpected)
 	}
 
-	resolved, err := client.ResolveWorkspace(context.Background(), " "+resolveRelative+" ")
+	resolved, err := client.ResolveWorkspace(context.Background(), " "+resolveInput+" ")
 	if err != nil {
 		t.Fatalf("ResolveWorkspace(relative) error = %v", err)
 	}
 	if resolved.RootDir != resolveExpected {
 		t.Fatalf("ResolveWorkspace(relative) = %#v, want root %q", resolved, resolveExpected)
 	}
+}
+
+func bestEffortRelativeOrAbsoluteClientPath(t *testing.T, base string, target string) string {
+	t.Helper()
+
+	relative, err := filepath.Rel(base, target)
+	if err == nil {
+		return relative
+	}
+
+	absolute, absErr := filepath.Abs(target)
+	if absErr == nil {
+		return absolute
+	}
+
+	t.Fatalf(
+		"resolve client test path for %q: filepath.Rel error = %v; filepath.Abs error = %v",
+		target,
+		err,
+		absErr,
+	)
+	return ""
 }
 
 func TestClientOperatorRequestsUseCanonicalContract(t *testing.T) {

--- a/internal/api/client/client_transport_test.go
+++ b/internal/api/client/client_transport_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -173,6 +175,93 @@ func TestTargetAndClientTransportHelpers(t *testing.T) {
 			t.Fatalf("nil RemoteError.Error() = %q, want empty string", got)
 		}
 	})
+}
+
+func TestClientNormalizesRelativeWorkspacePaths(t *testing.T) {
+	t.Parallel()
+
+	registerDir := t.TempDir()
+	resolveDir := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd() error = %v", err)
+	}
+	registerRelative, err := filepath.Rel(cwd, registerDir)
+	if err != nil {
+		t.Fatalf("filepath.Rel(registerDir) error = %v", err)
+	}
+	resolveRelative, err := filepath.Rel(cwd, resolveDir)
+	if err != nil {
+		t.Fatalf("filepath.Rel(resolveDir) error = %v", err)
+	}
+
+	workspace := contract.Workspace{
+		ID:      "ws-relative",
+		RootDir: registerDir,
+		Name:    "relative",
+	}
+	registerExpected := filepath.Clean(registerDir)
+	resolveExpected := filepath.Clean(resolveDir)
+	if filepath.IsAbs(registerRelative) || filepath.IsAbs(resolveRelative) {
+		t.Fatalf("relative paths unexpectedly absolute from cwd %q", cwd)
+	}
+
+	client := &Client{
+		baseURL: "http://daemon",
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.Method + " " + req.URL.EscapedPath() {
+				case http.MethodPost + " /api/workspaces":
+					var payload contract.WorkspaceRegisterRequest
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode register request: %v", err)
+					}
+					if payload.Path != registerExpected || payload.Name != "Demo" {
+						t.Fatalf("register payload = %#v, want absolute %q and trimmed name", payload, registerExpected)
+					}
+					workspace.RootDir = registerExpected
+					return jsonStructResponse(
+						t,
+						http.StatusCreated,
+						contract.WorkspaceResponse{Workspace: workspace},
+					), nil
+				case http.MethodPost + " /api/workspaces/resolve":
+					var payload contract.WorkspaceResolveRequest
+					if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+						t.Fatalf("decode resolve request: %v", err)
+					}
+					if payload.Path != resolveExpected {
+						t.Fatalf("resolve payload = %#v, want absolute %q", payload, resolveExpected)
+					}
+					workspace.RootDir = resolveExpected
+					return jsonStructResponse(t, http.StatusOK, contract.WorkspaceResponse{Workspace: workspace}), nil
+				default:
+					t.Fatalf("unexpected request %s %s", req.Method, req.URL.EscapedPath())
+					return nil, nil
+				}
+			}),
+		},
+	}
+
+	registered, err := client.RegisterWorkspace(
+		context.Background(),
+		" "+registerRelative+" ",
+		" Demo ",
+	)
+	if err != nil {
+		t.Fatalf("RegisterWorkspace(relative) error = %v", err)
+	}
+	if !registered.Created || registered.Workspace.RootDir != registerExpected {
+		t.Fatalf("RegisterWorkspace(relative) = %#v, want created workspace at %q", registered, registerExpected)
+	}
+
+	resolved, err := client.ResolveWorkspace(context.Background(), " "+resolveRelative+" ")
+	if err != nil {
+		t.Fatalf("ResolveWorkspace(relative) error = %v", err)
+	}
+	if resolved.RootDir != resolveExpected {
+		t.Fatalf("ResolveWorkspace(relative) = %#v, want root %q", resolved, resolveExpected)
+	}
 }
 
 func TestClientOperatorRequestsUseCanonicalContract(t *testing.T) {

--- a/internal/api/client/operator.go
+++ b/internal/api/client/operator.go
@@ -3,8 +3,10 @@ package client
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/compozy/compozy/internal/api/contract"
@@ -47,10 +49,14 @@ func (c *Client) RegisterWorkspace(
 	if c == nil {
 		return apicore.WorkspaceRegisterResult{}, ErrDaemonClientRequired
 	}
+	normalizedPath, err := normalizeWorkspacePathArg(path)
+	if err != nil {
+		return apicore.WorkspaceRegisterResult{}, err
+	}
 
 	var response contract.WorkspaceResponse
 	statusCode, err := c.doJSON(ctx, http.MethodPost, "/api/workspaces", contract.WorkspaceRegisterRequest{
-		Path: strings.TrimSpace(path),
+		Path: normalizedPath,
 		Name: strings.TrimSpace(name),
 	}, &response)
 	if err != nil {
@@ -115,14 +121,34 @@ func (c *Client) ResolveWorkspace(ctx context.Context, path string) (apicore.Wor
 	if c == nil {
 		return apicore.Workspace{}, ErrDaemonClientRequired
 	}
+	normalizedPath, err := normalizeWorkspacePathArg(path)
+	if err != nil {
+		return apicore.Workspace{}, err
+	}
 
 	var response contract.WorkspaceResponse
 	if _, err := c.doJSON(ctx, http.MethodPost, "/api/workspaces/resolve", contract.WorkspaceResolveRequest{
-		Path: strings.TrimSpace(path),
+		Path: normalizedPath,
 	}, &response); err != nil {
 		return apicore.Workspace{}, err
 	}
 	return response.Workspace, nil
+}
+
+func normalizeWorkspacePathArg(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(trimmed) {
+		return filepath.Clean(trimmed), nil
+	}
+
+	absolutePath, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve workspace path %q: %w", path, err)
+	}
+	return filepath.Clean(absolutePath), nil
 }
 
 // ListTaskWorkflows loads synced workflow summaries for one workspace.

--- a/internal/cli/operator_commands_integration_test.go
+++ b/internal/cli/operator_commands_integration_test.go
@@ -284,6 +284,11 @@ func TestWorkspaceCommandsIgnoreGlobalHomeMarkerForProjectsWithoutLocalWorkspace
 		waitForCLITestDaemonState(t, paths, daemon.ReadyStateStopped)
 	})
 
+	markerPath := filepath.Join(homeDir, ".compozy")
+	if err := os.MkdirAll(markerPath, 0o755); err != nil {
+		t.Fatalf("mkdir global marker: %v", err)
+	}
+
 	projectRoot := filepath.Join(homeDir, "www", "my-project")
 	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
 		t.Fatalf("mkdir project root: %v", err)

--- a/internal/cli/operator_commands_integration_test.go
+++ b/internal/cli/operator_commands_integration_test.go
@@ -272,6 +272,225 @@ func TestWorkspaceCommandsReflectDaemonRegistryAgainstRealDaemon(t *testing.T) {
 	}
 }
 
+func TestWorkspaceCommandsIgnoreGlobalHomeMarkerForProjectsWithoutLocalWorkspace(t *testing.T) {
+	homeDir := newShortCLITestHomeDir(t)
+	t.Setenv("HOME", homeDir)
+	configureCLITestDaemonHTTPPort(t)
+
+	paths := mustCLITestHomePaths(t)
+	commandDir := t.TempDir()
+	t.Cleanup(func() {
+		_, _, _ = runCLICommand(t, commandDir, "daemon", "stop", "--force", "--format", "json")
+		waitForCLITestDaemonState(t, paths, daemon.ReadyStateStopped)
+	})
+
+	projectRoot := filepath.Join(homeDir, "www", "my-project")
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+		t.Fatalf("mkdir project root: %v", err)
+	}
+
+	stdout, stderr, exitCode := runCLICommand(
+		t,
+		commandDir,
+		"workspaces",
+		"register",
+		projectRoot,
+		"--format",
+		"json",
+	)
+	if exitCode != 0 {
+		t.Fatalf("execute workspaces register: exit=%d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+	var registerPayload struct {
+		Created   bool `json:"created"`
+		Workspace struct {
+			ID      string `json:"id"`
+			RootDir string `json:"root_dir"`
+		} `json:"workspace"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &registerPayload); err != nil {
+		t.Fatalf("decode register payload: %v\nstdout:\n%s", err, stdout)
+	}
+	if !registerPayload.Created ||
+		mustEvalSymlinksCLITest(t, registerPayload.Workspace.RootDir) != mustEvalSymlinksCLITest(t, projectRoot) {
+		t.Fatalf("unexpected register payload: %#v", registerPayload)
+	}
+
+	stdout, stderr, exitCode = runCLICommand(
+		t,
+		commandDir,
+		"workspaces",
+		"show",
+		projectRoot,
+		"--format",
+		"json",
+	)
+	if exitCode != 0 {
+		t.Fatalf("execute workspaces show: exit=%d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+	var showPayload struct {
+		Workspace struct {
+			ID      string `json:"id"`
+			RootDir string `json:"root_dir"`
+		} `json:"workspace"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &showPayload); err != nil {
+		t.Fatalf("decode show payload: %v\nstdout:\n%s", err, stdout)
+	}
+	if showPayload.Workspace.ID != registerPayload.Workspace.ID ||
+		mustEvalSymlinksCLITest(t, showPayload.Workspace.RootDir) != mustEvalSymlinksCLITest(t, projectRoot) {
+		t.Fatalf("unexpected show payload: %#v", showPayload)
+	}
+
+	stdout, stderr, exitCode = runCLICommand(
+		t,
+		commandDir,
+		"workspaces",
+		"resolve",
+		projectRoot,
+		"--format",
+		"json",
+	)
+	if exitCode != 0 {
+		t.Fatalf("execute workspaces resolve: exit=%d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+	var resolvePayload struct {
+		Action    string `json:"action"`
+		Workspace struct {
+			ID      string `json:"id"`
+			RootDir string `json:"root_dir"`
+		} `json:"workspace"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resolvePayload); err != nil {
+		t.Fatalf("decode resolve payload: %v\nstdout:\n%s", err, stdout)
+	}
+	if resolvePayload.Action != "resolved" ||
+		resolvePayload.Workspace.ID != registerPayload.Workspace.ID ||
+		mustEvalSymlinksCLITest(t, resolvePayload.Workspace.RootDir) != mustEvalSymlinksCLITest(t, projectRoot) {
+		t.Fatalf("unexpected resolve payload: %#v", resolvePayload)
+	}
+
+	stdout, stderr, exitCode = runCLICommand(t, commandDir, "workspaces", "list", "--format", "json")
+	if exitCode != 0 {
+		t.Fatalf("execute workspaces list: exit=%d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+	var listPayload struct {
+		Workspaces []struct {
+			RootDir string `json:"root_dir"`
+		} `json:"workspaces"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &listPayload); err != nil {
+		t.Fatalf("decode workspace list payload: %v\nstdout:\n%s", err, stdout)
+	}
+	if len(listPayload.Workspaces) != 1 ||
+		mustEvalSymlinksCLITest(t, listPayload.Workspaces[0].RootDir) != mustEvalSymlinksCLITest(t, projectRoot) {
+		t.Fatalf("unexpected workspace list payload: %#v", listPayload)
+	}
+}
+
+func TestWorkspaceCommandsResolveRelativePathsAgainstRealDaemon(t *testing.T) {
+	homeDir := newShortCLITestHomeDir(t)
+	t.Setenv("HOME", homeDir)
+	configureCLITestDaemonHTTPPort(t)
+
+	paths := mustCLITestHomePaths(t)
+	daemonDir := t.TempDir()
+	t.Cleanup(func() {
+		_, _, _ = runCLICommand(t, daemonDir, "daemon", "stop", "--force", "--format", "json")
+		waitForCLITestDaemonState(t, paths, daemon.ReadyStateStopped)
+	})
+
+	stdout, stderr, exitCode := runCLICommand(t, daemonDir, "daemon", "start", "--format", "json")
+	if exitCode != 0 {
+		t.Fatalf("execute daemon start: exit=%d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+
+	projectRoot := filepath.Join(homeDir, "www", "relative-project")
+	projectNested := filepath.Join(homeDir, "www", "relative-nested", "pkg", "feature")
+	workspaceRoot := filepath.Join(homeDir, "www", "workspace-real")
+	workspaceNested := filepath.Join(workspaceRoot, "pkg", "feature")
+	for _, dir := range []string{projectRoot, projectNested, workspaceNested} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %q: %v", dir, err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks"), 0o755); err != nil {
+		t.Fatalf("mkdir workspace marker: %v", err)
+	}
+
+	stdout, stderr, exitCode = runCLICommand(
+		t,
+		projectRoot,
+		"workspaces",
+		"register",
+		".",
+		"--format",
+		"json",
+	)
+	if exitCode != 0 {
+		t.Fatalf("execute relative workspaces register: exit=%d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+	var registerPayload struct {
+		Workspace struct {
+			RootDir string `json:"root_dir"`
+		} `json:"workspace"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &registerPayload); err != nil {
+		t.Fatalf("decode relative register payload: %v\nstdout:\n%s", err, stdout)
+	}
+	if mustEvalSymlinksCLITest(t, registerPayload.Workspace.RootDir) != mustEvalSymlinksCLITest(t, projectRoot) {
+		t.Fatalf("unexpected relative register payload: %#v", registerPayload)
+	}
+
+	stdout, stderr, exitCode = runCLICommand(
+		t,
+		projectNested,
+		"workspaces",
+		"resolve",
+		".",
+		"--format",
+		"json",
+	)
+	if exitCode != 0 {
+		t.Fatalf("execute relative workspaces resolve: exit=%d\nstdout:\n%s\nstderr:\n%s", exitCode, stdout, stderr)
+	}
+	var resolvePayload struct {
+		Workspace struct {
+			RootDir string `json:"root_dir"`
+		} `json:"workspace"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &resolvePayload); err != nil {
+		t.Fatalf("decode relative resolve payload: %v\nstdout:\n%s", err, stdout)
+	}
+	if mustEvalSymlinksCLITest(t, resolvePayload.Workspace.RootDir) != mustEvalSymlinksCLITest(t, projectNested) {
+		t.Fatalf("unexpected relative resolve payload: %#v", resolvePayload)
+	}
+
+	stdout, stderr, exitCode = runCLICommand(
+		t,
+		workspaceNested,
+		"workspaces",
+		"resolve",
+		".",
+		"--format",
+		"json",
+	)
+	if exitCode != 0 {
+		t.Fatalf(
+			"execute nested workspace resolve: exit=%d\nstdout:\n%s\nstderr:\n%s",
+			exitCode,
+			stdout,
+			stderr,
+		)
+	}
+	if err := json.Unmarshal([]byte(stdout), &resolvePayload); err != nil {
+		t.Fatalf("decode nested workspace resolve payload: %v\nstdout:\n%s", err, stdout)
+	}
+	if mustEvalSymlinksCLITest(t, resolvePayload.Workspace.RootDir) != mustEvalSymlinksCLITest(t, workspaceRoot) {
+		t.Fatalf("unexpected nested workspace resolve payload: %#v", resolvePayload)
+	}
+}
+
 func TestWorkspacesUnregisterRejectsActiveRunsAgainstRealDaemon(t *testing.T) {
 	homeDir := newShortCLITestHomeDir(t)
 	t.Setenv("HOME", homeDir)

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -112,6 +112,7 @@ func discoverWorkspaceRootFromStart(ctx context.Context, startDir string) (strin
 		return "", fmt.Errorf("resolve workspace start dir symlinks: %w", err)
 	}
 
+	globalMarkerDir, hasGlobalMarker := discoverGlobalWorkspaceMarkerDir()
 	current := realStart
 	for {
 		if err := context.Cause(ctx); err != nil {
@@ -121,7 +122,11 @@ func discoverWorkspaceRootFromStart(ctx context.Context, startDir string) (strin
 		candidate := filepath.Join(current, model.WorkflowRootDirName)
 		info, err := os.Stat(candidate)
 		if err == nil && info.IsDir() {
-			return current, nil
+			// The home-scoped Compozy directory stores global runtime/config state.
+			// It must not redefine arbitrary paths under HOME as local workspaces.
+			if !hasGlobalMarker || !sameWorkspaceMarkerDir(candidate, globalMarkerDir) {
+				return current, nil
+			}
 		}
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("stat workspace marker %s: %w", candidate, err)
@@ -133,6 +138,33 @@ func discoverWorkspaceRootFromStart(ctx context.Context, startDir string) (strin
 		}
 		current = parent
 	}
+}
+
+func discoverGlobalWorkspaceMarkerDir() (string, bool) {
+	homeDir, err := osUserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	resolvedHomeDir, err := resolveConfigBaseDir(homeDir)
+	if err != nil {
+		return "", false
+	}
+
+	markerDir := filepath.Join(resolvedHomeDir, model.WorkflowRootDirName)
+	resolvedMarkerDir, err := filepath.EvalSymlinks(markerDir)
+	if err == nil {
+		return filepath.Clean(resolvedMarkerDir), true
+	}
+	return filepath.Clean(markerDir), true
+}
+
+func sameWorkspaceMarkerDir(left string, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
 }
 
 func LoadConfig(ctx context.Context, workspaceRoot string) (ProjectConfig, string, error) {

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -159,12 +159,25 @@ func discoverGlobalWorkspaceMarkerDir() (string, bool) {
 }
 
 func sameWorkspaceMarkerDir(left string, right string) bool {
-	left = strings.TrimSpace(left)
-	right = strings.TrimSpace(right)
+	left = canonicalWorkspaceMarkerDir(left)
+	right = canonicalWorkspaceMarkerDir(right)
 	if left == "" || right == "" {
 		return false
 	}
-	return filepath.Clean(left) == filepath.Clean(right)
+	return left == right
+}
+
+func canonicalWorkspaceMarkerDir(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(path)
 }
 
 func LoadConfig(ctx context.Context, workspaceRoot string) (ProjectConfig, string, error) {

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -48,6 +48,43 @@ func TestDiscoverFallsBackToStartDirectoryWhenWorkspaceIsMissing(t *testing.T) {
 	}
 }
 
+func TestDiscoverIgnoresGlobalHomeCompozyMarker(t *testing.T) {
+	homeDir := t.TempDir()
+	stubWorkspaceUserHomeDir(t, func() (string, error) {
+		return homeDir, nil
+	})
+	if err := os.MkdirAll(filepath.Join(homeDir, ".compozy"), 0o755); err != nil {
+		t.Fatalf("mkdir global .compozy: %v", err)
+	}
+
+	projectRoot := filepath.Join(homeDir, "www", "my-project")
+	nested := filepath.Join(projectRoot, "pkg", "feature")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("mkdir nested project path: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		start string
+		want  string
+	}{
+		{name: "project root", start: projectRoot, want: projectRoot},
+		{name: "nested path", start: nested, want: nested},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Discover(context.Background(), tc.start)
+			if err != nil {
+				t.Fatalf("discover workspace: %v", err)
+			}
+			if mustEvalSymlinksWorkspaceTest(t, got) != mustEvalSymlinksWorkspaceTest(t, tc.want) {
+				t.Fatalf("unexpected workspace root\nwant: %q\ngot:  %q", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestDiscoverMemoizesSuccessfulResultPerStartDir(t *testing.T) {
 	root := t.TempDir()
 	nested := filepath.Join(root, "pkg", "feature", "subdir")

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -85,6 +85,22 @@ func TestDiscoverIgnoresGlobalHomeCompozyMarker(t *testing.T) {
 	}
 }
 
+func TestSameWorkspaceMarkerDirTreatsSymlinkAndTargetAsEqual(t *testing.T) {
+	realHome := filepath.Join(t.TempDir(), "real-home")
+	if err := os.MkdirAll(filepath.Join(realHome, ".compozy"), 0o755); err != nil {
+		t.Fatalf("mkdir real .compozy: %v", err)
+	}
+
+	linkedHome := filepath.Join(t.TempDir(), "linked-home")
+	if err := os.Symlink(realHome, linkedHome); err != nil {
+		t.Fatalf("symlink home dir: %v", err)
+	}
+
+	if !sameWorkspaceMarkerDir(filepath.Join(realHome, ".compozy"), filepath.Join(linkedHome, ".compozy")) {
+		t.Fatal("sameWorkspaceMarkerDir() = false, want true for symlinked marker dir")
+	}
+}
+
 func TestDiscoverMemoizesSuccessfulResultPerStartDir(t *testing.T) {
 	root := t.TempDir()
 	nested := filepath.Join(root, "pkg", "feature", "subdir")

--- a/internal/store/globaldb/registry_test.go
+++ b/internal/store/globaldb/registry_test.go
@@ -85,6 +85,58 @@ func TestResolveOrRegisterUsesDefaultNameAndReturnsExistingRow(t *testing.T) {
 	}
 }
 
+func TestRegisterIgnoresGlobalHomeCompozyMarker(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	db := openTestGlobalDB(t)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	projectRoot := filepath.Join(homeDir, "www", "my-project")
+	if err := os.MkdirAll(filepath.Join(homeDir, ".compozy"), 0o755); err != nil {
+		t.Fatalf("mkdir global .compozy: %v", err)
+	}
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+		t.Fatalf("mkdir project root: %v", err)
+	}
+
+	workspace, err := db.Register(context.Background(), projectRoot, "demo")
+	if err != nil {
+		t.Fatalf("Register(project root): %v", err)
+	}
+	if mustEvalSymlinksRegistryTest(t, workspace.RootDir) != mustEvalSymlinksRegistryTest(t, projectRoot) {
+		t.Fatalf("workspace root = %q, want %q", workspace.RootDir, projectRoot)
+	}
+}
+
+func TestResolveOrRegisterIgnoresGlobalHomeCompozyMarker(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+
+	db := openTestGlobalDB(t)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	projectRoot := filepath.Join(homeDir, "www", "my-project")
+	if err := os.MkdirAll(filepath.Join(homeDir, ".compozy"), 0o755); err != nil {
+		t.Fatalf("mkdir global .compozy: %v", err)
+	}
+	if err := os.MkdirAll(projectRoot, 0o755); err != nil {
+		t.Fatalf("mkdir project root: %v", err)
+	}
+
+	workspace, err := db.ResolveOrRegister(context.Background(), projectRoot)
+	if err != nil {
+		t.Fatalf("ResolveOrRegister(project root): %v", err)
+	}
+	if mustEvalSymlinksRegistryTest(t, workspace.RootDir) != mustEvalSymlinksRegistryTest(t, projectRoot) {
+		t.Fatalf("workspace root = %q, want %q", workspace.RootDir, projectRoot)
+	}
+}
+
 func TestGetByPathPrefersResolvedCanonicalWorkspaceRow(t *testing.T) {
 	t.Parallel()
 
@@ -581,3 +633,13 @@ func (i fakeFileInfo) Mode() fs.FileMode  { return fs.ModeDir }
 func (i fakeFileInfo) ModTime() time.Time { return time.Time{} }
 func (i fakeFileInfo) IsDir() bool        { return true }
 func (i fakeFileInfo) Sys() any           { return nil }
+
+func mustEvalSymlinksRegistryTest(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("eval symlinks for %s: %v", path, err)
+	}
+	return resolved
+}


### PR DESCRIPTION
close #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace path normalization for relative and absolute inputs
  * Workspace discovery no longer treats the global home marker as a local workspace root

* **Tests**
  * Added tests covering normalization, resolution, and symlink equivalence
  * Added CLI integration tests exercising real-daemon workspace register/resolve behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->