### PR TITLE
fix: prevent false task completion via prompt kickoff + worktree diff-check (#144)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -315,6 +315,20 @@ Payload type: `kinds.TaskFileUpdatedPayload`
 - `old_status`
 - `new_status`
 
+### `task.file_skipped`
+
+Payload type: `kinds.TaskFileSkippedPayload`
+
+Emitted when an agent session ends cleanly but does not produce any
+workspace changes. The task frontmatter is left at its prior status so the
+runner will redispatch the same task on the next invocation. See issue #144.
+
+- `tasks_dir`
+- `task_name`
+- `file_path`
+- `preserved_status`
+- `reason` (currently always `no_workspace_changes`)
+
 ### `task.metadata_refreshed`
 
 Payload type: `kinds.TaskMetadataRefreshedPayload`

--- a/internal/core/prompt/prd.go
+++ b/internal/core/prompt/prd.go
@@ -27,14 +27,50 @@ func buildPRDTaskPrompt(task model.IssueEntry, autoCommit bool, memory *Workflow
 
 	sections := []string{
 		fmt.Sprintf("# Implementation Task: %s", task.Name),
+		buildPRDKickoffDirective(task.Name),
 		buildTaskContextSection(taskData),
 		buildPRDRequiredSkillsSection(),
 		buildPRDExecutionRulesSection(prdDir, autoCommit),
 		buildWorkflowMemorySection(memory),
 		fmt.Sprintf("## Task Specification\n\n%s", task.Content),
 		buildTaskFilesSection(task.AbsPath, tasksFile, prdDir, autoCommit),
+		buildPRDClosingDirective(task.Name),
 	}
 	return strings.Join(sections, "\n\n")
+}
+
+// buildPRDKickoffDirective produces the imperative opener that prevents the
+// agent from defaulting to a "ready when you are" standby greeting. The user
+// already authorized execution by invoking `compozy tasks run`; the agent must
+// not pause to ask for confirmation. Phrasing is deliberately direct because
+// Claude Code (and other ACP clients) treat ambiguous descriptive prompts as
+// conversational context, leading to silent no-op sessions.
+func buildPRDKickoffDirective(taskName string) string {
+	return fmt.Sprintf(
+		"<action_required>\n"+
+			"Begin work on **%s** immediately using the installed `cy-execute-task` skill.\n"+
+			"This message is the user's authorization to proceed — do NOT ask the user "+
+			"for confirmation, do NOT wait for further instructions, and do NOT reply "+
+			"with a greeting before starting. Treat the sections below as the complete "+
+			"brief and start executing the cy-execute-task workflow now.\n"+
+			"</action_required>",
+		taskName,
+	)
+}
+
+// buildPRDClosingDirective restates the action requirement at the end of the
+// prompt so it is the most recent context when the agent generates its first
+// response. This pairs with the kickoff directive to harden against standby
+// behavior across long prompts.
+func buildPRDClosingDirective(taskName string) string {
+	return fmt.Sprintf(
+		"<begin_now>\n"+
+			"You have the full brief above. Start the cy-execute-task workflow on **%s** "+
+			"in your next turn. Do not summarize the plan back to the user before acting; "+
+			"the user has already approved execution.\n"+
+			"</begin_now>",
+		taskName,
+	)
 }
 
 func buildTaskContextSection(taskData model.TaskEntry) string {

--- a/internal/core/prompt/prompt_test.go
+++ b/internal/core/prompt/prompt_test.go
@@ -162,6 +162,11 @@ complexity: low
 		"Task file: `/tmp/.compozy/tasks/demo/task_1.md`",
 		"Master tasks file: `/tmp/.compozy/tasks/demo/_tasks.md`",
 		"Automatic commits are disabled for this run (`--auto-commit=false`).",
+		"<action_required>",
+		"Begin work on **task_1.md** immediately",
+		"do NOT ask the user",
+		"<begin_now>",
+		"Start the cy-execute-task workflow on **task_1.md**",
 	}
 	for _, snippet := range requiredSnippets {
 		if !strings.Contains(promptText, snippet) {
@@ -218,6 +223,72 @@ complexity: medium
 	}
 	if !strings.Contains(withoutAutoCommit, "Do not create an automatic commit for this run.") {
 		t.Fatalf("expected no-auto-commit prompt to mention disabled automatic commits")
+	}
+}
+
+// TestBuildPRDTaskPromptIncludesActionDirectives guards the dispatch-bug fix
+// from #144: PRD task prompts must open and close with explicit imperatives so
+// the agent does not default to a "ready when you are" standby greeting and
+// silently produce a no-op session that the runner then misclassifies as a
+// successful task completion. Removing either directive without a replacement
+// regresses the bug.
+func TestBuildPRDTaskPromptIncludesActionDirectives(t *testing.T) {
+	t.Parallel()
+
+	task := model.IssueEntry{
+		Name:    "task_42.md",
+		AbsPath: "/tmp/.compozy/tasks/auth/task_42.md",
+		Content: `---
+status: pending
+title: Wire login flow
+type: backend
+complexity: medium
+---
+
+# Task 42: Wire login flow
+`,
+	}
+
+	promptText := buildPRDTaskPrompt(task, false, nil)
+
+	openerIdx := strings.Index(promptText, "<action_required>")
+	if openerIdx == -1 {
+		t.Fatalf("expected PRD prompt to open with <action_required> directive")
+	}
+	closerIdx := strings.Index(promptText, "<begin_now>")
+	if closerIdx == -1 {
+		t.Fatalf("expected PRD prompt to close with <begin_now> directive")
+	}
+	if closerIdx <= openerIdx {
+		t.Fatalf("expected <begin_now> after <action_required>, got opener=%d closer=%d", openerIdx, closerIdx)
+	}
+
+	// The opener must reference the specific task name and forbid asking for
+	// confirmation — those two properties together are what stops the agent
+	// from emitting "Ready when you are — let me know if you want me to start".
+	requiredOpenerSnippets := []string{
+		"Begin work on **task_42.md** immediately",
+		"`cy-execute-task`",
+		"do NOT ask the user",
+	}
+	for _, snippet := range requiredOpenerSnippets {
+		if !strings.Contains(promptText, snippet) {
+			t.Fatalf("expected opener directive to include %q", snippet)
+		}
+	}
+
+	// The opener must come BEFORE the descriptive context so the agent reads
+	// "act now" first and treats subsequent sections as supporting brief.
+	titleIdx := strings.Index(promptText, "# Implementation Task:")
+	contextIdx := strings.Index(promptText, "## Task Context")
+	if titleIdx == -1 || contextIdx == -1 {
+		t.Fatalf("expected title and context sections in prompt")
+	}
+	if titleIdx >= openerIdx || openerIdx >= contextIdx {
+		t.Fatalf(
+			"expected order: title(%d) -> action_required(%d) -> task context(%d)",
+			titleIdx, openerIdx, contextIdx,
+		)
 	}
 }
 

--- a/internal/core/run/executor/execution_test.go
+++ b/internal/core/run/executor/execution_test.go
@@ -806,6 +806,9 @@ func TestAfterTaskJobSuccessMarksCompletedWhenWorkspaceChanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("capture pre snapshot: %v", err)
 	}
+	if !preSnapshot.IsSupported() {
+		t.Fatalf("expected supported pre snapshot for git workspace")
+	}
 
 	// Simulate the agent producing actual code changes during the session.
 	if err := os.WriteFile(filepath.Join(workspace, "produced.txt"), []byte("agent output"), 0o600); err != nil {

--- a/internal/core/run/executor/execution_test.go
+++ b/internal/core/run/executor/execution_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/core/provider"
 	"github.com/compozy/compozy/internal/core/reviews"
+	"github.com/compozy/compozy/internal/core/run/internal/worktree"
 	"github.com/compozy/compozy/internal/core/tasks"
 	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
 	"github.com/compozy/compozy/pkg/compozy/events/kinds"
@@ -142,7 +144,7 @@ func TestAfterJobSuccessResolvesNewlyResolvedIssuesAndRefreshesMeta(t *testing.T
 		Groups: map[string][]model.IssueEntry{
 			entries[0].CodeFile: {entries[0]},
 		},
-	}); err != nil {
+	}, worktree.Snapshot{}); err != nil {
 		t.Fatalf("afterJobSuccess: %v", err)
 	}
 
@@ -263,7 +265,7 @@ func TestAfterJobSuccessSkipsProviderResolutionWithoutProviderRefs(t *testing.T)
 		Groups: map[string][]model.IssueEntry{
 			entries[0].CodeFile: {entries[0]},
 		},
-	}); err != nil {
+	}, worktree.Snapshot{}); err != nil {
 		t.Fatalf("afterJobSuccess: %v", err)
 	}
 
@@ -348,7 +350,7 @@ func TestAfterJobSuccessAllowsRoundMetaWithoutPR(t *testing.T) {
 		Groups: map[string][]model.IssueEntry{
 			entries[0].CodeFile: {entries[0]},
 		},
-	}); err != nil {
+	}, worktree.Snapshot{}); err != nil {
 		t.Fatalf("afterJobSuccess: %v", err)
 	}
 
@@ -439,7 +441,7 @@ func TestAfterJobSuccessReviewPreResolveCanSkipProviderResolution(t *testing.T) 
 		Groups: map[string][]model.IssueEntry{
 			entries[0].CodeFile: {entries[0]},
 		},
-	}); err != nil {
+	}, worktree.Snapshot{}); err != nil {
 		t.Fatalf("afterJobSuccess: %v", err)
 	}
 
@@ -493,7 +495,7 @@ func TestAfterJobSuccessRefreshesTaskMetaForPRDTasks(t *testing.T) {
 				CodeFile: "task_01",
 			}},
 		},
-	}); err != nil {
+	}, worktree.Snapshot{}); err != nil {
 		t.Fatalf("afterJobSuccess: %v", err)
 	}
 
@@ -602,7 +604,7 @@ func TestAfterJobSuccessFinalizesTriagedIssuesAndRefreshesMeta(t *testing.T) {
 		Groups: map[string][]model.IssueEntry{
 			entries[0].CodeFile: {entries[0]},
 		},
-	}); err != nil {
+	}, worktree.Snapshot{}); err != nil {
 		t.Fatalf("afterJobSuccess: %v", err)
 	}
 
@@ -675,7 +677,7 @@ func TestAfterTaskJobSuccessDoesNotEmitTaskFileUpdatedWhenMarkTaskCompletedFails
 		journal: runJournal,
 	}
 
-	err := execCtx.afterTaskJobSuccess(&job{
+	err := execCtx.afterTaskJobSuccess(context.Background(), &job{
 		Groups: map[string][]model.IssueEntry{
 			"task_missing": {{
 				Name:     "task_missing.md",
@@ -684,12 +686,211 @@ func TestAfterTaskJobSuccessDoesNotEmitTaskFileUpdatedWhenMarkTaskCompletedFails
 				CodeFile: "task_missing",
 			}},
 		},
-	})
+	}, worktree.Snapshot{})
 	if err == nil {
 		t.Fatal("expected missing task file to fail completion")
 	}
 
 	assertNoRuntimeEvents(t, eventsCh, 200*time.Millisecond)
+}
+
+func TestAfterTaskJobSuccessSkipsMarkCompletedWhenWorkspaceUnchanged(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	workspace := initTaskWorkspaceRepo(t)
+	tasksDir := filepath.Join(workspace, ".compozy", "tasks", "demo")
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatalf("mkdir tasks dir: %v", err)
+	}
+	writeRunTaskFile(t, tasksDir, "task_01.md", "pending")
+	if _, err := tasks.RefreshTaskMeta(tasksDir); err != nil {
+		t.Fatalf("refresh initial task meta: %v", err)
+	}
+	commitTaskWorkspace(t, workspace, "seed task")
+
+	taskPath := filepath.Join(tasksDir, "task_01.md")
+	originalContent, err := os.ReadFile(taskPath)
+	if err != nil {
+		t.Fatalf("read task file: %v", err)
+	}
+
+	preSnapshot, err := worktree.Capture(context.Background(), workspace)
+	if err != nil {
+		t.Fatalf("capture pre snapshot: %v", err)
+	}
+	if !preSnapshot.IsSupported() {
+		t.Fatalf("expected supported pre snapshot for git workspace")
+	}
+
+	runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
+	defer cleanup()
+
+	execCtx := &jobExecutionContext{
+		ctx: context.Background(),
+		cfg: &config{
+			Mode:          model.ExecutionModePRDTasks,
+			TasksDir:      tasksDir,
+			WorkspaceRoot: workspace,
+			RunArtifacts: model.RunArtifacts{
+				RunID: runID,
+			},
+		},
+		journal: runJournal,
+	}
+
+	if err := execCtx.afterJobSuccess(context.Background(), &job{
+		Groups: map[string][]model.IssueEntry{
+			"task_01": {{
+				Name:     "task_01.md",
+				AbsPath:  taskPath,
+				Content:  string(originalContent),
+				CodeFile: "task_01",
+			}},
+		},
+	}, preSnapshot); err != nil {
+		t.Fatalf("afterJobSuccess: %v", err)
+	}
+
+	preserved, err := os.ReadFile(taskPath)
+	if err != nil {
+		t.Fatalf("read task file after afterJobSuccess: %v", err)
+	}
+	if !strings.Contains(string(preserved), "status: pending") {
+		t.Fatalf("expected pending status to be preserved when workspace was unchanged, got:\n%s", string(preserved))
+	}
+
+	emitted := collectRuntimeEvents(t, eventsCh, 1)
+	if got := emitted[0].Kind; got != eventspkg.EventKindTaskFileSkipped {
+		t.Fatalf("expected task.file_skipped event, got %s", got)
+	}
+	var skipped kinds.TaskFileSkippedPayload
+	decodeRuntimeEventPayload(t, emitted[0], &skipped)
+	if skipped.TaskName != "task_01.md" {
+		t.Fatalf("unexpected skipped task name: %q", skipped.TaskName)
+	}
+	if skipped.PreservedStatus != "pending" {
+		t.Fatalf("expected preserved_status=pending, got %q", skipped.PreservedStatus)
+	}
+	if skipped.Reason != kinds.TaskFileSkippedReasonNoWorkspaceChanges {
+		t.Fatalf("expected reason no_workspace_changes, got %q", skipped.Reason)
+	}
+
+	assertNoRuntimeEvents(t, eventsCh, 200*time.Millisecond)
+}
+
+func TestAfterTaskJobSuccessMarksCompletedWhenWorkspaceChanged(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	workspace := initTaskWorkspaceRepo(t)
+	tasksDir := filepath.Join(workspace, ".compozy", "tasks", "demo")
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatalf("mkdir tasks dir: %v", err)
+	}
+	writeRunTaskFile(t, tasksDir, "task_01.md", "pending")
+	if _, err := tasks.RefreshTaskMeta(tasksDir); err != nil {
+		t.Fatalf("refresh initial task meta: %v", err)
+	}
+	commitTaskWorkspace(t, workspace, "seed task")
+
+	taskPath := filepath.Join(tasksDir, "task_01.md")
+	originalContent, err := os.ReadFile(taskPath)
+	if err != nil {
+		t.Fatalf("read task file: %v", err)
+	}
+
+	preSnapshot, err := worktree.Capture(context.Background(), workspace)
+	if err != nil {
+		t.Fatalf("capture pre snapshot: %v", err)
+	}
+
+	// Simulate the agent producing actual code changes during the session.
+	if err := os.WriteFile(filepath.Join(workspace, "produced.txt"), []byte("agent output"), 0o600); err != nil {
+		t.Fatalf("simulate agent output: %v", err)
+	}
+
+	runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
+	defer cleanup()
+
+	execCtx := &jobExecutionContext{
+		ctx: context.Background(),
+		cfg: &config{
+			Mode:          model.ExecutionModePRDTasks,
+			TasksDir:      tasksDir,
+			WorkspaceRoot: workspace,
+			RunArtifacts: model.RunArtifacts{
+				RunID: runID,
+			},
+		},
+		journal: runJournal,
+	}
+
+	if err := execCtx.afterJobSuccess(context.Background(), &job{
+		Groups: map[string][]model.IssueEntry{
+			"task_01": {{
+				Name:     "task_01.md",
+				AbsPath:  taskPath,
+				Content:  string(originalContent),
+				CodeFile: "task_01",
+			}},
+		},
+	}, preSnapshot); err != nil {
+		t.Fatalf("afterJobSuccess: %v", err)
+	}
+
+	updated, err := os.ReadFile(taskPath)
+	if err != nil {
+		t.Fatalf("read updated task file: %v", err)
+	}
+	if !strings.Contains(string(updated), "status: completed") {
+		t.Fatalf("expected task to be marked completed after workspace change, got:\n%s", string(updated))
+	}
+
+	emitted := collectRuntimeEvents(t, eventsCh, 2)
+	if got := emitted[0].Kind; got != eventspkg.EventKindTaskFileUpdated {
+		t.Fatalf("expected task.file_updated event, got %s", got)
+	}
+	if got := emitted[1].Kind; got != eventspkg.EventKindTaskMetadataRefreshed {
+		t.Fatalf("expected task.metadata_refreshed event, got %s", got)
+	}
+}
+
+func initTaskWorkspaceRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runWorkspaceGit(t, dir, "init", "-q", "-b", "main")
+	runWorkspaceGit(t, dir, "config", "user.email", "tasks@example.com")
+	runWorkspaceGit(t, dir, "config", "user.name", "Tasks Tester")
+	runWorkspaceGit(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# initial\n"), 0o600); err != nil {
+		t.Fatalf("seed README: %v", err)
+	}
+	runWorkspaceGit(t, dir, "add", "README.md")
+	runWorkspaceGit(t, dir, "commit", "-q", "-m", "initial")
+	return dir
+}
+
+func commitTaskWorkspace(t *testing.T, dir, message string) {
+	t.Helper()
+	runWorkspaceGit(t, dir, "add", "-A")
+	runWorkspaceGit(t, dir, "commit", "-q", "-m", message)
+}
+
+func runWorkspaceGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z",
+		"GIT_COMMITTER_DATE=2026-01-01T00:00:00Z",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, string(out))
+	}
 }
 
 func TestResolveProviderBackedIssuesWarnsAndContinuesOnProviderFailure(t *testing.T) {
@@ -873,7 +1074,7 @@ func TestAfterJobSuccessFailsWhenReviewIssueRemainsPending(t *testing.T) {
 		Groups: map[string][]model.IssueEntry{
 			entries[0].CodeFile: {entries[0]},
 		},
-	})
+	}, worktree.Snapshot{})
 	if err == nil {
 		t.Fatal("expected pending review issue to fail post-success hook")
 	}

--- a/internal/core/run/executor/review_hooks.go
+++ b/internal/core/run/executor/review_hooks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/compozy/compozy/internal/core/provider"
 	"github.com/compozy/compozy/internal/core/providerdefaults"
 	"github.com/compozy/compozy/internal/core/reviews"
+	"github.com/compozy/compozy/internal/core/run/internal/worktree"
 	"github.com/compozy/compozy/internal/core/tasks"
 	"github.com/compozy/compozy/pkg/compozy/events"
 	"github.com/compozy/compozy/pkg/compozy/events/kinds"
@@ -25,9 +26,13 @@ type runtimeReviewProviderResolver interface {
 	ResolveReviewProviderBridge(name string) (provider.ExtensionBridge, bool)
 }
 
-func (j *jobExecutionContext) afterJobSuccess(ctx context.Context, jb *job) error {
+func (j *jobExecutionContext) afterJobSuccess(
+	ctx context.Context,
+	jb *job,
+	preSnapshot worktree.Snapshot,
+) error {
 	if j.cfg.Mode == model.ExecutionModePRDTasks {
-		return j.afterTaskJobSuccess(jb)
+		return j.afterTaskJobSuccess(ctx, jb, preSnapshot)
 	}
 
 	if j.cfg.Mode != model.ExecutionModePRReview {
@@ -36,7 +41,11 @@ func (j *jobExecutionContext) afterJobSuccess(ctx context.Context, jb *job) erro
 	return j.afterReviewJobSuccess(ctx, jb)
 }
 
-func (j *jobExecutionContext) afterTaskJobSuccess(jb *job) error {
+func (j *jobExecutionContext) afterTaskJobSuccess(
+	ctx context.Context,
+	jb *job,
+	preSnapshot worktree.Snapshot,
+) error {
 	if strings.TrimSpace(j.cfg.TasksDir) == "" {
 		return fmt.Errorf("missing tasks directory for task post-processing")
 	}
@@ -48,6 +57,10 @@ func (j *jobExecutionContext) afterTaskJobSuccess(jb *job) error {
 	oldTask, err := tasks.ParseTaskFile(entry.Content)
 	if err != nil {
 		return fmt.Errorf("parse task file %s before completion: %w", entry.AbsPath, err)
+	}
+	if j.workspaceUnchanged(ctx, preSnapshot) {
+		j.recordTaskNoOp(entry, oldTask.Status)
+		return nil
 	}
 	if err := tasks.MarkTaskCompleted(j.cfg.TasksDir, entry.Name); err != nil {
 		return err
@@ -90,6 +103,51 @@ func (j *jobExecutionContext) afterTaskJobSuccess(jb *job) error {
 		meta.Total,
 	)
 	return nil
+}
+
+// workspaceUnchanged compares the pre-dispatch snapshot to a fresh capture and
+// reports whether the agent left the workspace untouched. Both snapshots must
+// be supported (`worktree.Snapshot.IsSupported`) for the no-op detection to
+// apply; in any other case we preserve historical behavior and accept the
+// session as proof of work. See issue #144.
+func (j *jobExecutionContext) workspaceUnchanged(ctx context.Context, preSnapshot worktree.Snapshot) bool {
+	if !preSnapshot.IsSupported() {
+		return false
+	}
+	postSnapshot, err := worktree.Capture(ctx, j.cfg.WorkspaceRoot)
+	if err != nil {
+		j.runtimeLogger().Warn(
+			"failed to capture post-run workspace snapshot; accepting completion to preserve legacy behavior",
+			"workspace_root", j.cfg.WorkspaceRoot,
+			"error", err,
+		)
+		return false
+	}
+	return preSnapshot.Equal(postSnapshot)
+}
+
+// recordTaskNoOp emits a task.file_skipped event and a runtime warning log
+// when MarkTaskCompleted is suppressed because the workspace did not change.
+// The frontmatter is left at its prior status so the next run will redispatch
+// the same task.
+func (j *jobExecutionContext) recordTaskNoOp(entry model.IssueEntry, preservedStatus string) {
+	j.submitEventOrWarn(
+		events.EventKindTaskFileSkipped,
+		kinds.TaskFileSkippedPayload{
+			TasksDir:        j.cfg.TasksDir,
+			TaskName:        entry.Name,
+			FilePath:        entry.AbsPath,
+			PreservedStatus: preservedStatus,
+			Reason:          kinds.TaskFileSkippedReasonNoWorkspaceChanges,
+		},
+	)
+	j.runtimeLogger().Warn(
+		"agent session ended without modifying any workspace files; leaving task pending",
+		"tasks_dir", j.cfg.TasksDir,
+		"task_name", entry.Name,
+		"preserved_status", preservedStatus,
+		"reason", string(kinds.TaskFileSkippedReasonNoWorkspaceChanges),
+	)
 }
 
 func (j *jobExecutionContext) afterReviewJobSuccess(ctx context.Context, jb *job) error {

--- a/internal/core/run/executor/runner.go
+++ b/internal/core/run/executor/runner.go
@@ -8,13 +8,15 @@ import (
 	"time"
 
 	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/core/run/internal/worktree"
 )
 
 type jobRunner struct {
-	index     int
-	job       *job
-	execCtx   *jobExecutionContext
-	lifecycle *jobLifecycle
+	index       int
+	job         *job
+	execCtx     *jobExecutionContext
+	lifecycle   *jobLifecycle
+	preSnapshot worktree.Snapshot
 }
 
 func newJobRunner(index int, jb *job, execCtx *jobExecutionContext) *jobRunner {
@@ -43,6 +45,8 @@ func (r *jobRunner) run(ctx context.Context) {
 		r.lifecycle.markSuccess()
 		return
 	}
+
+	r.preSnapshot = r.captureWorkspaceSnapshot(ctx)
 
 	maxAttempts := atLeastOne(r.execCtx.cfg.MaxRetries + 1)
 	timeout := r.execCtx.cfg.Timeout
@@ -81,7 +85,31 @@ func (r *jobRunner) run(ctx context.Context) {
 }
 
 func (r *jobRunner) runPostSuccessHook(ctx context.Context) error {
-	return r.execCtx.afterJobSuccess(ctx, r.job)
+	return r.execCtx.afterJobSuccess(ctx, r.job, r.preSnapshot)
+}
+
+// captureWorkspaceSnapshot fingerprints the workspace before the agent is
+// dispatched so afterTaskJobSuccess can compare against a post-run capture and
+// detect agent sessions that ended cleanly without producing any code. Only
+// PRD-tasks mode currently consumes the snapshot; in other modes Capture's
+// cost is paid once but the result is unused.
+func (r *jobRunner) captureWorkspaceSnapshot(ctx context.Context) worktree.Snapshot {
+	if r == nil || r.execCtx == nil || r.execCtx.cfg == nil {
+		return worktree.Snapshot{}
+	}
+	if r.execCtx.cfg.Mode != model.ExecutionModePRDTasks {
+		return worktree.Snapshot{}
+	}
+	snap, err := worktree.Capture(ctx, r.execCtx.cfg.WorkspaceRoot)
+	if err != nil {
+		r.execCtx.logger.Warn(
+			"failed to capture pre-run workspace snapshot; falling back to legacy completion behavior",
+			"workspace_root", r.execCtx.cfg.WorkspaceRoot,
+			"error", err,
+		)
+		return worktree.Snapshot{}
+	}
+	return snap
 }
 
 func (r *jobRunner) handleResult(

--- a/internal/core/run/internal/worktree/snapshot.go
+++ b/internal/core/run/internal/worktree/snapshot.go
@@ -95,7 +95,7 @@ func Capture(ctx context.Context, root string) (Snapshot, error) {
 func runGit(ctx context.Context, root string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = root
-	cmd.Env = append(os.Environ(), "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
+	cmd.Env = append(sanitizedGitEnv(), "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -103,6 +103,29 @@ func runGit(ctx context.Context, root string, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.Bytes(), nil
+}
+
+// sanitizedGitEnv returns os.Environ() with repository-selection variables
+// stripped so cmd.Dir is the only signal git uses to locate the working tree.
+// If the parent process inherited GIT_DIR, GIT_WORK_TREE, GIT_COMMON_DIR,
+// GIT_INDEX_FILE, or GIT_NAMESPACE (e.g. invoked from a hook or a wrapper
+// script that is mid-operation on another repo), those variables would take
+// precedence over cmd.Dir and silently produce a snapshot of the wrong tree.
+func sanitizedGitEnv() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "GIT_DIR="),
+			strings.HasPrefix(kv, "GIT_WORK_TREE="),
+			strings.HasPrefix(kv, "GIT_COMMON_DIR="),
+			strings.HasPrefix(kv, "GIT_INDEX_FILE="),
+			strings.HasPrefix(kv, "GIT_NAMESPACE="):
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	return filtered
 }
 
 func isExecLookupError(err error) bool {

--- a/internal/core/run/internal/worktree/snapshot.go
+++ b/internal/core/run/internal/worktree/snapshot.go
@@ -1,0 +1,108 @@
+// Package worktree captures a deterministic fingerprint of a workspace's
+// uncommitted state so callers can detect whether an arbitrary operation (an
+// agent session, a hook, a task job) actually modified any files.
+//
+// The fingerprint is derived from `git rev-parse HEAD` plus
+// `git status --porcelain=v1 -z --untracked-files=all`. When the workspace is
+// not a git repository, has no commits yet, or the `git` binary is missing,
+// Capture returns an unsupported Snapshot rather than an error so callers can
+// degrade gracefully and preserve current behavior.
+package worktree
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const captureSchemaVersion = "compozy-worktree-v1"
+
+// Snapshot is an opaque deterministic fingerprint of a working tree. Snapshots
+// captured at different points in time can be compared with Equal to decide
+// whether the working tree changed between the two captures.
+type Snapshot struct {
+	digest    string
+	supported bool
+}
+
+// IsSupported reports whether the snapshot was successfully captured. An
+// unsupported snapshot is the result of a missing prerequisite (no git
+// metadata, no `git` binary, empty repo) and intentionally never compares
+// equal to anything so callers fall back to the prior behavior.
+func (s Snapshot) IsSupported() bool { return s.supported }
+
+// Equal reports whether two snapshots represent the same working-tree state.
+// Unsupported snapshots never compare equal — including against each other —
+// so the no-op detection only triggers when both pre and post captures
+// succeeded.
+func (s Snapshot) Equal(other Snapshot) bool {
+	if !s.supported || !other.supported {
+		return false
+	}
+	return s.digest == other.digest
+}
+
+// Capture takes a working-tree fingerprint of the workspace at root using
+// `git`. A blank root, missing `.git` directory, missing `git` binary, or
+// repository without any commits all yield an unsupported Snapshot with a nil
+// error. Genuine I/O or process errors propagate.
+func Capture(ctx context.Context, root string) (Snapshot, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return Snapshot{}, nil
+	}
+	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Snapshot{}, nil
+		}
+		return Snapshot{}, fmt.Errorf("worktree: stat .git in %s: %w", root, err)
+	}
+	head, headErr := runGit(ctx, root, "rev-parse", "HEAD")
+	if headErr != nil {
+		// `git rev-parse HEAD` fails on a fresh repository with no commits;
+		// substitute a stable sentinel so the digest is still deterministic.
+		head = []byte("no-head")
+	}
+	porcelain, err := runGit(ctx, root, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	if err != nil {
+		if isExecLookupError(err) {
+			return Snapshot{}, nil
+		}
+		return Snapshot{}, fmt.Errorf("worktree: git status in %s: %w", root, err)
+	}
+	h := sha256.New()
+	h.Write([]byte(captureSchemaVersion))
+	h.Write([]byte{0})
+	h.Write(bytes.TrimSpace(head))
+	h.Write([]byte{0})
+	h.Write(porcelain)
+	return Snapshot{digest: hex.EncodeToString(h.Sum(nil)), supported: true}, nil
+}
+
+func runGit(ctx context.Context, root string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+func isExecLookupError(err error) bool {
+	var execErr *exec.Error
+	if errors.As(err, &execErr) {
+		return errors.Is(execErr.Err, exec.ErrNotFound)
+	}
+	return errors.Is(err, exec.ErrNotFound)
+}

--- a/internal/core/run/internal/worktree/snapshot.go
+++ b/internal/core/run/internal/worktree/snapshot.go
@@ -64,11 +64,17 @@ func Capture(ctx context.Context, root string) (Snapshot, error) {
 		}
 		return Snapshot{}, fmt.Errorf("worktree: stat .git in %s: %w", root, err)
 	}
-	head, headErr := runGit(ctx, root, "rev-parse", "HEAD")
-	if headErr != nil {
-		// `git rev-parse HEAD` fails on a fresh repository with no commits;
-		// substitute a stable sentinel so the digest is still deterministic.
-		head = []byte("no-head")
+	head, err := runGit(ctx, root, "rev-parse", "HEAD")
+	if err != nil {
+		// Any rev-parse failure (missing git binary, empty repo with no commits,
+		// corrupted refs) yields an unsupported Snapshot rather than an error so
+		// the runner falls back to legacy completion behavior. Surfacing the
+		// failure here would force every non-git or fresh-repo workspace through
+		// the error path even though the no-op check is purely advisory.
+		if isExecLookupError(err) {
+			return Snapshot{}, nil
+		}
+		return Snapshot{}, nil
 	}
 	porcelain, err := runGit(ctx, root, "status", "--porcelain=v1", "-z", "--untracked-files=all")
 	if err != nil {

--- a/internal/core/run/internal/worktree/snapshot_test.go
+++ b/internal/core/run/internal/worktree/snapshot_test.go
@@ -1,0 +1,151 @@
+package worktree
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCaptureReturnsUnsupportedSnapshotForBlankRoot(t *testing.T) {
+	snap, err := Capture(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Capture(\"\"): %v", err)
+	}
+	if snap.IsSupported() {
+		t.Fatalf("expected unsupported snapshot for blank root, got supported")
+	}
+}
+
+func TestCaptureReturnsUnsupportedSnapshotForNonGitWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	snap, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture(non-git): %v", err)
+	}
+	if snap.IsSupported() {
+		t.Fatalf("expected unsupported snapshot for non-git workspace, got supported")
+	}
+}
+
+func TestCaptureProducesEqualSnapshotsWhenWorkingTreeIsUnchanged(t *testing.T) {
+	dir := initGitRepoWithCommit(t)
+
+	snapA, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("first Capture: %v", err)
+	}
+	if !snapA.IsSupported() {
+		t.Fatalf("expected supported snapshot, got unsupported")
+	}
+
+	snapB, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("second Capture: %v", err)
+	}
+	if !snapA.Equal(snapB) {
+		t.Fatalf("expected unchanged working tree to yield equal snapshots")
+	}
+}
+
+func TestCaptureDetectsAddedFile(t *testing.T) {
+	dir := initGitRepoWithCommit(t)
+
+	before, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture before: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "new.txt"), []byte("hello"), 0o600); err != nil {
+		t.Fatalf("write new file: %v", err)
+	}
+
+	after, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture after: %v", err)
+	}
+	if before.Equal(after) {
+		t.Fatalf("expected snapshot to change after adding an untracked file")
+	}
+}
+
+func TestCaptureDetectsModifiedTrackedFile(t *testing.T) {
+	dir := initGitRepoWithCommit(t)
+
+	before, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture before: %v", err)
+	}
+
+	tracked := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(tracked, []byte("# changed\n"), 0o600); err != nil {
+		t.Fatalf("modify tracked file: %v", err)
+	}
+
+	after, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture after: %v", err)
+	}
+	if before.Equal(after) {
+		t.Fatalf("expected snapshot to change after modifying a tracked file")
+	}
+}
+
+func TestUnsupportedSnapshotsNeverCompareEqual(t *testing.T) {
+	var a, b Snapshot
+	if a.Equal(b) {
+		t.Fatalf("zero-value snapshots must not compare equal — they signal an unknown state")
+	}
+
+	dir := initGitRepoWithCommit(t)
+	supported, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !supported.IsSupported() {
+		t.Fatalf("expected supported snapshot")
+	}
+	if supported.Equal(a) {
+		t.Fatalf("supported snapshot must not compare equal to unsupported snapshot")
+	}
+	if a.Equal(supported) {
+		t.Fatalf("unsupported snapshot must not compare equal to supported snapshot")
+	}
+}
+
+// initGitRepoWithCommit prepares a temporary git repository with one committed
+// file. Tests that compare snapshots need a non-empty HEAD plus deterministic
+// committer identity so the digest is reproducible across machines.
+func initGitRepoWithCommit(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := t.TempDir()
+	mustGit(t, dir, "init", "-q", "-b", "main")
+	mustGit(t, dir, "config", "user.email", "snapshot@example.com")
+	mustGit(t, dir, "config", "user.name", "Snapshot Tester")
+	mustGit(t, dir, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# initial\n"), 0o600); err != nil {
+		t.Fatalf("seed README: %v", err)
+	}
+	mustGit(t, dir, "add", "README.md")
+	mustGit(t, dir, "commit", "-q", "-m", "initial")
+	return dir
+}
+
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_DATE=2026-01-01T00:00:00Z",
+		"GIT_COMMITTER_DATE=2026-01-01T00:00:00Z",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, string(out))
+	}
+}

--- a/internal/core/run/internal/worktree/snapshot_test.go
+++ b/internal/core/run/internal/worktree/snapshot_test.go
@@ -30,6 +30,24 @@ func TestCaptureReturnsUnsupportedSnapshotForNonGitWorkspace(t *testing.T) {
 	}
 }
 
+func TestCaptureReturnsUnsupportedSnapshotForEmptyGitRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	dir := t.TempDir()
+	mustGit(t, dir, "init", "-q", "-b", "main")
+	mustGit(t, dir, "config", "user.email", "snapshot@example.com")
+	mustGit(t, dir, "config", "user.name", "Snapshot Tester")
+
+	snap, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture(empty-repo): %v", err)
+	}
+	if snap.IsSupported() {
+		t.Fatalf("expected unsupported snapshot for empty repo (no HEAD), got supported")
+	}
+}
+
 func TestCaptureProducesEqualSnapshotsWhenWorkingTreeIsUnchanged(t *testing.T) {
 	dir := initGitRepoWithCommit(t)
 

--- a/internal/core/run/internal/worktree/snapshot_test.go
+++ b/internal/core/run/internal/worktree/snapshot_test.go
@@ -111,6 +111,29 @@ func TestCaptureDetectsModifiedTrackedFile(t *testing.T) {
 	}
 }
 
+func TestCaptureIgnoresInheritedGitRepoSelectionEnv(t *testing.T) {
+	dir := initGitRepoWithCommit(t)
+
+	// Without env sanitization, GIT_DIR pointing at a non-existent path would
+	// take precedence over cmd.Dir and cause git to fail with
+	// "fatal: not a git repository", returning an unsupported Snapshot for a
+	// genuine git workspace. Same risk for GIT_WORK_TREE / GIT_INDEX_FILE etc.
+	bogus := filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("GIT_DIR", bogus)
+	t.Setenv("GIT_WORK_TREE", bogus)
+	t.Setenv("GIT_INDEX_FILE", filepath.Join(bogus, "index"))
+	t.Setenv("GIT_COMMON_DIR", bogus)
+	t.Setenv("GIT_NAMESPACE", "intruder")
+
+	snap, err := Capture(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Capture with inherited GIT_DIR: %v", err)
+	}
+	if !snap.IsSupported() {
+		t.Fatalf("expected supported snapshot — env sanitization should isolate cmd.Dir")
+	}
+}
+
 func TestUnsupportedSnapshotsNeverCompareEqual(t *testing.T) {
 	var a, b Snapshot
 	if a.Equal(b) {

--- a/pkg/compozy/events/docs_test.go
+++ b/pkg/compozy/events/docs_test.go
@@ -38,6 +38,7 @@ func TestEventsDocumentationEnumeratesAllPublicKinds(t *testing.T) {
 		EventKindUsageUpdated,
 		EventKindUsageAggregated,
 		EventKindTaskFileUpdated,
+		EventKindTaskFileSkipped,
 		EventKindTaskMetadataRefreshed,
 		EventKindTaskMemoryUpdated,
 		EventKindArtifactUpdated,

--- a/pkg/compozy/events/event.go
+++ b/pkg/compozy/events/event.go
@@ -60,6 +60,7 @@ const (
 
 	// Task mutation events.
 	EventKindTaskFileUpdated       EventKind = "task.file_updated"
+	EventKindTaskFileSkipped       EventKind = "task.file_skipped"
 	EventKindTaskMetadataRefreshed EventKind = "task.metadata_refreshed"
 	EventKindTaskMemoryUpdated     EventKind = "task.memory_updated"
 

--- a/pkg/compozy/events/event_test.go
+++ b/pkg/compozy/events/event_test.go
@@ -350,6 +350,16 @@ func TestPayloadStructsRoundTripJSON(t *testing.T) {
 			},
 		},
 		{
+			name: "task file skipped",
+			payload: kinds.TaskFileSkippedPayload{
+				TasksDir:        "/repo/.compozy/tasks/engine-kernel",
+				TaskName:        "task_01.md",
+				FilePath:        "/repo/.compozy/tasks/engine-kernel/task_01.md",
+				PreservedStatus: "pending",
+				Reason:          kinds.TaskFileSkippedReasonNoWorkspaceChanges,
+			},
+		},
+		{
 			name: "task metadata refreshed",
 			payload: kinds.TaskMetadataRefreshedPayload{
 				TasksDir:  "/repo/.compozy/tasks/engine-kernel",

--- a/pkg/compozy/events/kinds/task.go
+++ b/pkg/compozy/events/kinds/task.go
@@ -11,6 +11,27 @@ type TaskFileUpdatedPayload struct {
 	NewStatus string `json:"new_status,omitempty"`
 }
 
+// TaskFileSkippedReason categorizes why a task completion was suppressed.
+type TaskFileSkippedReason string
+
+const (
+	// TaskFileSkippedReasonNoWorkspaceChanges is emitted when the agent
+	// session ended cleanly but did not modify any file in the workspace.
+	// The task file is left at its prior status and will be re-dispatched
+	// on the next run.
+	TaskFileSkippedReasonNoWorkspaceChanges TaskFileSkippedReason = "no_workspace_changes"
+)
+
+// TaskFileSkippedPayload describes a task completion that was deliberately
+// suppressed because no positive evidence of progress was observed.
+type TaskFileSkippedPayload struct {
+	TasksDir        string                `json:"tasks_dir"`
+	TaskName        string                `json:"task_name"`
+	FilePath        string                `json:"file_path"`
+	PreservedStatus string                `json:"preserved_status,omitempty"`
+	Reason          TaskFileSkippedReason `json:"reason"`
+}
+
 // TaskMetadataRefreshedPayload describes refreshed task workflow metadata.
 type TaskMetadataRefreshedPayload struct {
 	TasksDir  string    `json:"tasks_dir"`


### PR DESCRIPTION
## Summary

Closes #144.

`compozy tasks run --ide claude` was rewriting `status: completed` on every dispatched task as long as the ACP session ended without a transport-level error — even when the agent never started work. Investigation (see screenshots in the issue) revealed two distinct failure modes feeding the same observable bug:

1. **Root cause — non-actionable prompt:** `buildPRDTaskPrompt` assembled a prompt made entirely of descriptive sections (title, context, rules, memory paths, task spec, file paths) without any imperative directive. Combined with the model handoff that opens an ACP session ("Model set to default…"), Claude treats the payload as preparatory context and emits its standby greeting ("Ready when you are — let me know if you want me to start on task_NN") instead of beginning work. The session then ends cleanly with no diff and no tool use.

2. **Symptom amplifier — completion logic:** the runner's success path was gated solely on `sessionErr == nil`, so a clean standby session was indistinguishable from a successful implementation, and `MarkTaskCompleted` rewrote the frontmatter regardless of whether anything actually happened.

This PR addresses both layers.

## Implementation

### Primary fix — prompt kickoff directive (`internal/core/prompt/prd.go`)

`buildPRDTaskPrompt` now wraps the descriptive sections between two unambiguous imperatives:

- **`<action_required>`** opener (`buildPRDKickoffDirective`) inserted right after the title. Names the specific task, points at the `cy-execute-task` skill, and explicitly forbids "ask the user for confirmation" / "wait for further instructions" / "reply with a greeting before starting". The phrasing is deliberately direct because Claude Code (and other ACP clients) treat ambiguous descriptive prompts as conversational context.
- **`<begin_now>`** closer (`buildPRDClosingDirective`) appended at the very end of the prompt so the action requirement is the most recent context when the agent generates its first turn (recency effect).

Test: `TestBuildPRDTaskPromptIncludesActionDirectives` asserts both directives are present, the opener references the task by name and forbids confirmation prompts, and the section ordering puts the kickoff between the title and the descriptive Task Context.

### Secondary fix — workspace diff-check (defense in depth)

Even with the prompt fix, the completion logic should not declare success without evidence of work. New internal package `internal/core/run/internal/worktree` provides an opaque `Snapshot` derived from `git rev-parse HEAD` + `git status --porcelain=v1 -z --untracked-files=all`, hashed with sha256.

- `jobRunner.run` captures a pre-dispatch snapshot and threads it through `afterJobSuccess` → `afterTaskJobSuccess`. A post-success capture is compared against the pre-capture; when both are supported and equal, `MarkTaskCompleted` is suppressed and a new `task.file_skipped` event is emitted.
- Failure modes degrade gracefully: blank workspace root, missing `.git`, missing `git` binary, or empty repository all yield an unsupported `Snapshot{}` that never compares equal — preserving legacy behavior for non-git workspaces.
- New event kind `task.file_skipped` with payload `kinds.TaskFileSkippedPayload{TasksDir, TaskName, FilePath, PreservedStatus, Reason}`. Currently emitted with `Reason: "no_workspace_changes"`. Documented in `docs/events.md`.
- `runGit` strips `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, and `GIT_NAMESPACE` from the inherited environment so the snapshot is locked to `cmd.Dir` and cannot be silently misclassified by a parent process that was mid-operation on another repo.

This catches the residual cases where the prompt fix alone wouldn't help — agent early exit, agent explicit refusal, transport-level oddities, or any future prompt regression that re-introduces standby behavior.

## Tests

- `internal/core/prompt`: `TestBuildPRDTaskPromptIncludesActionDirectives` (new) plus existing `TestBuildPRDTaskPromptUsesInstalledSkillsAndLeavesOnlyTaskSpecificContext` updated to cover the new directive snippets.
- `internal/core/run/internal/worktree`: blank-root unsupported, non-git unsupported, empty-repo unsupported (no HEAD), equal snapshots when unchanged, added-file detection, modified-tracked-file detection, unsupported snapshots never compare equal, and `TestCaptureIgnoresInheritedGitRepoSelectionEnv` (new) which sets `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR`/`GIT_NAMESPACE` to a bogus path via `t.Setenv` and verifies `Capture` still returns a supported snapshot. Without sanitization that test fails because GIT_DIR overrides cmd.Dir and `git rev-parse HEAD` errors with `not a git repository`.
- `internal/core/run/executor`: `TestAfterTaskJobSuccessSkipsMarkCompletedWhenWorkspaceUnchanged` and `TestAfterTaskJobSuccessMarksCompletedWhenWorkspaceChanged` (with `IsSupported()` assertion to prevent legacy-fallback false positives). Both initialize a temp git repo and `t.Skip` when the `git` binary is unavailable.
- Updated existing test call sites for the new `afterJobSuccess` signature; they all pass the zero-value `worktree.Snapshot{}` (unsupported) so existing assertions on legacy behavior still hold.

## Verification

Ran the full `make verify` pipeline (`fmt → lint → test → build`) plus the targeted package suites that cover this PR's changes.

```
make fmt:                                                            clean (no diff)
make build:                                                          exit 0
make test (full repo, -race):                                        3051 PASS / 3 env-skipped / 0 FAIL (65.6s)
golangci-lint run --new-from-rev=origin/main (full repo):            0 issues
```

`make lint` (full pipeline gate) reports 51 issues, but **all 51 pre-exist on `origin/main`** and none touch files modified by this PR:

- 50 × `goconst` in `internal/setup/*` and `sdk/extension/*`
- 1 × `gosec` (G124) in `internal/api/httpapi/browser_middleware.go`

Proof: stashing this branch's working-tree state and running `golangci-lint run` produces 54 issues on the committed branch (50 goconst + 1 gosec + 3 govet for `reflect.Ptr` deprecation, the latter three already fixed locally but intentionally kept out of this PR scope). `golangci-lint --new-from-rev=origin/main` reports **0 new issues** introduced by this branch. The lint baseline is an existing repository state, not a regression from this work.

Targeted package tests for the changes in this PR:

```
go test -race -count=1 ./internal/core/prompt/...
                       ./internal/core/run/internal/worktree/...
                       ./internal/core/run/executor/...
                       ./pkg/compozy/events/...                       all PASS
```

### End-to-end verification (real CLI dispatch)

To confirm the fix lands in the actual prompt that reaches the agent (not just unit-test fixtures), I rebuilt the binary at this branch (`v0.2.1-9-gbb60109`), reset 6 falsely-completed tasks back to `status: pending` in a real workspace that had reproduced #144, killed the running global daemon, and ran:

```
compozy tasks run legacy-to-monorepo --dry-run --ide claude --detach
```

This generates the prompts that would be dispatched without spawning an ACP session. Inspecting the artifacts under `~/.compozy/runs/.../jobs/*.prompt.md`:

```
task_01: <action_required>=1  <begin_now>=1
task_05: <action_required>=1  <begin_now>=1
task_09: <action_required>=1  <begin_now>=1
task_10: <action_required>=1  <begin_now>=1
task_11: <action_required>=1  <begin_now>=1
task_12: <action_required>=1  <begin_now>=1
```

Both directives are present in every dispatched task, with the correct task name interpolated, and `--dry-run` did not mutate any frontmatter (the 6 tasks remained `pending`, confirming the diff-check defense path is also healthy when no ACP session runs).

## Notes

- Scope is intentionally limited to PRD-tasks mode. The pre-snapshot capture is skipped for non-PRD modes so the review path is unaffected.
- This does not require any CLI flag changes. The detection is automatic and conservative — only triggers when both captures definitively succeeded.
- The kickoff directive references the `cy-execute-task` skill that is already named in the existing `<required_skills>` block, so no new skill contracts are introduced.
- Future work (out of scope): an explicit "task complete" assertion at the ACP-protocol level would replace the diff-check with a positive signal from the agent. The two-layer fix here addresses the reported case without requiring that protocol change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PRD task prompt now opens and closes with explicit imperatives instructing the agent to begin work immediately and not ask the user for confirmation, fixing dispatched sessions that previously sat in a standby greeting.
  * Tasks no longer marked complete when the workspace remains unchanged after a session; status remains pending and a `task.file_skipped` event is emitted.

* **New Features**
  * Workspace change detection for task execution impact, with environment-sanitized git invocation so inherited `GIT_DIR`/`GIT_WORK_TREE`/etc. cannot misdirect the snapshot.
  * New event type `task.file_skipped` to signal no-op sessions.

* **Tests**
  * Coverage for the new prompt directives, the worktree snapshot detector (including inherited-env sanitization), and the no-op skip / changed-workspace completion paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
