### PR TITLE
fix: codex acp integration

### DIFF
--- a/.codex/ledger/2026-05-13-MEMORY-reviews-fix-watch.md
+++ b/.codex/ledger/2026-05-13-MEMORY-reviews-fix-watch.md
@@ -1,0 +1,57 @@
+# Goal (incl. success criteria):
+
+- Implement accepted plan to fix compozy reviews fix ACP terminal failure and reviews watch CodeRabbit stale/current-head status handling.
+- Success: focused provider/daemon/agent tests pass and make verify passes.
+
+# Constraints/Assumptions:
+
+- Use rtk prefix for shell commands.
+- No destructive git commands.
+- Work in /Users/pedronauck/Dev/compozy/looper; do not modify /Users/pedronauck/Dev/compozy/agh2 unless explicitly asked for live smoke.
+- Tests must prove behavior, not mocks. Fix production code if tests reveal bugs.
+
+# Key decisions:
+
+- Persisted accepted plan to .codex/plans/2026-05-13-reviews-fix-watch.md.
+- Add current_settled watch state for CodeRabbit status-success/no-current-review-object path.
+- Implement real ACP terminal support rather than suppressing Codex tool use.
+
+# State:
+
+- Implemented provider/watch current_settled behavior and ACP terminal support; focused tests and full make verify passed.
+
+# Done:
+
+- Root-cause investigation completed in Plan Mode.
+- Applicable skills loaded: golang-pro, systematic-debugging, no-workarounds, testing-anti-patterns.
+- Persisted accepted plan under .codex/plans/.
+- Added provider current_settled state and CodeRabbit status-gate behavior.
+- Updated review watch readiness to accept current_settled and added daemon coverage for clean and child-fix paths.
+- Added ACP terminal command lifecycle support and agent/client terminal tests.
+- Focused tests passed:
+  - rtk go test ./internal/core/provider/coderabbit -count=1
+  - rtk go test ./internal/daemon -run 'ReviewWatch|WaitForCurrentReview' -count=1
+  - rtk go test ./internal/core/agent -count=1
+- Final verification passed:
+  - rtk make verify (first run found errcheck issues; fixed terminal cleanup error handling; rerun exit 0)
+- Removed unrelated formatter churn in CHANGELOG.md, RELEASE_BODY.md, and package.json caused by make verify formatting.
+
+# Now:
+
+- Completion audit against plan deliverables.
+
+# Next:
+
+- Report results to user.
+
+# Open questions (UNCONFIRMED if needed):
+
+- None.
+
+# Working set (files/ids/commands):
+
+- .codex/plans/2026-05-13-reviews-fix-watch.md
+- .codex/ledger/2026-05-13-MEMORY-reviews-fix-watch.md
+- internal/core/provider/\*
+- internal/daemon/review_watch.go
+- internal/core/agent/\*

--- a/.compozy/tasks/codex-acp/reviews-001/issue_001.md
+++ b/.compozy/tasks/codex-acp/reviews-001/issue_001.md
@@ -1,0 +1,104 @@
+---
+provider: coderabbit
+pr: "151"
+round: 1
+round_created_at: 2026-05-14T00:24:33.853673Z
+status: resolved
+file: internal/core/agent/terminal.go
+line: 129
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc6B7N8J,comment:PRRC_kwDORy7nkc7BA5V8
+---
+
+# Issue 001: _⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_
+## Review Comment
+
+_⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_
+
+**Don’t drop terminal tracking before the process is actually gone.**
+
+If `waitFor(ctx)` returns on deadline/cancellation, this terminal has already been removed from `c.terminals`. After that, `Close()`/`Kill()` cannot retry cleanup, so the subprocess can be orphaned.
+
+
+
+
+<details>
+<summary>💡 Suggested fix</summary>
+
+```diff
+-	terminal, err := c.removeTerminal(params.SessionId, params.TerminalId)
++	terminal, err := c.lookupTerminal(params.SessionId, params.TerminalId)
+ 	if err != nil {
+ 		return acp.ReleaseTerminalResponse{}, err
+ 	}
+ 	terminal.kill()
+ 	if err := terminal.waitFor(ctx); err != nil {
+ 		return acp.ReleaseTerminalResponse{}, err
+ 	}
++	if _, err := c.removeTerminal(params.SessionId, params.TerminalId); err != nil {
++		return acp.ReleaseTerminalResponse{}, err
++	}
+ 	return acp.ReleaseTerminalResponse{}, nil
+```
+</details>
+
+<!-- suggestion_start -->
+
+<details>
+<summary>📝 Committable suggestion</summary>
+
+> ‼️ **IMPORTANT**
+> Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements.
+
+```suggestion
+	terminal, err := c.lookupTerminal(params.SessionId, params.TerminalId)
+	if err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	terminal.kill()
+	if err := terminal.waitFor(ctx); err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	if _, err := c.removeTerminal(params.SessionId, params.TerminalId); err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	return acp.ReleaseTerminalResponse{}, nil
+```
+
+</details>
+
+<!-- suggestion_end -->
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against current code. Fix only still-valid issues, skip the
+rest with a brief reason, keep changes minimal, and validate.
+
+In `@internal/core/agent/terminal.go` around lines 123 - 129, The code currently
+calls c.removeTerminal(...) before terminal.waitFor(ctx), which removes the
+terminal from c.terminals and can orphan the subprocess on context deadline;
+instead, look up the terminal without removing it (or fetch it from c.terminals
+directly), call terminal.kill(), wait for it with terminal.waitFor(ctx), and
+only after waitFor returns (successful cleanup or final error) call
+c.removeTerminal(...) to remove tracking; update code paths that used
+removeTerminal(...) to use the non-destructive lookup first, then call
+removeTerminal by name/ID after waitFor completes.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:medusa:grasshopper -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Notes:
+  - `releaseTerminal` currently calls `removeTerminal(...)` before `terminal.waitFor(ctx)`.
+  - If the caller context is already canceled or times out before the subprocess exit is observed, `waitFor` returns `ctx.Err()` after tracking has already been removed.
+  - That makes the terminal unreachable for a follow-up `ReleaseTerminal`, `KillTerminalCommand`, or `WaitForTerminalExit`, which can orphan cleanup after a deadline-driven first attempt.
+  - Fix approach: keep the terminal registered until `waitFor` completes successfully, then remove it from `c.terminals`; add client coverage for the retry-after-timeout path.
+  - Resolution: `releaseTerminal` now looks up without removing, waits for completion, and only then drops tracking; `TestClientReleaseTerminalRetainsTrackingWhenWaitContextExpires` covers the retryable timeout/cancel path.

--- a/.compozy/tasks/codex-acp/reviews-001/issue_002.md
+++ b/.compozy/tasks/codex-acp/reviews-001/issue_002.md
@@ -1,0 +1,53 @@
+---
+provider: coderabbit
+pr: "151"
+round: 1
+round_created_at: 2026-05-14T00:24:33.853673Z
+status: resolved
+file: internal/core/agent/terminal.go
+line: 337
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc6B7N8O,comment:PRRC_kwDORy7nkc7BA5WE
+---
+
+# Issue 002: _⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_
+## Review Comment
+
+_⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_
+
+**Add a server-side output cap when `OutputByteLimit` is unset.**
+
+`nil`/`<= 0` currently means “buffer everything in RAM”. One noisy command can exhaust the agent process before the caller ever polls `TerminalOutput`.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against current code. Fix only still-valid issues, skip the
+rest with a brief reason, keep changes minimal, and validate.
+
+In `@internal/core/agent/terminal.go` around lines 332 - 337,
+newTerminalOutputBuffer currently treats a nil or non-positive limit as
+"unlimited", which can let a single command exhaust RAM; change
+newTerminalOutputBuffer to apply a server-side default cap when limit is nil or
+<= 0 (e.g., a constant like defaultOutputByteLimit such as 10*1024*1024 bytes),
+so resolvedLimit is set to that default instead of 0; update/introduce the
+default constant (name: defaultOutputByteLimit) and ensure
+terminalOutputBuffer{limit: resolvedLimit} uses that capped value so
+OutputByteLimit unset no longer means unlimited.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:medusa:grasshopper -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Notes:
+  - `newTerminalOutputBuffer` currently resolves nil or non-positive `OutputByteLimit` to `0`, which disables truncation entirely.
+  - That means ACP terminal output can grow without bound in RAM when clients omit the field, which is not safe for a long-lived agent process.
+  - Fix approach: introduce a server-side default cap and apply it whenever the caller does not provide a positive limit; add buffer-level coverage for nil and non-positive inputs.
+  - Resolution: unset or non-positive limits now fall back to a 10 MiB server-side cap via `defaultOutputByteLimit`; `TestNewTerminalOutputBufferAppliesServerDefaultWhenLimitUnset` covers nil/zero/negative inputs.

--- a/.compozy/tasks/codex-acp/reviews-001/issue_003.md
+++ b/.compozy/tasks/codex-acp/reviews-001/issue_003.md
@@ -1,0 +1,58 @@
+---
+provider: coderabbit
+pr: "151"
+round: 1
+round_created_at: 2026-05-14T00:24:33.853673Z
+status: resolved
+file: internal/core/provider/coderabbit/coderabbit_test.go
+line: 175
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc6B7N8P,comment:PRRC_kwDORy7nkc7BA5WF
+---
+
+# Issue 003: _🛠️ Refactor suggestion_ | _🟠 Major_ | _⚡ Quick win_
+## Review Comment
+
+_🛠️ Refactor suggestion_ | _🟠 Major_ | _⚡ Quick win_
+
+**Use `Should...` naming for these new table-driven `t.Run` cases.**
+
+These case names are passed directly to `t.Run`, so they should follow the required `Should ...` pattern for consistency and policy compliance.
+
+
+As per coding guidelines, `**/*_test.go`: MUST use t.Run("Should...") pattern for ALL test cases.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against current code. Fix only still-valid issues, skip the
+rest with a brief reason, keep changes minimal, and validate.
+
+In `@internal/core/provider/coderabbit/coderabbit_test.go` around lines 147 - 175,
+The test table entries use names that will be passed to t.Run but do not follow
+the required "Should ..." pattern; update the name fields for the affected cases
+in the test table in coderabbit_test.go (the entries with headSHA
+"head-without-review", "head-new" with stale latest provider review, and
+"head-new" with stale review + pending status) so each name begins with "Should
+..." (e.g., "Should mark current settled when CodeRabbit completed current head
+without a provider review", "Should mark current settled when CodeRabbit
+completed current head but latest provider review is stale", "Should be pending
+when CodeRabbit is still processing current head with stale latest review") to
+comply with the t.Run naming convention.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:poseidon:hawk -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Notes:
+  - These table entries are passed directly to `t.Run`, and this repository’s newer Go tests in the surrounding daemon/provider suites consistently use `t.Run("Should ...")` naming.
+  - The affected cases are the newly added review-state scenarios, so aligning them does not change behavior but does bring the suite back to the project’s current test-shape convention.
+  - Fix approach: rename only the affected case names to start with `Should ...`.
+  - Resolution: the three affected table-driven `t.Run` names now start with `Should ...`, with behavior verified by the focused provider tests and the full `rtk make verify` gate.

--- a/.compozy/tasks/codex-acp/reviews-001/issue_004.md
+++ b/.compozy/tasks/codex-acp/reviews-001/issue_004.md
@@ -1,0 +1,58 @@
+---
+provider: coderabbit
+pr: "151"
+round: 1
+round_created_at: 2026-05-14T00:24:33.853673Z
+status: resolved
+file: internal/core/provider/coderabbit/coderabbit_test.go
+line: 218
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc6B7N8R,comment:PRRC_kwDORy7nkc7BA5WH
+---
+
+# Issue 004: _🛠️ Refactor suggestion_ | _🟠 Major_ | _⚡ Quick win_
+## Review Comment
+
+_🛠️ Refactor suggestion_ | _🟠 Major_ | _⚡ Quick win_
+
+**Wrap this scenario in a `t.Run("Should ...")` subtest.**
+
+The new test currently executes assertions directly in the top-level function; please move it into a `Should...` subtest block to match the enforced test pattern.
+
+
+As per coding guidelines, `**/*_test.go`: MUST use t.Run("Should...") pattern for ALL test cases.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against current code. Fix only still-valid issues, skip the
+rest with a brief reason, keep changes minimal, and validate.
+
+In `@internal/core/provider/coderabbit/coderabbit_test.go` around lines 203 - 218,
+Wrap the test body of
+TestWatchStatusFailsWhenCodeRabbitStatusFailsWithoutProviderReview in a t.Run
+subtest whose name starts with "Should" (e.g., t.Run("Should return coderabbit
+status failure", func(t *testing.T) { ... })), move the assertions and the call
+to New(...).WatchStatus(...) into that subtest, and call t.Parallel()
+appropriately (either keep the existing top-level t.Parallel() or call
+t.Parallel() inside the subtest) so the test follows the required
+t.Run("Should...") pattern while preserving the existing logic and referenced
+symbols (TestWatchStatusFailsWhenCodeRabbitStatusFailsWithoutProviderReview,
+New, WithCommandRunner, testWatchStatusRunnerWithStatuses, WatchStatus).
+```
+
+</details>
+
+<!-- fingerprinting:phantom:poseidon:hawk -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Notes:
+  - This file already mixes top-level test functions with `t.Run("Should ...")` subtests, and the neighboring malformed-payload coverage uses the `Should ...` subtest shape.
+  - The new failure-path scenario is the outlier in the touched area because it performs its assertions directly in the top-level function.
+  - Fix approach: wrap that single scenario in one `t.Run("Should ...")` subtest and keep the existing assertions unchanged.
+  - Resolution: `TestWatchStatusFailsWhenCodeRabbitStatusFailsWithoutProviderReview` now executes through a `Should ...` subtest with the same assertions preserved.

--- a/.compozy/tasks/codex-acp/reviews-001/issue_005.md
+++ b/.compozy/tasks/codex-acp/reviews-001/issue_005.md
@@ -1,0 +1,56 @@
+---
+provider: coderabbit
+pr: "151"
+round: 1
+round_created_at: 2026-05-14T00:24:33.853673Z
+status: resolved
+file: internal/daemon/review_watch_test.go
+line: 190
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc6B7N8S,comment:PRRC_kwDORy7nkc7BA5WJ
+---
+
+# Issue 005: _🛠️ Refactor suggestion_ | _🟠 Major_ | _⚡ Quick win_
+## Review Comment
+
+_🛠️ Refactor suggestion_ | _🟠 Major_ | _⚡ Quick win_
+
+**Add `t.Parallel()` in the new subtests if they are independent.**
+
+Both added `t.Run("Should ...")` blocks look isolated and can likely run in parallel; adding `t.Parallel()` aligns with the test policy.
+
+
+As per coding guidelines, `**/*_test.go`: Use `t.Parallel()` for independent subtests.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against current code. Fix only still-valid issues, skip the
+rest with a brief reason, keep changes minimal, and validate.
+
+In `@internal/daemon/review_watch_test.go` around lines 117 - 190, Both subtests
+titled "Should fetch and fix unresolved reviews when provider settled without a
+current review object" and "Should declare clean after provider settled current
+head and no unresolved reviews remain" are independent and should be marked
+parallel; add t.Parallel() as the first line inside each subtest's anonymous
+func(t *testing.T) to enable concurrent execution and follow the test guideline.
+Locate the two t.Run(...) blocks in internal/daemon/review_watch_test.go and
+insert t.Parallel() at the top of each subtest function body (the funcs passed
+to t.Run).
+```
+
+</details>
+
+<!-- fingerprinting:phantom:poseidon:hawk -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Notes:
+  - The two added `current_settled` review-watch scenarios construct isolated fake providers, git state, and test environments; they do not share mutable state across subtests.
+  - Adding `t.Parallel()` is safe here and matches the existing policy used throughout the daemon test suite for independent `Should ...` subtests.
+  - Fix approach: mark those two subtests parallel without changing their assertions or fixtures.
+  - Resolution: both `current_settled` review-watch subtests now call `t.Parallel()` at the start of the subtest body.

--- a/.compozy/tasks/codex-acp/reviews-001/issue_006.md
+++ b/.compozy/tasks/codex-acp/reviews-001/issue_006.md
@@ -1,0 +1,52 @@
+---
+provider: coderabbit
+pr: "151"
+round: 1
+round_created_at: 2026-05-14T00:24:33.853673Z
+status: resolved
+file: internal/daemon/run_manager.go
+line: 1176
+author: coderabbitai[bot]
+provider_ref: thread:PRRT_kwDORy7nkc6B7N8T,comment:PRRC_kwDORy7nkc7BA5WM
+---
+
+# Issue 006: _⚠️ Potential issue_ | _🟠 Major_ | _🏗️ Heavy lift_
+## Review Comment
+
+_⚠️ Potential issue_ | _🟠 Major_ | _🏗️ Heavy lift_
+
+**Don't drop the resumed row's start-state signal.**
+
+At Line 1168 `resumeExistingExecRun` can already insert or reset a persisted exec row to `starting`, but Line 1173 always returns `createdRun=false` on that success path. If `openRunScopeForStart` fails right after, `startRun` skips both cleanup and terminal-state mirroring, so the resumed run can be left stranded in `starting`. Preserve whether the resume path touched the row and use that to either roll it back or mark it failed before returning.
+
+<details>
+<summary>🤖 Prompt for AI Agents</summary>
+
+```
+Verify each finding against current code. Fix only still-valid issues, skip the
+rest with a brief reason, keep changes minimal, and validate.
+
+In `@internal/daemon/run_manager.go` around lines 1164 - 1176, The
+resumeExistingExecRun success path currently returns createdRun=false which
+loses the fact the persisted row was touched; change the return to propagate the
+`ok` flag returned by `resumeExistingExecRun` (i.e., return row, ok, nil) so
+callers like `openRunScopeForStart`/`startRun` know the row was resumed and can
+run rollback/terminal-state mirroring; ensure the code path that calls
+`resumeExistingExecRun` uses the `ok` boolean instead of a hardcoded false when
+deciding cleanup or failure-marking.
+```
+
+</details>
+
+<!-- fingerprinting:phantom:medusa:grasshopper -->
+
+<!-- This is an auto-generated comment by CodeRabbit -->
+
+## Triage
+
+- Decision: `valid`
+- Notes:
+  - `prepareRunRow` currently calls `resumeExistingExecRun(...)`, but when that succeeds it returns `createdRun=false` unconditionally.
+  - On the resumed-exec path, `resumeExistingExecRun` may either insert a fresh global row or reset an existing row back to `starting`. If `openRunScopeForStart` then fails, `startRun` returns before `failStartRun`, so the touched row can remain stranded in `starting`.
+  - Fix approach: preserve resume-path state in `prepareRunRow`/`startRun`, and on scope-open failure route resumed exec rows through failure cleanup instead of the generic “delete only newly created rows” branch; add run-manager coverage for the resumed exec failure path.
+  - Resolution: resumed exec rows now preserve both “resumed” and “created” state through `prepareRunRow`, and scope-open failures route through `failStartRun`; new run-manager coverage exercises both inserted and existing resumed rows.

--- a/.compozy/tasks/codex-acp/reviews-002/issue_001.md
+++ b/.compozy/tasks/codex-acp/reviews-002/issue_001.md
@@ -1,0 +1,30 @@
+---
+provider: coderabbit
+pr: "151"
+round: 2
+round_created_at: 2026-05-14T00:39:21.050231Z
+status: resolved
+file: internal/daemon/run_manager_test.go
+line: 1127
+severity: nitpick
+author: coderabbitai[bot]
+provider_ref: review:4286341126,nitpick_hash:bad7facac44f
+review_hash: bad7facac44f
+source_review_id: "4286341126"
+source_review_submitted_at: "2026-05-14T00:38:52Z"
+---
+
+# Issue 001: Wrap new exec-run scenarios in t.Run("Should...") subtests.
+## Review Comment
+
+Line 1127, Line 1176, and Line 1209 add standalone test cases. Please wrap these scenarios in `t.Run("Should ...")` (or table-driven subtests) to match the test-case pattern required for this repo.
+
+As per coding guidelines, `**/*_test.go`: MUST use t.Run("Should...") pattern for ALL test cases.
+
+## Triage
+
+- Decision: `valid`
+- Notes:
+  - The three flagged exec-run scenarios in `internal/daemon/run_manager_test.go` are currently expressed as standalone top-level test bodies, while this suite already uses explicit `t.Run("Should ...")` subtests for scenario-style coverage.
+  - The invariant belongs in the existing exec-run test suite, so the fix is to wrap each affected scenario in a single `Should ...` subtest without changing the test semantics or widening scope.
+  - Implemented the subtest wrappers and verified the batch with a focused `go test` run plus a clean `make verify`.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 web/src/generated/**
 web/src/routeTree.gen.ts
+CHANGELOG.md
+RELEASE_BODY.md
+package.json

--- a/internal/core/agent/client.go
+++ b/internal/core/agent/client.go
@@ -243,6 +243,9 @@ type clientImpl struct {
 	pendingCreates int
 	pendingUpdates map[string][]model.SessionUpdate
 	loadSupported  bool
+	terminalMu     sync.Mutex
+	terminalNext   int
+	terminals      map[string]*terminalProcess
 
 	wg sync.WaitGroup
 }
@@ -455,27 +458,29 @@ func (c *clientImpl) SupportsLoadSession() bool {
 // Close terminates the agent subprocess and waits for background goroutines to exit.
 func (c *clientImpl) Close() error {
 	c.markClosed()
+	terminalErr := c.closeTerminals()
 
 	process := c.processRef()
 	if process == nil {
-		return nil
+		return terminalErr
 	}
 
 	processErr := process.Shutdown(c.shutdownTimeout)
-	return c.awaitBackgroundShutdown(processErr)
+	return errors.Join(terminalErr, c.awaitBackgroundShutdown(processErr))
 }
 
 // Kill force-terminates the agent subprocess and waits for background goroutines to exit.
 func (c *clientImpl) Kill() error {
 	c.markClosed()
+	terminalErr := c.closeTerminals()
 
 	process := c.processRef()
 	if process == nil {
-		return nil
+		return terminalErr
 	}
 
 	processErr := process.Kill()
-	return c.awaitBackgroundShutdown(processErr)
+	return errors.Join(terminalErr, c.awaitBackgroundShutdown(processErr))
 }
 
 // ReadTextFile handles ACP file read requests from the agent.
@@ -550,44 +555,39 @@ func (c *clientImpl) SessionUpdate(ctx context.Context, params acp.SessionNotifi
 	return nil
 }
 
-// CreateTerminal rejects terminal integration because the current ACP wrapper does not expose terminal handles.
 func (c *clientImpl) CreateTerminal(
-	context.Context,
-	acp.CreateTerminalRequest,
+	ctx context.Context,
+	params acp.CreateTerminalRequest,
 ) (acp.CreateTerminalResponse, error) {
-	return acp.CreateTerminalResponse{}, errors.New("terminal integration is not supported")
+	return c.createTerminal(ctx, params)
 }
 
-// KillTerminalCommand rejects terminal integration because the current ACP wrapper does not expose terminal handles.
 func (c *clientImpl) KillTerminalCommand(
-	context.Context,
-	acp.KillTerminalCommandRequest,
+	ctx context.Context,
+	params acp.KillTerminalCommandRequest,
 ) (acp.KillTerminalCommandResponse, error) {
-	return acp.KillTerminalCommandResponse{}, errors.New("terminal integration is not supported")
+	return c.killTerminalCommand(ctx, params)
 }
 
-// TerminalOutput rejects terminal integration because the current ACP wrapper does not expose terminal handles.
 func (c *clientImpl) TerminalOutput(
-	context.Context,
-	acp.TerminalOutputRequest,
+	ctx context.Context,
+	params acp.TerminalOutputRequest,
 ) (acp.TerminalOutputResponse, error) {
-	return acp.TerminalOutputResponse{}, errors.New("terminal integration is not supported")
+	return c.terminalOutput(ctx, params)
 }
 
-// ReleaseTerminal rejects terminal integration because the current ACP wrapper does not expose terminal handles.
 func (c *clientImpl) ReleaseTerminal(
-	context.Context,
-	acp.ReleaseTerminalRequest,
+	ctx context.Context,
+	params acp.ReleaseTerminalRequest,
 ) (acp.ReleaseTerminalResponse, error) {
-	return acp.ReleaseTerminalResponse{}, errors.New("terminal integration is not supported")
+	return c.releaseTerminal(ctx, params)
 }
 
-// WaitForTerminalExit rejects terminal integration because the current ACP wrapper does not expose terminal handles.
 func (c *clientImpl) WaitForTerminalExit(
-	context.Context,
-	acp.WaitForTerminalExitRequest,
+	ctx context.Context,
+	params acp.WaitForTerminalExitRequest,
 ) (acp.WaitForTerminalExitResponse, error) {
-	return acp.WaitForTerminalExitResponse{}, errors.New("terminal integration is not supported")
+	return c.waitForTerminalExit(ctx, params)
 }
 
 func (c *clientImpl) ensureStarted(ctx context.Context, req SessionRequest) error {
@@ -642,7 +642,7 @@ func (c *clientImpl) ensureStarted(ctx context.Context, req SessionRequest) erro
 				ReadTextFile:  true,
 				WriteTextFile: true,
 			},
-			Terminal: false,
+			Terminal: true,
 		},
 		ClientInfo: &acp.Implementation{
 			Name:    "compozy",
@@ -709,16 +709,56 @@ func (c *clientImpl) waitForProcess() {
 		return
 	}
 	err := process.Wait()
+	if terminalErr := c.closeTerminals(); terminalErr != nil && c.logger != nil {
+		c.logger.Warn("failed to close ACP terminals after agent process exit", "error", terminalErr)
+	}
 
 	if process.Forced() {
 		c.failOpenSessions(context.Canceled)
 		return
 	}
 	if err == nil {
-		c.failOpenSessions(errors.New("ACP agent process exited before all sessions completed"))
+		c.failOpenSessions(c.agentProcessExitError("ACP agent process exited before all sessions completed", nil))
 		return
 	}
-	c.failOpenSessions(err)
+	c.failOpenSessions(c.agentProcessExitError("ACP agent process failed before all sessions completed", err))
+}
+
+func (c *clientImpl) agentProcessExitError(message string, err error) error {
+	openSessions := c.openSessionCount()
+	stderr := ""
+	if process := c.processRef(); process != nil && process.StderrBuffer() != nil {
+		stderr = strings.TrimSpace(process.StderrBuffer().String())
+	}
+	if err == nil {
+		err = errors.New(message)
+	} else {
+		err = fmt.Errorf("%s: %w", message, err)
+	}
+	if diagnostic := acpProcessStderrDiagnostic(stderr); diagnostic != "" {
+		err = fmt.Errorf("%w. %s", err, diagnostic)
+	}
+	if stderr == "" {
+		return fmt.Errorf("%w (open_sessions=%d)", err, openSessions)
+	}
+	return fmt.Errorf("%w (open_sessions=%d, stderr=%q)", err, openSessions, stderr)
+}
+
+func acpProcessStderrDiagnostic(stderr string) string {
+	switch {
+	case strings.Contains(stderr, "Failed to reserve virtual memory for CodeRange"):
+		return "adapter stderr indicates the Codex Code Mode runtime crashed while reserving V8 CodeRange memory"
+	case strings.Contains(stderr, "failed to initialize code mode runtime"):
+		return "adapter stderr indicates the Codex Code Mode runtime failed to initialize"
+	default:
+		return ""
+	}
+}
+
+func (c *clientImpl) openSessionCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.sessions)
 }
 
 func (c *clientImpl) markClosed() {

--- a/internal/core/agent/client_test.go
+++ b/internal/core/agent/client_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -127,6 +128,45 @@ func TestClientCreateSessionBuffersUpdatesArrivingBeforeNewSessionReturns(t *tes
 	}
 	if session.Err() != nil {
 		t.Fatalf("unexpected session error: %v", session.Err())
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("close client: %v", err)
+	}
+}
+
+func TestClientCreateSessionServesTerminalRequestsFromAgent(t *testing.T) {
+	t.Parallel()
+
+	wantExitCode := 0
+	scenario := helperScenario{
+		ExpectedCWD:          t.TempDir(),
+		ExpectedPrompt:       "run a terminal command",
+		StopReason:           string(acp.StopReasonEndTurn),
+		TerminalCommand:      os.Args[0],
+		TerminalArgs:         []string{"-test.run=TestTerminalCommandHelperProcess", "--"},
+		TerminalEnv:          terminalHelperEnv("print-exit", "acp-terminal-ok", "0"),
+		TerminalWantOutput:   "acp-terminal-ok",
+		TerminalWantExitCode: &wantExitCode,
+	}
+
+	client := newTestClient(t, scenario)
+	session, err := client.CreateSession(context.Background(), SessionRequest{
+		WorkingDir: scenario.ExpectedCWD,
+		Prompt:     []byte(scenario.ExpectedPrompt),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	updates := collectSessionUpdates(t, session)
+	if len(updates) != 1 {
+		t.Fatalf("updates length = %d, want 1", len(updates))
+	}
+	if updates[0].Status != model.StatusCompleted {
+		t.Fatalf("final status = %q, want completed", updates[0].Status)
+	}
+	if err := session.Err(); err != nil {
+		t.Fatalf("session error = %v, want nil", err)
 	}
 	if err := client.Close(); err != nil {
 		t.Fatalf("close client: %v", err)
@@ -1190,59 +1230,144 @@ func TestClientHelperMethods(t *testing.T) {
 	}
 }
 
-func TestClientTerminalMethodsReturnUnsupported(t *testing.T) {
+func TestClientTerminalMethodsExecuteCommandAndRetainOutput(t *testing.T) {
 	t.Parallel()
 
-	client := &clientImpl{}
-	cases := []struct {
-		name string
-		call func() error
-	}{
-		{
-			name: "create",
-			call: func() error {
-				_, err := client.CreateTerminal(context.Background(), acp.CreateTerminalRequest{})
-				return err
-			},
-		},
-		{
-			name: "kill",
-			call: func() error {
-				_, err := client.KillTerminalCommand(context.Background(), acp.KillTerminalCommandRequest{})
-				return err
-			},
-		},
-		{
-			name: "output",
-			call: func() error {
-				_, err := client.TerminalOutput(context.Background(), acp.TerminalOutputRequest{})
-				return err
-			},
-		},
-		{
-			name: "release",
-			call: func() error {
-				_, err := client.ReleaseTerminal(context.Background(), acp.ReleaseTerminalRequest{})
-				return err
-			},
-		},
-		{
-			name: "wait_for_exit",
-			call: func() error {
-				_, err := client.WaitForTerminalExit(context.Background(), acp.WaitForTerminalExitRequest{})
-				return err
-			},
-		},
+	client, sessionID := newTerminalTestClient(t)
+	limit := 4
+	resp, err := client.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		SessionId:       acp.SessionId(sessionID),
+		Command:         os.Args[0],
+		Args:            []string{"-test.run=TestTerminalCommandHelperProcess", "--"},
+		Env:             terminalHelperEnv("print-exit", "alpha-beta", "7"),
+		OutputByteLimit: &limit,
+	})
+	if err != nil {
+		t.Fatalf("create terminal: %v", err)
 	}
 
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			if err := tc.call(); err == nil {
-				t.Fatal("expected unsupported terminal error")
-			}
-		})
+	waitResp, err := client.WaitForTerminalExit(context.Background(), acp.WaitForTerminalExitRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: resp.TerminalId,
+	})
+	if err != nil {
+		t.Fatalf("wait for terminal: %v", err)
+	}
+	if waitResp.ExitCode == nil || *waitResp.ExitCode != 7 {
+		t.Fatalf("terminal exit code = %#v, want 7", waitResp.ExitCode)
+	}
+
+	output, err := client.TerminalOutput(context.Background(), acp.TerminalOutputRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: resp.TerminalId,
+	})
+	if err != nil {
+		t.Fatalf("terminal output: %v", err)
+	}
+	if output.Output != "beta" || !output.Truncated {
+		t.Fatalf("terminal output = %#v truncated=%v, want beta truncated", output.Output, output.Truncated)
+	}
+	if output.ExitStatus == nil || output.ExitStatus.ExitCode == nil || *output.ExitStatus.ExitCode != 7 {
+		t.Fatalf("terminal output exit status = %#v, want exit code 7", output.ExitStatus)
+	}
+	if _, err := client.ReleaseTerminal(context.Background(), acp.ReleaseTerminalRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: resp.TerminalId,
+	}); err != nil {
+		t.Fatalf("release terminal: %v", err)
+	}
+}
+
+func TestClientTerminalRejectsCWDOutsideSessionRoots(t *testing.T) {
+	t.Parallel()
+
+	client, sessionID := newTerminalTestClient(t)
+	outside := t.TempDir()
+	_, err := client.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		SessionId: acp.SessionId(sessionID),
+		Command:   os.Args[0],
+		Args:      []string{"-test.run=TestTerminalCommandHelperProcess", "--"},
+		Cwd:       &outside,
+		Env:       terminalHelperEnv("print-exit", "outside", "0"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "outside allowed session roots") {
+		t.Fatalf("CreateTerminal() error = %v, want outside allowed roots", err)
+	}
+}
+
+func TestClientTerminalKillTerminatesCommandAndKeepsOutput(t *testing.T) {
+	t.Parallel()
+
+	client, sessionID := newTerminalTestClient(t)
+	resp, err := client.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		SessionId: acp.SessionId(sessionID),
+		Command:   os.Args[0],
+		Args:      []string{"-test.run=TestTerminalCommandHelperProcess", "--"},
+		Env:       terminalHelperEnv("block", "ready", "0"),
+	})
+	if err != nil {
+		t.Fatalf("create terminal: %v", err)
+	}
+	waitForTerminalOutput(t, client, sessionID, resp.TerminalId, "ready")
+
+	if _, err := client.KillTerminalCommand(context.Background(), acp.KillTerminalCommandRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: resp.TerminalId,
+	}); err != nil {
+		t.Fatalf("kill terminal: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := client.WaitForTerminalExit(waitCtx, acp.WaitForTerminalExitRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: resp.TerminalId,
+	}); err != nil {
+		t.Fatalf("wait for killed terminal: %v", err)
+	}
+	output, err := client.TerminalOutput(context.Background(), acp.TerminalOutputRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: resp.TerminalId,
+	})
+	if err != nil {
+		t.Fatalf("terminal output after kill: %v", err)
+	}
+	if !strings.Contains(output.Output, "ready") {
+		t.Fatalf("terminal output after kill = %q, want ready", output.Output)
+	}
+	if _, err := client.ReleaseTerminal(context.Background(), acp.ReleaseTerminalRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: resp.TerminalId,
+	}); err != nil {
+		t.Fatalf("release killed terminal: %v", err)
+	}
+}
+
+func TestClientCloseCleansUpActiveTerminals(t *testing.T) {
+	t.Parallel()
+
+	client, sessionID := newTerminalTestClient(t)
+	resp, err := client.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		SessionId: acp.SessionId(sessionID),
+		Command:   os.Args[0],
+		Args:      []string{"-test.run=TestTerminalCommandHelperProcess", "--"},
+		Env:       terminalHelperEnv("block", "ready", "0"),
+	})
+	if err != nil {
+		t.Fatalf("create terminal: %v", err)
+	}
+	waitForTerminalOutput(t, client, sessionID, resp.TerminalId, "ready")
+	terminal, err := client.lookupTerminal(acp.SessionId(sessionID), resp.TerminalId)
+	if err != nil {
+		t.Fatalf("lookup terminal: %v", err)
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("close client: %v", err)
+	}
+	select {
+	case <-terminal.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("terminal still running after client close")
 	}
 }
 
@@ -1338,6 +1463,44 @@ func TestClientCreateSessionSurfacesStartupCommandAndStderr(t *testing.T) {
 	}
 }
 
+func TestClientAgentProcessExitErrorDiagnosesCodexCodeModeOOM(t *testing.T) {
+	t.Parallel()
+
+	process, err := subprocess.Launch(context.Background(), subprocess.LaunchConfig{
+		Command: []string{os.Args[0], "-test.run=TestProcessStderrHelperProcess", "--"},
+		Env: subprocess.MergeEnvironment(nil, map[string]string{
+			"GO_WANT_PROCESS_STDERR_HELPER": "1",
+			"GO_PROCESS_STDERR_OUTPUT":      "Fatal process out of memory: Failed to reserve virtual memory for CodeRange",
+			"GO_PROCESS_STDERR_EXIT_CODE":   "0",
+		}),
+		WorkingDir:      t.TempDir(),
+		WaitErrorPrefix: "wait for test ACP process",
+	})
+	if err != nil {
+		t.Fatalf("launch helper process: %v", err)
+	}
+	if err := process.Wait(); err != nil {
+		t.Fatalf("wait helper process: %v", err)
+	}
+
+	client := &clientImpl{
+		process: process,
+		sessions: map[string]*sessionImpl{
+			"sess-oom": newSession("sess-oom"),
+		},
+	}
+	got := client.agentProcessExitError("ACP agent process exited before all sessions completed", nil).Error()
+	for _, want := range []string{
+		"open_sessions=1",
+		"Failed to reserve virtual memory for CodeRange",
+		"Codex Code Mode runtime crashed",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("agentProcessExitError() = %q, want %q", got, want)
+		}
+	}
+}
+
 func TestClientCreateSessionChecksCodexModelCompatibilityBeforeLaunch(t *testing.T) {
 	installCodexACPNPMPackage(t, "0.11.1")
 
@@ -1409,6 +1572,35 @@ func TestACPHelperProcess(_ *testing.T) {
 	os.Exit(0)
 }
 
+func TestTerminalCommandHelperProcess(_ *testing.T) {
+	if os.Getenv("GO_WANT_TERMINAL_HELPER_PROCESS") != "1" {
+		return
+	}
+	fmt.Print(os.Getenv("GO_TERMINAL_HELPER_OUTPUT"))
+	if os.Getenv("GO_TERMINAL_HELPER_MODE") == "block" {
+		select {}
+	}
+	code, err := strconv.Atoi(os.Getenv("GO_TERMINAL_HELPER_EXIT_CODE"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse terminal helper exit code: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(code)
+}
+
+func TestProcessStderrHelperProcess(_ *testing.T) {
+	if os.Getenv("GO_WANT_PROCESS_STDERR_HELPER") != "1" {
+		return
+	}
+	fmt.Fprint(os.Stderr, os.Getenv("GO_PROCESS_STDERR_OUTPUT"))
+	code, err := strconv.Atoi(firstNonEmpty(os.Getenv("GO_PROCESS_STDERR_EXIT_CODE"), "0"))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse process stderr helper exit code: %v\n", err)
+		os.Exit(2)
+	}
+	os.Exit(code)
+}
+
 type helperScenario struct {
 	SessionID                     string              `json:"session_id,omitempty"`
 	ExpectedCWD                   string              `json:"expected_cwd,omitempty"`
@@ -1429,6 +1621,11 @@ type helperScenario struct {
 	NewSessionError               *helperRequestError `json:"new_session_error,omitempty"`
 	PromptError                   *helperRequestError `json:"prompt_error,omitempty"`
 	PromptErrorAfterUpdates       bool                `json:"prompt_error_after_updates,omitempty"`
+	TerminalCommand               string              `json:"terminal_command,omitempty"`
+	TerminalArgs                  []string            `json:"terminal_args,omitempty"`
+	TerminalEnv                   []acp.EnvVariable   `json:"terminal_env,omitempty"`
+	TerminalWantOutput            string              `json:"terminal_want_output,omitempty"`
+	TerminalWantExitCode          *int                `json:"terminal_want_exit_code,omitempty"`
 }
 
 type helperRequestError struct {
@@ -1538,6 +1735,12 @@ func (a *helperAgent) Prompt(ctx context.Context, req acp.PromptRequest) (acp.Pr
 		return acp.PromptResponse{}, err
 	}
 
+	if a.scenario.TerminalCommand != "" {
+		if err := a.runTerminalRequest(ctx, req.SessionId); err != nil {
+			return acp.PromptResponse{}, err
+		}
+	}
+
 	if a.scenario.PromptError != nil && a.scenario.PromptErrorAfterUpdates {
 		return acp.PromptResponse{}, a.scenario.PromptError.toACPError()
 	}
@@ -1552,6 +1755,51 @@ func (a *helperAgent) Prompt(ctx context.Context, req acp.PromptRequest) (acp.Pr
 		stopReason = acp.StopReason(a.scenario.StopReason)
 	}
 	return acp.PromptResponse{StopReason: stopReason}, nil
+}
+
+func (a *helperAgent) runTerminalRequest(ctx context.Context, sessionID acp.SessionId) error {
+	terminalResp, err := a.connection().CreateTerminal(ctx, acp.CreateTerminalRequest{
+		SessionId: sessionID,
+		Command:   a.scenario.TerminalCommand,
+		Args:      append([]string(nil), a.scenario.TerminalArgs...),
+		Env:       append([]acp.EnvVariable(nil), a.scenario.TerminalEnv...),
+	})
+	if err != nil {
+		return fmt.Errorf("create helper terminal: %w", err)
+	}
+	defer func() {
+		_, _ = a.connection().ReleaseTerminal(context.Background(), acp.ReleaseTerminalRequest{
+			SessionId:  sessionID,
+			TerminalId: terminalResp.TerminalId,
+		})
+	}()
+
+	waitResp, err := a.connection().WaitForTerminalExit(ctx, acp.WaitForTerminalExitRequest{
+		SessionId:  sessionID,
+		TerminalId: terminalResp.TerminalId,
+	})
+	if err != nil {
+		return fmt.Errorf("wait for helper terminal: %w", err)
+	}
+	if a.scenario.TerminalWantExitCode != nil &&
+		(waitResp.ExitCode == nil || *waitResp.ExitCode != *a.scenario.TerminalWantExitCode) {
+		return fmt.Errorf(
+			"helper terminal exit code = %#v, want %d",
+			waitResp.ExitCode,
+			*a.scenario.TerminalWantExitCode,
+		)
+	}
+	outputResp, err := a.connection().TerminalOutput(ctx, acp.TerminalOutputRequest{
+		SessionId:  sessionID,
+		TerminalId: terminalResp.TerminalId,
+	})
+	if err != nil {
+		return fmt.Errorf("read helper terminal output: %w", err)
+	}
+	if a.scenario.TerminalWantOutput != "" && !strings.Contains(outputResp.Output, a.scenario.TerminalWantOutput) {
+		return fmt.Errorf("helper terminal output = %q, want %q", outputResp.Output, a.scenario.TerminalWantOutput)
+	}
+	return nil
 }
 
 func (a *helperAgent) emitUpdates(ctx context.Context, updates []acp.SessionUpdate) error {
@@ -1672,6 +1920,58 @@ func collectSessionUpdates(t *testing.T, session Session) []model.SessionUpdate 
 	}
 
 	return updates
+}
+
+func newTerminalTestClient(t *testing.T) (*clientImpl, string) {
+	t.Helper()
+	workingDir := t.TempDir()
+	sessionID := "sess-terminal"
+	return &clientImpl{
+		shutdownTimeout: time.Second,
+		sessions: map[string]*sessionImpl{
+			sessionID: newSessionWithAccess(sessionID, workingDir, []string{workingDir}),
+		},
+	}, sessionID
+}
+
+func terminalHelperEnv(mode string, output string, exitCode string) []acp.EnvVariable {
+	return []acp.EnvVariable{
+		{Name: "GO_WANT_TERMINAL_HELPER_PROCESS", Value: "1"},
+		{Name: "GO_TERMINAL_HELPER_MODE", Value: mode},
+		{Name: "GO_TERMINAL_HELPER_OUTPUT", Value: output},
+		{Name: "GO_TERMINAL_HELPER_EXIT_CODE", Value: exitCode},
+	}
+}
+
+func waitForTerminalOutput(
+	t *testing.T,
+	client *clientImpl,
+	sessionID string,
+	terminalID string,
+	want string,
+) {
+	t.Helper()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		output, err := client.TerminalOutput(context.Background(), acp.TerminalOutputRequest{
+			SessionId:  acp.SessionId(sessionID),
+			TerminalId: terminalID,
+		})
+		if err != nil {
+			t.Fatalf("terminal output: %v", err)
+		}
+		if strings.Contains(output.Output, want) {
+			return
+		}
+		select {
+		case <-ticker.C:
+		case <-timer.C:
+			t.Fatalf("timed out waiting for terminal output %q, last output %q", want, output.Output)
+		}
+	}
 }
 
 func canonicalTestPath(path string) string {

--- a/internal/core/agent/client_test.go
+++ b/internal/core/agent/client_test.go
@@ -1342,6 +1342,83 @@ func TestClientTerminalKillTerminatesCommandAndKeepsOutput(t *testing.T) {
 	}
 }
 
+func TestClientReleaseTerminalRetainsTrackingWhenWaitContextExpires(t *testing.T) {
+	t.Parallel()
+
+	client, sessionID := newTerminalTestClient(t)
+	done := make(chan struct{})
+	terminal := &terminalProcess{
+		id:        "term-timeout",
+		sessionID: sessionID,
+		cancel:    func() {},
+		done:      done,
+		output:    newTerminalOutputBuffer(nil),
+	}
+	client.storeTerminal(terminal)
+
+	releaseCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := client.ReleaseTerminal(releaseCtx, acp.ReleaseTerminalRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: terminal.id,
+	}); !errors.Is(err, context.Canceled) {
+		t.Fatalf("ReleaseTerminal(canceled) error = %v, want context.Canceled", err)
+	}
+	if _, err := client.lookupTerminal(acp.SessionId(sessionID), terminal.id); err != nil {
+		t.Fatalf("lookup terminal after canceled release: %v", err)
+	}
+
+	close(done)
+	if _, err := client.ReleaseTerminal(context.Background(), acp.ReleaseTerminalRequest{
+		SessionId:  acp.SessionId(sessionID),
+		TerminalId: terminal.id,
+	}); err != nil {
+		t.Fatalf("release terminal after wait: %v", err)
+	}
+	if _, err := client.lookupTerminal(acp.SessionId(sessionID), terminal.id); err == nil {
+		t.Fatal("lookup terminal after successful release = nil error, want unknown terminal")
+	}
+}
+
+func TestNewTerminalOutputBufferAppliesServerDefaultWhenLimitUnset(t *testing.T) {
+	t.Parallel()
+
+	zero := 0
+	negative := -1
+	tests := []struct {
+		name      string
+		limit     *int
+		wantLimit int
+	}{
+		{
+			name:      "Should use the server default when the limit is nil",
+			wantLimit: defaultOutputByteLimit,
+		},
+		{
+			name:      "Should use the server default when the limit is zero",
+			limit:     &zero,
+			wantLimit: defaultOutputByteLimit,
+		},
+		{
+			name:      "Should use the server default when the limit is negative",
+			limit:     &negative,
+			wantLimit: defaultOutputByteLimit,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			buffer := newTerminalOutputBuffer(tt.limit)
+			if buffer.limit != tt.wantLimit {
+				t.Fatalf("buffer.limit = %d, want %d", buffer.limit, tt.wantLimit)
+			}
+		})
+	}
+}
+
 func TestClientCloseCleansUpActiveTerminals(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/agent/registry_specs.go
+++ b/internal/core/agent/registry_specs.go
@@ -243,21 +243,38 @@ var (
 	}
 )
 
+// Managed ACP runs execute headlessly; keep them off the interactive Code Mode runtime.
+var codexManagedRuntimeConfigOverrides = []string{
+	"features.code_mode=false",
+	"features.code_mode_only=false",
+}
+
 func codexBootstrapArgs(modelName, reasoningEffort string, _ []string, accessMode string) []string {
-	args := make([]string, 0, 10)
+	args := make([]string, 0, 14)
 	if selected := strings.TrimSpace(modelName); selected != "" {
-		args = append(args, "-c", "model="+strconv.Quote(selected))
+		args = appendCodexConfigOverrides(args, "model="+strconv.Quote(selected))
 	}
 	if effort := strings.TrimSpace(reasoningEffort); effort != "" {
-		args = append(args, "-c", "model_reasoning_effort="+strconv.Quote(effort))
+		args = appendCodexConfigOverrides(args, "model_reasoning_effort="+strconv.Quote(effort))
 	}
+	args = appendCodexConfigOverrides(args, codexManagedRuntimeConfigOverrides...)
 	if accessMode == model.AccessModeFull {
-		args = append(
+		args = appendCodexConfigOverrides(
 			args,
-			"-c", `approval_policy="never"`,
-			"-c", `sandbox_mode="danger-full-access"`,
-			"-c", `web_search="live"`,
+			`approval_policy="never"`,
+			`sandbox_mode="danger-full-access"`,
+			`web_search="live"`,
 		)
+	}
+	return args
+}
+
+func appendCodexConfigOverrides(args []string, overrides ...string) []string {
+	for _, override := range overrides {
+		if strings.TrimSpace(override) == "" {
+			continue
+		}
+		args = append(args, "-c", override)
 	}
 	return args
 }

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -50,6 +50,10 @@ func TestAgentRegistryEntries(t *testing.T) {
 				"-c",
 				`model_reasoning_effort="medium"`,
 				"-c",
+				"features.code_mode=false",
+				"-c",
+				"features.code_mode_only=false",
+				"-c",
 				`approval_policy="never"`,
 				"-c",
 				`sandbox_mode="danger-full-access"`,
@@ -198,33 +202,63 @@ func TestResolveRuntimeModelNormalizesCodexProviderPrefix(t *testing.T) {
 	})
 }
 
-func TestCodexBootstrapArgsSetModelAndReasoningEffort(t *testing.T) {
+func TestCodexBootstrapArgsSetManagedRuntimeOverrides(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should pass model and reasoning through codex config overrides", func(t *testing.T) {
-		t.Parallel()
+	spec, err := lookupAgentSpec(model.IDECodex)
+	if err != nil {
+		t.Fatalf("lookup codex spec: %v", err)
+	}
+	if !spec.UsesBootstrapModel {
+		t.Fatal("expected codex to use bootstrap model configuration")
+	}
 
-		spec, err := lookupAgentSpec(model.IDECodex)
-		if err != nil {
-			t.Fatalf("lookup codex spec: %v", err)
-		}
-		if !spec.UsesBootstrapModel {
-			t.Fatal("expected codex to use bootstrap model configuration")
-		}
+	cases := []struct {
+		name            string
+		reasoningEffort string
+		accessMode      string
+		want            []string
+	}{
+		{
+			name:            "Should pass model, reasoning, stable features, and full access overrides",
+			reasoningEffort: "high",
+			accessMode:      model.AccessModeFull,
+			want: []string{
+				"codex-acp",
+				"-c", `model="gpt-5.5"`,
+				"-c", `model_reasoning_effort="high"`,
+				"-c", "features.code_mode=false",
+				"-c", "features.code_mode_only=false",
+				"-c", `approval_policy="never"`,
+				"-c", `sandbox_mode="danger-full-access"`,
+				"-c", `web_search="live"`,
+			},
+		},
+		{
+			name:            "Should disable Code Mode without full access overrides in default access mode",
+			reasoningEffort: "low",
+			accessMode:      model.AccessModeDefault,
+			want: []string{
+				"codex-acp",
+				"-c", `model="gpt-5.5"`,
+				"-c", `model_reasoning_effort="low"`,
+				"-c", "features.code_mode=false",
+				"-c", "features.code_mode_only=false",
+			},
+		},
+	}
 
-		command := spec.launchCommand("gpt-5.5", "high", nil, model.AccessModeFull)
-		want := []string{
-			"codex-acp",
-			"-c", `model="gpt-5.5"`,
-			"-c", `model_reasoning_effort="high"`,
-			"-c", `approval_policy="never"`,
-			"-c", `sandbox_mode="danger-full-access"`,
-			"-c", `web_search="live"`,
-		}
-		if !slices.Equal(command, want) {
-			t.Fatalf("codex launch command = %#v, want %#v", command, want)
-		}
-	})
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			command := spec.launchCommand("gpt-5.5", tc.reasoningEffort, nil, tc.accessMode)
+			if !slices.Equal(command, tc.want) {
+				t.Fatalf("codex launch command = %#v, want %#v", command, tc.want)
+			}
+		})
+	}
 }
 
 func TestEnsureAvailableChecksCodexModelCompatibility(t *testing.T) {
@@ -454,6 +488,8 @@ func TestCodexFallbackLaunchBootstrapsDefaultModel(t *testing.T) {
 		"npx --yes @zed-industries/codex-acp",
 		"-c",
 		`'model="` + model.DefaultCodexModel + `"'`,
+		"features.code_mode=false",
+		"features.code_mode_only=false",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("BuildShellCommandString() = %q, want to contain %q", got, want)

--- a/internal/core/agent/terminal.go
+++ b/internal/core/agent/terminal.go
@@ -1,0 +1,378 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	acp "github.com/coder/acp-go-sdk"
+)
+
+const terminalIDPrefix = "term-"
+
+type terminalProcess struct {
+	id        string
+	sessionID string
+	cancel    context.CancelFunc
+	cmd       *exec.Cmd
+	output    *terminalOutputBuffer
+	done      chan struct{}
+
+	mu       sync.Mutex
+	exitCode *int
+	signal   *string
+}
+
+type terminalOutputBuffer struct {
+	mu        sync.Mutex
+	data      []byte
+	limit     int
+	truncated bool
+}
+
+func (c *clientImpl) createTerminal(
+	ctx context.Context,
+	params acp.CreateTerminalRequest,
+) (acp.CreateTerminalResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	session, err := c.terminalSession(params.SessionId)
+	if err != nil {
+		return acp.CreateTerminalResponse{}, err
+	}
+	cwd, err := c.resolveTerminalCWD(session, params.Cwd)
+	if err != nil {
+		return acp.CreateTerminalResponse{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return acp.CreateTerminalResponse{}, err
+	}
+
+	terminalCtx, cancel := context.WithCancel(context.Background())
+	// #nosec G204 -- ACP terminal execution is the requested session-scoped command runner.
+	cmd := exec.CommandContext(terminalCtx, params.Command, params.Args...)
+	cmd.Dir = cwd
+	cmd.Env = terminalEnvironment(params.Env)
+	output := newTerminalOutputBuffer(params.OutputByteLimit)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return acp.CreateTerminalResponse{}, fmt.Errorf("start terminal command %q: %w", params.Command, err)
+	}
+
+	terminal := &terminalProcess{
+		id:        c.nextTerminalID(),
+		sessionID: string(params.SessionId),
+		cancel:    cancel,
+		cmd:       cmd,
+		output:    output,
+		done:      make(chan struct{}),
+	}
+	c.storeTerminal(terminal)
+	go terminal.wait()
+	return acp.CreateTerminalResponse{TerminalId: terminal.id}, nil
+}
+
+func (c *clientImpl) killTerminalCommand(
+	_ context.Context,
+	params acp.KillTerminalCommandRequest,
+) (acp.KillTerminalCommandResponse, error) {
+	terminal, err := c.lookupTerminal(params.SessionId, params.TerminalId)
+	if err != nil {
+		return acp.KillTerminalCommandResponse{}, err
+	}
+	terminal.kill()
+	return acp.KillTerminalCommandResponse{}, nil
+}
+
+func (c *clientImpl) terminalOutput(
+	_ context.Context,
+	params acp.TerminalOutputRequest,
+) (acp.TerminalOutputResponse, error) {
+	terminal, err := c.lookupTerminal(params.SessionId, params.TerminalId)
+	if err != nil {
+		return acp.TerminalOutputResponse{}, err
+	}
+	output, truncated := terminal.output.snapshot()
+	response := acp.TerminalOutputResponse{
+		Output:    output,
+		Truncated: truncated,
+	}
+	if status := terminal.exitStatus(); status != nil {
+		response.ExitStatus = status
+	}
+	return response, nil
+}
+
+func (c *clientImpl) releaseTerminal(
+	ctx context.Context,
+	params acp.ReleaseTerminalRequest,
+) (acp.ReleaseTerminalResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	terminal, err := c.removeTerminal(params.SessionId, params.TerminalId)
+	if err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	terminal.kill()
+	if err := terminal.waitFor(ctx); err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	return acp.ReleaseTerminalResponse{}, nil
+}
+
+func (c *clientImpl) waitForTerminalExit(
+	ctx context.Context,
+	params acp.WaitForTerminalExitRequest,
+) (acp.WaitForTerminalExitResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	terminal, err := c.lookupTerminal(params.SessionId, params.TerminalId)
+	if err != nil {
+		return acp.WaitForTerminalExitResponse{}, err
+	}
+	if err := terminal.waitFor(ctx); err != nil {
+		return acp.WaitForTerminalExitResponse{}, err
+	}
+	exitCode, signal := terminal.exitResult()
+	return acp.WaitForTerminalExitResponse{
+		ExitCode: exitCode,
+		Signal:   signal,
+	}, nil
+}
+
+func (c *clientImpl) terminalSession(sessionID acp.SessionId) (*sessionImpl, error) {
+	session := c.lookupSession(string(sessionID))
+	if session == nil {
+		return nil, fmt.Errorf("received terminal request for unknown session %q", sessionID)
+	}
+	return session, nil
+}
+
+func (c *clientImpl) resolveTerminalCWD(session *sessionImpl, rawCWD *string) (string, error) {
+	if session == nil {
+		return "", errors.New("terminal session is required")
+	}
+	cwd := session.workingDir
+	if rawCWD != nil && strings.TrimSpace(*rawCWD) != "" {
+		resolved, err := resolveSessionPath(session.workingDir, *rawCWD)
+		if err != nil {
+			return "", err
+		}
+		cwd = resolved
+	}
+	if !pathWithinRoots(cwd, session.allowedRoots) {
+		return "", fmt.Errorf("terminal cwd %q is outside allowed session roots", cwd)
+	}
+	return cwd, nil
+}
+
+func (c *clientImpl) nextTerminalID() string {
+	c.terminalMu.Lock()
+	defer c.terminalMu.Unlock()
+	c.terminalNext++
+	return terminalIDPrefix + strconv.Itoa(c.terminalNext)
+}
+
+func (c *clientImpl) storeTerminal(terminal *terminalProcess) {
+	c.terminalMu.Lock()
+	defer c.terminalMu.Unlock()
+	if c.terminals == nil {
+		c.terminals = make(map[string]*terminalProcess)
+	}
+	c.terminals[terminal.id] = terminal
+}
+
+func (c *clientImpl) lookupTerminal(sessionID acp.SessionId, terminalID string) (*terminalProcess, error) {
+	c.terminalMu.Lock()
+	defer c.terminalMu.Unlock()
+	terminal := c.terminals[terminalID]
+	if terminal == nil {
+		return nil, fmt.Errorf("unknown terminal %q", terminalID)
+	}
+	if terminal.sessionID != string(sessionID) {
+		return nil, fmt.Errorf("terminal %q does not belong to session %q", terminalID, sessionID)
+	}
+	return terminal, nil
+}
+
+func (c *clientImpl) removeTerminal(sessionID acp.SessionId, terminalID string) (*terminalProcess, error) {
+	c.terminalMu.Lock()
+	defer c.terminalMu.Unlock()
+	terminal := c.terminals[terminalID]
+	if terminal == nil {
+		return nil, fmt.Errorf("unknown terminal %q", terminalID)
+	}
+	if terminal.sessionID != string(sessionID) {
+		return nil, fmt.Errorf("terminal %q does not belong to session %q", terminalID, sessionID)
+	}
+	delete(c.terminals, terminalID)
+	return terminal, nil
+}
+
+func (c *clientImpl) closeTerminals() error {
+	terminals := c.drainTerminals()
+	if len(terminals) == 0 {
+		return nil
+	}
+	timeout := c.shutdownTimeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	var result error
+	for _, terminal := range terminals {
+		terminal.kill()
+		if err := terminal.waitFor(ctx); err != nil {
+			result = errors.Join(result, fmt.Errorf("wait for terminal %s during close: %w", terminal.id, err))
+		}
+	}
+	return result
+}
+
+func (c *clientImpl) drainTerminals() []*terminalProcess {
+	c.terminalMu.Lock()
+	defer c.terminalMu.Unlock()
+	terminals := make([]*terminalProcess, 0, len(c.terminals))
+	for id, terminal := range c.terminals {
+		terminals = append(terminals, terminal)
+		delete(c.terminals, id)
+	}
+	return terminals
+}
+
+func (t *terminalProcess) wait() {
+	waitErr := t.cmd.Wait()
+	t.cancel()
+	var exitCode *int
+	var signal *string
+	if t.cmd.ProcessState != nil {
+		code := t.cmd.ProcessState.ExitCode()
+		if code >= 0 {
+			exitCode = &code
+		}
+	}
+	if exitCode == nil && waitErr != nil {
+		message := waitErr.Error()
+		signal = &message
+	}
+	t.mu.Lock()
+	t.exitCode = exitCode
+	t.signal = signal
+	close(t.done)
+	t.mu.Unlock()
+}
+
+func (t *terminalProcess) kill() {
+	if t == nil || t.cancel == nil {
+		return
+	}
+	t.cancel()
+}
+
+func (t *terminalProcess) waitFor(ctx context.Context) error {
+	if t == nil {
+		return errors.New("terminal process is required")
+	}
+	select {
+	case <-t.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (t *terminalProcess) exitResult() (*int, *string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return cloneIntPtr(t.exitCode), cloneStringPtr(t.signal)
+}
+
+func (t *terminalProcess) exitStatus() *acp.TerminalExitStatus {
+	select {
+	case <-t.done:
+	default:
+		return nil
+	}
+	exitCode, signal := t.exitResult()
+	return &acp.TerminalExitStatus{
+		ExitCode: exitCode,
+		Signal:   signal,
+	}
+}
+
+func cloneIntPtr(src *int) *int {
+	if src == nil {
+		return nil
+	}
+	value := *src
+	return &value
+}
+
+func cloneStringPtr(src *string) *string {
+	if src == nil {
+		return nil
+	}
+	value := *src
+	return &value
+}
+
+func newTerminalOutputBuffer(limit *int) *terminalOutputBuffer {
+	resolvedLimit := 0
+	if limit != nil && *limit > 0 {
+		resolvedLimit = *limit
+	}
+	return &terminalOutputBuffer{limit: resolvedLimit}
+}
+
+func (b *terminalOutputBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.data = append(b.data, p...)
+	if b.limit > 0 && len(b.data) > b.limit {
+		b.data = trimUTF8Suffix(b.data, b.limit)
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *terminalOutputBuffer) snapshot() (string, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(append([]byte(nil), b.data...)), b.truncated
+}
+
+func trimUTF8Suffix(data []byte, limit int) []byte {
+	if limit <= 0 || len(data) <= limit {
+		return data
+	}
+	start := len(data) - limit
+	for start < len(data) && !utf8.RuneStart(data[start]) {
+		start++
+	}
+	return append([]byte(nil), data[start:]...)
+}
+
+func terminalEnvironment(env []acp.EnvVariable) []string {
+	merged := os.Environ()
+	for _, item := range env {
+		name := strings.TrimSpace(item.Name)
+		if name == "" {
+			continue
+		}
+		merged = append(merged, name+"="+item.Value)
+	}
+	return merged
+}

--- a/internal/core/agent/terminal.go
+++ b/internal/core/agent/terminal.go
@@ -15,7 +15,10 @@ import (
 	acp "github.com/coder/acp-go-sdk"
 )
 
-const terminalIDPrefix = "term-"
+const (
+	terminalIDPrefix       = "term-"
+	defaultOutputByteLimit = 10 * 1024 * 1024
+)
 
 type terminalProcess struct {
 	id        string
@@ -120,12 +123,15 @@ func (c *clientImpl) releaseTerminal(
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	terminal, err := c.removeTerminal(params.SessionId, params.TerminalId)
+	terminal, err := c.lookupTerminal(params.SessionId, params.TerminalId)
 	if err != nil {
 		return acp.ReleaseTerminalResponse{}, err
 	}
 	terminal.kill()
 	if err := terminal.waitFor(ctx); err != nil {
+		return acp.ReleaseTerminalResponse{}, err
+	}
+	if _, err := c.removeTerminal(params.SessionId, params.TerminalId); err != nil {
 		return acp.ReleaseTerminalResponse{}, err
 	}
 	return acp.ReleaseTerminalResponse{}, nil
@@ -330,7 +336,7 @@ func cloneStringPtr(src *string) *string {
 }
 
 func newTerminalOutputBuffer(limit *int) *terminalOutputBuffer {
-	resolvedLimit := 0
+	resolvedLimit := defaultOutputByteLimit
 	if limit != nil && *limit > 0 {
 		resolvedLimit = *limit
 	}

--- a/internal/core/model/run_scope.go
+++ b/internal/core/model/run_scope.go
@@ -2,10 +2,12 @@ package model
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -177,7 +179,11 @@ func openBaseRunScope(
 }
 
 func allocateRunArtifacts(cfg *RuntimeConfig) (RunArtifacts, error) {
-	runArtifacts, err := ResolveHomeRunArtifacts(BuildRunID(cfg))
+	runID, err := BuildRunID(cfg)
+	if err != nil {
+		return RunArtifacts{}, err
+	}
+	runArtifacts, err := ResolveHomeRunArtifacts(runID)
 	if err != nil {
 		return RunArtifacts{}, err
 	}
@@ -187,29 +193,58 @@ func allocateRunArtifacts(cfg *RuntimeConfig) (RunArtifacts, error) {
 	return runArtifacts, nil
 }
 
+const generatedRunIDEntropyBytes = 8
+
 // BuildRunID returns the effective run identifier for one runtime config.
-func BuildRunID(cfg *RuntimeConfig) string {
+func BuildRunID(cfg *RuntimeConfig) (string, error) {
+	return buildRunID(cfg, time.Now().UTC(), rand.Reader)
+}
+
+func buildRunID(cfg *RuntimeConfig, now time.Time, entropy io.Reader) (string, error) {
 	if cfg != nil && strings.TrimSpace(cfg.RunID) != "" {
-		return cfg.RunID
+		return cfg.RunID, nil
 	}
-	label := runLabel(cfg)
-	timestamp := time.Now().UTC().Format("20060102-150405-000000000")
-	return fmt.Sprintf("%s-%s", label, timestamp)
+	return buildGeneratedRunID(runLabel(cfg), now, entropy)
+}
+
+func buildGeneratedRunID(label string, now time.Time, entropy io.Reader) (string, error) {
+	if entropy == nil {
+		return "", errors.New("build run id: missing entropy reader")
+	}
+	var random [generatedRunIDEntropyBytes]byte
+	if _, err := io.ReadFull(entropy, random[:]); err != nil {
+		return "", fmt.Errorf("build run id: read entropy: %w", err)
+	}
+	utc := now.UTC()
+	return fmt.Sprintf(
+		"%s-%s-%09d-%s",
+		label,
+		utc.Format("20060102-150405"),
+		utc.Nanosecond(),
+		hex.EncodeToString(random[:]),
+	), nil
 }
 
 func runLabel(cfg *RuntimeConfig) string {
-	if cfg.Mode == ExecutionModeExec {
+	if cfg != nil && cfg.Mode == ExecutionModeExec {
 		return "exec"
 	}
-	if cfg.Mode == ExecutionModePRDTasks {
+	if cfg != nil && cfg.Mode == ExecutionModePRDTasks {
 		return "tasks-" + safeScopeLabel(cfg.Name)
 	}
 
-	scope := cfg.Name
-	if strings.TrimSpace(scope) == "" {
-		scope = "pr-" + cfg.PR
+	scope := ""
+	pr := ""
+	round := 0
+	if cfg != nil {
+		scope = cfg.Name
+		pr = cfg.PR
+		round = cfg.Round
 	}
-	return fmt.Sprintf("reviews-%s-round-%03d", safeScopeLabel(scope), cfg.Round)
+	if strings.TrimSpace(scope) == "" {
+		scope = "pr-" + pr
+	}
+	return fmt.Sprintf("reviews-%s-round-%03d", safeScopeLabel(scope), round)
 }
 
 func safeScopeLabel(value string) string {

--- a/internal/core/model/run_scope_internal_test.go
+++ b/internal/core/model/run_scope_internal_test.go
@@ -1,0 +1,111 @@
+package model
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type failingEntropyReader struct {
+	err error
+}
+
+func (r failingEntropyReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func TestBuildRunIDPreservesExplicitRunIDWithoutEntropy(t *testing.T) {
+	const explicitRunID = " explicit-run "
+	got, err := buildRunID(&RuntimeConfig{RunID: explicitRunID}, time.Time{}, nil)
+	if err != nil {
+		t.Fatalf("buildRunID() error = %v", err)
+	}
+	if got != explicitRunID {
+		t.Fatalf("buildRunID() = %q, want %q", got, explicitRunID)
+	}
+}
+
+func TestBuildRunIDGeneratesEntropyBackedLabeledIDs(t *testing.T) {
+	now := time.Date(2026, 5, 13, 20, 4, 5, 123456789, time.UTC)
+	entropy := bytes.NewReader(append(
+		bytes.Repeat([]byte{0x11}, generatedRunIDEntropyBytes),
+		bytes.Repeat([]byte{0x22}, generatedRunIDEntropyBytes)...,
+	))
+	cfg := &RuntimeConfig{Mode: ExecutionModeExec}
+
+	first, err := buildRunID(cfg, now, entropy)
+	if err != nil {
+		t.Fatalf("buildRunID(first) error = %v", err)
+	}
+	second, err := buildRunID(cfg, now, entropy)
+	if err != nil {
+		t.Fatalf("buildRunID(second) error = %v", err)
+	}
+	if first == second {
+		t.Fatalf("generated run IDs should differ for different entropy: %q", first)
+	}
+	if !strings.HasPrefix(first, "exec-20260513-200405-123456789-1111111111111111") {
+		t.Fatalf("first generated run ID = %q, want exec temporal prefix with entropy", first)
+	}
+	if !strings.HasPrefix(second, "exec-20260513-200405-123456789-2222222222222222") {
+		t.Fatalf("second generated run ID = %q, want exec temporal prefix with entropy", second)
+	}
+}
+
+func TestBuildRunIDUsesModeSpecificLabels(t *testing.T) {
+	now := time.Date(2026, 5, 13, 20, 4, 5, 0, time.UTC)
+	testCases := []struct {
+		name       string
+		cfg        *RuntimeConfig
+		wantPrefix string
+	}{
+		{
+			name:       "exec",
+			cfg:        &RuntimeConfig{Mode: ExecutionModeExec},
+			wantPrefix: "exec-",
+		},
+		{
+			name:       "tasks",
+			cfg:        &RuntimeConfig{Mode: ExecutionModePRDTasks, Name: "feature/auth"},
+			wantPrefix: "tasks-feature_auth-",
+		},
+		{
+			name:       "reviews",
+			cfg:        &RuntimeConfig{Mode: ExecutionModePRReview, Name: "user/auth", Round: 2},
+			wantPrefix: "reviews-user_auth-",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildRunID(
+				tc.cfg,
+				now,
+				bytes.NewReader(bytes.Repeat([]byte{0xaa}, generatedRunIDEntropyBytes)),
+			)
+			if err != nil {
+				t.Fatalf("buildRunID() error = %v", err)
+			}
+			if !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Fatalf("buildRunID() = %q, want prefix %q", got, tc.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestBuildRunIDReturnsEntropyErrors(t *testing.T) {
+	entropyErr := errors.New("entropy unavailable")
+	_, err := buildRunID(
+		&RuntimeConfig{Mode: ExecutionModeExec},
+		time.Date(2026, 5, 13, 20, 4, 5, 0, time.UTC),
+		failingEntropyReader{err: entropyErr},
+	)
+	if !errors.Is(err, entropyErr) {
+		t.Fatalf("buildRunID() error = %v, want wrapped entropy error", err)
+	}
+	if !strings.Contains(err.Error(), "build run id: read entropy") {
+		t.Fatalf("buildRunID() error = %q, want entropy context", err)
+	}
+}

--- a/internal/core/provider/coderabbit/coderabbit.go
+++ b/internal/core/provider/coderabbit/coderabbit.go
@@ -169,14 +169,7 @@ func (p *Provider) WatchStatus(
 	}
 	latest, ok := latestProviderReview(reviews, p.botLogin)
 	if !ok {
-		status := provider.WatchStatus{
-			PRHeadSHA: strings.TrimSpace(pr.Head.SHA),
-			State:     provider.WatchStatusPending,
-		}
-		if hasStatus {
-			applyCommitStatus(&status, latestStatus)
-		}
-		return status, nil
+		return classifyWatchStatusWithoutReview(pr.Head.SHA, latestStatus, hasStatus)
 	}
 
 	return classifyWatchStatus(pr.Head.SHA, latest, latestStatus, hasStatus)
@@ -315,7 +308,66 @@ func classifyWatchStatus(
 	}
 	if hasStatus {
 		applyCommitStatus(&status, latestStatus)
+		ready, err := applyCodeRabbitStatusGate(&status, latestStatus)
+		if err != nil || !ready {
+			return status, err
+		}
+		return classifySuccessfulWatchStatus(status, review)
 	}
+	return classifyWatchStatusFromReviewOnly(status, review)
+}
+
+func classifyWatchStatusWithoutReview(
+	headSHA string,
+	latestStatus commitStatus,
+	hasStatus bool,
+) (provider.WatchStatus, error) {
+	status := provider.WatchStatus{
+		PRHeadSHA: strings.TrimSpace(headSHA),
+		State:     provider.WatchStatusPending,
+	}
+	if !hasStatus {
+		return status, nil
+	}
+	applyCommitStatus(&status, latestStatus)
+	ready, err := applyCodeRabbitStatusGate(&status, latestStatus)
+	if err != nil || !ready {
+		return status, err
+	}
+	status.State = provider.WatchStatusCurrentSettled
+	return status, nil
+}
+
+func classifySuccessfulWatchStatus(
+	status provider.WatchStatus,
+	review pullRequestReview,
+) (provider.WatchStatus, error) {
+	if status.ReviewCommitSHA == "" || reviewStateIsPending(status.ReviewState) {
+		status.State = provider.WatchStatusCurrentSettled
+		return status, nil
+	}
+
+	submittedAt := parseReviewSubmittedAt(review.SubmittedAt)
+	if submittedAt.IsZero() {
+		return provider.WatchStatus{}, fmt.Errorf(
+			"decode pull request review %d submitted_at: %q",
+			review.ID,
+			review.SubmittedAt,
+		)
+	}
+	status.SubmittedAt = submittedAt
+	if status.ReviewCommitSHA != status.PRHeadSHA {
+		status.State = provider.WatchStatusCurrentSettled
+		return status, nil
+	}
+	status.State = provider.WatchStatusCurrentReviewed
+	return status, nil
+}
+
+func classifyWatchStatusFromReviewOnly(
+	status provider.WatchStatus,
+	review pullRequestReview,
+) (provider.WatchStatus, error) {
 	if status.ReviewCommitSHA == "" || reviewStateIsPending(status.ReviewState) {
 		return status, nil
 	}
@@ -331,27 +383,7 @@ func classifyWatchStatus(
 	status.SubmittedAt = submittedAt
 	if status.ReviewCommitSHA != status.PRHeadSHA {
 		status.State = provider.WatchStatusStale
-		return status, nil
 	}
-	if !hasStatus || commitStatusIsPending(latestStatus) {
-		return status, nil
-	}
-	if commitStatusFailed(latestStatus) {
-		return provider.WatchStatus{}, fmt.Errorf(
-			"coderabbit status %q for head %s: %s",
-			strings.TrimSpace(latestStatus.State),
-			status.PRHeadSHA,
-			strings.TrimSpace(latestStatus.Description),
-		)
-	}
-	if !commitStatusSucceeded(latestStatus) {
-		return provider.WatchStatus{}, fmt.Errorf(
-			"coderabbit status %q for head %s is unsupported",
-			strings.TrimSpace(latestStatus.State),
-			status.PRHeadSHA,
-		)
-	}
-	status.State = provider.WatchStatusCurrentReviewed
 	return status, nil
 }
 
@@ -366,6 +398,29 @@ func applyCommitStatus(status *provider.WatchStatus, commitStatus commitStatus) 
 	status.ProviderStatusState = strings.TrimSpace(commitStatus.State)
 	status.ProviderStatusDescription = strings.TrimSpace(commitStatus.Description)
 	status.ProviderStatusUpdatedAt = commitStatusTimestamp(commitStatus)
+}
+
+func applyCodeRabbitStatusGate(status *provider.WatchStatus, latestStatus commitStatus) (bool, error) {
+	if commitStatusIsPending(latestStatus) {
+		status.State = provider.WatchStatusPending
+		return false, nil
+	}
+	if commitStatusFailed(latestStatus) {
+		return false, fmt.Errorf(
+			"coderabbit status %q for head %s: %s",
+			strings.TrimSpace(latestStatus.State),
+			status.PRHeadSHA,
+			strings.TrimSpace(latestStatus.Description),
+		)
+	}
+	if !commitStatusSucceeded(latestStatus) {
+		return false, fmt.Errorf(
+			"coderabbit status %q for head %s is unsupported",
+			strings.TrimSpace(latestStatus.State),
+			status.PRHeadSHA,
+		)
+	}
+	return true, nil
 }
 
 func commitStatusIsPending(status commitStatus) bool {

--- a/internal/core/provider/coderabbit/coderabbit_test.go
+++ b/internal/core/provider/coderabbit/coderabbit_test.go
@@ -145,7 +145,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 			wantState: provider.WatchStatusPending,
 		},
 		{
-			name:    "current settled when CodeRabbit completed current head without a provider review",
+			name:    "Should mark current settled when CodeRabbit completed current head without a provider review",
 			headSHA: "head-without-review",
 			reviews: []pullRequestReview{
 				testPullRequestReview(4103, "old-head", "COMMENTED", "2026-04-10T14:33:25Z", "pedro", ""),
@@ -154,7 +154,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 			wantState: provider.WatchStatusCurrentSettled,
 		},
 		{
-			name:    "current settled when CodeRabbit completed current head but latest provider review is stale",
+			name:    "Should mark current settled when CodeRabbit completed current head but latest provider review is stale",
 			headSHA: "head-new",
 			reviews: []pullRequestReview{
 				testPullRequestReview(4101, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
@@ -164,7 +164,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 			wantCommit: "old-head",
 		},
 		{
-			name:    "pending when CodeRabbit is still processing current head with stale latest review",
+			name:    "Should stay pending when CodeRabbit is still processing current head with a stale latest review",
 			headSHA: "head-new",
 			reviews: []pullRequestReview{
 				testPullRequestReview(4101, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
@@ -203,18 +203,22 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 func TestWatchStatusFailsWhenCodeRabbitStatusFailsWithoutProviderReview(t *testing.T) {
 	t.Parallel()
 
-	reviews := []pullRequestReview{
-		testPullRequestReview(4103, "head-current", "COMMENTED", "2026-04-10T14:33:25Z", "pedro", ""),
-	}
-	_, err := New(WithCommandRunner(testWatchStatusRunnerWithStatuses(
-		t,
-		"head-current",
-		reviews,
-		[]commitStatus{testCommitStatus("failure", "Review failed", "2026-04-10T14:34:25Z")},
-	))).WatchStatus(context.Background(), provider.WatchStatusRequest{PR: "259"})
-	if err == nil || !strings.Contains(err.Error(), "coderabbit status") {
-		t.Fatalf("WatchStatus() error = %v, want coderabbit status failure", err)
-	}
+	t.Run("Should fail when CodeRabbit status fails without a provider review", func(t *testing.T) {
+		t.Parallel()
+
+		reviews := []pullRequestReview{
+			testPullRequestReview(4103, "head-current", "COMMENTED", "2026-04-10T14:33:25Z", "pedro", ""),
+		}
+		_, err := New(WithCommandRunner(testWatchStatusRunnerWithStatuses(
+			t,
+			"head-current",
+			reviews,
+			[]commitStatus{testCommitStatus("failure", "Review failed", "2026-04-10T14:34:25Z")},
+		))).WatchStatus(context.Background(), provider.WatchStatusRequest{PR: "259"})
+		if err == nil || !strings.Contains(err.Error(), "coderabbit status") {
+			t.Fatalf("WatchStatus() error = %v, want coderabbit status failure", err)
+		}
+	})
 }
 
 func TestWatchStatusUsesCodeRabbitCommitStatusAsProcessingGate(t *testing.T) {

--- a/internal/core/provider/coderabbit/coderabbit_test.go
+++ b/internal/core/provider/coderabbit/coderabbit_test.go
@@ -102,6 +102,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 		name       string
 		headSHA    string
 		reviews    []pullRequestReview
+		statuses   []commitStatus
 		wantState  provider.WatchStatusState
 		wantCommit string
 	}{
@@ -131,6 +132,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 				testPullRequestReview(4101, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
 				testPullRequestReview(4102, "head-current", "COMMENTED", "2026-04-10T14:33:25Z", defaultBotLogin, ""),
 			},
+			statuses:   []commitStatus{testCommitStatus("success", "Review completed", "2026-04-10T14:34:25Z")},
 			wantState:  provider.WatchStatusCurrentReviewed,
 			wantCommit: "head-current",
 		},
@@ -142,6 +144,35 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 			},
 			wantState: provider.WatchStatusPending,
 		},
+		{
+			name:    "current settled when CodeRabbit completed current head without a provider review",
+			headSHA: "head-without-review",
+			reviews: []pullRequestReview{
+				testPullRequestReview(4103, "old-head", "COMMENTED", "2026-04-10T14:33:25Z", "pedro", ""),
+			},
+			statuses:  []commitStatus{testCommitStatus("success", "Review completed", "2026-04-10T14:34:25Z")},
+			wantState: provider.WatchStatusCurrentSettled,
+		},
+		{
+			name:    "current settled when CodeRabbit completed current head but latest provider review is stale",
+			headSHA: "head-new",
+			reviews: []pullRequestReview{
+				testPullRequestReview(4101, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
+			},
+			statuses:   []commitStatus{testCommitStatus("success", "Review completed", "2026-04-10T14:34:25Z")},
+			wantState:  provider.WatchStatusCurrentSettled,
+			wantCommit: "old-head",
+		},
+		{
+			name:    "pending when CodeRabbit is still processing current head with stale latest review",
+			headSHA: "head-new",
+			reviews: []pullRequestReview{
+				testPullRequestReview(4101, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
+			},
+			statuses:   []commitStatus{testCommitStatus("pending", "Review in progress", "2026-04-10T14:34:25Z")},
+			wantState:  provider.WatchStatusPending,
+			wantCommit: "old-head",
+		},
 	}
 
 	for _, tt := range tests {
@@ -149,7 +180,9 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			status, err := New(WithCommandRunner(testWatchStatusRunner(t, tt.headSHA, tt.reviews))).
+			status, err := New(
+				WithCommandRunner(testWatchStatusRunnerWithStatuses(t, tt.headSHA, tt.reviews, tt.statuses)),
+			).
 				WatchStatus(context.Background(), provider.WatchStatusRequest{PR: "259"})
 			if err != nil {
 				t.Fatalf("watch status: %v", err)
@@ -164,6 +197,23 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 				t.Fatalf("ReviewCommitSHA = %q, want %q", status.ReviewCommitSHA, tt.wantCommit)
 			}
 		})
+	}
+}
+
+func TestWatchStatusFailsWhenCodeRabbitStatusFailsWithoutProviderReview(t *testing.T) {
+	t.Parallel()
+
+	reviews := []pullRequestReview{
+		testPullRequestReview(4103, "head-current", "COMMENTED", "2026-04-10T14:33:25Z", "pedro", ""),
+	}
+	_, err := New(WithCommandRunner(testWatchStatusRunnerWithStatuses(
+		t,
+		"head-current",
+		reviews,
+		[]commitStatus{testCommitStatus("failure", "Review failed", "2026-04-10T14:34:25Z")},
+	))).WatchStatus(context.Background(), provider.WatchStatusRequest{PR: "259"})
+	if err == nil || !strings.Contains(err.Error(), "coderabbit status") {
+		t.Fatalf("WatchStatus() error = %v, want coderabbit status failure", err)
 	}
 }
 
@@ -386,6 +436,9 @@ func testWatchStatusRunnerWithStatuses(
 	statuses []commitStatus,
 ) CommandRunner {
 	t.Helper()
+	if statuses == nil {
+		statuses = []commitStatus{}
+	}
 	return testFullReviewRunner(t, headSHA, reviews, nil, statuses)
 }
 

--- a/internal/core/provider/provider.go
+++ b/internal/core/provider/provider.go
@@ -21,6 +21,7 @@ const (
 	WatchStatusPending         WatchStatusState = "pending"
 	WatchStatusStale           WatchStatusState = "stale"
 	WatchStatusCurrentReviewed WatchStatusState = "current_reviewed"
+	WatchStatusCurrentSettled  WatchStatusState = "current_settled"
 	WatchStatusUnsupported     WatchStatusState = "unsupported"
 )
 

--- a/internal/core/run/exec/exec.go
+++ b/internal/core/run/exec/exec.go
@@ -564,7 +564,11 @@ func prepareExecRunState(ctx context.Context, cfg *model.RuntimeConfig, scope mo
 func resolvePersistedExecRecord(cfg *model.RuntimeConfig) (PersistedExecRun, string, error) {
 	runID := strings.TrimSpace(cfg.RunID)
 	if runID == "" {
-		return PersistedExecRun{}, buildExecRunID(), nil
+		generatedRunID, err := model.BuildRunID(cfg)
+		if err != nil {
+			return PersistedExecRun{}, "", err
+		}
+		return PersistedExecRun{}, generatedRunID, nil
 	}
 	record, err := LoadPersistedExecRun(cfg.WorkspaceRoot, runID)
 	if err != nil {
@@ -1415,14 +1419,6 @@ func renderAssistantOutput(snapshot SessionViewSnapshot) string {
 		sections = append(sections, section)
 	}
 	return strings.Join(sections, "\n\n")
-}
-
-func buildExecRunID() string {
-	return formatExecRunID(time.Now().UTC())
-}
-
-func formatExecRunID(now time.Time) string {
-	return fmt.Sprintf("exec-%s-%09d", now.Format("20060102-150405"), now.Nanosecond())
 }
 
 func isExecRetryableError(err error) bool {

--- a/internal/daemon/review_watch.go
+++ b/internal/daemon/review_watch.go
@@ -873,7 +873,7 @@ func (m *RunManager) waitForCurrentReview(
 		if err != nil {
 			return provider.WatchStatus{}, err
 		}
-		if status.State == provider.WatchStatusCurrentReviewed &&
+		if reviewWatchStatusReady(status) &&
 			reviewWatchHeadMatches(status.PRHeadSHA, expectedHeadSHA) {
 			if err := m.waitForReviewWatchSettled(ctx, options, status); err != nil {
 				return provider.WatchStatus{}, reviewWatchContextError(err, "provider review wait timed out")
@@ -886,12 +886,12 @@ func (m *RunManager) waitForCurrentReview(
 			if err != nil {
 				return provider.WatchStatus{}, err
 			}
-			if confirmed.State == provider.WatchStatusCurrentReviewed &&
+			if reviewWatchStatusReady(confirmed) &&
 				reviewWatchHeadMatches(confirmed.PRHeadSHA, expectedHeadSHA) {
 				return confirmed, nil
 			}
 			status = confirmed
-		} else if status.State == provider.WatchStatusCurrentReviewed {
+		} else if reviewWatchStatusReady(status) {
 			status.State = provider.WatchStatusStale
 		}
 		if err := m.emitReviewWatchEvent(active, eventspkg.EventKindReviewWatchWaiting, kinds.ReviewWatchPayload{
@@ -909,6 +909,11 @@ func (m *RunManager) waitForCurrentReview(
 			return provider.WatchStatus{}, reviewWatchContextError(err, "provider review wait timed out")
 		}
 	}
+}
+
+func reviewWatchStatusReady(status provider.WatchStatus) bool {
+	return status.State == provider.WatchStatusCurrentReviewed ||
+		status.State == provider.WatchStatusCurrentSettled
 }
 
 func reviewWatchHeadMatches(providerHeadSHA string, expectedHeadSHA string) bool {

--- a/internal/daemon/review_watch_test.go
+++ b/internal/daemon/review_watch_test.go
@@ -113,6 +113,83 @@ func TestRunManagerReviewWatchPersistsRoundAndStartsOneChildRun(t *testing.T) {
 	})
 }
 
+func TestRunManagerReviewWatchCurrentSettledFetchesPendingItems(t *testing.T) {
+	t.Run(
+		"Should fetch and fix unresolved reviews when provider settled without a current review object",
+		func(t *testing.T) {
+			reviewProvider := &fakeReviewWatchProvider{
+				statuses: []provider.WatchStatus{settledWatchStatus("head-1", "old-head")},
+				fetches:  [][]provider.ReviewItem{{watchReviewItem()}},
+			}
+			git := &fakeReviewWatchGit{
+				states: []ReviewWatchGitState{
+					{HeadSHA: "head-1", UpstreamRemote: "origin", UpstreamBranch: "feature"},
+					{HeadSHA: "head-1", UpstreamRemote: "origin", UpstreamBranch: "feature"},
+					{HeadSHA: "head-1", UpstreamRemote: "origin", UpstreamBranch: "feature"},
+				},
+			}
+			env := newReviewWatchTestEnv(t, reviewProvider, git, runManagerTestDeps{
+				execute: resolveReviewIssuesDuringRun(t),
+			})
+
+			run := startReviewWatch(t, env, reviewWatchRequest("{\"run_id\":\"review-watch-settled-round\"}"))
+			row := waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+				return row.Status == runStatusCompleted
+			})
+			if row.ErrorText != "" {
+				t.Fatalf("watch row error = %q, want empty", row.ErrorText)
+			}
+
+			runs, err := env.manager.List(context.Background(), apicore.RunListQuery{
+				Workspace: env.workspaceRoot,
+				Mode:      runModeReview,
+				Limit:     10,
+			})
+			if err != nil {
+				t.Fatalf("List(review runs) error = %v", err)
+			}
+			if len(runs) != 1 {
+				t.Fatalf("review child runs = %d, want 1: %#v", len(runs), runs)
+			}
+			roundFetched := decodeReviewWatchPayload(
+				t,
+				requireRunEvent(t, run.RunID, eventspkg.EventKindReviewWatchRoundFetched),
+			)
+			if roundFetched.HeadSHA != "head-1" || roundFetched.Round != 1 {
+				t.Fatalf("round_fetched payload = %#v, want head-1 round 1", roundFetched)
+			}
+		},
+	)
+}
+
+func TestRunManagerReviewWatchCurrentSettledCanCompleteClean(t *testing.T) {
+	t.Run(
+		"Should declare clean after provider settled current head and no unresolved reviews remain",
+		func(t *testing.T) {
+			reviewProvider := &fakeReviewWatchProvider{
+				statuses: []provider.WatchStatus{settledWatchStatus("head-1", "old-head")},
+				fetches:  [][]provider.ReviewItem{{}},
+			}
+			git := &fakeReviewWatchGit{
+				states: []ReviewWatchGitState{{HeadSHA: "head-1", UpstreamRemote: "origin", UpstreamBranch: "feature"}},
+			}
+			env := newReviewWatchTestEnv(t, reviewProvider, git, runManagerTestDeps{})
+
+			run := startReviewWatch(t, env, reviewWatchRequest("{\"run_id\":\"review-watch-settled-clean\"}"))
+			row := waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+				return row.Status == runStatusCompleted
+			})
+			if row.ErrorText != "" {
+				t.Fatalf("watch row error = %q, want empty", row.ErrorText)
+			}
+			clean := decodeReviewWatchPayload(t, requireRunEvent(t, run.RunID, eventspkg.EventKindReviewWatchClean))
+			if clean.Status != string(provider.WatchStatusCurrentSettled) || clean.HeadSHA != "head-1" {
+				t.Fatalf("clean payload = %#v, want current_settled head-1", clean)
+			}
+		},
+	)
+}
+
 func TestRunManagerReviewWatchRejectsDuplicateActiveWatch(t *testing.T) {
 	t.Run("Should reject duplicate active review watch requests", func(t *testing.T) {
 		reviewProvider := &fakeReviewWatchProvider{
@@ -1246,6 +1323,20 @@ func currentWatchStatus(head string) provider.WatchStatus {
 		ReviewState:     "COMMENTED",
 		State:           provider.WatchStatusCurrentReviewed,
 		SubmittedAt:     time.Now().UTC(),
+	}
+}
+
+func settledWatchStatus(head string, reviewHead string) provider.WatchStatus {
+	return provider.WatchStatus{
+		PRHeadSHA:                 head,
+		ReviewCommitSHA:           reviewHead,
+		ReviewID:                  "review-" + reviewHead,
+		ReviewState:               "COMMENTED",
+		ProviderStatusState:       "success",
+		ProviderStatusDescription: "Review completed",
+		ProviderStatusUpdatedAt:   time.Now().UTC(),
+		State:                     provider.WatchStatusCurrentSettled,
+		SubmittedAt:               time.Now().UTC().Add(-time.Minute),
 	}
 }
 

--- a/internal/daemon/review_watch_test.go
+++ b/internal/daemon/review_watch_test.go
@@ -117,6 +117,8 @@ func TestRunManagerReviewWatchCurrentSettledFetchesPendingItems(t *testing.T) {
 	t.Run(
 		"Should fetch and fix unresolved reviews when provider settled without a current review object",
 		func(t *testing.T) {
+			t.Parallel()
+
 			reviewProvider := &fakeReviewWatchProvider{
 				statuses: []provider.WatchStatus{settledWatchStatus("head-1", "old-head")},
 				fetches:  [][]provider.ReviewItem{{watchReviewItem()}},
@@ -166,6 +168,8 @@ func TestRunManagerReviewWatchCurrentSettledCanCompleteClean(t *testing.T) {
 	t.Run(
 		"Should declare clean after provider settled current head and no unresolved reviews remain",
 		func(t *testing.T) {
+			t.Parallel()
+
 			reviewProvider := &fakeReviewWatchProvider{
 				statuses: []provider.WatchStatus{settledWatchStatus("head-1", "old-head")},
 				fetches:  [][]provider.ReviewItem{{}},

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -54,6 +54,8 @@ const (
 	defaultStreamPageLimit    = 256
 	cancelRequestedByDaemon   = "daemon"
 	completedNoWorkSummary    = "no work"
+
+	maxImplicitRunIDAllocationAttempts = 8
 )
 
 // RunManagerConfig wires the daemon-owned run manager dependencies.
@@ -62,6 +64,7 @@ type RunManagerConfig struct {
 	LifecycleContext       context.Context
 	ShutdownDrainTimeout   time.Duration
 	Now                    func() time.Time
+	BuildRunID             func(*model.RuntimeConfig) (string, error)
 	OpenRunScope           func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error)
 	Prepare                func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error)
 	Execute                func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error
@@ -81,6 +84,7 @@ type RunManager struct {
 	globalDB               *globaldb.GlobalDB
 	lifecycleCtx           context.Context
 	now                    func() time.Time
+	buildRunID             func(*model.RuntimeConfig) (string, error)
 	openRunScope           func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error)
 	prepare                func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error)
 	execute                func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error
@@ -226,6 +230,7 @@ func NewRunManager(cfg RunManagerConfig) (*RunManager, error) {
 		globalDB:               cfg.GlobalDB,
 		lifecycleCtx:           resolveRunManagerLifecycleContext(cfg.LifecycleContext),
 		now:                    resolveRunManagerNow(cfg.Now),
+		buildRunID:             resolveRunManagerBuildRunID(cfg.BuildRunID),
 		openRunScope:           resolveRunManagerOpenRunScope(cfg.OpenRunScope),
 		prepare:                resolveRunManagerPrepare(cfg.Prepare),
 		execute:                resolveRunManagerExecute(cfg.Execute),
@@ -264,6 +269,15 @@ func resolveRunManagerNow(now func() time.Time) func() time.Time {
 	return func() time.Time {
 		return time.Now().UTC()
 	}
+}
+
+func resolveRunManagerBuildRunID(
+	buildRunID func(*model.RuntimeConfig) (string, error),
+) func(*model.RuntimeConfig) (string, error) {
+	if buildRunID != nil {
+		return buildRunID
+	}
+	return model.BuildRunID
 }
 
 func resolveRunManagerOpenRunScope(
@@ -1082,14 +1096,14 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 
 	runtimeCfg := spec.runtimeCfg.Clone()
 	runtimeCfg.ApplyDefaults()
-	runtimeCfg.RunID = model.BuildRunID(runtimeCfg)
-	runID := runtimeCfg.RunID
+	explicitRunID := strings.TrimSpace(runtimeCfg.RunID) != ""
+	spec.runtimeCfg = runtimeCfg
 
 	startedAt := m.now().UTC()
 	row, createdRun, err := m.prepareRunRow(
 		detachContext(ctx),
 		spec,
-		runID,
+		explicitRunID,
 		startedAt,
 		apicore.RequestIDFromContext(ctx),
 	)
@@ -1098,6 +1112,7 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	}
 	m.publishRunWorkspaceEvent(ctx, row, spec.workflowSlug, apicore.WorkspaceEventKindRunCreated)
 
+	runID := row.RunID
 	scope, err := m.openRunScopeForStart(ctx, runtimeCfg, spec.workspace.RootDir)
 	if err != nil {
 		if createdRun {
@@ -1139,20 +1154,62 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 func (m *RunManager) prepareRunRow(
 	ctx context.Context,
 	spec startRunSpec,
+	explicitRunID bool,
+	startedAt time.Time,
+	requestID string,
+) (globaldb.Run, bool, error) {
+	if spec.runtimeCfg == nil {
+		return globaldb.Run{}, false, errors.New("daemon: runtime config is required")
+	}
+	if explicitRunID {
+		runID := strings.TrimSpace(spec.runtimeCfg.RunID)
+		spec.runtimeCfg.RunID = runID
+		if spec.mode == runModeExec {
+			row, ok, err := m.resumeExistingExecRun(ctx, spec, runID, startedAt, requestID)
+			if err != nil {
+				return globaldb.Run{}, false, err
+			}
+			if ok {
+				return row, false, nil
+			}
+		}
+		return m.insertRunRow(ctx, spec, runID, startedAt, requestID)
+	}
+
+	var lastErr error
+	for range maxImplicitRunIDAllocationAttempts {
+		spec.runtimeCfg.RunID = ""
+		runID, err := m.buildRunID(spec.runtimeCfg)
+		if err != nil {
+			return globaldb.Run{}, false, err
+		}
+		spec.runtimeCfg.RunID = runID
+		row, createdRun, err := m.insertRunRow(ctx, spec, runID, startedAt, requestID)
+		if err == nil {
+			return row, createdRun, nil
+		}
+		if !errors.Is(err, globaldb.ErrRunAlreadyExists) {
+			return globaldb.Run{}, false, err
+		}
+		lastErr = err
+	}
+	return globaldb.Run{}, false, fmt.Errorf(
+		"daemon: allocate implicit run id after %d attempts: %w",
+		maxImplicitRunIDAllocationAttempts,
+		lastErr,
+	)
+}
+
+func (m *RunManager) insertRunRow(
+	ctx context.Context,
+	spec startRunSpec,
 	runID string,
 	startedAt time.Time,
 	requestID string,
 ) (globaldb.Run, bool, error) {
-	if spec.mode == runModeExec && strings.TrimSpace(spec.runtimeCfg.RunID) != "" {
-		row, ok, err := m.resumeExistingExecRun(ctx, spec, runID, startedAt, requestID)
-		if err != nil {
-			return globaldb.Run{}, false, err
-		}
-		if ok {
-			return row, false, nil
-		}
+	if strings.TrimSpace(runID) == "" {
+		return globaldb.Run{}, false, errors.New("daemon: run id is required")
 	}
-
 	runArtifacts, err := model.ResolveHomeRunArtifacts(runID)
 	if err != nil {
 		return globaldb.Run{}, false, err

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -1100,7 +1100,7 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	spec.runtimeCfg = runtimeCfg
 
 	startedAt := m.now().UTC()
-	row, createdRun, err := m.prepareRunRow(
+	row, createdRun, resumedRun, err := m.prepareRunRow(
 		detachContext(ctx),
 		spec,
 		explicitRunID,
@@ -1115,6 +1115,9 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	runID := row.RunID
 	scope, err := m.openRunScopeForStart(ctx, runtimeCfg, spec.workspace.RootDir)
 	if err != nil {
+		if resumedRun {
+			return apicore.Run{}, m.failStartRun(ctx, row, 0, nil, createdRun, err)
+		}
 		if createdRun {
 			if runArtifacts, artifactsErr := model.ResolveHomeRunArtifacts(runID); artifactsErr == nil {
 				cleanupRunDirectory(runArtifacts.RunDir)
@@ -1157,23 +1160,24 @@ func (m *RunManager) prepareRunRow(
 	explicitRunID bool,
 	startedAt time.Time,
 	requestID string,
-) (globaldb.Run, bool, error) {
+) (globaldb.Run, bool, bool, error) {
 	if spec.runtimeCfg == nil {
-		return globaldb.Run{}, false, errors.New("daemon: runtime config is required")
+		return globaldb.Run{}, false, false, errors.New("daemon: runtime config is required")
 	}
 	if explicitRunID {
 		runID := strings.TrimSpace(spec.runtimeCfg.RunID)
 		spec.runtimeCfg.RunID = runID
 		if spec.mode == runModeExec {
-			row, ok, err := m.resumeExistingExecRun(ctx, spec, runID, startedAt, requestID)
+			row, resumedRun, createdRun, err := m.resumeExistingExecRun(ctx, spec, runID, startedAt, requestID)
 			if err != nil {
-				return globaldb.Run{}, false, err
+				return globaldb.Run{}, false, false, err
 			}
-			if ok {
-				return row, false, nil
+			if resumedRun {
+				return row, createdRun, true, nil
 			}
 		}
-		return m.insertRunRow(ctx, spec, runID, startedAt, requestID)
+		row, createdRun, err := m.insertRunRow(ctx, spec, runID, startedAt, requestID)
+		return row, createdRun, false, err
 	}
 
 	var lastErr error
@@ -1181,19 +1185,19 @@ func (m *RunManager) prepareRunRow(
 		spec.runtimeCfg.RunID = ""
 		runID, err := m.buildRunID(spec.runtimeCfg)
 		if err != nil {
-			return globaldb.Run{}, false, err
+			return globaldb.Run{}, false, false, err
 		}
 		spec.runtimeCfg.RunID = runID
 		row, createdRun, err := m.insertRunRow(ctx, spec, runID, startedAt, requestID)
 		if err == nil {
-			return row, createdRun, nil
+			return row, createdRun, false, nil
 		}
 		if !errors.Is(err, globaldb.ErrRunAlreadyExists) {
-			return globaldb.Run{}, false, err
+			return globaldb.Run{}, false, false, err
 		}
 		lastErr = err
 	}
-	return globaldb.Run{}, false, fmt.Errorf(
+	return globaldb.Run{}, false, false, fmt.Errorf(
 		"daemon: allocate implicit run id after %d attempts: %w",
 		maxImplicitRunIDAllocationAttempts,
 		lastErr,
@@ -1242,34 +1246,34 @@ func (m *RunManager) resumeExistingExecRun(
 	runID string,
 	startedAt time.Time,
 	requestID string,
-) (globaldb.Run, bool, error) {
+) (globaldb.Run, bool, bool, error) {
 	if active := m.getActive(runID); active != nil {
-		return globaldb.Run{}, false, globaldb.ErrRunAlreadyExists
+		return globaldb.Run{}, false, false, globaldb.ErrRunAlreadyExists
 	}
 
 	runArtifacts, err := model.ResolvePersistedRunArtifacts(spec.workspace.RootDir, runID)
 	if err != nil {
-		return globaldb.Run{}, false, err
+		return globaldb.Run{}, false, false, err
 	}
 	if _, err := os.Stat(runArtifacts.RunMetaPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return globaldb.Run{}, false, nil
+			return globaldb.Run{}, false, false, nil
 		}
-		return globaldb.Run{}, false, fmt.Errorf("stat persisted exec run %q: %w", runID, err)
+		return globaldb.Run{}, false, false, fmt.Errorf("stat persisted exec run %q: %w", runID, err)
 	}
 
 	record, err := runpkg.LoadPersistedExecRun(spec.workspace.RootDir, runID)
 	if err != nil {
-		return globaldb.Run{}, false, err
+		return globaldb.Run{}, false, false, err
 	}
 	if record.Mode != model.ModeExec {
-		return globaldb.Run{}, false, fmt.Errorf("run %q is not an exec run", runID)
+		return globaldb.Run{}, false, false, fmt.Errorf("run %q is not an exec run", runID)
 	}
 
 	row, err := m.globalDB.GetRun(ctx, runID)
 	if err != nil {
 		if !errors.Is(err, globaldb.ErrRunNotFound) {
-			return globaldb.Run{}, false, err
+			return globaldb.Run{}, false, false, err
 		}
 		if record.CreatedAt.IsZero() {
 			record.CreatedAt = startedAt
@@ -1285,13 +1289,13 @@ func (m *RunManager) resumeExistingExecRun(
 			RequestID:        requestID,
 		})
 		if err != nil {
-			return globaldb.Run{}, false, err
+			return globaldb.Run{}, false, false, err
 		}
-		return row, true, nil
+		return row, true, true, nil
 	}
 
 	if row.Mode != runModeExec {
-		return globaldb.Run{}, false, fmt.Errorf("run %q is not an exec run", runID)
+		return globaldb.Run{}, false, false, fmt.Errorf("run %q is not an exec run", runID)
 	}
 
 	row.WorkspaceID = spec.workspace.ID
@@ -1312,9 +1316,9 @@ func (m *RunManager) resumeExistingExecRun(
 
 	updatedRow, err := m.globalDB.UpdateRun(ctx, row)
 	if err != nil {
-		return globaldb.Run{}, false, err
+		return globaldb.Run{}, false, false, err
 	}
-	return updatedRow, true, nil
+	return updatedRow, true, false, nil
 }
 
 func setRunParentIDForSpec(row *globaldb.Run, spec startRunSpec) {

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -1123,6 +1123,164 @@ func TestRunManagerStartExecRunCancelsAndGetReturnsUpdatedRow(t *testing.T) {
 	}
 }
 
+func TestRunManagerStartExecRunRetriesImplicitRunIDCollision(t *testing.T) {
+	const collidingRunID = "exec-implicit-collision"
+	release := make(chan struct{})
+	started := make(chan string, 1)
+	var buildCalls atomic.Int64
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		buildRunID: func(*model.RuntimeConfig) (string, error) {
+			call := buildCalls.Add(1)
+			if call == 1 {
+				return collidingRunID, nil
+			}
+			return fmt.Sprintf("%s-%d", collidingRunID, call), nil
+		},
+		executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
+			started <- cfg.RunID
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+	collidingArtifacts, err := model.ResolveHomeRunArtifacts(collidingRunID)
+	if err != nil {
+		t.Fatalf("ResolveHomeRunArtifacts(%q) error = %v", collidingRunID, err)
+	}
+	if err := os.MkdirAll(collidingArtifacts.RunDir, 0o755); err != nil {
+		t.Fatalf("mkdir colliding run dir: %v", err)
+	}
+
+	run, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+		WorkspacePath:    env.workspaceRoot,
+		Prompt:           "daemon exec prompt",
+		PresentationMode: defaultPresentationMode,
+	})
+	if err != nil {
+		t.Fatalf("StartExecRun(implicit collision) error = %v", err)
+	}
+	if run.RunID != "exec-implicit-collision-2" {
+		t.Fatalf("run.RunID = %q, want retry candidate", run.RunID)
+	}
+	waitForString(t, started, run.RunID)
+	close(release)
+	waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusCompleted
+	})
+}
+
+func TestRunManagerStartExecRunExplicitDuplicateRunIDStillFails(t *testing.T) {
+	const runID = "exec-explicit-duplicate"
+	release := make(chan struct{})
+	started := make(chan string, 1)
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
+			started <- cfg.RunID
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+
+	run := env.startExecRun(t, runID, nil)
+	waitForString(t, started, run.RunID)
+	_, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+		WorkspacePath:    env.workspaceRoot,
+		Prompt:           "daemon exec prompt",
+		PresentationMode: defaultPresentationMode,
+		RuntimeOverrides: rawJSON(t, "{\"run_id\":\""+runID+"\"}"),
+	})
+	if !errors.Is(err, globaldb.ErrRunAlreadyExists) {
+		t.Fatalf("StartExecRun(explicit duplicate) error = %v, want ErrRunAlreadyExists", err)
+	}
+	close(release)
+	waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusCompleted
+	})
+}
+
+func TestRunManagerStartExecRunAllocatesDistinctImplicitRunIDsInParallel(t *testing.T) {
+	const totalRuns = 3
+	release := make(chan struct{})
+	started := make(chan string, totalRuns)
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
+			started <- cfg.RunID
+			select {
+			case <-release:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+
+	start := make(chan struct{})
+	type result struct {
+		run apicore.Run
+		err error
+	}
+	results := make(chan result, totalRuns)
+	for range totalRuns {
+		go func() {
+			<-start
+			run, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+				WorkspacePath:    env.workspaceRoot,
+				Prompt:           "daemon exec prompt",
+				PresentationMode: defaultPresentationMode,
+			})
+			results <- result{run: run, err: err}
+		}()
+	}
+	close(start)
+
+	runs := make([]apicore.Run, 0, totalRuns)
+	seen := make(map[string]struct{}, totalRuns)
+	for range totalRuns {
+		result := <-results
+		if result.err != nil {
+			t.Fatalf("StartExecRun(parallel implicit) error = %v", result.err)
+		}
+		if strings.TrimSpace(result.run.RunID) == "" {
+			t.Fatal("parallel implicit run id is empty")
+		}
+		if _, ok := seen[result.run.RunID]; ok {
+			t.Fatalf("duplicate implicit run id allocated: %q", result.run.RunID)
+		}
+		seen[result.run.RunID] = struct{}{}
+		runs = append(runs, result.run)
+	}
+
+	startedIDs := make(map[string]struct{}, totalRuns)
+	deadline := time.After(5 * time.Second)
+	for len(startedIDs) < totalRuns {
+		select {
+		case runID := <-started:
+			startedIDs[runID] = struct{}{}
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d exec starts; got %d", totalRuns, len(startedIDs))
+		}
+	}
+	for _, run := range runs {
+		if _, ok := startedIDs[run.RunID]; !ok {
+			t.Fatalf("run %q returned but executeExec did not start", run.RunID)
+		}
+	}
+
+	close(release)
+	for _, run := range runs {
+		waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCompleted
+		})
+	}
+}
+
 func TestRunManagerOpenRunScopeFailureCleansReservedDirectory(t *testing.T) {
 	scopeErr := errors.New("scope unavailable")
 	env := newRunManagerTestEnv(t, runManagerTestDeps{
@@ -2125,6 +2283,7 @@ type runManagerTestEnv struct {
 
 type runManagerTestDeps struct {
 	now                    func() time.Time
+	buildRunID             func(*model.RuntimeConfig) (string, error)
 	openRunScope           func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error)
 	prepare                func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error)
 	execute                func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error
@@ -2197,6 +2356,7 @@ func newRunManagerTestEnv(tb testing.TB, deps runManagerTestDeps) *runManagerTes
 		LifecycleContext:       context.Background(),
 		ShutdownDrainTimeout:   deps.shutdownDrainTimeout,
 		Now:                    deps.now,
+		BuildRunID:             deps.buildRunID,
 		OpenRunScope:           firstOpenRunScope(deps.openRunScope),
 		Prepare:                firstPrepare(deps.prepare),
 		Execute:                firstExecute(deps.execute),

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -1125,161 +1125,166 @@ func TestRunManagerStartExecRunCancelsAndGetReturnsUpdatedRow(t *testing.T) {
 }
 
 func TestRunManagerStartExecRunRetriesImplicitRunIDCollision(t *testing.T) {
-	const collidingRunID = "exec-implicit-collision"
-	release := make(chan struct{})
-	started := make(chan string, 1)
-	var buildCalls atomic.Int64
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		buildRunID: func(*model.RuntimeConfig) (string, error) {
-			call := buildCalls.Add(1)
-			if call == 1 {
-				return collidingRunID, nil
-			}
-			return fmt.Sprintf("%s-%d", collidingRunID, call), nil
-		},
-		executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
-			started <- cfg.RunID
-			select {
-			case <-release:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		},
-	})
-	collidingArtifacts, err := model.ResolveHomeRunArtifacts(collidingRunID)
-	if err != nil {
-		t.Fatalf("ResolveHomeRunArtifacts(%q) error = %v", collidingRunID, err)
-	}
-	if err := os.MkdirAll(collidingArtifacts.RunDir, 0o755); err != nil {
-		t.Fatalf("mkdir colliding run dir: %v", err)
-	}
+	t.Run("Should retry an implicit exec run ID collision", func(t *testing.T) {
+		const collidingRunID = "exec-implicit-collision"
+		release := make(chan struct{})
+		started := make(chan string, 1)
+		var buildCalls atomic.Int64
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID: func(*model.RuntimeConfig) (string, error) {
+				call := buildCalls.Add(1)
+				if call == 1 {
+					return collidingRunID, nil
+				}
+				return fmt.Sprintf("%s-%d", collidingRunID, call), nil
+			},
+			executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
+				started <- cfg.RunID
+				select {
+				case <-release:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+		})
+		collidingArtifacts, err := model.ResolveHomeRunArtifacts(collidingRunID)
+		if err != nil {
+			t.Fatalf("ResolveHomeRunArtifacts(%q) error = %v", collidingRunID, err)
+		}
+		if err := os.MkdirAll(collidingArtifacts.RunDir, 0o755); err != nil {
+			t.Fatalf("mkdir colliding run dir: %v", err)
+		}
 
-	run, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
-		WorkspacePath:    env.workspaceRoot,
-		Prompt:           "daemon exec prompt",
-		PresentationMode: defaultPresentationMode,
-	})
-	if err != nil {
-		t.Fatalf("StartExecRun(implicit collision) error = %v", err)
-	}
-	if run.RunID != "exec-implicit-collision-2" {
-		t.Fatalf("run.RunID = %q, want retry candidate", run.RunID)
-	}
-	waitForString(t, started, run.RunID)
-	close(release)
-	waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusCompleted
+		run, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+			WorkspacePath:    env.workspaceRoot,
+			Prompt:           "daemon exec prompt",
+			PresentationMode: defaultPresentationMode,
+		})
+		if err != nil {
+			t.Fatalf("StartExecRun(implicit collision) error = %v", err)
+		}
+		if run.RunID != "exec-implicit-collision-2" {
+			t.Fatalf("run.RunID = %q, want retry candidate", run.RunID)
+		}
+		waitForString(t, started, run.RunID)
+		close(release)
+		waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCompleted
+		})
 	})
 }
 
 func TestRunManagerStartExecRunExplicitDuplicateRunIDStillFails(t *testing.T) {
-	const runID = "exec-explicit-duplicate"
-	release := make(chan struct{})
-	started := make(chan string, 1)
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
-			started <- cfg.RunID
-			select {
-			case <-release:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		},
-	})
+	t.Run("Should reject an explicit duplicate exec run ID", func(t *testing.T) {
+		const runID = "exec-explicit-duplicate"
+		release := make(chan struct{})
+		started := make(chan string, 1)
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
+				started <- cfg.RunID
+				select {
+				case <-release:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+		})
 
-	run := env.startExecRun(t, runID, nil)
-	waitForString(t, started, run.RunID)
-	_, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
-		WorkspacePath:    env.workspaceRoot,
-		Prompt:           "daemon exec prompt",
-		PresentationMode: defaultPresentationMode,
-		RuntimeOverrides: rawJSON(t, "{\"run_id\":\""+runID+"\"}"),
-	})
-	if !errors.Is(err, globaldb.ErrRunAlreadyExists) {
-		t.Fatalf("StartExecRun(explicit duplicate) error = %v, want ErrRunAlreadyExists", err)
-	}
-	close(release)
-	waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusCompleted
+		run := env.startExecRun(t, runID, nil)
+		waitForString(t, started, run.RunID)
+		_, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+			WorkspacePath:    env.workspaceRoot,
+			Prompt:           "daemon exec prompt",
+			PresentationMode: defaultPresentationMode,
+			RuntimeOverrides: rawJSON(t, "{\"run_id\":\""+runID+"\"}"),
+		})
+		if !errors.Is(err, globaldb.ErrRunAlreadyExists) {
+			t.Fatalf("StartExecRun(explicit duplicate) error = %v, want ErrRunAlreadyExists", err)
+		}
+		close(release)
+		waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCompleted
+		})
 	})
 }
 
 func TestRunManagerStartExecRunAllocatesDistinctImplicitRunIDsInParallel(t *testing.T) {
-	const totalRuns = 3
-	release := make(chan struct{})
-	started := make(chan string, totalRuns)
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
-			started <- cfg.RunID
-			select {
-			case <-release:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		},
-	})
-
-	start := make(chan struct{})
-	type result struct {
-		run apicore.Run
-		err error
-	}
-	results := make(chan result, totalRuns)
-	for range totalRuns {
-		go func() {
-			<-start
-			run, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
-				WorkspacePath:    env.workspaceRoot,
-				Prompt:           "daemon exec prompt",
-				PresentationMode: defaultPresentationMode,
-			})
-			results <- result{run: run, err: err}
-		}()
-	}
-	close(start)
-
-	runs := make([]apicore.Run, 0, totalRuns)
-	seen := make(map[string]struct{}, totalRuns)
-	for range totalRuns {
-		result := <-results
-		if result.err != nil {
-			t.Fatalf("StartExecRun(parallel implicit) error = %v", result.err)
-		}
-		if strings.TrimSpace(result.run.RunID) == "" {
-			t.Fatal("parallel implicit run id is empty")
-		}
-		if _, ok := seen[result.run.RunID]; ok {
-			t.Fatalf("duplicate implicit run id allocated: %q", result.run.RunID)
-		}
-		seen[result.run.RunID] = struct{}{}
-		runs = append(runs, result.run)
-	}
-
-	startedIDs := make(map[string]struct{}, totalRuns)
-	deadline := time.After(5 * time.Second)
-	for len(startedIDs) < totalRuns {
-		select {
-		case runID := <-started:
-			startedIDs[runID] = struct{}{}
-		case <-deadline:
-			t.Fatalf("timed out waiting for %d exec starts; got %d", totalRuns, len(startedIDs))
-		}
-	}
-	for _, run := range runs {
-		if _, ok := startedIDs[run.RunID]; !ok {
-			t.Fatalf("run %q returned but executeExec did not start", run.RunID)
-		}
-	}
-
-	close(release)
-	for _, run := range runs {
-		waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
-			return row.Status == runStatusCompleted
+	t.Run("Should allocate distinct implicit exec run IDs in parallel", func(t *testing.T) {
+		const totalRuns = 3
+		release := make(chan struct{})
+		started := make(chan string, totalRuns)
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			executeExec: func(ctx context.Context, cfg *model.RuntimeConfig, _ model.RunScope) error {
+				started <- cfg.RunID
+				select {
+				case <-release:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
 		})
-	}
+		start := make(chan struct{})
+		type result struct {
+			run apicore.Run
+			err error
+		}
+		results := make(chan result, totalRuns)
+		for range totalRuns {
+			go func() {
+				<-start
+				run, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+					WorkspacePath:    env.workspaceRoot,
+					Prompt:           "daemon exec prompt",
+					PresentationMode: defaultPresentationMode,
+				})
+				results <- result{run: run, err: err}
+			}()
+		}
+		close(start)
+
+		runs := make([]apicore.Run, 0, totalRuns)
+		seen := make(map[string]struct{}, totalRuns)
+		for range totalRuns {
+			result := <-results
+			if result.err != nil {
+				t.Fatalf("StartExecRun(parallel implicit) error = %v", result.err)
+			}
+			if strings.TrimSpace(result.run.RunID) == "" {
+				t.Fatal("parallel implicit run id is empty")
+			}
+			if _, ok := seen[result.run.RunID]; ok {
+				t.Fatalf("duplicate implicit run id allocated: %q", result.run.RunID)
+			}
+			seen[result.run.RunID] = struct{}{}
+			runs = append(runs, result.run)
+		}
+
+		startedIDs := make(map[string]struct{}, totalRuns)
+		deadline := time.After(5 * time.Second)
+		for len(startedIDs) < totalRuns {
+			select {
+			case runID := <-started:
+				startedIDs[runID] = struct{}{}
+			case <-deadline:
+				t.Fatalf("timed out waiting for %d exec starts; got %d", totalRuns, len(startedIDs))
+			}
+		}
+		for _, run := range runs {
+			if _, ok := startedIDs[run.RunID]; !ok {
+				t.Fatalf("run %q returned but executeExec did not start", run.RunID)
+			}
+		}
+
+		close(release)
+		for _, run := range runs {
+			waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+				return row.Status == runStatusCompleted
+			})
+		}
+	})
 }
 
 func TestRunManagerOpenRunScopeFailureCleansReservedDirectory(t *testing.T) {

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -22,6 +22,7 @@ import (
 	extensions "github.com/compozy/compozy/internal/core/extension"
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/core/plan"
+	runpkg "github.com/compozy/compozy/internal/core/run"
 	workspacecfg "github.com/compozy/compozy/internal/core/workspace"
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/store/globaldb"
@@ -1319,6 +1320,88 @@ func TestRunManagerOpenRunScopeFailureCleansReservedDirectory(t *testing.T) {
 	) {
 		t.Fatalf("GetRun(open scope failure) error = %v, want ErrRunNotFound", err)
 	}
+}
+
+func TestRunManagerStartExecRunOpenRunScopeFailureMarksResumedRowFailed(t *testing.T) {
+	t.Run("Should fail a resumed exec row inserted from persisted metadata", func(t *testing.T) {
+		scopeErr := errors.New("scope unavailable")
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			openRunScope: func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error) {
+				return nil, scopeErr
+			},
+		})
+		const runID = "exec-resume-inserted"
+		writePersistedExecRun(t, env.workspaceRoot, runID, time.Date(2026, 5, 13, 15, 0, 0, 0, time.UTC))
+
+		_, err := env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+			WorkspacePath:    env.workspaceRoot,
+			Prompt:           "daemon exec prompt",
+			PresentationMode: defaultPresentationMode,
+			RuntimeOverrides: rawJSON(t, `{"run_id":"exec-resume-inserted"}`),
+		})
+		if !errors.Is(err, scopeErr) {
+			t.Fatalf("StartExecRun(resumed inserted open scope failure) error = %v, want %v", err, scopeErr)
+		}
+
+		row := waitForRun(t, env.globalDB, runID, func(row globaldb.Run) bool {
+			return row.Status == runStatusFailed
+		})
+		if row.EndedAt == nil {
+			t.Fatal("EndedAt = nil, want terminal timestamp")
+		}
+		if !strings.Contains(row.ErrorText, scopeErr.Error()) {
+			t.Fatalf("row.ErrorText = %q, want %q", row.ErrorText, scopeErr.Error())
+		}
+	})
+
+	t.Run("Should fail a resumed exec row reset from an existing global row", func(t *testing.T) {
+		scopeErr := errors.New("scope unavailable")
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			openRunScope: func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error) {
+				return nil, scopeErr
+			},
+		})
+		const runID = "exec-resume-existing"
+		createdAt := time.Date(2026, 5, 13, 15, 5, 0, 0, time.UTC)
+		writePersistedExecRun(t, env.workspaceRoot, runID, createdAt)
+		workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
+		if err != nil {
+			t.Fatalf("ResolveOrRegister() error = %v", err)
+		}
+		if _, err := env.globalDB.PutRun(context.Background(), globaldb.Run{
+			RunID:            runID,
+			WorkspaceID:      workspace.ID,
+			Mode:             runModeExec,
+			Status:           runStatusCompleted,
+			PresentationMode: defaultPresentationMode,
+			StartedAt:        createdAt,
+		}); err != nil {
+			t.Fatalf("PutRun(existing exec) error = %v", err)
+		}
+
+		_, err = env.manager.StartExecRun(context.Background(), apicore.ExecRequest{
+			WorkspacePath:    env.workspaceRoot,
+			Prompt:           "daemon exec prompt",
+			PresentationMode: defaultPresentationMode,
+			RuntimeOverrides: rawJSON(t, `{"run_id":"exec-resume-existing"}`),
+		})
+		if !errors.Is(err, scopeErr) {
+			t.Fatalf("StartExecRun(resumed existing open scope failure) error = %v, want %v", err, scopeErr)
+		}
+
+		row := waitForRun(t, env.globalDB, runID, func(row globaldb.Run) bool {
+			return row.Status == runStatusFailed
+		})
+		if row.EndedAt == nil {
+			t.Fatal("EndedAt = nil, want terminal timestamp")
+		}
+		if row.StartedAt != createdAt {
+			t.Fatalf("row.StartedAt = %v, want %v", row.StartedAt, createdAt)
+		}
+		if !strings.Contains(row.ErrorText, scopeErr.Error()) {
+			t.Fatalf("row.ErrorText = %q, want %q", row.ErrorText, scopeErr.Error())
+		}
+	})
 }
 
 func TestRunManagerStartRunSyncFailureMarksRunFailed(t *testing.T) {
@@ -2661,6 +2744,36 @@ func firstProjectConfig(
 func rawJSON(t *testing.T, value string) json.RawMessage {
 	t.Helper()
 	return json.RawMessage(value)
+}
+
+func writePersistedExecRun(t *testing.T, workspaceRoot string, runID string, createdAt time.Time) {
+	t.Helper()
+
+	runArtifacts, err := model.ResolvePersistedRunArtifacts(workspaceRoot, runID)
+	if err != nil {
+		t.Fatalf("ResolvePersistedRunArtifacts(%q) error = %v", runID, err)
+	}
+	if err := os.MkdirAll(runArtifacts.RunDir, 0o755); err != nil {
+		t.Fatalf("mkdir persisted exec run dir: %v", err)
+	}
+	record := runpkg.PersistedExecRun{
+		Version:       1,
+		Mode:          model.ModeExec,
+		RunID:         runID,
+		Status:        "completed",
+		WorkspaceRoot: workspaceRoot,
+		CreatedAt:     createdAt,
+		UpdatedAt:     createdAt.Add(time.Minute),
+		EventsPath:    runArtifacts.EventsPath,
+		TurnsDir:      runArtifacts.TurnsDir,
+	}
+	payload, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("json.Marshal(PersistedExecRun) error = %v", err)
+	}
+	if err := os.WriteFile(runArtifacts.RunMetaPath, payload, 0o644); err != nil {
+		t.Fatalf("write persisted exec run metadata: %v", err)
+	}
 }
 
 func mustRunManagerTextBlock(t *testing.T, text string) kinds.ContentBlock {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal process management for agent sessions: command execution, buffered output (with truncation), kill/release, and graceful shutdown handling
  * New provider watch state representing a “settled on current head” condition

* **Improvements**
  * Run IDs now include timestamp plus cryptographic entropy, with retrying to avoid collisions and clearer allocation error handling
  * Codex/bootstrap launch arguments include managed runtime overrides for more predictable runtime behavior
  * Review-watch logic treats the settled state as ready to progress

* **Tests**
  * Expanded test coverage for terminal lifecycle, run-manager run-id allocation/resumption, provider status gating, and diagnostic parsing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compozy/compozy/pull/151)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->