### PR TITLE
feat: add multi-task run support

### DIFF
--- a/.compozy/tasks/multi-task-run/_idea.md
+++ b/.compozy/tasks/multi-task-run/_idea.md
@@ -1,0 +1,100 @@
+# Multi-Task Run
+
+## Overview
+
+Allow `compozy tasks run` to accept a comma-separated list of workflow slugs, such as
+`compozy tasks run task_a,task_b --ide codex`, so a solo developer can start multiple
+independent task workflows with one command. V1 keeps each slug as its own daemon task
+run and adds `[tasks.run]` config to choose enqueued or parallel scheduling.
+
+## Problem
+
+Today, running more than one task workflow requires repeated commands:
+
+```bash
+compozy tasks run task_a --ide codex
+compozy tasks run task_b --ide codex
+```
+
+That is unnecessary friction for solo developers working through independent task
+bundles. The user must repeat flags, manually track which commands were started, and
+coordinate ordering or parallelism outside Compozy.
+
+The feature should reduce repeated CLI work without weakening Compozy's run accounting.
+A comma-separated invocation should still make it clear which slug produced which run,
+which runs started, which failed, and how to resume or inspect each child run.
+
+### Market Data
+
+Task runners such as Nx and Turborepo support multi-target execution with configurable
+parallelism. Tools like `concurrently` exist because repeated terminals and shell
+backgrounding make status and failure tracking hard. AI coding workflows are also moving
+toward parallel agent sessions, usually with explicit isolation or worktree guidance.
+
+## Core Features
+
+| #   | Feature                       | Priority | Description                                                                 |
+| --- | ----------------------------- | -------- | --------------------------------------------------------------------------- |
+| F1  | Comma-separated task slugs    | Critical | Accept `task_a,task_b` as one positional input while preserving current single-slug behavior. |
+| F2  | Config scheduling mode        | Critical | Add `[tasks.run]` config for enqueued vs parallel execution.                 |
+| F3  | Independent daemon runs       | Critical | Start one existing daemon task run per slug instead of creating a merged execution model. |
+| F4  | Shared runtime flags          | High     | Apply shared CLI flags such as `--ide`, `--model`, and `--include-completed` consistently to every child run. |
+| F5  | Aggregate reporting           | High     | Print each slug, run ID, startup/result status, and final aggregate outcome. |
+
+## KPIs
+
+| KPI                    | Target                                | How to Measure                         |
+| ---------------------- | ------------------------------------- | -------------------------------------- |
+| Command reduction      | 3 workflows start with 1 command instead of 3 | CLI invocation comparison in docs/tests |
+| Slug accounting        | 100% of requested slugs appear in output | CLI integration tests                  |
+| Backward compatibility | 100% existing single-slug tests pass unchanged | Regression suite                       |
+| Queued determinism     | 100% queued runs start in input order | Integration test with stub daemon client |
+| Parallel support       | At least 2 runs can be started concurrently | Integration test proving overlapping start calls |
+
+## Feature Assessment
+
+| Criteria            | Question                                            | Score  |
+| ------------------- | --------------------------------------------------- | ------ |
+| **Impact**          | How much more valuable does this make the product?  | Strong |
+| **Reach**           | What % of users would this affect?                  | Strong |
+| **Frequency**       | How often would users encounter this value?         | Strong |
+| **Differentiation** | Does this set us apart or just match competitors?   | Maybe  |
+| **Defensibility**   | Is this easy to copy or does it compound over time? | Maybe  |
+| **Feasibility**     | Can we actually build this?                         | Strong |
+
+Leverage type: Quick Win.
+
+## Council Insights
+
+- **Recommended approach:** Ship a thin orchestration layer over existing single-task daemon runs.
+- **Key trade-offs:** Fewer commands vs clearer run semantics; parallel speed vs shared-workspace conflict risk; simple CLI output vs richer batch UI.
+- **Risks identified:** Ambiguous partial failures, cancellation surprises, and parallel agents editing the same checkout.
+- **Stretch goal (V2+):** Add isolated worktree-backed parallel execution or a richer multi-run dashboard.
+
+## Out of Scope (V1)
+
+- **Dependency graph scheduling** — V1 does not infer relationships between task workflows.
+- **One aggregate "super run"** — each slug remains its own daemon run.
+- **Worktree isolation** — parallel mode shares the current workspace unless a later feature changes that.
+- **Multi-run TUI dashboard** — V1 should use conservative output and attachment behavior.
+- **Named task groups** — useful later, but not required for comma-separated execution.
+
+## Architecture Decision Records
+
+- [ADR-001: Model Multi-Task Run as Explicit Run Orchestration](adrs/adr-001.md) — Treat comma-separated slugs as orchestration over independent daemon runs.
+
+## Open Questions
+
+- What exact config key should represent scheduling mode: `schedule`, `execution_mode`, or `multi_run_mode`?
+- Should parallel mode have a numeric concurrency cap in V1?
+- For `--stream` or UI attach, should V1 disallow multi-slug attach or stream aggregate text output only?
+- Should `--name` accept comma-separated slugs or remain single-slug only?
+
+## References
+
+- [Nx run tasks](https://nx.dev/docs/features/run-tasks)
+- [Nx commands](https://nx.dev/docs/reference/nx-commands)
+- [Turborepo task configuration](https://turborepo.ai/docs/crafting-your-repository/configuring-tasks)
+- [concurrently](https://www.npmjs.com/package/concurrently?activeTab=readme)
+- [Claude Code worktrees](https://code.claude.com/docs/en/worktrees)
+- [Cursor CLI](https://cursor.com/blog/cli)

--- a/.compozy/tasks/multi-task-run/_prd.md
+++ b/.compozy/tasks/multi-task-run/_prd.md
@@ -1,0 +1,174 @@
+# Multi-Task Run PRD
+
+## Overview
+
+Multi-Task Run lets a solo developer start several task workflows from one
+command without changing existing `compozy tasks run <slug>` behavior. V1
+introduces `compozy tasks run-multiple`, accepts multiple workflow slugs, follows
+`[tasks.run] run_multiple_mode`, defaults to `enqueued`, and shows the familiar
+task-run TUI with one tab per requested task.
+
+The feature solves repeated command entry while protecting the stable single-task
+runner. Parallel execution is intentionally deferred because concurrent agents
+need git worktree isolation before they can safely edit files at the same time.
+
+## Goals
+
+- Reduce multi-workflow startup from repeated commands to one command.
+- Preserve current `compozy tasks run <slug>` behavior.
+- Use `run_multiple_mode` as the config source of truth for multi-run behavior.
+- Default to safe enqueued execution.
+- Show queued, running, completed, and failed tasks as TUI tabs.
+- Accept `parallel` in V1 but fall back to `enqueued` with a message that
+  parallel worktree-backed execution is planned for V2.
+
+## User Stories
+
+- As a solo developer, I want `compozy tasks run-multiple` so that I can start
+  several workflows without repeating flags.
+- As a solo developer, I want one tab per requested task so that queued and
+  active workflows stay visible in the familiar TUI.
+- As a cautious operator, I want enqueued execution by default so that agents do
+  not edit the same checkout concurrently.
+- As an existing Compozy user, I want `compozy tasks run <slug>` to remain stable
+  so that my current habits, scripts, and documentation keep working.
+
+## Core Features
+
+### Dedicated Multi-Run Command
+
+V1 adds `compozy tasks run-multiple` for multi-task workflows. The existing
+`compozy tasks run <slug>` command remains the canonical single-workflow runner.
+
+### Multiple Slug Input
+
+The command accepts multiple task workflow slugs in one invocation. The expected
+input shape is a comma-separated list of workflow slugs.
+
+### Config-Driven Mode
+
+`[tasks.run] run_multiple_mode` controls the scheduling mode. The default value
+is `enqueued`.
+
+### Enqueued Execution
+
+V1 runs requested task workflows in order. Later tasks remain queued until the
+current task finishes.
+
+### Parallel Fallback Messaging
+
+If `run_multiple_mode` is configured as `parallel` in V1, Compozy accepts the
+configuration but falls back to enqueued execution. The user sees a clear message
+that parallel mode is planned for V2 with git worktree isolation.
+
+### Tabbed TUI
+
+The task-run TUI shows one tab for each requested workflow. Tabs exist for queued
+tasks before they start, then remain available as tasks run and finish.
+
+### Per-Task Visibility
+
+Each tab identifies the workflow slug and shows whether the task is queued,
+running, completed, failed, or not started.
+
+## User Experience
+
+Primary flow:
+
+1. The user runs `compozy tasks run-multiple` with multiple task workflow slugs.
+2. Compozy reads `run_multiple_mode` and uses `enqueued` unless configured
+   otherwise.
+3. If the configured mode is `parallel`, Compozy displays the V2 fallback message
+   and proceeds in enqueued mode.
+4. The TUI opens with one tab per requested workflow.
+5. The first workflow runs while later workflows remain visible as queued tabs.
+6. The user can switch tabs to inspect each workflow's state.
+7. As each workflow finishes, the next queued workflow starts.
+8. The final state makes it clear which workflows completed, failed, or did not
+   start.
+
+The MVP should feel like the current task-run experience, not a new dashboard.
+Tabs are the primary new interaction.
+
+## High-Level Technical Constraints
+
+- Existing `compozy tasks run <slug>` behavior must remain unchanged.
+- Parallel execution is not part of V1 because safe concurrent agent execution
+  requires git worktree isolation.
+- The product must preserve per-workflow visibility so users know which slug maps
+  to which state.
+- `run_multiple_mode` should remain forward-compatible with V2 parallel support.
+
+## Non-Goals
+
+- Real parallel execution in V1.
+- Git worktree orchestration in V1.
+- Dependency graph scheduling.
+- A rich batch dashboard beyond tabbed task separation.
+- Changing the existing `compozy tasks run <slug>` command behavior.
+- Named task groups.
+
+## Phased Rollout Plan
+
+### MVP: Dedicated Enqueued Multi-Run
+
+- Add the dedicated `tasks run-multiple` user flow.
+- Support comma-separated task workflow slugs.
+- Default `run_multiple_mode` to `enqueued`.
+- Accept `parallel` but fall back to enqueued mode with a V2 message.
+- Add tabbed TUI separation for every requested workflow.
+- Keep `tasks run` stable.
+
+Success criteria: users can start multiple workflows from one command and track
+each workflow through tabs without changing the current single-run command.
+
+### Phase 2: Better Multi-Run Controls
+
+- Improve aggregate summaries and recovery affordances.
+- Refine documentation and examples for `tasks run` vs `tasks run-multiple`.
+- Clarify partial success, failure, and retry paths.
+
+Success criteria: users can understand partial success, failure, and recovery
+paths without reading raw logs.
+
+### Phase 3: Parallel With Isolation
+
+- Add parallel execution only after git worktree isolation is available.
+- Make parallel behavior explicit and safe.
+- Keep enqueued mode as the safe default.
+
+Success criteria: multiple agents can run concurrently without editing the same
+checkout.
+
+## Success Metrics
+
+| Metric | Target |
+| --- | --- |
+| Command reduction | 3 task workflows can start from 1 command |
+| Existing runner stability | Existing `tasks run` behavior remains unchanged |
+| Default safety | `run_multiple_mode` defaults to `enqueued` |
+| Task visibility | 100% of requested slugs appear as TUI tabs |
+| Parallel fallback clarity | 100% of V1 `parallel` uses show fallback messaging |
+
+## Risks and Mitigations
+
+- **Discoverability risk**: Users may not find the new command. Mitigate with
+  examples near `tasks run` help and documentation.
+- **Parallel expectation risk**: Users may expect `parallel` to run concurrently
+  immediately. Mitigate with clear fallback messaging and V2 documentation.
+- **UI complexity risk**: Tabs may make a simple feature feel larger than needed.
+  Mitigate by keeping the TUI familiar and limiting V1 to tabs plus clear state.
+- **Naming risk**: `run-multiple` adds a second command beside `run`. Mitigate by
+  documenting the distinction clearly: `run` for one workflow, `run-multiple` for
+  several workflows.
+
+## Architecture Decision Records
+
+- [ADR-001: Model Multi-Task Run as Explicit Run Orchestration](adrs/adr-001.md) — Treat multi-task execution as orchestration over independent task runs.
+- [ADR-002: Introduce a Dedicated Multi-Run Command for V1](adrs/adr-002.md) — Protect `tasks run` by adding a dedicated multi-run command.
+- [ADR-003: Fix V1 Command Name and Config Behavior](adrs/adr-003.md) — Fix the V1 command name, config key, parallel fallback, and tab behavior.
+
+## Open Questions
+
+None for PRD scope. The TechSpec should decide exact validation behavior and
+fallback message copy.

--- a/.compozy/tasks/multi-task-run/_tasks.md
+++ b/.compozy/tasks/multi-task-run/_tasks.md
@@ -1,0 +1,12 @@
+# Multi-Task Run — Task List
+
+## Tasks
+
+| # | Title | Status | Complexity | Dependencies |
+|---|-------|--------|------------|--------------|
+| 01 | Add Multi-Run Config and Slug Parsing Foundations | pending | medium | — |
+| 02 | Add Multi-Run Daemon API Contracts and Client Surface | pending | medium | task_01 |
+| 03 | Implement Daemon-Owned Sequential Multi-Run Coordinator | pending | critical | task_01, task_02 |
+| 04 | Wire `tasks run-multiple` CLI Command and Non-UI Modes | pending | high | task_01, task_02, task_03 |
+| 05 | Add Tabbed Multi-Run TUI Attach Experience | pending | critical | task_03, task_04 |
+| 06 | Document Multi-Run Usage and Add End-to-End Coverage | pending | medium | task_04, task_05 |

--- a/.compozy/tasks/multi-task-run/_tasks.md
+++ b/.compozy/tasks/multi-task-run/_tasks.md
@@ -4,7 +4,7 @@
 
 | # | Title | Status | Complexity | Dependencies |
 |---|-------|--------|------------|--------------|
-| 01 | Add Multi-Run Config and Slug Parsing Foundations | pending | medium | — |
+| 01 | Add Multi-Run Config and Slug Parsing Foundations | completed | medium | — |
 | 02 | Add Multi-Run Daemon API Contracts and Client Surface | pending | medium | task_01 |
 | 03 | Implement Daemon-Owned Sequential Multi-Run Coordinator | pending | critical | task_01, task_02 |
 | 04 | Wire `tasks run-multiple` CLI Command and Non-UI Modes | pending | high | task_01, task_02, task_03 |

--- a/.compozy/tasks/multi-task-run/_tasks.md
+++ b/.compozy/tasks/multi-task-run/_tasks.md
@@ -5,8 +5,8 @@
 | # | Title | Status | Complexity | Dependencies |
 |---|-------|--------|------------|--------------|
 | 01 | Add Multi-Run Config and Slug Parsing Foundations | completed | medium | — |
-| 02 | Add Multi-Run Daemon API Contracts and Client Surface | pending | medium | task_01 |
-| 03 | Implement Daemon-Owned Sequential Multi-Run Coordinator | pending | critical | task_01, task_02 |
-| 04 | Wire `tasks run-multiple` CLI Command and Non-UI Modes | pending | high | task_01, task_02, task_03 |
-| 05 | Add Tabbed Multi-Run TUI Attach Experience | pending | critical | task_03, task_04 |
-| 06 | Document Multi-Run Usage and Add End-to-End Coverage | pending | medium | task_04, task_05 |
+| 02 | Add Multi-Run Daemon API Contracts and Client Surface | completed | medium | task_01 |
+| 03 | Implement Daemon-Owned Sequential Multi-Run Coordinator | completed | critical | task_01, task_02 |
+| 04 | Wire `tasks run-multiple` CLI Command and Non-UI Modes | completed | high | task_01, task_02, task_03 |
+| 05 | Add Tabbed Multi-Run TUI Attach Experience | completed | critical | task_03, task_04 |
+| 06 | Document Multi-Run Usage and Add End-to-End Coverage | completed | medium | task_04, task_05 |

--- a/.compozy/tasks/multi-task-run/_techspec.md
+++ b/.compozy/tasks/multi-task-run/_techspec.md
@@ -1,0 +1,138 @@
+# TechSpec: Multi-Task Run
+
+## Executive Summary
+
+`compozy tasks run-multiple` will add a dedicated daemon-backed workflow for running multiple task slugs from one command without changing `compozy tasks run`. V1 is strictly sequential: it preflights every requested slug before starting, creates one daemon-owned parent multi-run, then starts normal child task runs one at a time.
+
+The main trade-off is implementation scope. A CLI-only queue would be smaller, but it cannot preserve the existing `Close TUI` behavior for queued tasks. The daemon-owned coordinator makes the whole queue survive TUI detach, at the cost of new API, run manager, event, and tabbed TUI work.
+
+## System Architecture
+
+### Component Overview
+
+- CLI command: `internal/cli/daemon_commands.go` adds `tasks run-multiple [slugs]`, parses comma-separated slugs, applies task-run defaults, preflights all slugs, resolves attach mode, and starts the daemon parent run.
+- Config: `internal/core/workspace` adds `[tasks.run] run_multiple_mode`, defaulting to `enqueued`; `parallel` validates but falls back to enqueued with a V2/worktree message.
+- Daemon API: a new multi-run start endpoint accepts the ordered slug list and returns the parent run.
+- Run manager: `internal/daemon` adds a `task_multi` parent mode, modeled after review-watch parent/child orchestration.
+- TUI: `internal/core/run/ui` adds a multi-run remote attach surface that renders tabs above the existing single-run task UI.
+
+## Implementation Design
+
+### Core Interfaces
+
+```go
+type TaskRunMultipleRequest struct {
+	Workspace        string          `json:"workspace"`
+	Slugs            []string        `json:"slugs"`
+	Mode             string          `json:"mode,omitempty"`
+	PresentationMode string          `json:"presentation_mode,omitempty"`
+	RuntimeOverrides json.RawMessage `json:"runtime_overrides,omitempty"`
+}
+
+type TaskRunMultipleItem struct {
+	Slug      string `json:"slug"`
+	Status    string `json:"status"`
+	RunID     string `json:"run_id,omitempty"`
+	ErrorText string `json:"error_text,omitempty"`
+}
+```
+
+### Data Models
+
+- Add `TaskRunConfig.RunMultipleMode *string` with TOML key `run_multiple_mode`.
+- Add daemon run mode constant `task_multi` for the parent run.
+- Child runs remain normal `task` runs and set `ParentRunID` to the parent.
+- Parent multi-run state is append-only in parent run events: queued item, child started, child completed, child failed, queue canceled, queue completed.
+- Duplicate slugs after trimming are invalid because running the same workflow twice in one queue is ambiguous.
+
+### API Endpoints
+
+- `POST /api/task-runs/multiple`: start a daemon-owned parent multi-run.
+- Request: `TaskRunMultipleRequest`.
+- Response: existing `RunResponse` containing the parent run.
+- `GET /api/task-runs/multiple/:run_id/snapshot`: return parent run plus ordered `TaskRunMultipleItem` state for attach/re-attach.
+- Existing child run endpoints remain unchanged: snapshots and streams still use `/api/runs/:run_id/...`.
+
+## Integration Points
+
+No external services or third-party integrations are required. The feature integrates only with Compozy's existing daemon transport, global run index, per-run databases, task workflow metadata, and Bubble Tea TUI runtime.
+
+## Impact Analysis
+
+| Component | Impact Type | Description and Risk | Required Action |
+|-----------|-------------|----------------------|-----------------|
+| `internal/cli/daemon_commands.go` | new | Adds command while preserving `tasks run` behavior | Add parser, command state, start handling, tests |
+| `internal/core/workspace` | modified | Config decoding rejects unknown fields today | Add field, merge, validation, config tests |
+| `internal/api/contract`, `internal/api/core`, `internal/api/client` | modified | New daemon transport surface | Add request/response, routes, client method, contract tests |
+| `internal/daemon` | modified | Parent/child queue ownership | Add coordinator, parent mode, cancellation, event emission |
+| `internal/core/run/ui` | modified | Current UI assumes one run and job indexes are local | Add multi-run wrapper with isolated child state per tab |
+| docs/README/config examples | modified | New command and config key | Document syntax, fallback, quit behavior |
+
+## Testing Approach
+
+### Unit Tests
+
+- Slug parser: trims whitespace, rejects empty entries, rejects duplicates, preserves order.
+- Config: default mode is `enqueued`; `enqueued` and `parallel` validate; unknown values fail.
+- CLI: `tasks run-multiple a,b` starts one parent request and does not call `StartTaskRun` directly.
+- CLI fallback: configured `parallel` prints the V2/worktree fallback message and sends `enqueued`.
+- Daemon coordinator: preflights all slugs before parent creation; starts exactly one child at a time; stops on first child failure.
+- Cancellation: parent cancel cancels active child and marks queued items canceled.
+
+### Integration Tests
+
+- In-process daemon command test for `run-multiple` with two workflows.
+- Parent/child global DB linkage test asserting child `ParentRunID`.
+- Remote multi-run snapshot reconstruction from parent events plus child runs.
+- TUI model tests for tab rendering, tab navigation, and quit dialog action mapping.
+
+## Development Sequencing
+
+### Build Order
+
+1. Add slug parsing and `run_multiple_mode` config support - no dependencies.
+2. Add CLI `tasks run-multiple` shell and tests - depends on step 1.
+3. Add API contract/client/handler types for parent multi-run start and snapshot - depends on step 2.
+4. Add daemon parent coordinator and `task_multi` run mode - depends on step 3.
+5. Add parent event payloads and snapshot reconstruction - depends on step 4.
+6. Add multi-run TUI wrapper with tabs and existing quit dialog behavior - depends on step 5.
+7. Wire CLI attach/stream/detach handling for parent multi-runs - depends on step 6.
+8. Add docs and end-to-end/integration coverage - depends on steps 1-7.
+
+### Technical Dependencies
+
+No external services or new third-party dependencies are required. V2 parallel execution depends on git worktree isolation and is explicitly out of scope.
+
+## Monitoring and Observability
+
+- Emit parent run events for queue started, item queued, child started, child completed, child failed, queue canceled, and queue completed.
+- Log structured fields: `parent_run_id`, `child_run_id`, `workflow_slug`, `index`, `total`, `run_multiple_mode`.
+- Count `task_multi` active and terminal runs in daemon mode metrics, alongside existing run modes.
+
+## Technical Considerations
+
+### Key Decisions
+
+- Decision: use a dedicated `tasks run-multiple` command.
+  Rationale: avoids regressions in `tasks run`.
+  Trade-off: shared flags/config must be wired twice.
+- Decision: use daemon-owned parent queue.
+  Rationale: required for the existing `Close TUI` behavior to apply to queued work.
+  Trade-off: larger daemon/API/TUI change set.
+- Decision: V1 accepts `parallel` but runs enqueued.
+  Rationale: preserves forward config compatibility while avoiding same-worktree agent collisions.
+  Trade-off: users must see a clear fallback message.
+
+### Known Risks
+
+- TUI state collision: isolate each child run UI state and translator by tab/run ID.
+- Partial queue starts: preflight all slugs before parent creation and duplicate-check before API start.
+- Cancel ambiguity: map the existing dialog exactly: `Close TUI` detaches, `Stop Run` cancels active and queued work, `Cancel` returns to the UI.
+- API route conflicts: use `/api/task-runs/multiple` instead of adding a static route under `/api/tasks`.
+
+## Architecture Decision Records
+
+- [ADR-001: Use Multi-Task Execution as Explicit Task-Run Orchestration](adrs/adr-001.md) - Treat multi-task execution as orchestration over independent task workflows.
+- [ADR-002: Introduce a Dedicated Multi-Run Command for V1](adrs/adr-002.md) - Add `tasks run-multiple` instead of widening `tasks run`.
+- [ADR-003: Fix V1 Command Name and Config Behavior](adrs/adr-003.md) - Set command/config names, parallel fallback, and tab expectation.
+- [ADR-004: Use a Daemon-Owned Sequential Multi-Run Coordinator](adrs/adr-004.md) - Own the queue in the daemon so the current TUI detach/stop behavior applies to the whole queue.

--- a/.compozy/tasks/multi-task-run/adrs/adr-001.md
+++ b/.compozy/tasks/multi-task-run/adrs/adr-001.md
@@ -1,0 +1,133 @@
+# ADR-001: Model Multi-Task Run as Explicit Run Orchestration
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+`compozy tasks run` currently accepts one workflow slug, resolves one task
+directory, starts one daemon task run, and attaches to that run. The requested
+feature lets a solo developer run multiple task workflows with one invocation:
+
+```bash
+compozy tasks run task_a,task_b --ide codex
+```
+
+The user clarified that V1 should be controlled by config, so `config.toml`
+can choose whether a comma-separated task list runs in parallel or enqueued.
+The primary value is reducing repeated command invocations while preserving the
+same shared flags users already pass to `tasks run`.
+
+The feature creates a semantic boundary even if the implementation is small.
+Multiple slugs mean multiple run identities, artifacts, logs, failure outcomes,
+cancellation targets, and attachment choices. Parallel mode also introduces
+workspace mutation risk because multiple agents can operate in the same checkout.
+
+## Decision
+
+Model comma-separated `tasks run` input as explicit orchestration over multiple
+independent task runs.
+
+V1 should:
+
+- Parse a comma-separated positional slug list while preserving existing
+  single-slug behavior.
+- Start one daemon task run per slug using the existing single-task run path.
+- Apply shared CLI flags and runtime overrides consistently to every child run.
+- Add a `[tasks.run]` config option that chooses enqueued or parallel scheduling.
+- Default to the safer scheduling mode unless the implementation spec decides a
+  different compatibility path is required.
+- Report every requested slug with its run ID and startup/result status.
+- Define cancellation, failure aggregation, and attachment behavior explicitly.
+
+V1 should not turn PRD task execution inside one workflow into a new scheduler,
+dependency graph, or merged "super run." It should treat one CLI invocation as a
+batch of independent daemon runs.
+
+## Alternatives Considered
+
+### Alternative 1: CLI string expansion only
+
+- **Description**: Split the comma-separated argument and invoke the existing
+  single-task command behavior repeatedly without naming a multi-run contract.
+- **Pros**: Smallest implementation surface; fastest to ship.
+- **Cons**: Leaves attachment, partial failure, cancellation, status reporting,
+  and artifacts ambiguous.
+- **Why rejected**: The user-visible command becomes one operation, so the
+  operation needs explicit semantics even if each child run uses existing code.
+
+### Alternative 2: One aggregate workflow run
+
+- **Description**: Treat the comma-separated list as one new run with multiple
+  workflow slugs inside it.
+- **Pros**: Natural place for one aggregate UI, one cancellation target, and one
+  result object.
+- **Cons**: Breaks the current one-run/one-workflow model and risks creating a
+  parallel execution path beside the existing daemon task runner.
+- **Why rejected**: Too much architecture for V1. The existing daemon run model
+  is already the right unit of execution.
+
+### Alternative 3: Require separate shell commands
+
+- **Description**: Keep the current command surface and document shell aliases,
+  scripts, or terminal multiplexing for parallel work.
+- **Pros**: No code change; no new semantics.
+- **Cons**: Preserves the current friction and makes Compozy worse than common
+  task runners for multi-target execution.
+- **Why rejected**: The requested value is reducing repeated invocations while
+  keeping Compozy responsible for clear task-run accounting.
+
+## Consequences
+
+### Positive
+
+- Solo developers can start multiple independent task workflows from one command.
+- Existing single-task daemon run behavior remains the execution primitive.
+- Config owns the parallel-versus-enqueued policy instead of requiring ad hoc
+  shell orchestration.
+- Output can become more useful by showing every slug, run ID, and result.
+
+### Negative
+
+- The CLI must define aggregate status and exit-code behavior.
+- Streaming or UI attachment cannot naively attach to multiple runs without a
+  clear policy.
+- Parallel mode can expose same-workspace conflict risks if agents edit
+  overlapping files.
+
+### Risks
+
+- **Ambiguous partial failure**: Mitigate by reporting each slug separately and
+  documenting aggregate exit-code rules.
+- **Cancellation surprises**: Mitigate by defining whether Ctrl-C cancels all
+  started child runs or only the attached child run.
+- **Workspace conflicts in parallel mode**: Mitigate by documenting that V1
+  parallel mode shares the current workspace unless a later worktree-isolation
+  feature changes that contract.
+
+## Implementation Notes
+
+- Prefer adding scheduling policy under `[tasks.run]`, near existing
+  task-run-specific config such as `include_completed`, `output_format`, `tui`,
+  and `task_runtime_rules`.
+- Preserve `compozy tasks run task_a --ide codex` behavior exactly.
+- Treat `--name` carefully. V1 should either keep `--name` single-slug only or
+  explicitly support comma-separated values with the same validation as the
+  positional argument.
+- For non-interactive output, print one line per child run plus an aggregate
+  summary.
+- For stream/UI attach, define one conservative V1 policy rather than building a
+  multi-run dashboard.
+
+## References
+
+- `internal/cli/daemon_commands.go` — current `tasks run` CLI and daemon start path
+- `internal/core/workspace/config_types.go` — existing `[tasks.run]` config shape
+- `internal/core/workspace/config_merge.go` — config merge precedence
+- Nx `run-many` and configurable parallelism documentation
+- Turborepo task configuration documentation

--- a/.compozy/tasks/multi-task-run/adrs/adr-002.md
+++ b/.compozy/tasks/multi-task-run/adrs/adr-002.md
@@ -1,0 +1,113 @@
+# ADR-002: Introduce a Dedicated Multi-Run Command for V1
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+The original idea explored accepting comma-separated workflow slugs through
+`compozy tasks run`. During PRD refinement, the user clarified that V1 should
+avoid adding risk to the existing single-run command. `tasks run` is already the
+canonical workflow runner, with established validation, attach, stream, and TUI
+behavior. Expanding that command to handle multiple workflow slugs would increase
+the chance of regressions in a critical path.
+
+The user also clarified two product constraints for MVP:
+
+- Multi-task execution should follow `config.toml`, with a safe default of
+  enqueued execution.
+- Parallel execution should be deferred until Compozy can isolate concurrent
+  agents with git worktrees.
+- The TUI should remain familiar, with tabs above the task surface separating
+  each requested task.
+
+## Decision
+
+V1 will introduce a dedicated multi-run command, using `compozy tasks
+run_multiple` as the product-facing command name unless a later naming pass
+changes it.
+
+The command will:
+
+- Accept multiple task workflow slugs as one comma-separated input.
+- Follow `[tasks.run]` configuration for multi-run behavior.
+- Default to enqueued execution.
+- Defer parallel execution until worktree-backed isolation exists.
+- Present a familiar task-run TUI with tabs above the task surface for each
+  requested workflow.
+- Preserve existing `compozy tasks run <slug>` behavior for single-run workflows.
+
+## Alternatives Considered
+
+### Alternative 1: Extend `tasks run`
+
+- **Description**: Let `compozy tasks run task_a,task_b` start multiple task
+  workflows.
+- **Pros**: Shortest command, direct continuation of the original idea, easy to
+  discover.
+- **Cons**: Increases regression risk in the existing canonical single-run
+  command.
+- **Why rejected**: The user explicitly prioritized protecting `tasks run` from
+  new multi-run complexity in V1.
+
+### Alternative 2: Headless multi-run command
+
+- **Description**: Add a dedicated command but only print text output and run IDs.
+- **Pros**: Smaller interface surface and faster to specify.
+- **Cons**: Misses the expected user experience of staying inside the familiar
+  TUI.
+- **Why rejected**: The user wants the same TUI experience with tabs separating
+  tasks.
+
+### Alternative 3: Parallel multi-run command in V1
+
+- **Description**: Add the dedicated command and support parallel execution
+  immediately.
+- **Pros**: Higher throughput for independent workflows.
+- **Cons**: Concurrent agents can edit the same files in the same checkout,
+  creating unsafe conflicts.
+- **Why rejected**: Parallel execution should wait for git worktree isolation.
+
+## Consequences
+
+### Positive
+
+- Existing `tasks run` behavior remains stable for current users.
+- V1 can validate the multi-run product experience without changing the
+  canonical single-run path.
+- The TUI can present multi-task state intentionally instead of overloading the
+  single-run screen.
+- Deferring parallel execution avoids unsafe same-worktree agent collisions.
+
+### Negative
+
+- Users must learn a second command for multi-run workflows.
+- The command name may need refinement before implementation if product naming
+  conventions prefer hyphens over underscores.
+- Documentation must clearly explain when to use `tasks run` vs
+  `tasks run_multiple`.
+
+### Risks
+
+- **Discoverability risk**: Mitigate with examples in task-run help and docs.
+- **Naming churn**: Mitigate by treating `run_multiple` as the PRD name and
+  leaving exact CLI naming open for TechSpec confirmation.
+- **Scope creep risk**: Mitigate by keeping V1 enqueued only and deferring
+  parallel/worktree support.
+
+## Implementation Notes
+
+- Keep this ADR product-facing. Technical implementation details belong in the
+  TechSpec.
+- The PRD should describe the command capability and user experience, not the
+  internal command wiring.
+
+## References
+
+- [ADR-001: Model Multi-Task Run as Explicit Run Orchestration](adr-001.md)
+- `.compozy/tasks/multi-task-run/_idea.md`

--- a/.compozy/tasks/multi-task-run/adrs/adr-003.md
+++ b/.compozy/tasks/multi-task-run/adrs/adr-003.md
@@ -1,0 +1,85 @@
+# ADR-003: Fix V1 Command Name and Config Behavior
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+The PRD draft left four open product questions: the final command name, the
+configuration key for multi-run scheduling, how V1 should handle a configured
+parallel mode before git worktree isolation exists, and how queued tasks should
+appear in the TUI.
+
+The user resolved those questions during PRD review. V1 should use a dedicated
+command named `run-multiple`, use `run_multiple_mode` as the config key, accept
+parallel as a configured value but fall back to enqueued mode with a clear
+message, and show queued tasks as tabs.
+
+## Decision
+
+V1 will use the following product contract:
+
+- Command name: `compozy tasks run-multiple`.
+- Config key: `[tasks.run] run_multiple_mode`.
+- Default mode: `enqueued`.
+- If `run_multiple_mode` is configured as `parallel` in V1, Compozy will display
+  a message that parallel mode is planned for V2 and will fall back to enqueued
+  execution.
+- The TUI will represent each requested workflow as a tab, including queued
+  workflows that have not started yet.
+
+## Alternatives Considered
+
+### Alternative 1: Keep `run_multiple`
+
+- **Description**: Use an underscore command name.
+- **Pros**: Matches the early idea wording.
+- **Cons**: Less idiomatic for CLI subcommands than hyphenated names.
+- **Why rejected**: The user selected `run-multiple`.
+
+### Alternative 2: Reject `parallel` config in V1
+
+- **Description**: Treat `parallel` as invalid until worktree isolation exists.
+- **Pros**: Strictly prevents unsupported behavior.
+- **Cons**: Makes forward-looking config harder to introduce and gives users a
+  hard failure where a safe fallback is possible.
+- **Why rejected**: The user wants `parallel` accepted with a clear fallback
+  message and V2 expectation.
+
+## Consequences
+
+### Positive
+
+- Product naming is resolved before TechSpec.
+- Users can adopt the final config key without waiting for V2 parallel support.
+- The fallback message makes V1 safety explicit instead of silently ignoring
+  user intent.
+- Tabs provide a single visual model for queued, running, and completed tasks.
+
+### Negative
+
+- Accepting `parallel` before it works may surprise users unless the fallback
+  message is prominent.
+- V1 documentation must explain that `parallel` is recognized but not executed
+  until V2.
+
+### Risks
+
+- **User confusion**: Mitigate with a clear runtime message and docs that name
+  V2 worktree-backed parallel support.
+- **Config compatibility**: Mitigate by keeping `run_multiple_mode` stable when
+  V2 adds real parallel execution.
+
+## Implementation Notes
+
+- This ADR defines product behavior only. Validation and message wording belong
+  in the TechSpec.
+
+## References
+
+- [ADR-002: Introduce a Dedicated Multi-Run Command for V1](adr-002.md)

--- a/.compozy/tasks/multi-task-run/adrs/adr-004.md
+++ b/.compozy/tasks/multi-task-run/adrs/adr-004.md
@@ -1,0 +1,115 @@
+# ADR-004: Use a Daemon-Owned Sequential Multi-Run Coordinator
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-17
+
+## Context
+
+`compozy tasks run-multiple` must preserve the existing task-run TUI quit
+behavior. When a run is active, the quit dialog offers `Close TUI`, `Stop Run`,
+and `Cancel`; `Close TUI` detaches while the daemon-owned run keeps running in
+the background.
+
+A CLI-owned queue cannot provide the same behavior for workflows that have not
+started yet. If the CLI exits, queued items would disappear unless a daemon
+process owns the queue. The feature also needs tab navigation across queued,
+running, completed, and failed workflows while preserving the existing
+single-run task execution path.
+
+## Decision
+
+V1 will introduce a daemon-owned sequential multi-run coordinator.
+
+The CLI will parse and preflight all requested slugs, then ask the daemon to
+start one parent multi-run. The daemon parent run will own the ordered queue,
+start one child task run at a time, set each child run's `ParentRunID` to the
+parent run, stop on the first failed child, and keep enough queue state in the
+parent run stream for attach/detach and tab reconstruction.
+
+The tabbed TUI will attach to the parent multi-run and render the existing
+single-run task UI inside the active tab. `Close TUI` detaches from the parent
+and leaves the queue running. `Stop Run` cancels the parent coordinator, which
+cancels the active child run and marks queued workflows as canceled. `Cancel`
+returns to the TUI without changing execution.
+
+## Alternatives Considered
+
+### Alternative 1: CLI-owned queue
+
+- **Description**: The CLI starts one child task run, waits for it, then starts
+  the next child run.
+- **Pros**: Smaller API and daemon change set.
+- **Cons**: Queued workflows are lost when the TUI closes, so `Close TUI` cannot
+  keep the whole queue running.
+- **Why rejected**: It does not match the current task-run quit behavior.
+
+### Alternative 2: Run every child immediately in parallel
+
+- **Description**: The daemon starts all requested child task runs at once and
+  only the TUI groups them visually.
+- **Pros**: Simple child lifecycle once launched.
+- **Cons**: Reintroduces the V1 parallel execution risk: agents can edit the
+  same working tree at the same time.
+- **Why rejected**: V1 intentionally defers parallel execution until
+  worktree-backed isolation exists.
+
+### Alternative 3: Sequential single-run TUI sessions
+
+- **Description**: Reuse the current TUI by closing each child session before
+  opening the next one.
+- **Pros**: Minimal TUI change.
+- **Cons**: Users cannot navigate back to completed tabs or see queued tasks as
+  tabs throughout the queue.
+- **Why rejected**: The PRD requires persistent tabs for all requested
+  workflows.
+
+## Consequences
+
+### Positive
+
+- The multi-run queue behaves like today's daemon-backed task run when the TUI
+  is closed.
+- Queued tasks survive client disconnects.
+- Child task execution keeps using the existing single-task run machinery.
+- Parent and child run rows preserve inspectable history through existing run
+  listing and parent-child fields.
+
+### Negative
+
+- V1 requires daemon API, run manager, and TUI changes rather than a pure CLI
+  wrapper.
+- The parent run stream needs new multi-run lifecycle events for queued and
+  child state.
+- The TUI must isolate per-child run UI state so child job indexes do not
+  collide.
+
+### Risks
+
+- **Cancellation ambiguity**: Mitigate by mapping the existing dialog actions to
+  queue-level behavior and documenting that `Stop Run` cancels active and queued
+  work.
+- **State reconstruction bugs**: Mitigate by making parent queue events
+  append-only and using child `ParentRunID` links as a secondary source of
+  truth.
+- **Scope creep into V2 parallelism**: Mitigate by keeping the coordinator
+  strictly sequential and treating `parallel` as an enqueued fallback.
+
+## Implementation Notes
+
+- Model the parent coordinator after the existing review-watch parent/child run
+  pattern.
+- Add a new internal run mode for the parent multi-run, such as `task_multi`.
+- Keep child task runs as normal `task` runs.
+- Preflight every slug before creating the parent run.
+- Do not change `compozy tasks run`.
+
+## References
+
+- [PRD: Multi-Task Run](../_prd.md)
+- [ADR-002: Introduce a Dedicated Multi-Run Command for V1](adr-002.md)
+- [ADR-003: Fix V1 Command Name and Config Behavior](adr-003.md)

--- a/.compozy/tasks/multi-task-run/memory/MEMORY.md
+++ b/.compozy/tasks/multi-task-run/memory/MEMORY.md
@@ -1,0 +1,30 @@
+# Workflow Memory
+
+Keep only durable, cross-task context here. Do not duplicate facts that are obvious from the repository, PRD documents, or git history.
+
+## Current State
+- task_01 implemented the multi-run foundations: workspace config now supports `TaskRunConfig.RunMultipleMode` and `EffectiveRunMultipleMode()`, and comma-separated slug parsing lives in `internal/core/tasks.ParseCommaSeparatedSlugs`.
+- task_02 added the daemon transport surface for multi-run parents: `POST /api/task-runs/multiple`, `GET /api/task-runs/multiple/:run_id/snapshot`, `contract.TaskRunMultipleRequest`, `contract.TaskRunMultipleSnapshot`, client methods `StartTaskRunMultiple` / `GetTaskRunMultipleSnapshot`, and OpenAPI/generated TS types.
+- task_03 implemented the daemon-owned sequential `task_multi` parent coordinator: preflight happens before parent creation, children are regular `task` runs linked by `ParentRunID`, and snapshots replay parent queue events into ordered item state.
+- task_04 wired `compozy tasks run-multiple [slugs]`: the CLI parses one comma-separated slug list, preflights all slugs before daemon contact, sends `TaskRunMultipleRequest` through the client, preserves `tasks run`, and supports non-UI detach/stream modes.
+- task_05 added the tabbed daemon attach UI for `task_multi` parents: `ui.AttachRemoteMultiple` builds ordered tabs from the parent snapshot, keeps child `uiModel`/translator state isolated per slug, follows parent and child streams, and maps the quit dialog to queue detach/stop/cancel semantics.
+- task_06 documented `tasks run-multiple`, `run_multiple_mode`, V1 `parallel` fallback, and queue-level TUI quit behavior in README, then added CLI integration coverage for comma-separated multi-run snapshot state and fallback-to-enqueued evidence.
+
+## Shared Decisions
+- Later tasks should consume `workspace.TaskRunMultipleModeEnqueued`, `workspace.TaskRunMultipleModeParallel`, and `TaskRunConfig.EffectiveRunMultipleMode()` instead of duplicating mode strings or default logic.
+
+## Shared Learnings
+- `parallel` is a valid configured value for V1, but execution tasks must still fall back to enqueued behavior until the daemon/worktree-backed parallel work lands.
+- Multi-run slug input validation is centralized in `internal/core/tasks.ParseCommaSeparatedSlugs`; it trims entries, preserves order, rejects empty entries, and rejects duplicates.
+- The local shell may export a stale `GOROOT=/Users/matheusbbarni/.local/go`; Go commands pass when run with `env -u GOROOT`.
+- Multi-run parent events use `task.multi.*` event kinds with item statuses `queued`, `running`, `completed`, `failed`, and `canceled`; task_05 should consume the snapshot first and use events for incremental attach updates.
+- CLI stream mode already renders `task.multi.*` parent queue events and returns exit code 1 when the parent ends failed/canceled/crashed; task_05 should avoid regressing this non-UI path when adding the tabbed TUI.
+- Multi-run TUI tab navigation uses `[` and `]`; `tab` and `shift+tab` remain single-run pane focus controls inside the active child view.
+
+## Open Risks
+
+## Handoffs
+- task_04 CLI wiring can call `tasks.ParseCommaSeparatedSlugs` for the `tasks run-multiple` positional argument, then use `cfg.Tasks.Run.EffectiveRunMultipleMode()` for the configured mode.
+- task_04 can call daemon client `StartTaskRunMultiple(ctx, apicore.TaskRunMultipleRequest{...})`; task_05 can call `GetTaskRunMultipleSnapshot(ctx, parentRunID)` for parent attach state.
+- Runtime override `run_id` is reserved for the parent multi-run request; children intentionally receive generated run IDs so a single request cannot duplicate child IDs.
+- task_06 should document UI attach behavior: queued tabs appear before child runs exist, completed tabs remain navigable, `Close TUI` detaches, and `Stop Run` cancels the parent queue.

--- a/.compozy/tasks/multi-task-run/memory/task_01.md
+++ b/.compozy/tasks/multi-task-run/memory/task_01.md
@@ -1,0 +1,27 @@
+# Task Memory: task_01.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement task_01 foundations: `[tasks.run] run_multiple_mode` config parsing/merge/validation/defaulting plus reusable comma-separated multi-run slug parsing.
+- Keep existing `compozy tasks run <slug>` behavior unchanged; V1 accepts only `enqueued` and `parallel`, with effective default `enqueued`.
+
+## Important Decisions
+- ADR-002/ADR-003 supersede the older ADR-001 wording around extending `tasks run`; this task targets dedicated `tasks run-multiple` foundations only.
+- Place slug parsing in `internal/core/tasks` rather than the large `internal/cli` package; this keeps it reusable by CLI/API/daemon work without daemon imports and gives the parser focused package coverage.
+
+## Learnings
+- Pre-change code has no `RunMultipleMode` / `run_multiple_mode` implementation under `internal/core/workspace` or `internal/cli`; strict TOML decoding would reject the key.
+- `GOROOT` is stale in this shell (`/Users/matheusbbarni/.local/go`); Go verification must run with `env -u GOROOT`.
+- Focused coverage after moving the parser: `internal/core/workspace` 81.5%, `internal/core/tasks` 84.6%.
+
+## Files / Surfaces
+- Expected config surfaces: `internal/core/workspace/config_types.go`, `config_merge.go`, `config_validate.go`, `config_test.go`.
+- Parser surfaces: `internal/core/tasks/slug_list.go` and `slug_list_test.go`.
+
+## Errors / Corrections
+- Initial parser placement in `internal/cli` passed focused tests but package coverage was below the task target because `internal/cli` is broad; moved the parser into `internal/core/tasks`.
+- Unknown task-run TOML keys still fail through the strict decoder, but the decoder error does not include the unknown field name; tests assert the decode failure rather than field-name text.
+
+## Ready for Next Run
+- Implementation and verification complete for task_01. `make verify` passed with `env -u GOROOT`: frontend lint/typecheck/tests/build, Go fmt/lint/test/build, and frontend e2e all completed successfully.

--- a/.compozy/tasks/multi-task-run/memory/task_02.md
+++ b/.compozy/tasks/multi-task-run/memory/task_02.md
@@ -1,0 +1,32 @@
+# Task Memory: task_02.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Add daemon API contract/client/handler/OpenAPI surface for starting a daemon-owned multi-run parent and reading its snapshot. Keep this task scoped to transport contracts; the coordinator implementation remains task_03.
+
+## Important Decisions
+- Treat ADR-002/003/004 as superseding ADR-001's earlier `tasks run` extension wording. This task uses `/api/task-runs/multiple` and preserves existing `StartTaskRun`.
+- Keep task_02 limited to contracts/client/handlers. The real daemon coordinator remains task_03, so `transportTaskService` exposes the new methods but returns service-unavailable placeholders for now.
+- Multi-run start and snapshot routes are workspace-context compatible like existing start routes; `workspace` remains optional in OpenAPI because the active workspace header can supply it.
+
+## Learnings
+- Pre-change signal: no `TaskRunMultipleRequest`, `TaskRunMultipleSnapshot`, or `/api/task-runs/multiple` route/client surface exists under `internal` or `openapi`.
+- Updating `openapi/compozy-daemon.json` requires regenerating `web/src/generated/compozy-openapi.d.ts` with `bun run codegen`.
+- The shell exports a stale `GOROOT=/Users/matheusbbarni/.local/go`; use `env -u GOROOT` for Go verification commands in this worktree.
+- `RegisterRoutes` was already near the lint statement limit. Adding routes required splitting route registration into helper functions instead of suppressing `funlen`.
+- To avoid stale turbo log replay from previous environment warnings, use `TURBO_FORCE=true` with `make verify` when clean verification output matters.
+
+## Files / Surfaces
+- `internal/api/contract`: multi-run request/snapshot types, route inventory, timeout and round-trip tests.
+- `internal/api/core`: shared interface aliases, routes, handlers, smoke/contract/error-path stubs.
+- `internal/api/client`: `StartTaskRunMultiple`, `GetTaskRunMultipleSnapshot`, client routing/encoding/nil-context tests.
+- `internal/daemon/task_transport_service.go`: temporary multi-run service method stubs for task_03.
+- `openapi/compozy-daemon.json` and `web/src/generated/compozy-openapi.d.ts`: daemon API schema and generated TS contract.
+
+## Errors / Corrections
+- First `make verify` failed because generated OpenAPI TS was stale; ran `bun run codegen`.
+- Second `make verify` failed on `internal/api/core/routes.go` `funlen`; refactored route registration into focused helper functions.
+
+## Ready for Next Run
+- Clean verification command used for final gate: `env -u GOROOT -u NO_COLOR TURBO_FORCE=true make verify`.

--- a/.compozy/tasks/multi-task-run/memory/task_03.md
+++ b/.compozy/tasks/multi-task-run/memory/task_03.md
@@ -1,0 +1,32 @@
+# Task Memory: task_03.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement the daemon-owned sequential `task_multi` parent coordinator behind the task_02 multi-run API stubs. The coordinator must preflight all slugs before parent creation, start normal `task` child runs one at a time with `ParentRunID`, emit reconstructable parent queue events, and cancel active/queued work from parent cancellation.
+- Completed the coordinator, snapshot reconstruction, parent/child linkage, cancellation behavior, and run manager integration coverage for task_03.
+
+## Important Decisions
+- Treat `parallel` requests as accepted V1 input but execute with enqueued semantics in the daemon, matching the shared workflow memory and PRD/ADR contract.
+- Use parent runtime override `run_id` only for the parent run and strip it from child runtime overrides so a single multi-run request does not force duplicate child run IDs.
+
+## Learnings
+- Baseline focused daemon test fails at compile time because `task_multi` mode, multi-run snapshot reconstruction, item status constants, and queue event kinds are not implemented yet.
+- `make verify` initially failed on `gocyclo` in `runTaskMultiCoordinator`; extracting one-child execution into `runTaskMultiChildAt` fixed the lint failure without changing behavior.
+- Parent cancellation events must be written with a detached context so queued/active item cancellation is still reconstructable after the parent context is canceled.
+
+## Files / Surfaces
+- `internal/daemon/task_multi_test.go`
+- `internal/daemon/task_multi.go`
+- `internal/daemon/run_manager.go`
+- `internal/daemon/service.go`
+- `internal/daemon/task_transport_service.go`
+- `pkg/compozy/events/event.go`
+- `pkg/compozy/events/kinds/task.go`
+- `pkg/compozy/events/kinds/payload_compat_test.go`
+
+## Errors / Corrections
+- Corrected the initial coordinator shape to keep cyclomatic complexity under the repository lint threshold.
+
+## Ready for Next Run
+- `make verify` passed after implementation. task_04 can rely on `StartRunMultiple` creating a durable `task_multi` parent and normal child `task` rows with `ParentRunID`; task_05 can reconstruct queue state from the parent snapshot/events.

--- a/.compozy/tasks/multi-task-run/memory/task_04.md
+++ b/.compozy/tasks/multi-task-run/memory/task_04.md
@@ -1,0 +1,31 @@
+# Task Memory: task_04.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement task_04: expose `compozy tasks run-multiple [slugs]` as a daemon-backed parent multi-run command with non-UI detach/stream behavior, while preserving `tasks run` single-slug behavior.
+- Pre-change signal: `go run ./cmd/compozy tasks run-multiple --help` showed only `run` and `validate` under `tasks`; no `run-multiple` command is registered yet.
+
+## Important Decisions
+- Treat the PRD/TechSpec/ADRs as the approved design for this implementation run. The brainstorming skill's approval gate is satisfied by the existing approved PRD task and the user's explicit "begin now" authorization.
+- Use the existing centralized slug parser (`internal/core/tasks.ParseCommaSeparatedSlugs`) and workspace mode constants/defaulting instead of duplicating validation or mode strings.
+- Keep `tasks run-multiple` beside `tasks run` with shared task-run flags factored through a helper. Do not add `--name` to multi-run because the positional comma-separated slug list is the only accepted workflow selector.
+- Stream mode now watches parent run events until a terminal snapshot and returns exit code 1 for failed/canceled/crashed parent runs, while detach mode prints only the parent run ID summary.
+
+## Learnings
+- ADR-002/ADR-003 supersede ADR-001's earlier wording around extending `tasks run`; task_04 must add a separate `run-multiple` command.
+- The CLI stream renderer currently handles run/job/session events only; parent multi-run queue events need explicit text rendering for useful non-UI output.
+- `make verify` runs Go through `env -u GOROOT` from the Makefile and succeeds with the local environment. Direct ad-hoc Go commands should continue using `rtk env -u GOROOT ...`.
+- Package-wide `internal/cli` coverage remains below 80% due existing broad CLI surface, but the new command parsing/config helpers are covered directly: slug-list resolution 100%, multi-run preflight 84%+, and mode resolution 100%.
+
+## Files / Surfaces
+- Expected code surfaces: `internal/cli/daemon_commands.go`, `internal/cli/root.go`, `internal/cli/state.go`, `internal/cli/workspace_config.go`, `internal/cli/run.go`, `internal/cli/run_observe.go`, CLI test files, and in-process daemon test helpers.
+- Implemented surfaces: `internal/cli/daemon_commands.go`, `internal/cli/root.go`, `internal/cli/state.go`, `internal/cli/workspace_config.go`, `internal/cli/run.go`, `internal/cli/run_observe.go`, `internal/cli/skills_preflight.go`, `internal/cli/extensions_bootstrap.go`, `internal/cli/commands_test.go`, `internal/cli/daemon_commands_test.go`, `internal/cli/daemon_exec_test_helpers_test.go`, `internal/cli/root_command_execution_test.go`, and `internal/cli/validate_tasks_test.go`.
+
+## Errors / Corrections
+- First full `make verify` failed at `golangci-lint` because `watchCLIRunUntilTerminalSuccess` had cyclomatic complexity 16 (>15). The fix split rendering/terminal-check/status mapping into helpers instead of suppressing lint.
+- Initial daemon request-shape test compared a `/var/...` workspace path with the client-resolved `/private/var/...` path. The test now resolves symlinks before comparison, matching the CLI behavior.
+
+## Ready for Next Run
+- Full verification passed on 2026-05-17: `rtk make verify` completed fmt, lint, tests, build, and frontend e2e. Node emitted the known `NO_COLOR`/`FORCE_COLOR` warning during frontend steps, but lint reported 0 issues and verification exited successfully.
+- task_05 can focus on the tabbed TUI attach experience; command registration, runtime overrides, mode fallback, detach output, and parent stream output are now wired.

--- a/.compozy/tasks/multi-task-run/memory/task_05.md
+++ b/.compozy/tasks/multi-task-run/memory/task_05.md
@@ -1,0 +1,35 @@
+# Task Memory: task_05.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Implement the tabbed multi-run TUI attach path for daemon-owned `task_multi` parents: tabs for every requested slug, isolated child run UI state per tab, live parent/child updates, and queue-level quit dialog semantics.
+- Preserve single-run `tasks run` UI behavior; scope is limited to multi-run parent attach and the CLI bridge that chooses it.
+
+## Important Decisions
+- Follow ADR-004 exactly: `Close TUI` detaches from the parent queue, `Stop Run` cancels the parent coordinator, and `Cancel` returns to the tabbed UI without side effects.
+- Implemented the multi-run TUI as a wrapper around the existing single-run `uiModel` instead of changing the single-run layout; each tab owns its own child `uiModel` and `uiEventTranslator`.
+- Chose `[` and `]` for tab navigation so `tab` / `shift+tab` continue to control existing pane focus inside the child run UI.
+- CLI attach now detects parent snapshots with mode `task_multi` and routes UI/auto presentation to `ui.AttachRemoteMultiple`; single-run settled-before-attach behavior remains unchanged.
+
+## Learnings
+- Parent queue snapshots are the initial source of tab ordering and queued/not-started visibility; `task.multi.*` parent events are used for incremental tab status and child run discovery.
+- Child streams should start once per discovered child run ID and route events back by slug, otherwise job indexes/transcripts can bleed across tabs.
+- `Close TUI` must never call parent cancel from the CLI bridge; only the queue-level `Stop Run` quit action or context-owned cancellation should request `CancelRun` on the parent.
+
+## Files / Surfaces
+- Expected implementation surfaces: `internal/core/run/ui/*`, `internal/cli/run_observe.go`, and focused TUI/remote tests.
+- Added `internal/core/run/ui/multi_remote.go` for the remote multi-run attach model/controller.
+- Added `internal/core/run/ui/multi_remote_test.go` for tab rendering/state, quit behavior, and remote attach parent/child stream tests.
+- Updated `internal/cli/run_observe.go` to route `task_multi` parent runs to the multi-run TUI attach session.
+- Updated `internal/core/run/ui/update.go`, `view.go`, and `update_test.go` to centralize key literals required by lint while preserving single-run behavior.
+
+## Errors / Corrections
+- Initial full `make verify` failed on `gocyclo` in `attachRemoteCLIRunUI`; extracted request normalization and shared remote UI wait/cancel handling.
+- Earlier lint also required key literal constants and a no-result parent-event helper; fixed before the passing full gate.
+
+## Ready for Next Run
+- Verified with `env -u GOROOT go test -timeout=60s ./internal/core/run/ui ./internal/cli`.
+- Verified with `env -u GOROOT go test -coverprofile=/tmp/compozy-ui.cover ./internal/core/run/ui` at 80.2% statement coverage.
+- Verified with `env -u GOROOT make lint`.
+- Verified with `env -u GOROOT make verify`; full pipeline passed: frontend bootstrap/lint/typecheck/tests/build, Go fmt/lint/race tests/build, and frontend e2e.

--- a/.compozy/tasks/multi-task-run/memory/task_06.md
+++ b/.compozy/tasks/multi-task-run/memory/task_06.md
@@ -1,0 +1,33 @@
+# Task Memory: task_06.md
+
+Keep only task-local execution context here. Do not duplicate facts that are obvious from the repository, task file, PRD documents, or git history.
+
+## Objective Snapshot
+- Document `compozy tasks run-multiple` usage in README near the existing `tasks run` and config guidance.
+- Add integration coverage proving comma-separated `tasks run-multiple alpha,beta` creates a daemon-owned parent queue whose snapshot contains both requested slugs.
+- Cover the `run_multiple_mode = "parallel"` V1 fallback path with observable fallback messaging and enqueued execution evidence.
+
+## Important Decisions
+- Keep documentation in README only unless implementation shows generated command docs are also required.
+- Reuse the existing in-process daemon CLI test harness rather than adding a separate external process or web smoke test.
+
+## Learnings
+- Shared memory says task_04 already centralized comma-separated slug parsing in `internal/core/tasks.ParseCommaSeparatedSlugs`.
+- Shared memory says task_05 established queue TUI semantics: queued tabs exist before child runs, completed tabs remain navigable, `Close TUI` detaches, and `Stop Run` cancels the parent queue.
+- The existing CLI command help already had `run-multiple` examples; task_06 added a focused help test to keep those examples and shared task-run flags covered.
+- In-process CLI stream mode gives deterministic end-to-end evidence for parent queue events and snapshots after both dry-run child workflows complete.
+- Focused CLI tests passed, and the full `make verify` gate passed after implementation and tracking updates.
+
+## Files / Surfaces
+- `README.md`
+- `internal/cli/root_command_execution_test.go`
+- `internal/cli/daemon_exec_test_helpers_test.go`
+- `internal/cli/root_test.go`
+- `.compozy/tasks/multi-task-run/task_06.md`
+- `.compozy/tasks/multi-task-run/_tasks.md`
+
+## Errors / Corrections
+- `rtk git diff -- ...` treated the path as a revision; use `rtk proxy git diff -- ...` for path-limited diffs.
+
+## Ready for Next Run
+- No known follow-up work for task_06.

--- a/.compozy/tasks/multi-task-run/task_01.md
+++ b/.compozy/tasks/multi-task-run/task_01.md
@@ -1,0 +1,92 @@
+---
+status: pending
+title: Add Multi-Run Config and Slug Parsing Foundations
+type: backend
+complexity: medium
+dependencies: []
+---
+
+# Task 1: Add Multi-Run Config and Slug Parsing Foundations
+
+## Overview
+
+This task adds the configuration and input parsing foundations required by `tasks run-multiple`. It keeps the existing `tasks run` path stable while introducing shared validation helpers that later CLI, API, and daemon work can rely on.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- The implementation MUST add `[tasks.run] run_multiple_mode` to the workspace config model.
+- The implementation MUST merge global and workspace config using the same precedence pattern as the existing `[tasks.run]` fields.
+- The implementation MUST validate only `enqueued` and `parallel` as accepted V1 values.
+- The implementation MUST expose a default effective mode of `enqueued` when no config value is present.
+- The implementation MUST provide a reusable comma-separated slug parser that trims entries, preserves order, rejects empty entries, and rejects duplicates.
+- The implementation MUST NOT change the existing `compozy tasks run <slug>` command behavior.
+</requirements>
+
+## Subtasks
+
+- [ ] 1.1 Add the `run_multiple_mode` field to the task-run config model.
+- [ ] 1.2 Add merge and validation behavior for the new config field.
+- [ ] 1.3 Add a small parser for comma-separated multi-run slug input.
+- [ ] 1.4 Add unit tests for config loading, merge precedence, invalid modes, parser errors, and duplicate slugs.
+- [ ] 1.5 Confirm existing single-run config tests still pass unchanged.
+
+## Implementation Details
+
+Update the config layer first, then place the slug parser near the future CLI command wiring so later tasks can reuse it without importing daemon internals. See the TechSpec "Data Models" and "Development Sequencing" sections for the expected field name and accepted values.
+
+### Relevant Files
+
+- `internal/core/workspace/config_types.go` — defines `TaskRunConfig`, which must accept `run_multiple_mode`.
+- `internal/core/workspace/config_merge.go` — merges global and workspace `[tasks.run]` values.
+- `internal/core/workspace/config_validate.go` — validates task-run config fields and should reject unsupported modes.
+- `internal/core/workspace/config_test.go` — covers config parsing, validation, and merge behavior.
+- `internal/cli/daemon_commands.go` — current task command file and likely home for the parser or parser call site.
+- `internal/cli/commands_test.go` — existing command-level tests for task-run defaults.
+
+### Dependent Files
+
+- `internal/cli/workspace_config.go` — later tasks will apply the new config value to the multi-run command state.
+- `internal/cli/workspace_config_test.go` — later tests should assert config defaults are applied to `run-multiple`.
+- `README.md` — later documentation should mention the config key.
+
+### Related ADRs
+
+- [ADR-002: Introduce a Dedicated Multi-Run Command for V1](adrs/adr-002.md) — Keeps this work off the existing single-run command.
+- [ADR-003: Fix V1 Command Name and Config Behavior](adrs/adr-003.md) — Defines the config key, default mode, and accepted `parallel` fallback.
+
+## Deliverables
+
+- `run_multiple_mode` parsed, merged, and validated in workspace config.
+- Reusable comma-separated slug parser with order-preserving validation.
+- Unit tests with 80%+ coverage for the changed config and parser behavior **(REQUIRED)**.
+- Integration-oriented config tests that load workspace/global TOML combinations **(REQUIRED)**.
+
+## Tests
+
+- Unit tests:
+  - [ ] Loading `[tasks.run] run_multiple_mode = "enqueued"` stores the configured value.
+  - [ ] Loading `[tasks.run] run_multiple_mode = "parallel"` stores the configured value without error.
+  - [ ] Loading `[tasks.run] run_multiple_mode = "invalid"` returns a validation error naming `tasks.run.run_multiple_mode`.
+  - [ ] Workspace config overrides global config for `run_multiple_mode`.
+  - [ ] Parsing `alpha,beta,gamma` returns slugs in that order.
+  - [ ] Parsing `alpha,,beta` rejects the empty slug.
+  - [ ] Parsing `alpha, beta ,alpha` rejects the duplicate `alpha`.
+- Integration tests:
+  - [ ] `workspace.LoadConfig` accepts the new key while still rejecting unknown task-run keys.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+
+- All tests passing.
+- Test coverage >=80%.
+- Config accepts `enqueued` and `parallel` only.
+- Parser behavior is deterministic and reusable by later tasks.
+- Existing `tasks run` tests remain green without behavioral changes.

--- a/.compozy/tasks/multi-task-run/task_01.md
+++ b/.compozy/tasks/multi-task-run/task_01.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: Add Multi-Run Config and Slug Parsing Foundations
 type: backend
 complexity: medium
@@ -31,11 +31,11 @@ This task adds the configuration and input parsing foundations required by `task
 
 ## Subtasks
 
-- [ ] 1.1 Add the `run_multiple_mode` field to the task-run config model.
-- [ ] 1.2 Add merge and validation behavior for the new config field.
-- [ ] 1.3 Add a small parser for comma-separated multi-run slug input.
-- [ ] 1.4 Add unit tests for config loading, merge precedence, invalid modes, parser errors, and duplicate slugs.
-- [ ] 1.5 Confirm existing single-run config tests still pass unchanged.
+- [x] 1.1 Add the `run_multiple_mode` field to the task-run config model.
+- [x] 1.2 Add merge and validation behavior for the new config field.
+- [x] 1.3 Add a small parser for comma-separated multi-run slug input.
+- [x] 1.4 Add unit tests for config loading, merge precedence, invalid modes, parser errors, and duplicate slugs.
+- [x] 1.5 Confirm existing single-run config tests still pass unchanged.
 
 ## Implementation Details
 
@@ -71,15 +71,15 @@ Update the config layer first, then place the slug parser near the future CLI co
 ## Tests
 
 - Unit tests:
-  - [ ] Loading `[tasks.run] run_multiple_mode = "enqueued"` stores the configured value.
-  - [ ] Loading `[tasks.run] run_multiple_mode = "parallel"` stores the configured value without error.
-  - [ ] Loading `[tasks.run] run_multiple_mode = "invalid"` returns a validation error naming `tasks.run.run_multiple_mode`.
-  - [ ] Workspace config overrides global config for `run_multiple_mode`.
-  - [ ] Parsing `alpha,beta,gamma` returns slugs in that order.
-  - [ ] Parsing `alpha,,beta` rejects the empty slug.
-  - [ ] Parsing `alpha, beta ,alpha` rejects the duplicate `alpha`.
+  - [x] Loading `[tasks.run] run_multiple_mode = "enqueued"` stores the configured value.
+  - [x] Loading `[tasks.run] run_multiple_mode = "parallel"` stores the configured value without error.
+  - [x] Loading `[tasks.run] run_multiple_mode = "invalid"` returns a validation error naming `tasks.run.run_multiple_mode`.
+  - [x] Workspace config overrides global config for `run_multiple_mode`.
+  - [x] Parsing `alpha,beta,gamma` returns slugs in that order.
+  - [x] Parsing `alpha,,beta` rejects the empty slug.
+  - [x] Parsing `alpha, beta ,alpha` rejects the duplicate `alpha`.
 - Integration tests:
-  - [ ] `workspace.LoadConfig` accepts the new key while still rejecting unknown task-run keys.
+  - [x] `workspace.LoadConfig` accepts the new key while still rejecting unknown task-run keys.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/multi-task-run/task_02.md
+++ b/.compozy/tasks/multi-task-run/task_02.md
@@ -1,0 +1,93 @@
+---
+status: pending
+title: Add Multi-Run Daemon API Contracts and Client Surface
+type: backend
+complexity: medium
+dependencies:
+  - task_01
+---
+
+# Task 2: Add Multi-Run Daemon API Contracts and Client Surface
+
+## Overview
+
+This task adds the daemon transport contract for starting and inspecting a daemon-owned multi-run parent. It establishes typed request, response, handler, client, and OpenAPI surfaces before the run manager implements the coordinator.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- The implementation MUST add a typed request for starting a multi-run parent with workspace, ordered slugs, mode, presentation mode, and runtime overrides.
+- The implementation MUST add a typed item/snapshot shape for reconstructing queued, active, completed, failed, and canceled child state.
+- The implementation MUST add daemon routes that do not conflict with `/api/tasks/:slug`.
+- The implementation MUST add client methods for starting and loading a multi-run parent snapshot.
+- The implementation MUST preserve all existing `StartTaskRun` request and route behavior.
+- The implementation MUST update contract/OpenAPI tests for the new request schema and route.
+</requirements>
+
+## Subtasks
+
+- [ ] 2.1 Add contract types for multi-run start and snapshot payloads.
+- [ ] 2.2 Extend the shared API interfaces with multi-run start and snapshot methods.
+- [ ] 2.3 Register non-conflicting daemon routes for multi-run start and snapshot reads.
+- [ ] 2.4 Add client methods that call the new routes and decode typed responses.
+- [ ] 2.5 Add contract, client, handler, and OpenAPI tests for the new API surface.
+
+## Implementation Details
+
+Use `/api/task-runs/multiple` for the start route and `/api/task-runs/multiple/:run_id/snapshot` for the multi-run snapshot route, as described in the TechSpec "API Endpoints" section. Keep child run observation on the existing `/api/runs/:run_id/...` routes.
+
+### Relevant Files
+
+- `internal/api/contract/types.go` — home for transport request and response structs.
+- `internal/api/contract/routes.go` — canonical route metadata and timeout classes.
+- `internal/api/core/interfaces.go` — shared service interfaces used by HTTP handlers.
+- `internal/api/core/routes.go` — route registration for daemon HTTP transport.
+- `internal/api/core/handlers.go` — request decoding and service delegation.
+- `internal/api/client/client.go` and `internal/api/client/runs.go` — existing client request patterns.
+- `internal/api/client/client_contract_test.go` — timeout and request routing expectations.
+- `internal/api/httpapi/openapi_contract_test.go` — OpenAPI schema and route contract assertions.
+
+### Dependent Files
+
+- `internal/daemon/task_transport_service.go` — later task will implement the new service methods with `RunManager`.
+- `internal/cli/daemon_commands.go` — later task will call the new client methods.
+- `internal/core/run/ui/remote.go` — later task will use snapshots to attach the multi-run TUI.
+
+### Related ADRs
+
+- [ADR-004: Use a Daemon-Owned Sequential Multi-Run Coordinator](adrs/adr-004.md) — Requires a parent run API instead of a CLI-only queue.
+
+## Deliverables
+
+- Typed daemon contract for multi-run start and snapshot.
+- Registered API routes that avoid `/api/tasks/:slug` conflicts.
+- Client methods for multi-run start and snapshot reads.
+- Unit tests with 80%+ coverage for request encoding, route timeout class, and response decoding **(REQUIRED)**.
+- Handler/OpenAPI integration tests for the new route and schema **(REQUIRED)**.
+
+## Tests
+
+- Unit tests:
+  - [ ] Client start method posts to `/api/task-runs/multiple` with ordered slugs.
+  - [ ] Client snapshot method gets `/api/task-runs/multiple/<run_id>/snapshot`.
+  - [ ] Client rejects a nil context consistently with existing daemon client methods.
+  - [ ] Contract route metadata classifies multi-run start as long mutating work.
+  - [ ] Contract route metadata classifies multi-run snapshot as read work.
+- Integration tests:
+  - [ ] Shared handler smoke test starts a multi-run parent through the new route and returns `201`.
+  - [ ] OpenAPI contract exposes `TaskRunMultipleRequest` and the new route request body.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+
+- All tests passing.
+- Test coverage >=80%.
+- API contracts compile without changing `TaskRunRequest`.
+- Existing daemon task-run client and handler tests remain unchanged except for shared interface stubs.

--- a/.compozy/tasks/multi-task-run/task_02.md
+++ b/.compozy/tasks/multi-task-run/task_02.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: Add Multi-Run Daemon API Contracts and Client Surface
 type: backend
 complexity: medium
@@ -32,11 +32,11 @@ This task adds the daemon transport contract for starting and inspecting a daemo
 
 ## Subtasks
 
-- [ ] 2.1 Add contract types for multi-run start and snapshot payloads.
-- [ ] 2.2 Extend the shared API interfaces with multi-run start and snapshot methods.
-- [ ] 2.3 Register non-conflicting daemon routes for multi-run start and snapshot reads.
-- [ ] 2.4 Add client methods that call the new routes and decode typed responses.
-- [ ] 2.5 Add contract, client, handler, and OpenAPI tests for the new API surface.
+- [x] 2.1 Add contract types for multi-run start and snapshot payloads.
+- [x] 2.2 Extend the shared API interfaces with multi-run start and snapshot methods.
+- [x] 2.3 Register non-conflicting daemon routes for multi-run start and snapshot reads.
+- [x] 2.4 Add client methods that call the new routes and decode typed responses.
+- [x] 2.5 Add contract, client, handler, and OpenAPI tests for the new API surface.
 
 ## Implementation Details
 
@@ -74,14 +74,14 @@ Use `/api/task-runs/multiple` for the start route and `/api/task-runs/multiple/:
 ## Tests
 
 - Unit tests:
-  - [ ] Client start method posts to `/api/task-runs/multiple` with ordered slugs.
-  - [ ] Client snapshot method gets `/api/task-runs/multiple/<run_id>/snapshot`.
-  - [ ] Client rejects a nil context consistently with existing daemon client methods.
-  - [ ] Contract route metadata classifies multi-run start as long mutating work.
-  - [ ] Contract route metadata classifies multi-run snapshot as read work.
+  - [x] Client start method posts to `/api/task-runs/multiple` with ordered slugs.
+  - [x] Client snapshot method gets `/api/task-runs/multiple/<run_id>/snapshot`.
+  - [x] Client rejects a nil context consistently with existing daemon client methods.
+  - [x] Contract route metadata classifies multi-run start as long mutating work.
+  - [x] Contract route metadata classifies multi-run snapshot as read work.
 - Integration tests:
-  - [ ] Shared handler smoke test starts a multi-run parent through the new route and returns `201`.
-  - [ ] OpenAPI contract exposes `TaskRunMultipleRequest` and the new route request body.
+  - [x] Shared handler smoke test starts a multi-run parent through the new route and returns `201`.
+  - [x] OpenAPI contract exposes `TaskRunMultipleRequest` and the new route request body.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/multi-task-run/task_03.md
+++ b/.compozy/tasks/multi-task-run/task_03.md
@@ -1,0 +1,102 @@
+---
+status: pending
+title: Implement Daemon-Owned Sequential Multi-Run Coordinator
+type: backend
+complexity: critical
+dependencies:
+  - task_01
+  - task_02
+---
+
+# Task 3: Implement Daemon-Owned Sequential Multi-Run Coordinator
+
+## Overview
+
+This task implements the daemon-owned parent queue that makes `Close TUI` keep the whole multi-run running in the background. The coordinator preflights all slugs, starts one normal task child at a time, links child runs to the parent, emits parent lifecycle state, and stops on the first child failure.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- The implementation MUST add a parent daemon run mode for multi-task orchestration, such as `task_multi`.
+- The implementation MUST preflight every requested slug before creating the parent run.
+- The implementation MUST start child runs sequentially in the requested order.
+- Each child task run MUST remain a normal `task` run and MUST set `ParentRunID` to the parent run ID.
+- The coordinator MUST stop on the first failed child run and leave later queued items not started.
+- Parent cancellation MUST cancel the active child and mark queued items canceled.
+- The parent stream MUST expose enough append-only queue state for later TUI attach and reattach.
+- The implementation MUST NOT add parallel execution or worktree orchestration in V1.
+</requirements>
+
+## Subtasks
+
+- [ ] 3.1 Add parent run mode and active-run accounting for multi-run parents.
+- [ ] 3.2 Add preflight logic that validates every slug before parent run creation.
+- [ ] 3.3 Add coordinator state for ordered queued/running/completed/failed/canceled items.
+- [ ] 3.4 Start child task runs through the existing task-run machinery with parent linkage.
+- [ ] 3.5 Emit parent queue lifecycle events and reconstructable snapshot state.
+- [ ] 3.6 Implement cancellation behavior for active and queued children.
+- [ ] 3.7 Add run manager tests for success, child failure, duplicate/invalid slugs, and cancellation.
+
+## Implementation Details
+
+Model this after the existing review-watch parent/child run pattern, but keep task children as regular `task` runs. See TechSpec "System Architecture", "Data Models", and "Monitoring and Observability" for the parent mode, child linkage, queue states, and event requirements.
+
+### Relevant Files
+
+- `internal/daemon/run_manager.go` — owns daemon run modes, active runs, parent/child linkage, cancellation, and execution dispatch.
+- `internal/daemon/review_watch.go` — existing daemon-owned parent/child coordinator pattern.
+- `internal/daemon/task_transport_service.go` — service bridge from API handlers to the run manager.
+- `internal/store/globaldb/registry.go` — durable run row shape already includes `ParentRunID`.
+- `pkg/compozy/events/event.go` — event kind registry for parent queue lifecycle events.
+- `pkg/compozy/events/kinds/task.go` or a new event payload file — typed payloads for multi-run queue events.
+- `internal/daemon/run_manager_test.go` and `internal/daemon/review_watch_test.go` — relevant test patterns.
+
+### Dependent Files
+
+- `internal/api/core/handlers.go` — calls the service method added in task 02.
+- `internal/api/client/client.go` — later CLI task depends on the run manager behavior behind this client surface.
+- `internal/core/run/ui/remote.go` — later TUI task consumes parent snapshots and child run IDs.
+- `internal/daemon/service.go` and `internal/daemon/shutdown.go` — metrics and active-run counts must include the new parent mode.
+
+### Related ADRs
+
+- [ADR-001: Use Multi-Task Execution as Explicit Task-Run Orchestration](adrs/adr-001.md) — Treats each workflow as an independent child run.
+- [ADR-004: Use a Daemon-Owned Sequential Multi-Run Coordinator](adrs/adr-004.md) — Defines daemon ownership, stop-on-failure, child linkage, and queue-level quit behavior.
+
+## Deliverables
+
+- Daemon-owned sequential parent coordinator for multi-run task queues.
+- Child task runs linked with `ParentRunID`.
+- Parent queue events and snapshot reconstruction state.
+- Cancellation behavior that cancels active child work and queued items.
+- Unit tests with 80%+ coverage for coordinator state transitions **(REQUIRED)**.
+- Run manager integration tests for parent/child lifecycle and global DB linkage **(REQUIRED)**.
+
+## Tests
+
+- Unit tests:
+  - [ ] Starting `alpha,beta` creates one `task_multi` parent and later child task runs in order.
+  - [ ] Child runs have `ParentRunID` equal to the parent run ID.
+  - [ ] A failed first child marks the parent failed and does not start the second child.
+  - [ ] A successful first child starts the second child only after the first reaches a terminal state.
+  - [ ] Parent cancellation cancels the active child and marks queued items canceled.
+  - [ ] Invalid or completed workflow preflight prevents parent run creation.
+- Integration tests:
+  - [ ] Run manager list/snapshot APIs expose the parent and child rows with correct modes and relationships.
+  - [ ] Parent event log can reconstruct queued, running, completed, failed, and canceled item state.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+
+- All tests passing.
+- Test coverage >=80%.
+- Multi-run queues continue under daemon ownership after client detach.
+- No V1 code path starts multiple child task runs concurrently.
+- Existing `StartTaskRun` behavior and tests remain stable.

--- a/.compozy/tasks/multi-task-run/task_03.md
+++ b/.compozy/tasks/multi-task-run/task_03.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: Implement Daemon-Owned Sequential Multi-Run Coordinator
 type: backend
 complexity: critical
@@ -35,13 +35,13 @@ This task implements the daemon-owned parent queue that makes `Close TUI` keep t
 
 ## Subtasks
 
-- [ ] 3.1 Add parent run mode and active-run accounting for multi-run parents.
-- [ ] 3.2 Add preflight logic that validates every slug before parent run creation.
-- [ ] 3.3 Add coordinator state for ordered queued/running/completed/failed/canceled items.
-- [ ] 3.4 Start child task runs through the existing task-run machinery with parent linkage.
-- [ ] 3.5 Emit parent queue lifecycle events and reconstructable snapshot state.
-- [ ] 3.6 Implement cancellation behavior for active and queued children.
-- [ ] 3.7 Add run manager tests for success, child failure, duplicate/invalid slugs, and cancellation.
+- [x] 3.1 Add parent run mode and active-run accounting for multi-run parents.
+- [x] 3.2 Add preflight logic that validates every slug before parent run creation.
+- [x] 3.3 Add coordinator state for ordered queued/running/completed/failed/canceled items.
+- [x] 3.4 Start child task runs through the existing task-run machinery with parent linkage.
+- [x] 3.5 Emit parent queue lifecycle events and reconstructable snapshot state.
+- [x] 3.6 Implement cancellation behavior for active and queued children.
+- [x] 3.7 Add run manager tests for success, child failure, duplicate/invalid slugs, and cancellation.
 
 ## Implementation Details
 
@@ -81,15 +81,15 @@ Model this after the existing review-watch parent/child run pattern, but keep ta
 ## Tests
 
 - Unit tests:
-  - [ ] Starting `alpha,beta` creates one `task_multi` parent and later child task runs in order.
-  - [ ] Child runs have `ParentRunID` equal to the parent run ID.
-  - [ ] A failed first child marks the parent failed and does not start the second child.
-  - [ ] A successful first child starts the second child only after the first reaches a terminal state.
-  - [ ] Parent cancellation cancels the active child and marks queued items canceled.
-  - [ ] Invalid or completed workflow preflight prevents parent run creation.
+  - [x] Starting `alpha,beta` creates one `task_multi` parent and later child task runs in order.
+  - [x] Child runs have `ParentRunID` equal to the parent run ID.
+  - [x] A failed first child marks the parent failed and does not start the second child.
+  - [x] A successful first child starts the second child only after the first reaches a terminal state.
+  - [x] Parent cancellation cancels the active child and marks queued items canceled.
+  - [x] Invalid or completed workflow preflight prevents parent run creation.
 - Integration tests:
-  - [ ] Run manager list/snapshot APIs expose the parent and child rows with correct modes and relationships.
-  - [ ] Parent event log can reconstruct queued, running, completed, failed, and canceled item state.
+  - [x] Run manager list/snapshot APIs expose the parent and child rows with correct modes and relationships.
+  - [x] Parent event log can reconstruct queued, running, completed, failed, and canceled item state.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/multi-task-run/task_04.md
+++ b/.compozy/tasks/multi-task-run/task_04.md
@@ -1,0 +1,101 @@
+---
+status: pending
+title: Wire tasks run-multiple CLI Command and Non-UI Modes
+type: backend
+complexity: high
+dependencies:
+  - task_01
+  - task_02
+  - task_03
+---
+
+# Task 4: Wire tasks run-multiple CLI Command and Non-UI Modes
+
+## Overview
+
+This task exposes the daemon-backed multi-run parent through `compozy tasks run-multiple`. It applies shared task-run flags and runtime overrides, handles `parallel` fallback messaging, and supports detach and stream modes before the tabbed TUI is layered on top.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- The implementation MUST add `compozy tasks run-multiple [slugs]`.
+- The command MUST accept one comma-separated positional slug list.
+- The command MUST reject missing, empty, or duplicate slugs before contacting the daemon.
+- The command MUST apply the same shared runtime flags that are valid for task runs.
+- The command MUST read `[tasks.run] run_multiple_mode` and default to `enqueued`.
+- If the configured mode is `parallel`, the command MUST print a clear V2/worktree fallback message and send enqueued execution.
+- The command MUST preserve existing `tasks run` flags and behavior.
+- Non-UI attach modes MUST provide useful parent run output without requiring the tabbed TUI.
+</requirements>
+
+## Subtasks
+
+- [ ] 4.1 Add a new Cobra subcommand under `tasks`.
+- [ ] 4.2 Add command state and defaults for task-run shared flags, runtime overrides, and config application.
+- [ ] 4.3 Resolve mode and print the `parallel` fallback message when needed.
+- [ ] 4.4 Start the daemon parent multi-run through the client method from task 02.
+- [ ] 4.5 Support detach and stream output for parent multi-runs.
+- [ ] 4.6 Add CLI tests for command registration, parser failures, fallback messaging, daemon request shape, and existing `tasks run` stability.
+
+## Implementation Details
+
+Keep the new command beside `newTasksRunCommandWithDefaults` rather than modifying the single-run command's argument contract. Use the parser and config behavior from task 01 and the client/API surface from task 02. See TechSpec "Component Overview" and "Known Risks" for command boundaries and fallback behavior.
+
+### Relevant Files
+
+- `internal/cli/daemon_commands.go` — current `tasks` command registration, single-run command, daemon client interface, and start handling.
+- `internal/cli/root.go` — command kind constants and workflow execution classification.
+- `internal/cli/state.go` — runtime config and executable extension enablement by command kind.
+- `internal/cli/workspace_config.go` — project config defaults applied to command state.
+- `internal/cli/run_observe.go` — current attach/watch helpers for daemon-backed runs.
+- `internal/cli/commands_test.go` — command flag registration and default behavior tests.
+- `internal/cli/daemon_commands_test.go` and `internal/cli/root_command_execution_test.go` — daemon-backed CLI tests.
+
+### Dependent Files
+
+- `internal/api/client/client.go` — must expose multi-run methods added in task 02.
+- `internal/daemon/run_manager.go` — must implement parent behavior from task 03.
+- `README.md` — later docs task will describe the final command examples.
+
+### Related ADRs
+
+- [ADR-002: Introduce a Dedicated Multi-Run Command for V1](adrs/adr-002.md) — Requires a new command instead of overloading `tasks run`.
+- [ADR-003: Fix V1 Command Name and Config Behavior](adrs/adr-003.md) — Defines `run-multiple`, `run_multiple_mode`, and fallback messaging.
+- [ADR-004: Use a Daemon-Owned Sequential Multi-Run Coordinator](adrs/adr-004.md) — Requires the CLI to start a daemon parent run.
+
+## Deliverables
+
+- `compozy tasks run-multiple` command registered under `tasks`.
+- Config-driven mode resolution and `parallel` fallback messaging.
+- Detach and stream output for parent multi-runs.
+- Unit tests with 80%+ coverage for command parsing and config behavior **(REQUIRED)**.
+- CLI integration tests that verify daemon request shape and single-run stability **(REQUIRED)**.
+
+## Tests
+
+- Unit tests:
+  - [ ] `tasks run-multiple alpha,beta --detach` sends ordered slugs `alpha`, `beta` to the multi-run client method.
+  - [ ] Missing slug input returns a user-facing workflow slug error.
+  - [ ] `alpha,,beta` returns an empty-slug validation error without contacting the daemon.
+  - [ ] `alpha,beta,alpha` returns a duplicate-slug validation error without contacting the daemon.
+  - [ ] Configured `parallel` prints a fallback message that mentions V2 and worktree isolation.
+  - [ ] `tasks run` still accepts exactly one slug and still calls `StartTaskRun`.
+- Integration tests:
+  - [ ] In-process CLI daemon test starts a parent multi-run in detach mode and prints the parent run ID.
+  - [ ] Stream mode follows parent queue events and exits with a non-zero code on parent failure.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+
+- All tests passing.
+- Test coverage >=80%.
+- Users can start a daemon-owned multi-run parent from one command.
+- Parallel fallback is explicit and deterministic.
+- Existing single-run command output and attach behavior are unchanged.

--- a/.compozy/tasks/multi-task-run/task_04.md
+++ b/.compozy/tasks/multi-task-run/task_04.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: Wire tasks run-multiple CLI Command and Non-UI Modes
 type: backend
 complexity: high
@@ -36,12 +36,12 @@ This task exposes the daemon-backed multi-run parent through `compozy tasks run-
 
 ## Subtasks
 
-- [ ] 4.1 Add a new Cobra subcommand under `tasks`.
-- [ ] 4.2 Add command state and defaults for task-run shared flags, runtime overrides, and config application.
-- [ ] 4.3 Resolve mode and print the `parallel` fallback message when needed.
-- [ ] 4.4 Start the daemon parent multi-run through the client method from task 02.
-- [ ] 4.5 Support detach and stream output for parent multi-runs.
-- [ ] 4.6 Add CLI tests for command registration, parser failures, fallback messaging, daemon request shape, and existing `tasks run` stability.
+- [x] 4.1 Add a new Cobra subcommand under `tasks`.
+- [x] 4.2 Add command state and defaults for task-run shared flags, runtime overrides, and config application.
+- [x] 4.3 Resolve mode and print the `parallel` fallback message when needed.
+- [x] 4.4 Start the daemon parent multi-run through the client method from task 02.
+- [x] 4.5 Support detach and stream output for parent multi-runs.
+- [x] 4.6 Add CLI tests for command registration, parser failures, fallback messaging, daemon request shape, and existing `tasks run` stability.
 
 ## Implementation Details
 
@@ -80,15 +80,15 @@ Keep the new command beside `newTasksRunCommandWithDefaults` rather than modifyi
 ## Tests
 
 - Unit tests:
-  - [ ] `tasks run-multiple alpha,beta --detach` sends ordered slugs `alpha`, `beta` to the multi-run client method.
-  - [ ] Missing slug input returns a user-facing workflow slug error.
-  - [ ] `alpha,,beta` returns an empty-slug validation error without contacting the daemon.
-  - [ ] `alpha,beta,alpha` returns a duplicate-slug validation error without contacting the daemon.
-  - [ ] Configured `parallel` prints a fallback message that mentions V2 and worktree isolation.
-  - [ ] `tasks run` still accepts exactly one slug and still calls `StartTaskRun`.
+  - [x] `tasks run-multiple alpha,beta --detach` sends ordered slugs `alpha`, `beta` to the multi-run client method.
+  - [x] Missing slug input returns a user-facing workflow slug error.
+  - [x] `alpha,,beta` returns an empty-slug validation error without contacting the daemon.
+  - [x] `alpha,beta,alpha` returns a duplicate-slug validation error without contacting the daemon.
+  - [x] Configured `parallel` prints a fallback message that mentions V2 and worktree isolation.
+  - [x] `tasks run` still accepts exactly one slug and still calls `StartTaskRun`.
 - Integration tests:
-  - [ ] In-process CLI daemon test starts a parent multi-run in detach mode and prints the parent run ID.
-  - [ ] Stream mode follows parent queue events and exits with a non-zero code on parent failure.
+  - [x] In-process CLI daemon test starts a parent multi-run in detach mode and prints the parent run ID.
+  - [x] Stream mode follows parent queue events and exits with a non-zero code on parent failure.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/multi-task-run/task_05.md
+++ b/.compozy/tasks/multi-task-run/task_05.md
@@ -1,0 +1,101 @@
+---
+status: pending
+title: Add Tabbed Multi-Run TUI Attach Experience
+type: frontend
+complexity: critical
+dependencies:
+  - task_03
+  - task_04
+---
+
+# Task 5: Add Tabbed Multi-Run TUI Attach Experience
+
+## Overview
+
+This task adds the tabbed TUI experience required for queued, running, completed, failed, and canceled workflows. It attaches to the daemon-owned parent run, keeps one tab per requested slug, renders the existing task-run UI inside the active tab, and preserves the current quit dialog semantics at queue level.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- The TUI MUST show one tab for every requested workflow, including queued workflows that have not started.
+- The user MUST be able to navigate between tabs without closing completed child views.
+- The active tab MUST render the familiar task-run UI for its child run once that child exists.
+- Queued tabs MUST show clear queued/not-started state before their child run exists.
+- The TUI MUST isolate child UI state by tab so job indexes, transcripts, and translators do not collide.
+- `Close TUI` MUST detach from the parent and keep the queue running.
+- `Stop Run` MUST cancel the parent queue, cancel the active child, and mark queued work canceled.
+- `Cancel` MUST return to the multi-run TUI without changing execution.
+</requirements>
+
+## Subtasks
+
+- [ ] 5.1 Add a remote multi-run attach surface that loads parent snapshot state.
+- [ ] 5.2 Add tab state for ordered workflows, active tab, child run IDs, and item statuses.
+- [ ] 5.3 Render tabs above the existing task-run surface without changing single-run TUI layout.
+- [ ] 5.4 Wire tab navigation keys and help text without breaking existing pane focus controls.
+- [ ] 5.5 Follow parent queue events and child run streams so tabs update live.
+- [ ] 5.6 Map the existing quit dialog actions to parent queue detach/stop/cancel behavior.
+- [ ] 5.7 Add TUI model, rendering, remote attach, and quit behavior tests.
+
+## Implementation Details
+
+Build a wrapper around the existing remote run UI instead of rewriting the single-run cockpit. Use parent queue state from task 03 and child snapshots/streams from existing run APIs. See TechSpec "TUI" component, "Known Risks", and ADR-004 for state isolation and quit behavior.
+
+### Relevant Files
+
+- `internal/core/run/ui/model.go` — current single-run model and controller state.
+- `internal/core/run/ui/remote.go` — current daemon-backed single-run attach flow.
+- `internal/core/run/ui/view.go` — title, progress, separator, body, and help rendering.
+- `internal/core/run/ui/update.go` — key handling, focus cycling, quit dialog behavior.
+- `internal/core/run/ui/types.go` — UI message and state types.
+- `internal/core/run/ui/remote_test.go`, `view_test.go`, `update_test.go`, and `model_test.go` — existing TUI test patterns.
+- `internal/cli/run_observe.go` — CLI bridge from daemon-started runs into TUI attach sessions.
+
+### Dependent Files
+
+- `internal/api/client/runs.go` — existing child snapshot and stream methods remain the child observation primitive.
+- `internal/api/client/client.go` — multi-run snapshot method from task 02 supplies parent state.
+- `internal/daemon/run_manager.go` — parent events and cancellation semantics from task 03 drive the TUI.
+- `internal/cli/daemon_commands.go` — CLI command from task 04 must attach the multi-run TUI in UI mode.
+
+### Related ADRs
+
+- [ADR-003: Fix V1 Command Name and Config Behavior](adrs/adr-003.md) — Requires queued workflows to appear as tabs.
+- [ADR-004: Use a Daemon-Owned Sequential Multi-Run Coordinator](adrs/adr-004.md) — Defines detach, stop, and cancel behavior for the queue.
+
+## Deliverables
+
+- Tabbed multi-run TUI for parent run attach.
+- Live tab state for queued, running, completed, failed, and canceled workflows.
+- Existing quit dialog behavior mapped to parent queue actions.
+- Unit tests with 80%+ coverage for multi-run TUI state and rendering **(REQUIRED)**.
+- Integration-style remote attach tests for parent/child event flow **(REQUIRED)**.
+
+## Tests
+
+- Unit tests:
+  - [ ] Initial parent snapshot with three queued items renders three tabs in order.
+  - [ ] Starting child `beta` changes only the `beta` tab state and does not mutate `alpha` transcript state.
+  - [ ] Completed tabs remain navigable after the active tab advances to the next queued workflow.
+  - [ ] Tab navigation changes active tab without cycling the existing job/timeline focus unexpectedly.
+  - [ ] `Close TUI` exits the UI without calling parent cancel.
+  - [ ] `Stop Run` calls parent cancel once and marks active/queued visual state as stopping or canceled.
+- Integration tests:
+  - [ ] Remote attach reconstructs parent queue state from snapshot, then follows parent and child streams.
+  - [ ] Reattaching to an in-progress parent run restores completed, active, and queued tabs.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+
+- All tests passing.
+- Test coverage >=80%.
+- 100% of requested slugs appear as tabs before their child runs start.
+- Users can navigate between queued, active, and completed tabs.
+- Single-run TUI behavior remains unchanged for `tasks run`.

--- a/.compozy/tasks/multi-task-run/task_05.md
+++ b/.compozy/tasks/multi-task-run/task_05.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: Add Tabbed Multi-Run TUI Attach Experience
 type: frontend
 complexity: critical
@@ -35,13 +35,13 @@ This task adds the tabbed TUI experience required for queued, running, completed
 
 ## Subtasks
 
-- [ ] 5.1 Add a remote multi-run attach surface that loads parent snapshot state.
-- [ ] 5.2 Add tab state for ordered workflows, active tab, child run IDs, and item statuses.
-- [ ] 5.3 Render tabs above the existing task-run surface without changing single-run TUI layout.
-- [ ] 5.4 Wire tab navigation keys and help text without breaking existing pane focus controls.
-- [ ] 5.5 Follow parent queue events and child run streams so tabs update live.
-- [ ] 5.6 Map the existing quit dialog actions to parent queue detach/stop/cancel behavior.
-- [ ] 5.7 Add TUI model, rendering, remote attach, and quit behavior tests.
+- [x] 5.1 Add a remote multi-run attach surface that loads parent snapshot state.
+- [x] 5.2 Add tab state for ordered workflows, active tab, child run IDs, and item statuses.
+- [x] 5.3 Render tabs above the existing task-run surface without changing single-run TUI layout.
+- [x] 5.4 Wire tab navigation keys and help text without breaking existing pane focus controls.
+- [x] 5.5 Follow parent queue events and child run streams so tabs update live.
+- [x] 5.6 Map the existing quit dialog actions to parent queue detach/stop/cancel behavior.
+- [x] 5.7 Add TUI model, rendering, remote attach, and quit behavior tests.
 
 ## Implementation Details
 
@@ -80,15 +80,15 @@ Build a wrapper around the existing remote run UI instead of rewriting the singl
 ## Tests
 
 - Unit tests:
-  - [ ] Initial parent snapshot with three queued items renders three tabs in order.
-  - [ ] Starting child `beta` changes only the `beta` tab state and does not mutate `alpha` transcript state.
-  - [ ] Completed tabs remain navigable after the active tab advances to the next queued workflow.
-  - [ ] Tab navigation changes active tab without cycling the existing job/timeline focus unexpectedly.
-  - [ ] `Close TUI` exits the UI without calling parent cancel.
-  - [ ] `Stop Run` calls parent cancel once and marks active/queued visual state as stopping or canceled.
+  - [x] Initial parent snapshot with three queued items renders three tabs in order.
+  - [x] Starting child `beta` changes only the `beta` tab state and does not mutate `alpha` transcript state.
+  - [x] Completed tabs remain navigable after the active tab advances to the next queued workflow.
+  - [x] Tab navigation changes active tab without cycling the existing job/timeline focus unexpectedly.
+  - [x] `Close TUI` exits the UI without calling parent cancel.
+  - [x] `Stop Run` calls parent cancel once and marks active/queued visual state as stopping or canceled.
 - Integration tests:
-  - [ ] Remote attach reconstructs parent queue state from snapshot, then follows parent and child streams.
-  - [ ] Reattaching to an in-progress parent run restores completed, active, and queued tabs.
+  - [x] Remote attach reconstructs parent queue state from snapshot, then follows parent and child streams.
+  - [x] Reattaching to an in-progress parent run restores completed, active, and queued tabs.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/.compozy/tasks/multi-task-run/task_06.md
+++ b/.compozy/tasks/multi-task-run/task_06.md
@@ -1,0 +1,96 @@
+---
+status: pending
+title: Document Multi-Run Usage and Add End-to-End Coverage
+type: docs
+complexity: medium
+dependencies:
+  - task_04
+  - task_05
+---
+
+# Task 6: Document Multi-Run Usage and Add End-to-End Coverage
+
+## Overview
+
+This task finishes the feature by documenting the user-facing command, config behavior, fallback semantics, and quit dialog behavior. It also adds end-to-end coverage for the complete multi-run flow so the command, daemon coordinator, and TUI-facing state remain protected.
+
+<critical>
+- ALWAYS READ the PRD and TechSpec before starting
+- REFERENCE TECHSPEC for implementation details — do not duplicate here
+- FOCUS ON "WHAT" — describe what needs to be accomplished, not how
+- MINIMIZE CODE — show code only to illustrate current structure or problem areas
+- TESTS REQUIRED — every task MUST include tests in deliverables
+</critical>
+
+<requirements>
+- Documentation MUST explain when to use `tasks run` versus `tasks run-multiple`.
+- Documentation MUST show the comma-separated input shape.
+- Documentation MUST document `[tasks.run] run_multiple_mode = "enqueued"` as the default behavior.
+- Documentation MUST explain that `parallel` is accepted in V1 but falls back to enqueued with V2 worktree messaging.
+- Documentation MUST describe tab states and the existing `Close TUI`, `Stop Run`, and `Cancel` quit behavior as applied to the queue.
+- End-to-end coverage MUST exercise multiple slugs in one invocation.
+- The final implementation MUST pass `make verify`.
+</requirements>
+
+## Subtasks
+
+- [ ] 6.1 Add README or command documentation for `tasks run-multiple`.
+- [ ] 6.2 Add config examples for `run_multiple_mode`.
+- [ ] 6.3 Document V1 `parallel` fallback and V2 worktree expectation.
+- [ ] 6.4 Document queue-level quit dialog behavior.
+- [ ] 6.5 Add end-to-end or smoke coverage for multi-run command execution with multiple slugs.
+- [ ] 6.6 Run and document full project verification.
+
+## Implementation Details
+
+Keep documentation near existing `tasks run` and `[tasks.run]` config guidance so users can compare single-run and multi-run behavior. The end-to-end test should use disposable task workflows and must verify the exact comma-separated input shape.
+
+### Relevant Files
+
+- `README.md` — primary user-facing CLI and config documentation.
+- `internal/cli/root_command_execution_test.go` — end-to-end CLI execution patterns against temp workspaces.
+- `internal/cli/daemon_exec_test_helpers_test.go` — in-process daemon helper patterns for CLI tests.
+- `web/e2e/daemon-ui.smoke.spec.ts` — existing daemon UI smoke coverage if web-visible run state changes are surfaced.
+- `Makefile` — final verification entrypoint.
+
+### Dependent Files
+
+- `internal/cli/daemon_commands.go` — final CLI command behavior documented by this task.
+- `internal/daemon/run_manager.go` — final daemon parent/child behavior verified by this task.
+- `internal/core/run/ui` — final tab behavior documented by this task.
+- `openapi/compozy-daemon.json` — may change if API contracts are regenerated as part of prior tasks.
+
+### Related ADRs
+
+- [ADR-002: Introduce a Dedicated Multi-Run Command for V1](adrs/adr-002.md) — Documents the separate command decision.
+- [ADR-003: Fix V1 Command Name and Config Behavior](adrs/adr-003.md) — Documents config, fallback, and tabs.
+- [ADR-004: Use a Daemon-Owned Sequential Multi-Run Coordinator](adrs/adr-004.md) — Documents queue-level detach/stop behavior.
+
+## Deliverables
+
+- User-facing documentation for `compozy tasks run-multiple`.
+- Config documentation for `run_multiple_mode` and V1 `parallel` fallback.
+- End-to-end test coverage for multiple slugs in one invocation.
+- Unit tests with 80%+ coverage for any changed helper code **(REQUIRED)**.
+- Integration or e2e tests for the documented multi-run flow **(REQUIRED)**.
+
+## Tests
+
+- Unit tests:
+  - [ ] Any new documentation helper or formatter code has focused unit coverage.
+  - [ ] Any changed command help text tests assert `run-multiple` examples are present.
+- Integration tests:
+  - [ ] CLI e2e starts two task workflows using `tasks run-multiple alpha,beta`.
+  - [ ] CLI e2e verifies both requested slugs appear in parent queue state.
+  - [ ] CLI e2e verifies `parallel` config fallback messaging appears and execution remains enqueued.
+  - [ ] Full `make verify` passes after docs and tests.
+- Test coverage target: >=80%
+- All tests must pass
+
+## Success Criteria
+
+- All tests passing.
+- Test coverage >=80%.
+- Documentation clearly distinguishes `tasks run` and `tasks run-multiple`.
+- End-to-end coverage exercises comma-separated multi-slug input.
+- `make verify` passes with zero lint issues.

--- a/.compozy/tasks/multi-task-run/task_06.md
+++ b/.compozy/tasks/multi-task-run/task_06.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: completed
 title: Document Multi-Run Usage and Add End-to-End Coverage
 type: docs
 complexity: medium
@@ -34,12 +34,12 @@ This task finishes the feature by documenting the user-facing command, config be
 
 ## Subtasks
 
-- [ ] 6.1 Add README or command documentation for `tasks run-multiple`.
-- [ ] 6.2 Add config examples for `run_multiple_mode`.
-- [ ] 6.3 Document V1 `parallel` fallback and V2 worktree expectation.
-- [ ] 6.4 Document queue-level quit dialog behavior.
-- [ ] 6.5 Add end-to-end or smoke coverage for multi-run command execution with multiple slugs.
-- [ ] 6.6 Run and document full project verification.
+- [x] 6.1 Add README or command documentation for `tasks run-multiple`.
+- [x] 6.2 Add config examples for `run_multiple_mode`.
+- [x] 6.3 Document V1 `parallel` fallback and V2 worktree expectation.
+- [x] 6.4 Document queue-level quit dialog behavior.
+- [x] 6.5 Add end-to-end or smoke coverage for multi-run command execution with multiple slugs.
+- [x] 6.6 Run and document full project verification.
 
 ## Implementation Details
 
@@ -77,13 +77,13 @@ Keep documentation near existing `tasks run` and `[tasks.run]` config guidance s
 ## Tests
 
 - Unit tests:
-  - [ ] Any new documentation helper or formatter code has focused unit coverage.
-  - [ ] Any changed command help text tests assert `run-multiple` examples are present.
+  - [x] Any new documentation helper or formatter code has focused unit coverage.
+  - [x] Any changed command help text tests assert `run-multiple` examples are present.
 - Integration tests:
-  - [ ] CLI e2e starts two task workflows using `tasks run-multiple alpha,beta`.
-  - [ ] CLI e2e verifies both requested slugs appear in parent queue state.
-  - [ ] CLI e2e verifies `parallel` config fallback messaging appears and execution remains enqueued.
-  - [ ] Full `make verify` passes after docs and tests.
+  - [x] CLI e2e starts two task workflows using `tasks run-multiple alpha,beta`.
+  - [x] CLI e2e verifies both requested slugs appear in parent queue state.
+  - [x] CLI e2e verifies `parallel` config fallback messaging appears and execution remains enqueued.
+  - [x] Full `make verify` passes after docs and tests.
 - Test coverage target: >=80%
 - All tests must pass
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Task and review issue files use YAML frontmatter for parseable metadata such as 
 - `compozy daemon start|status|stop` manages the home-scoped daemon lifecycle. `daemon start` is idempotent, and task/review/exec commands auto-start the daemon when needed.
 - `compozy workspaces list|show|register|unregister|resolve` exposes the daemon workspace registry. Workspaces are also lazily registered when you run daemon-backed commands inside them.
 - `compozy tasks run <slug>` is the canonical single-workflow runner. In interactive terminals it attaches to the TUI by default; in non-interactive environments it falls back to streaming. Use `--ui`, `--stream`, `--detach`, or `--attach` to override that behavior.
-- `compozy tasks run-multiple alpha,beta` starts one daemon-owned queue for several task workflows. Use `tasks run-multiple` when the same flags and runtime defaults should apply to an ordered batch; keep using `tasks run` for one workflow or scripts that expect one run ID per invocation.
+- `compozy tasks run --multiple alpha,beta` starts one daemon-owned queue for several task workflows. Use `tasks run --multiple` when the same flags and runtime defaults should apply to an ordered batch; keep using `tasks run <slug>` for one workflow or scripts that expect one run ID per invocation.
 - `compozy runs attach <run-id>` restores the interactive TUI for an existing daemon-managed run, while `compozy runs watch <run-id>` streams textual observation from the same snapshot-plus-stream transport.
 - `compozy reviews fetch|list|show|fix` is the canonical review command family.
 
@@ -194,7 +194,7 @@ Supported sections:
 - `[defaults]` for shared execution defaults such as `ide`, `model`, `reasoning_effort`, `access_mode`, `timeout`, `tail_lines`, `add_dirs`, `auto_commit`, `max_retries`, and `retry_backoff_multiplier`
 - `[exec]` for `output_format` plus exec-specific runtime overrides such as `ide`, `model`, `reasoning_effort`, `access_mode`, `timeout`, `tail_lines`, `add_dirs`, `max_retries`, and `retry_backoff_multiplier`
 - `[tasks]` for the allowed task `type` list used by `cy-create-tasks` and `compozy tasks validate`
-- `[tasks.run]` for workflow-run defaults used by `compozy tasks run` and `compozy tasks run-multiple`, such as `include_completed` and `run_multiple_mode`
+- `[tasks.run]` for workflow-run defaults used by `compozy tasks run`, such as `include_completed` and `run_multiple_mode`
 - `[fix_reviews]` for `concurrent`, `batch_size`, and `include_resolved`
 - `[fetch_reviews]` for `provider` and `nitpicks` (controls CodeRabbit review-body comments; default is enabled when unset)
 - `[sound]` for optional run-completion audio presets or absolute file paths
@@ -205,7 +205,7 @@ Notes:
 - `.compozy/tasks` remains the fixed workflow root in this version; the config file does not change the workflow root path.
 - Unknown keys and invalid value types are rejected during config loading.
 - Relative `add_dirs` are resolved against the owning config scope: the user home directory for `~/.compozy/config.toml` and the workspace root for `.compozy/config.toml`.
-- `[tasks.run] run_multiple_mode` controls `tasks run-multiple` scheduling. When unset, the built-in default is `"enqueued"`.
+- `[tasks.run] run_multiple_mode` controls `tasks run --multiple` scheduling. When unset, the built-in default is `"enqueued"`.
 - `run_multiple_mode = "parallel"` is accepted in V1 for forward-compatible config, but Compozy prints a V2 worktree-isolation fallback message and runs the queue in enqueued order. Real parallel multi-run execution waits for git worktree isolation.
 - `max_retries` applies to execution-stage ACP failures and inactivity timeouts for `compozy exec`, `compozy tasks run`, and `compozy reviews fix`.
 - Built-in CLI defaults retry timed-out or transient ACP failures twice; set `max_retries = 0` or pass `--max-retries 0` to opt out.
@@ -398,12 +398,12 @@ Generated task files use task schema v2 (`status`, `title`, `type`, `complexity`
 
 ```bash
 compozy tasks run user-auth --ide claude
-compozy tasks run-multiple user-auth,cleanup --ide claude
+compozy tasks run --multiple user-auth,cleanup --ide claude
 ```
 
 Each pending task is processed sequentially through the shared daemon — the agent reads the spec, implements the code, validates it, and updates the task status. Use `--dry-run` to preview prompts without executing.
 `compozy tasks run` validates task metadata before execution. Use `--skip-validation` when validation already ran elsewhere, or `--force` to continue after validation failures in non-interactive environments.
-Use `compozy tasks run-multiple <slug-a>,<slug-b>` when you want one command to enqueue several workflows with the same runtime flags. The input is one comma-separated slug list; `compozy tasks run <slug>` remains the single-workflow command.
+Use `compozy tasks run --multiple <slug-a>,<slug-b>` when you want one command to enqueue several workflows with the same runtime flags. The input is one comma-separated slug list; `compozy tasks run <slug>` remains the single-workflow command.
 
 ### 7. Review
 
@@ -613,6 +613,7 @@ The CLI resolves workspace defaults locally, validates the task metadata, auto-s
 | Flag                  | Default | Description                                                                         |
 | --------------------- | ------- | ----------------------------------------------------------------------------------- |
 | `--name`              |         | Workflow slug (defaults to the positional slug)                                     |
+| `--multiple`          |         | Comma-separated workflow slugs to run through one daemon-owned parent queue         |
 | `--include-completed` | `false` | Re-run completed tasks                                                              |
 | `--recursive`, `-r`   | `false` | Discover `task_NNN.md` files in nested subdirectories of the workflow root          |
 | `--skip-validation`   | `false` | Skip task metadata preflight; use only when validation already ran elsewhere        |
@@ -625,23 +626,14 @@ The CLI resolves workspace defaults locally, validates the task metadata, auto-s
 
 When `--recursive` is set, tasks are grouped by directory (root tasks first, then each subdirectory in alphabetical order, numerically within), and `_`/`.`-prefixed directories, `reviews-*` rounds, `adrs/`, and `memory/` are skipped. The same setting can be persisted as `[tasks.run] recursive = true` in workspace TOML or chosen from the interactive task-runtime form.
 
-</details>
+Use `tasks run --multiple` when you want to start several task workflows from one invocation with the same runtime flags. Use `tasks run <slug>` when you only need one workflow run, when a script expects a single workflow slug, or when you want the existing single-run command path.
 
-<details>
-<summary><code>compozy tasks run-multiple</code> — Start a daemon-backed queue of workflow runs</summary>
-
-```bash
-compozy tasks run-multiple <slug-a>,<slug-b> [flags]
-```
-
-Use `tasks run-multiple` when you want to start several task workflows from one invocation with the same runtime flags. Use `tasks run <slug>` when you only need one workflow run, when a script expects a single workflow slug, or when you want the existing single-run command path.
-
-The positional argument is one comma-separated slug list:
+The `--multiple` flag takes one comma-separated slug list:
 
 ```bash
-compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5
-compozy tasks run-multiple alpha,beta --stream
-compozy tasks run-multiple alpha,beta --detach
+compozy tasks run --multiple alpha,beta --ide codex --model gpt-5.5
+compozy tasks run --multiple alpha,beta --stream
+compozy tasks run --multiple alpha,beta --detach
 ```
 
 Scheduling is controlled by `.compozy/config.toml` or `~/.compozy/config.toml`:
@@ -655,7 +647,7 @@ run_multiple_mode = "enqueued"
 
 In the TUI, every requested slug has a tab. Queued tabs appear before their child run exists, the running tab shows the familiar task-run surface, and completed, failed, or canceled tabs remain available for inspection. The quit dialog applies to the parent queue: `Close TUI` detaches and leaves the queue running in the daemon, `Stop Run` cancels the parent queue, cancels the active child, and marks queued workflows canceled, and `Cancel` returns to the TUI without changing execution.
 
-The command uses the same attach and runtime flags as `tasks run`, except it accepts the comma-separated positional slug list instead of `--name`.
+The multi-run path uses the same attach and runtime flags as single-run `tasks run`, except `--multiple` cannot be combined with a positional slug or `--name`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Task and review issue files use YAML frontmatter for parseable metadata such as 
 
 - `compozy daemon start|status|stop` manages the home-scoped daemon lifecycle. `daemon start` is idempotent, and task/review/exec commands auto-start the daemon when needed.
 - `compozy workspaces list|show|register|unregister|resolve` exposes the daemon workspace registry. Workspaces are also lazily registered when you run daemon-backed commands inside them.
-- `compozy tasks run <slug>` is the canonical workflow runner. In interactive terminals it attaches to the TUI by default; in non-interactive environments it falls back to streaming. Use `--ui`, `--stream`, `--detach`, or `--attach` to override that behavior.
+- `compozy tasks run <slug>` is the canonical single-workflow runner. In interactive terminals it attaches to the TUI by default; in non-interactive environments it falls back to streaming. Use `--ui`, `--stream`, `--detach`, or `--attach` to override that behavior.
+- `compozy tasks run-multiple alpha,beta` starts one daemon-owned queue for several task workflows. Use `tasks run-multiple` when the same flags and runtime defaults should apply to an ordered batch; keep using `tasks run` for one workflow or scripts that expect one run ID per invocation.
 - `compozy runs attach <run-id>` restores the interactive TUI for an existing daemon-managed run, while `compozy runs watch <run-id>` streams textual observation from the same snapshot-plus-stream transport.
 - `compozy reviews fetch|list|show|fix` is the canonical review command family.
 
@@ -173,6 +174,7 @@ types = ["frontend", "backend", "docs", "test", "infra", "refactor", "chore", "b
 
 [tasks.run]
 include_completed = false
+run_multiple_mode = "enqueued"
 
 [exec]
 output_format = "text"
@@ -192,7 +194,7 @@ Supported sections:
 - `[defaults]` for shared execution defaults such as `ide`, `model`, `reasoning_effort`, `access_mode`, `timeout`, `tail_lines`, `add_dirs`, `auto_commit`, `max_retries`, and `retry_backoff_multiplier`
 - `[exec]` for `output_format` plus exec-specific runtime overrides such as `ide`, `model`, `reasoning_effort`, `access_mode`, `timeout`, `tail_lines`, `add_dirs`, `max_retries`, and `retry_backoff_multiplier`
 - `[tasks]` for the allowed task `type` list used by `cy-create-tasks` and `compozy tasks validate`
-- `[tasks.run]` for workflow-run defaults used by `compozy tasks run`, such as `include_completed`
+- `[tasks.run]` for workflow-run defaults used by `compozy tasks run` and `compozy tasks run-multiple`, such as `include_completed` and `run_multiple_mode`
 - `[fix_reviews]` for `concurrent`, `batch_size`, and `include_resolved`
 - `[fetch_reviews]` for `provider` and `nitpicks` (controls CodeRabbit review-body comments; default is enabled when unset)
 - `[sound]` for optional run-completion audio presets or absolute file paths
@@ -203,6 +205,8 @@ Notes:
 - `.compozy/tasks` remains the fixed workflow root in this version; the config file does not change the workflow root path.
 - Unknown keys and invalid value types are rejected during config loading.
 - Relative `add_dirs` are resolved against the owning config scope: the user home directory for `~/.compozy/config.toml` and the workspace root for `.compozy/config.toml`.
+- `[tasks.run] run_multiple_mode` controls `tasks run-multiple` scheduling. When unset, the built-in default is `"enqueued"`.
+- `run_multiple_mode = "parallel"` is accepted in V1 for forward-compatible config, but Compozy prints a V2 worktree-isolation fallback message and runs the queue in enqueued order. Real parallel multi-run execution waits for git worktree isolation.
 - `max_retries` applies to execution-stage ACP failures and inactivity timeouts for `compozy exec`, `compozy tasks run`, and `compozy reviews fix`.
 - Built-in CLI defaults retry timed-out or transient ACP failures twice; set `max_retries = 0` or pass `--max-retries 0` to opt out.
 - `retry_backoff_multiplier` only increases the next attempt timeout; retries restart immediately and do not add a sleep delay.
@@ -394,10 +398,12 @@ Generated task files use task schema v2 (`status`, `title`, `type`, `complexity`
 
 ```bash
 compozy tasks run user-auth --ide claude
+compozy tasks run-multiple user-auth,cleanup --ide claude
 ```
 
 Each pending task is processed sequentially through the shared daemon — the agent reads the spec, implements the code, validates it, and updates the task status. Use `--dry-run` to preview prompts without executing.
 `compozy tasks run` validates task metadata before execution. Use `--skip-validation` when validation already ran elsewhere, or `--force` to continue after validation failures in non-interactive environments.
+Use `compozy tasks run-multiple <slug-a>,<slug-b>` when you want one command to enqueue several workflows with the same runtime flags. The input is one comma-separated slug list; `compozy tasks run <slug>` remains the single-workflow command.
 
 ### 7. Review
 
@@ -615,6 +621,38 @@ The CLI resolves workspace defaults locally, validates the task metadata, auto-s
 | `--stream`            | `false` | Force textual stream attach mode                                                    |
 | `--detach`            | `false` | Start the run without attaching a client                                            |
 | `--task-runtime`      |         | Per-task runtime override rule (`type=...`, `id=...`, `ide=...`, `model=...`, etc.) |
+
+</details>
+
+<details>
+<summary><code>compozy tasks run-multiple</code> — Start a daemon-backed queue of workflow runs</summary>
+
+```bash
+compozy tasks run-multiple <slug-a>,<slug-b> [flags]
+```
+
+Use `tasks run-multiple` when you want to start several task workflows from one invocation with the same runtime flags. Use `tasks run <slug>` when you only need one workflow run, when a script expects a single workflow slug, or when you want the existing single-run command path.
+
+The positional argument is one comma-separated slug list:
+
+```bash
+compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5
+compozy tasks run-multiple alpha,beta --stream
+compozy tasks run-multiple alpha,beta --detach
+```
+
+Scheduling is controlled by `.compozy/config.toml` or `~/.compozy/config.toml`:
+
+```toml
+[tasks.run]
+run_multiple_mode = "enqueued"
+```
+
+`"enqueued"` is the default and runs one child workflow at a time in the requested order. `"parallel"` is also accepted in V1, but Compozy prints a fallback message and still runs the queue as `"enqueued"` until V2 adds git worktree-backed isolation for concurrent agents.
+
+In the TUI, every requested slug has a tab. Queued tabs appear before their child run exists, the running tab shows the familiar task-run surface, and completed, failed, or canceled tabs remain available for inspection. The quit dialog applies to the parent queue: `Close TUI` detaches and leaves the queue running in the daemon, `Stop Run` cancels the parent queue, cancels the active child, and marks queued workflows canceled, and `Cancel` returns to the TUI without changing execution.
+
+The command uses the same attach and runtime flags as `tasks run`, except it accepts the comma-separated positional slug list instead of `--name`.
 
 </details>
 

--- a/internal/api/client/client.go
+++ b/internal/api/client/client.go
@@ -173,6 +173,49 @@ func (c *Client) StartTaskRun(
 	return response.Run, nil
 }
 
+// StartTaskRunMultiple starts one daemon-owned parent run for an ordered set of task workflows.
+func (c *Client) StartTaskRunMultiple(
+	ctx context.Context,
+	req apicore.TaskRunMultipleRequest,
+) (apicore.Run, error) {
+	if c == nil {
+		return apicore.Run{}, ErrDaemonClientRequired
+	}
+	slugs, err := normalizeClientSlugs(req.Slugs)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+
+	body := contract.TaskRunMultipleRequest{
+		Workspace:        strings.TrimSpace(req.Workspace),
+		Slugs:            slugs,
+		Mode:             strings.TrimSpace(req.Mode),
+		PresentationMode: strings.TrimSpace(req.PresentationMode),
+		RuntimeOverrides: req.RuntimeOverrides,
+	}
+
+	var response contract.RunResponse
+	if _, err := c.doJSON(ctx, http.MethodPost, "/api/task-runs/multiple", body, &response); err != nil {
+		return apicore.Run{}, err
+	}
+	return response.Run, nil
+}
+
+func normalizeClientSlugs(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, ErrWorkflowSlugRequired
+	}
+	slugs := make([]string, 0, len(values))
+	for _, value := range values {
+		slug := strings.TrimSpace(value)
+		if slug == "" {
+			return nil, ErrWorkflowSlugRequired
+		}
+		slugs = append(slugs, slug)
+	}
+	return slugs, nil
+}
+
 func (c *Client) doJSON(
 	ctx context.Context,
 	method string,

--- a/internal/api/client/client_contract_test.go
+++ b/internal/api/client/client_contract_test.go
@@ -62,6 +62,9 @@ func TestClientUsesCanonicalTimeoutClassesByRoute(t *testing.T) {
 				case "/api/tasks/demo/runs":
 					assertApproxDeadline(req.Context(), t, 120*time.Second)
 					return jsonResponse(http.StatusCreated, `{"run":{"run_id":"task-run-1","mode":"task"}}`), nil
+				case "/api/task-runs/multiple":
+					assertApproxDeadline(req.Context(), t, 120*time.Second)
+					return jsonResponse(http.StatusCreated, `{"run":{"run_id":"multi-run-1","mode":"task_multi"}}`), nil
 				case "/api/runs/run-1/cancel":
 					assertApproxDeadline(req.Context(), t, 30*time.Second)
 					return jsonResponse(http.StatusAccepted, `{"accepted":true}`), nil
@@ -81,8 +84,111 @@ func TestClientUsesCanonicalTimeoutClassesByRoute(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("StartTaskRun() error = %v", err)
 	}
+	if _, err := client.StartTaskRunMultiple(context.Background(), apicore.TaskRunMultipleRequest{
+		Workspace: "/tmp/workspace",
+		Slugs:     []string{"alpha", "beta"},
+	}); err != nil {
+		t.Fatalf("StartTaskRunMultiple() error = %v", err)
+	}
 	if err := client.CancelRun(context.Background(), "run-1"); err != nil {
 		t.Fatalf("CancelRun() error = %v", err)
+	}
+}
+
+func TestClientStartTaskRunMultiplePostsOrderedSlugs(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{
+		target:  Target{SocketPath: "/tmp/compozy.sock"},
+		baseURL: "http://daemon",
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodPost {
+					t.Fatalf("method = %s, want POST", req.Method)
+				}
+				if req.URL.Path != "/api/task-runs/multiple" {
+					t.Fatalf("path = %s, want /api/task-runs/multiple", req.URL.Path)
+				}
+				var body contract.TaskRunMultipleRequest
+				if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+				if body.Workspace != "/tmp/workspace" {
+					t.Fatalf("workspace = %q, want /tmp/workspace", body.Workspace)
+				}
+				if want := []string{"alpha", "beta", "gamma"}; !reflect.DeepEqual(body.Slugs, want) {
+					t.Fatalf("slugs = %#v, want %#v", body.Slugs, want)
+				}
+				if body.Mode != "enqueued" || body.PresentationMode != "stream" {
+					t.Fatalf("mode/presentation = %q/%q, want enqueued/stream", body.Mode, body.PresentationMode)
+				}
+				if string(body.RuntimeOverrides) != `{"persist":true}` {
+					t.Fatalf("runtime_overrides = %s, want persist override", body.RuntimeOverrides)
+				}
+				return jsonResponse(http.StatusCreated, `{"run":{"run_id":"multi-run-1","mode":"task_multi"}}`), nil
+			}),
+		},
+	}
+
+	run, err := client.StartTaskRunMultiple(context.Background(), apicore.TaskRunMultipleRequest{
+		Workspace:        " /tmp/workspace ",
+		Slugs:            []string{" alpha ", "beta", " gamma "},
+		Mode:             " enqueued ",
+		PresentationMode: " stream ",
+		RuntimeOverrides: json.RawMessage(`{"persist":true}`),
+	})
+	if err != nil {
+		t.Fatalf("StartTaskRunMultiple() error = %v", err)
+	}
+	if run.RunID != "multi-run-1" || run.Mode != "task_multi" {
+		t.Fatalf("run = %#v, want multi-run parent", run)
+	}
+}
+
+func TestClientGetTaskRunMultipleSnapshotUsesDedicatedRouteAndDecodes(t *testing.T) {
+	t.Parallel()
+
+	want := contract.TaskRunMultipleSnapshot{
+		Run: contract.Run{
+			RunID: "multi-run-1",
+			Mode:  "task_multi",
+		},
+		Items: []contract.TaskRunMultipleItem{
+			{Slug: "alpha", Status: "completed", RunID: "run-alpha"},
+			{Slug: "beta", Status: "failed", RunID: "run-beta", ErrorText: "boom"},
+			{Slug: "gamma", Status: "canceled"},
+		},
+	}
+	body, err := json.Marshal(contract.TaskRunMultipleSnapshotResponseFromSnapshot(want))
+	if err != nil {
+		t.Fatalf("marshal multi-run snapshot response: %v", err)
+	}
+
+	client := &Client{
+		target:  Target{SocketPath: "/tmp/compozy.sock"},
+		baseURL: "http://daemon",
+		httpClient: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Method != http.MethodGet {
+					t.Fatalf("method = %s, want GET", req.Method)
+				}
+				if req.URL.Path != "/api/task-runs/multiple/multi-run-1/snapshot" {
+					t.Fatalf("path = %s, want /api/task-runs/multiple/multi-run-1/snapshot", req.URL.Path)
+				}
+				return jsonResponse(http.StatusOK, string(body)), nil
+			}),
+		},
+	}
+
+	got, err := client.GetTaskRunMultipleSnapshot(context.Background(), " multi-run-1 ")
+	if err != nil {
+		t.Fatalf("GetTaskRunMultipleSnapshot() error = %v", err)
+	}
+	if got.Run.RunID != want.Run.RunID || got.Run.Mode != want.Run.Mode {
+		t.Fatalf("snapshot run = %#v, want %#v", got.Run, want.Run)
+	}
+	if !reflect.DeepEqual(got.Items, want.Items) {
+		t.Fatalf("snapshot items = %#v, want %#v", got.Items, want.Items)
 	}
 }
 
@@ -240,6 +346,33 @@ func TestGetRunSnapshotPreservesCanonicalFields(t *testing.T) {
 	}
 	if got.NextCursor == nil || got.NextCursor.Sequence != 9 || !got.NextCursor.Timestamp.Equal(now.Add(time.Second)) {
 		t.Fatalf("snapshot next cursor = %#v, want seq 9", got.NextCursor)
+	}
+}
+
+func TestClientTaskRunMultipleMethodsRejectNilContext(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{
+		target:  Target{SocketPath: "/tmp/compozy.sock"},
+		baseURL: "http://daemon",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				t.Fatal("unexpected transport call for nil context")
+				return nil, nil
+			}),
+		},
+	}
+
+	var nilCtx context.Context
+	if _, err := client.StartTaskRunMultiple(nilCtx, apicore.TaskRunMultipleRequest{
+		Workspace: "/tmp/workspace",
+		Slugs:     []string{"alpha", "beta"},
+	}); !errors.Is(err, ErrDaemonContextRequired) {
+		t.Fatalf("StartTaskRunMultiple(nil) error = %v, want %v", err, ErrDaemonContextRequired)
+	}
+	if _, err := client.GetTaskRunMultipleSnapshot(nilCtx, "multi-run-1"); !errors.Is(err, ErrDaemonContextRequired) {
+		t.Fatalf("GetTaskRunMultipleSnapshot(nil) error = %v, want %v", err, ErrDaemonContextRequired)
 	}
 }
 

--- a/internal/api/client/client_contract_test.go
+++ b/internal/api/client/client_contract_test.go
@@ -98,98 +98,104 @@ func TestClientUsesCanonicalTimeoutClassesByRoute(t *testing.T) {
 func TestClientStartTaskRunMultiplePostsOrderedSlugs(t *testing.T) {
 	t.Parallel()
 
-	client := &Client{
-		target:  Target{SocketPath: "/tmp/compozy.sock"},
-		baseURL: "http://daemon",
-		httpClient: &http.Client{
-			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				if req.Method != http.MethodPost {
-					t.Fatalf("method = %s, want POST", req.Method)
-				}
-				if req.URL.Path != "/api/task-runs/multiple" {
-					t.Fatalf("path = %s, want /api/task-runs/multiple", req.URL.Path)
-				}
-				var body contract.TaskRunMultipleRequest
-				if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
-					t.Fatalf("decode request body: %v", err)
-				}
-				if body.Workspace != "/tmp/workspace" {
-					t.Fatalf("workspace = %q, want /tmp/workspace", body.Workspace)
-				}
-				if want := []string{"alpha", "beta", "gamma"}; !reflect.DeepEqual(body.Slugs, want) {
-					t.Fatalf("slugs = %#v, want %#v", body.Slugs, want)
-				}
-				if body.Mode != "enqueued" || body.PresentationMode != "stream" {
-					t.Fatalf("mode/presentation = %q/%q, want enqueued/stream", body.Mode, body.PresentationMode)
-				}
-				if string(body.RuntimeOverrides) != `{"persist":true}` {
-					t.Fatalf("runtime_overrides = %s, want persist override", body.RuntimeOverrides)
-				}
-				return jsonResponse(http.StatusCreated, `{"run":{"run_id":"multi-run-1","mode":"task_multi"}}`), nil
-			}),
-		},
-	}
+	t.Run("Should start multiple task run with ordered slugs", func(t *testing.T) {
+		t.Parallel()
 
-	run, err := client.StartTaskRunMultiple(context.Background(), apicore.TaskRunMultipleRequest{
-		Workspace:        " /tmp/workspace ",
-		Slugs:            []string{" alpha ", "beta", " gamma "},
-		Mode:             " enqueued ",
-		PresentationMode: " stream ",
-		RuntimeOverrides: json.RawMessage(`{"persist":true}`),
+		client := &Client{
+			target:  Target{SocketPath: "/tmp/compozy.sock"},
+			baseURL: "http://daemon",
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.Method != http.MethodPost {
+						t.Fatalf("method = %s, want POST", req.Method)
+					}
+					if req.URL.Path != "/api/task-runs/multiple" {
+						t.Fatalf("path = %s, want /api/task-runs/multiple", req.URL.Path)
+					}
+					var body contract.TaskRunMultipleRequest
+					if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+						t.Fatalf("decode request body: %v", err)
+					}
+					if body.Workspace != "/tmp/workspace" {
+						t.Fatalf("workspace = %q, want /tmp/workspace", body.Workspace)
+					}
+					if want := []string{"alpha", "beta", "gamma"}; !reflect.DeepEqual(body.Slugs, want) {
+						t.Fatalf("slugs = %#v, want %#v", body.Slugs, want)
+					}
+					if body.Mode != "enqueued" || body.PresentationMode != "stream" {
+						t.Fatalf("mode/presentation = %q/%q, want enqueued/stream", body.Mode, body.PresentationMode)
+					}
+					if string(body.RuntimeOverrides) != `{"persist":true}` {
+						t.Fatalf("runtime_overrides = %s, want persist override", body.RuntimeOverrides)
+					}
+					return jsonResponse(http.StatusCreated, `{"run":{"run_id":"multi-run-1","mode":"task_multi"}}`), nil
+				}),
+			},
+		}
+
+		run, err := client.StartTaskRunMultiple(context.Background(), apicore.TaskRunMultipleRequest{
+			Workspace:        " /tmp/workspace ",
+			Slugs:            []string{" alpha ", "beta", " gamma "},
+			Mode:             " enqueued ",
+			PresentationMode: " stream ",
+			RuntimeOverrides: json.RawMessage(`{"persist":true}`),
+		})
+		if err != nil {
+			t.Fatalf("StartTaskRunMultiple() error = %v", err)
+		}
+		if run.RunID != "multi-run-1" || run.Mode != "task_multi" {
+			t.Fatalf("run = %#v, want multi-run parent", run)
+		}
 	})
-	if err != nil {
-		t.Fatalf("StartTaskRunMultiple() error = %v", err)
-	}
-	if run.RunID != "multi-run-1" || run.Mode != "task_multi" {
-		t.Fatalf("run = %#v, want multi-run parent", run)
-	}
 }
 
 func TestClientGetTaskRunMultipleSnapshotUsesDedicatedRouteAndDecodes(t *testing.T) {
-	t.Parallel()
+	t.Run("Should return decoded multiple snapshot", func(t *testing.T) {
+		t.Parallel()
 
-	want := contract.TaskRunMultipleSnapshot{
-		Run: contract.Run{
-			RunID: "multi-run-1",
-			Mode:  "task_multi",
-		},
-		Items: []contract.TaskRunMultipleItem{
-			{Slug: "alpha", Status: "completed", RunID: "run-alpha"},
-			{Slug: "beta", Status: "failed", RunID: "run-beta", ErrorText: "boom"},
-			{Slug: "gamma", Status: "canceled"},
-		},
-	}
-	body, err := json.Marshal(contract.TaskRunMultipleSnapshotResponseFromSnapshot(want))
-	if err != nil {
-		t.Fatalf("marshal multi-run snapshot response: %v", err)
-	}
+		want := contract.TaskRunMultipleSnapshot{
+			Run: contract.Run{
+				RunID: "multi-run-1",
+				Mode:  "task_multi",
+			},
+			Items: []contract.TaskRunMultipleItem{
+				{Slug: "alpha", Status: "completed", RunID: "run-alpha"},
+				{Slug: "beta", Status: "failed", RunID: "run-beta", ErrorText: "boom"},
+				{Slug: "gamma", Status: "canceled"},
+			},
+		}
+		body, err := json.Marshal(contract.TaskRunMultipleSnapshotResponseFromSnapshot(want))
+		if err != nil {
+			t.Fatalf("marshal multi-run snapshot response: %v", err)
+		}
 
-	client := &Client{
-		target:  Target{SocketPath: "/tmp/compozy.sock"},
-		baseURL: "http://daemon",
-		httpClient: &http.Client{
-			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-				if req.Method != http.MethodGet {
-					t.Fatalf("method = %s, want GET", req.Method)
-				}
-				if req.URL.Path != "/api/task-runs/multiple/multi-run-1/snapshot" {
-					t.Fatalf("path = %s, want /api/task-runs/multiple/multi-run-1/snapshot", req.URL.Path)
-				}
-				return jsonResponse(http.StatusOK, string(body)), nil
-			}),
-		},
-	}
+		client := &Client{
+			target:  Target{SocketPath: "/tmp/compozy.sock"},
+			baseURL: "http://daemon",
+			httpClient: &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					if req.Method != http.MethodGet {
+						t.Fatalf("method = %s, want GET", req.Method)
+					}
+					if req.URL.Path != "/api/task-runs/multiple/multi-run-1/snapshot" {
+						t.Fatalf("path = %s, want /api/task-runs/multiple/multi-run-1/snapshot", req.URL.Path)
+					}
+					return jsonResponse(http.StatusOK, string(body)), nil
+				}),
+			},
+		}
 
-	got, err := client.GetTaskRunMultipleSnapshot(context.Background(), " multi-run-1 ")
-	if err != nil {
-		t.Fatalf("GetTaskRunMultipleSnapshot() error = %v", err)
-	}
-	if got.Run.RunID != want.Run.RunID || got.Run.Mode != want.Run.Mode {
-		t.Fatalf("snapshot run = %#v, want %#v", got.Run, want.Run)
-	}
-	if !reflect.DeepEqual(got.Items, want.Items) {
-		t.Fatalf("snapshot items = %#v, want %#v", got.Items, want.Items)
-	}
+		got, err := client.GetTaskRunMultipleSnapshot(context.Background(), " multi-run-1 ")
+		if err != nil {
+			t.Fatalf("GetTaskRunMultipleSnapshot() error = %v", err)
+		}
+		if got.Run.RunID != want.Run.RunID || got.Run.Mode != want.Run.Mode {
+			t.Fatalf("snapshot run = %#v, want %#v", got.Run, want.Run)
+		}
+		if !reflect.DeepEqual(got.Items, want.Items) {
+			t.Fatalf("snapshot items = %#v, want %#v", got.Items, want.Items)
+		}
+	})
 }
 
 func TestClientRemoteErrorsDecodeCanonicalEnvelopeAndRequestID(t *testing.T) {
@@ -365,14 +371,37 @@ func TestClientTaskRunMultipleMethodsRejectNilContext(t *testing.T) {
 	}
 
 	var nilCtx context.Context
-	if _, err := client.StartTaskRunMultiple(nilCtx, apicore.TaskRunMultipleRequest{
-		Workspace: "/tmp/workspace",
-		Slugs:     []string{"alpha", "beta"},
-	}); !errors.Is(err, ErrDaemonContextRequired) {
-		t.Fatalf("StartTaskRunMultiple(nil) error = %v, want %v", err, ErrDaemonContextRequired)
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "Should reject nil context for StartTaskRunMultiple",
+			call: func() error {
+				_, err := client.StartTaskRunMultiple(nilCtx, apicore.TaskRunMultipleRequest{
+					Workspace: "/tmp/workspace",
+					Slugs:     []string{"alpha", "beta"},
+				})
+				return err
+			},
+		},
+		{
+			name: "Should reject nil context for GetTaskRunMultipleSnapshot",
+			call: func() error {
+				_, err := client.GetTaskRunMultipleSnapshot(nilCtx, "multi-run-1")
+				return err
+			},
+		},
 	}
-	if _, err := client.GetTaskRunMultipleSnapshot(nilCtx, "multi-run-1"); !errors.Is(err, ErrDaemonContextRequired) {
-		t.Fatalf("GetTaskRunMultipleSnapshot(nil) error = %v, want %v", err, ErrDaemonContextRequired)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if err := tc.call(); !errors.Is(err, ErrDaemonContextRequired) {
+				t.Fatalf("nil context error = %v, want %v", err, ErrDaemonContextRequired)
+			}
+		})
 	}
 }
 

--- a/internal/api/client/client_transport_test.go
+++ b/internal/api/client/client_transport_test.go
@@ -840,6 +840,18 @@ func TestNilReceiverAndUtilityGuards(t *testing.T) {
 	if _, err := nilClient.GetRunSnapshot(context.Background(), "run-1"); !errors.Is(err, ErrDaemonClientRequired) {
 		t.Fatalf("nil GetRunSnapshot() error = %v, want ErrDaemonClientRequired", err)
 	}
+	if _, err := nilClient.StartTaskRunMultiple(
+		context.Background(),
+		apicore.TaskRunMultipleRequest{Slugs: []string{"alpha"}},
+	); !errors.Is(err, ErrDaemonClientRequired) {
+		t.Fatalf("nil StartTaskRunMultiple() error = %v, want ErrDaemonClientRequired", err)
+	}
+	if _, err := nilClient.GetTaskRunMultipleSnapshot(
+		context.Background(),
+		"run-1",
+	); !errors.Is(err, ErrDaemonClientRequired) {
+		t.Fatalf("nil GetTaskRunMultipleSnapshot() error = %v, want ErrDaemonClientRequired", err)
+	}
 	if _, err := nilClient.ListRunEvents(
 		context.Background(),
 		"run-1",

--- a/internal/api/client/client_transport_test.go
+++ b/internal/api/client/client_transport_test.go
@@ -840,18 +840,22 @@ func TestNilReceiverAndUtilityGuards(t *testing.T) {
 	if _, err := nilClient.GetRunSnapshot(context.Background(), "run-1"); !errors.Is(err, ErrDaemonClientRequired) {
 		t.Fatalf("nil GetRunSnapshot() error = %v, want ErrDaemonClientRequired", err)
 	}
-	if _, err := nilClient.StartTaskRunMultiple(
-		context.Background(),
-		apicore.TaskRunMultipleRequest{Slugs: []string{"alpha"}},
-	); !errors.Is(err, ErrDaemonClientRequired) {
-		t.Fatalf("nil StartTaskRunMultiple() error = %v, want ErrDaemonClientRequired", err)
-	}
-	if _, err := nilClient.GetTaskRunMultipleSnapshot(
-		context.Background(),
-		"run-1",
-	); !errors.Is(err, ErrDaemonClientRequired) {
-		t.Fatalf("nil GetTaskRunMultipleSnapshot() error = %v, want ErrDaemonClientRequired", err)
-	}
+	t.Run("Should return ErrDaemonClientRequired for StartTaskRunMultiple", func(t *testing.T) {
+		if _, err := nilClient.StartTaskRunMultiple(
+			context.Background(),
+			apicore.TaskRunMultipleRequest{Slugs: []string{"alpha"}},
+		); !errors.Is(err, ErrDaemonClientRequired) {
+			t.Fatalf("nil StartTaskRunMultiple() error = %v, want ErrDaemonClientRequired", err)
+		}
+	})
+	t.Run("Should return ErrDaemonClientRequired for GetTaskRunMultipleSnapshot", func(t *testing.T) {
+		if _, err := nilClient.GetTaskRunMultipleSnapshot(
+			context.Background(),
+			"run-1",
+		); !errors.Is(err, ErrDaemonClientRequired) {
+			t.Fatalf("nil GetTaskRunMultipleSnapshot() error = %v, want ErrDaemonClientRequired", err)
+		}
+	})
 	if _, err := nilClient.ListRunEvents(
 		context.Background(),
 		"run-1",

--- a/internal/api/client/runs.go
+++ b/internal/api/client/runs.go
@@ -187,6 +187,29 @@ func (c *Client) GetRunSnapshot(ctx context.Context, runID string) (apicore.RunS
 	return snapshot, nil
 }
 
+// GetTaskRunMultipleSnapshot loads the ordered child-state snapshot for a daemon-owned multi-run parent.
+func (c *Client) GetTaskRunMultipleSnapshot(
+	ctx context.Context,
+	runID string,
+) (apicore.TaskRunMultipleSnapshot, error) {
+	if c == nil {
+		return apicore.TaskRunMultipleSnapshot{}, ErrDaemonClientRequired
+	}
+
+	trimmedRunID := strings.TrimSpace(runID)
+	if trimmedRunID == "" {
+		return apicore.TaskRunMultipleSnapshot{}, ErrRunIDRequired
+	}
+
+	var payload contract.TaskRunMultipleSnapshotResponse
+	path := "/api/task-runs/multiple/" + url.PathEscape(trimmedRunID) + "/snapshot"
+	if _, err := c.doJSON(ctx, http.MethodGet, path, nil, &payload); err != nil {
+		return apicore.TaskRunMultipleSnapshot{}, err
+	}
+
+	return payload.Decode(), nil
+}
+
 // GetRunTranscript loads the canonical structured transcript for one run.
 func (c *Client) GetRunTranscript(ctx context.Context, runID string) (apicore.RunTranscript, error) {
 	if c == nil {

--- a/internal/api/client/runs.go
+++ b/internal/api/client/runs.go
@@ -204,7 +204,11 @@ func (c *Client) GetTaskRunMultipleSnapshot(
 	var payload contract.TaskRunMultipleSnapshotResponse
 	path := "/api/task-runs/multiple/" + url.PathEscape(trimmedRunID) + "/snapshot"
 	if _, err := c.doJSON(ctx, http.MethodGet, path, nil, &payload); err != nil {
-		return apicore.TaskRunMultipleSnapshot{}, err
+		return apicore.TaskRunMultipleSnapshot{}, fmt.Errorf(
+			"failed to fetch multiple snapshot for run %s: %w",
+			trimmedRunID,
+			err,
+		)
 	}
 
 	return payload.Decode(), nil

--- a/internal/api/contract/contract_test.go
+++ b/internal/api/contract/contract_test.go
@@ -406,7 +406,7 @@ func TestContractRoundTripsCanonicalResponses(t *testing.T) {
 		}
 	})
 
-	t.Run("task run multiple snapshot", func(t *testing.T) {
+	t.Run("Should round trip task run multiple snapshot", func(t *testing.T) {
 		t.Parallel()
 
 		resp := contract.TaskRunMultipleSnapshotResponseFromSnapshot(contract.TaskRunMultipleSnapshot{

--- a/internal/api/contract/contract_test.go
+++ b/internal/api/contract/contract_test.go
@@ -92,6 +92,22 @@ func TestTimeoutClassesFollowCanonicalRoutePolicy(t *testing.T) {
 			true,
 			120 * time.Second,
 		},
+		{
+			"Should classify multi-run starts as long mutations",
+			http.MethodPost,
+			"/api/task-runs/multiple",
+			contract.TimeoutLongMutate,
+			true,
+			120 * time.Second,
+		},
+		{
+			"Should classify multi-run snapshots as reads",
+			http.MethodGet,
+			"/api/task-runs/multiple/multi-run-1/snapshot",
+			contract.TimeoutRead,
+			true,
+			15 * time.Second,
+		},
 		{"Should classify run streams", http.MethodGet, "/api/runs/run-1/stream", contract.TimeoutStream, false, 0},
 		{
 			"Should classify workspace sockets",
@@ -387,6 +403,45 @@ func TestContractRoundTripsCanonicalResponses(t *testing.T) {
 			if _, ok := meta[field]; !ok {
 				t.Fatalf("wire session meta missing %q: %#v", field, meta)
 			}
+		}
+	})
+
+	t.Run("task run multiple snapshot", func(t *testing.T) {
+		t.Parallel()
+
+		resp := contract.TaskRunMultipleSnapshotResponseFromSnapshot(contract.TaskRunMultipleSnapshot{
+			Run: contract.Run{
+				RunID:       "multi-run-1",
+				WorkspaceID: "ws-1",
+				Mode:        "task_multi",
+				Status:      "running",
+				StartedAt:   now,
+			},
+			Items: []contract.TaskRunMultipleItem{
+				{Slug: "queued", Status: "queued"},
+				{Slug: "active", Status: "active", RunID: "run-active"},
+				{Slug: "completed", Status: "completed", RunID: "run-completed"},
+				{Slug: "failed", Status: "failed", RunID: "run-failed", ErrorText: "boom"},
+				{Slug: "canceled", Status: "canceled"},
+			},
+		})
+
+		var decoded contract.TaskRunMultipleSnapshotResponse
+		roundTripJSON(t, resp, &decoded)
+		snapshot := decoded.Decode()
+
+		if snapshot.Run.RunID != "multi-run-1" || snapshot.Run.Mode != "task_multi" {
+			t.Fatalf("decoded multi-run = %#v, want parent run", snapshot.Run)
+		}
+		if len(snapshot.Items) != 5 {
+			t.Fatalf("decoded multi-run item count = %d, want 5", len(snapshot.Items))
+		}
+		if snapshot.Items[0].Status != "queued" ||
+			snapshot.Items[1].Status != "active" ||
+			snapshot.Items[2].Status != "completed" ||
+			snapshot.Items[3].Status != "failed" ||
+			snapshot.Items[4].Status != "canceled" {
+			t.Fatalf("decoded multi-run items = %#v, want queued/active/completed/failed/canceled", snapshot.Items)
 		}
 	})
 

--- a/internal/api/contract/routes.go
+++ b/internal/api/contract/routes.go
@@ -125,6 +125,18 @@ var RouteInventory = []RouteSpec{
 	},
 	{
 		Method:       http.MethodPost,
+		Path:         "/api/task-runs/multiple",
+		ResponseType: "RunResponse",
+		TimeoutClass: TimeoutLongMutate,
+	},
+	{
+		Method:       http.MethodGet,
+		Path:         "/api/task-runs/multiple/:run_id/snapshot",
+		ResponseType: "TaskRunMultipleSnapshotResponse",
+		TimeoutClass: TimeoutRead,
+	},
+	{
+		Method:       http.MethodPost,
 		Path:         "/api/reviews/:slug/fetch",
 		ResponseType: "ReviewFetchResponse",
 		TimeoutClass: TimeoutLongMutate,

--- a/internal/api/contract/types.go
+++ b/internal/api/contract/types.go
@@ -42,6 +42,26 @@ type TaskRunRequest struct {
 	RuntimeOverrides json.RawMessage `json:"runtime_overrides,omitempty"`
 }
 
+type TaskRunMultipleRequest struct {
+	Workspace        string          `json:"workspace"`
+	Slugs            []string        `json:"slugs"`
+	Mode             string          `json:"mode,omitempty"`
+	PresentationMode string          `json:"presentation_mode,omitempty"`
+	RuntimeOverrides json.RawMessage `json:"runtime_overrides,omitempty"`
+}
+
+type TaskRunMultipleItem struct {
+	Slug      string `json:"slug"`
+	Status    string `json:"status"`
+	RunID     string `json:"run_id,omitempty"`
+	ErrorText string `json:"error_text,omitempty"`
+}
+
+type TaskRunMultipleSnapshot struct {
+	Run   Run                   `json:"run"`
+	Items []TaskRunMultipleItem `json:"items,omitempty"`
+}
+
 type ReviewFetchRequest struct {
 	Workspace string `json:"workspace"`
 	Provider  string `json:"provider,omitempty"`
@@ -573,6 +593,11 @@ type RunSnapshotResponse struct {
 	NextCursor        string                 `json:"next_cursor,omitempty"`
 }
 
+type TaskRunMultipleSnapshotResponse struct {
+	Run   Run                   `json:"run"`
+	Items []TaskRunMultipleItem `json:"items,omitempty"`
+}
+
 type RunTranscriptResponse struct {
 	RunID             string              `json:"run_id"`
 	Messages          []RunUIMessage      `json:"messages"`
@@ -622,6 +647,20 @@ func (r RunSnapshotResponse) Decode() (RunSnapshot, error) {
 		snapshot.NextCursor = &nextCursor
 	}
 	return snapshot, nil
+}
+
+func TaskRunMultipleSnapshotResponseFromSnapshot(snapshot TaskRunMultipleSnapshot) TaskRunMultipleSnapshotResponse {
+	return TaskRunMultipleSnapshotResponse{
+		Run:   snapshot.Run,
+		Items: append([]TaskRunMultipleItem(nil), snapshot.Items...),
+	}
+}
+
+func (r TaskRunMultipleSnapshotResponse) Decode() TaskRunMultipleSnapshot {
+	return TaskRunMultipleSnapshot{
+		Run:   r.Run,
+		Items: append([]TaskRunMultipleItem(nil), r.Items...),
+	}
 }
 
 func RunTranscriptResponseFromTranscript(transcript RunTranscript) RunTranscriptResponse {

--- a/internal/api/core/handlers.go
+++ b/internal/api/core/handlers.go
@@ -268,6 +268,38 @@ func requireNonEmptyString(field string, value string) error {
 	return nil
 }
 
+func normalizeRequiredSlugs(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, validationProblem(
+			"slugs_required",
+			"slugs is required",
+			map[string]any{"field": "slugs"},
+		)
+	}
+	seen := make(map[string]struct{}, len(values))
+	slugs := make([]string, 0, len(values))
+	for idx, raw := range values {
+		slug := strings.TrimSpace(raw)
+		if slug == "" {
+			return nil, validationProblem(
+				"slug_required",
+				"slugs must not contain empty entries",
+				map[string]any{"field": "slugs", "index": idx},
+			)
+		}
+		if _, ok := seen[slug]; ok {
+			return nil, validationProblem(
+				"slug_duplicate",
+				fmt.Sprintf("duplicate slug %q", slug),
+				map[string]any{"field": "slugs", "slug": slug},
+			)
+		}
+		seen[slug] = struct{}{}
+		slugs = append(slugs, slug)
+	}
+	return slugs, nil
+}
+
 func parsePositiveInt(value string, field string) (int, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -342,6 +374,7 @@ type workspaceResolveBody = contract.WorkspaceResolveRequest
 type workflowRefBody = contract.WorkflowRefRequest
 type workflowArchiveBody = contract.WorkflowArchiveRequest
 type taskRunBody = contract.TaskRunRequest
+type taskRunMultipleBody = contract.TaskRunMultipleRequest
 type reviewFetchBody = contract.ReviewFetchRequest
 type reviewRunBody = contract.ReviewRunRequest
 type reviewWatchBody = contract.ReviewWatchRequest
@@ -810,6 +843,62 @@ func (h *Handlers) StartTaskRun(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusCreated, contract.RunResponse{Run: run})
+}
+
+// StartTaskRunMultiple starts a daemon-owned parent for an ordered task workflow queue.
+func (h *Handlers) StartTaskRunMultiple(c *gin.Context) {
+	if h.Tasks == nil {
+		h.respondError(c, serviceUnavailableProblem("task service"))
+		return
+	}
+
+	var body taskRunMultipleBody
+	if !h.bindJSON(c, "decode multi-run task request", &body) {
+		return
+	}
+	workspace, ok := h.requireWorkspaceContext(c, body.Workspace)
+	if !ok {
+		return
+	}
+	slugs, err := normalizeRequiredSlugs(body.Slugs)
+	if err != nil {
+		h.respondError(c, err)
+		return
+	}
+
+	run, err := h.Tasks.StartRunMultiple(c.Request.Context(), workspace, TaskRunMultipleRequest{
+		Workspace:        workspace,
+		Slugs:            slugs,
+		Mode:             strings.TrimSpace(body.Mode),
+		PresentationMode: strings.TrimSpace(body.PresentationMode),
+		RuntimeOverrides: body.RuntimeOverrides,
+	})
+	if err != nil {
+		h.respondWorkspaceContextError(c, workspace, err)
+		return
+	}
+	c.JSON(http.StatusCreated, contract.RunResponse{Run: run})
+}
+
+// GetTaskRunMultipleSnapshot returns the parent multi-run state for attach or reattach flows.
+func (h *Handlers) GetTaskRunMultipleSnapshot(c *gin.Context) {
+	if h.Tasks == nil {
+		h.respondError(c, serviceUnavailableProblem("task service"))
+		return
+	}
+
+	runID := strings.TrimSpace(c.Param("run_id"))
+	if err := requireNonEmptyString("run_id", runID); err != nil {
+		h.respondError(c, err)
+		return
+	}
+	snapshot, err := h.Tasks.RunMultipleSnapshot(c.Request.Context(), runID)
+	if err != nil {
+		h.respondError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, contract.TaskRunMultipleSnapshotResponseFromSnapshot(snapshot))
 }
 
 // ArchiveTaskWorkflow archives a completed workflow.

--- a/internal/api/core/handlers_contract_test.go
+++ b/internal/api/core/handlers_contract_test.go
@@ -129,11 +129,21 @@ func TestRunStartEndpointsReturnCanonicalRunEnvelopes(t *testing.T) {
 		StartedAt:        now,
 		RequestID:        "run-req-review-watch",
 	}
+	multiRun := core.Run{
+		RunID:            "multi-run-1",
+		WorkspaceID:      "ws-1",
+		Mode:             "task_multi",
+		Status:           "running",
+		PresentationMode: "stream",
+		StartedAt:        now,
+		RequestID:        "run-req-multi",
+	}
 
 	engine := newCanonicalHandlersEngine(core.NewHandlers(&core.HandlerConfig{
 		TransportName: "test",
 		Tasks: &smokeTaskService{
-			run: taskRun,
+			run:      taskRun,
+			multiRun: multiRun,
 		},
 		Reviews: &smokeReviewService{
 			run:      reviewRun,
@@ -156,6 +166,14 @@ func TestRunStartEndpointsReturnCanonicalRunEnvelopes(t *testing.T) {
 			requestID:  "req-task",
 			wantStatus: http.StatusCreated,
 			wantRun:    taskRun,
+		},
+		{
+			name:       "task run multiple",
+			target:     "/api/task-runs/multiple",
+			body:       `{"workspace":"ws-1","slugs":["daemon","followup"],"mode":"enqueued","presentation_mode":"stream"}`,
+			requestID:  "req-multi",
+			wantStatus: http.StatusCreated,
+			wantRun:    multiRun,
 		},
 		{
 			name:       "review run",

--- a/internal/api/core/handlers_contract_test.go
+++ b/internal/api/core/handlers_contract_test.go
@@ -168,7 +168,7 @@ func TestRunStartEndpointsReturnCanonicalRunEnvelopes(t *testing.T) {
 			wantRun:    taskRun,
 		},
 		{
-			name:       "task run multiple",
+			name:       "Should run multiple tasks",
 			target:     "/api/task-runs/multiple",
 			body:       `{"workspace":"ws-1","slugs":["daemon","followup"],"mode":"enqueued","presentation_mode":"stream"}`,
 			requestID:  "req-multi",

--- a/internal/api/core/handlers_service_errors_test.go
+++ b/internal/api/core/handlers_service_errors_test.go
@@ -725,6 +725,18 @@ func (s *errorTaskService) StartRun(context.Context, string, string, core.TaskRu
 	return core.Run{}, s.err
 }
 
+func (s *errorTaskService) StartRunMultiple(
+	context.Context,
+	string,
+	core.TaskRunMultipleRequest,
+) (core.Run, error) {
+	return core.Run{}, s.err
+}
+
+func (s *errorTaskService) RunMultipleSnapshot(context.Context, string) (core.TaskRunMultipleSnapshot, error) {
+	return core.TaskRunMultipleSnapshot{}, s.err
+}
+
 func (s *errorTaskService) Archive(context.Context, string, string, core.ArchiveRequest) (core.ArchiveResult, error) {
 	return core.ArchiveResult{}, s.err
 }

--- a/internal/api/core/handlers_smoke_test.go
+++ b/internal/api/core/handlers_smoke_test.go
@@ -332,7 +332,7 @@ func TestSharedHandlersSmokeSuccessPaths(t *testing.T) {
 			`"run":{"run_id":"run-1"`,
 		},
 		{
-			"task run multiple",
+			"Should run multiple tasks",
 			http.MethodPost,
 			"/api/task-runs/multiple",
 			`{"workspace":"ws-1","slugs":["daemon","followup"],"mode":"enqueued","presentation_mode":"stream"}`,
@@ -340,7 +340,7 @@ func TestSharedHandlersSmokeSuccessPaths(t *testing.T) {
 			`"run":{"run_id":"multi-run-1"`,
 		},
 		{
-			"task run multiple snapshot",
+			"Should return snapshot for multiple run",
 			http.MethodGet,
 			"/api/task-runs/multiple/multi-run-1/snapshot",
 			"",

--- a/internal/api/core/handlers_smoke_test.go
+++ b/internal/api/core/handlers_smoke_test.go
@@ -74,6 +74,28 @@ func TestSharedHandlersSmokeSuccessPaths(t *testing.T) {
 				PresentationMode: "stream",
 				StartedAt:        now,
 			},
+			multiRun: core.Run{
+				RunID:            "multi-run-1",
+				WorkspaceID:      "ws-1",
+				Mode:             "task_multi",
+				Status:           "running",
+				PresentationMode: "stream",
+				StartedAt:        now,
+			},
+			multiSnapshot: core.TaskRunMultipleSnapshot{
+				Run: core.Run{
+					RunID:            "multi-run-1",
+					WorkspaceID:      "ws-1",
+					Mode:             "task_multi",
+					Status:           "running",
+					PresentationMode: "stream",
+					StartedAt:        now,
+				},
+				Items: []core.TaskRunMultipleItem{
+					{Slug: "daemon", Status: "active", RunID: "run-1"},
+					{Slug: "followup", Status: "queued"},
+				},
+			},
 		},
 		Reviews: &smokeReviewService{
 			summary: core.ReviewSummary{
@@ -310,6 +332,22 @@ func TestSharedHandlersSmokeSuccessPaths(t *testing.T) {
 			`"run":{"run_id":"run-1"`,
 		},
 		{
+			"task run multiple",
+			http.MethodPost,
+			"/api/task-runs/multiple",
+			`{"workspace":"ws-1","slugs":["daemon","followup"],"mode":"enqueued","presentation_mode":"stream"}`,
+			http.StatusCreated,
+			`"run":{"run_id":"multi-run-1"`,
+		},
+		{
+			"task run multiple snapshot",
+			http.MethodGet,
+			"/api/task-runs/multiple/multi-run-1/snapshot",
+			"",
+			http.StatusOK,
+			`"items":[`,
+		},
+		{
 			"task archive",
 			http.MethodPost,
 			"/api/tasks/daemon/archive",
@@ -487,9 +525,11 @@ func (*smokeWorkspaceService) Sync(context.Context) (core.WorkspaceSyncResult, e
 }
 
 type smokeTaskService struct {
-	workflow core.WorkflowSummary
-	item     core.TaskItem
-	run      core.Run
+	workflow      core.WorkflowSummary
+	item          core.TaskItem
+	run           core.Run
+	multiRun      core.Run
+	multiSnapshot core.TaskRunMultipleSnapshot
 }
 
 func (s *smokeTaskService) Dashboard(context.Context, string) (core.DashboardPayload, error) {
@@ -538,6 +578,18 @@ func (*smokeTaskService) Validate(context.Context, string, string) (core.Validat
 
 func (s *smokeTaskService) StartRun(context.Context, string, string, core.TaskRunRequest) (core.Run, error) {
 	return s.run, nil
+}
+
+func (s *smokeTaskService) StartRunMultiple(
+	context.Context,
+	string,
+	core.TaskRunMultipleRequest,
+) (core.Run, error) {
+	return s.multiRun, nil
+}
+
+func (s *smokeTaskService) RunMultipleSnapshot(context.Context, string) (core.TaskRunMultipleSnapshot, error) {
+	return s.multiSnapshot, nil
 }
 
 func (*smokeTaskService) Archive(context.Context, string, string, core.ArchiveRequest) (core.ArchiveResult, error) {

--- a/internal/api/core/handlers_smoke_test.go
+++ b/internal/api/core/handlers_smoke_test.go
@@ -345,7 +345,7 @@ func TestSharedHandlersSmokeSuccessPaths(t *testing.T) {
 			"/api/task-runs/multiple/multi-run-1/snapshot",
 			"",
 			http.StatusOK,
-			`"items":[`,
+			`"items":[{"slug":"daemon","status":"active","run_id":"run-1"},{"slug":"followup","status":"queued"}]`,
 		},
 		{
 			"task archive",

--- a/internal/api/core/interfaces.go
+++ b/internal/api/core/interfaces.go
@@ -69,6 +69,8 @@ type TaskService interface {
 	TaskDetail(context.Context, string, string, string) (TaskDetailPayload, error)
 	Validate(context.Context, string, string) (ValidationSuccess, error)
 	StartRun(context.Context, string, string, TaskRunRequest) (Run, error)
+	StartRunMultiple(context.Context, string, TaskRunMultipleRequest) (Run, error)
+	RunMultipleSnapshot(context.Context, string) (TaskRunMultipleSnapshot, error)
 	Archive(context.Context, string, string, ArchiveRequest) (ArchiveResult, error)
 }
 
@@ -395,6 +397,9 @@ type RunListQuery = contract.RunListQuery
 type RunEventPageQuery = contract.RunEventPageQuery
 type RunEventPage = contract.RunEventPage
 type TaskRunRequest = contract.TaskRunRequest
+type TaskRunMultipleRequest = contract.TaskRunMultipleRequest
+type TaskRunMultipleItem = contract.TaskRunMultipleItem
+type TaskRunMultipleSnapshot = contract.TaskRunMultipleSnapshot
 type ReviewRunRequest = contract.ReviewRunRequest
 type SyncRequest = contract.SyncRequest
 type SyncResult = contract.SyncResult

--- a/internal/api/core/routes.go
+++ b/internal/api/core/routes.go
@@ -9,13 +9,23 @@ func RegisterRoutes(router gin.IRouter, handlers *Handlers) {
 	}
 
 	api := router.Group("/api")
+	registerDaemonRoutes(api, handlers)
+	registerWorkspaceRoutes(api, handlers)
+	registerTaskRoutes(api, handlers)
+	registerReviewRoutes(api, handlers)
+	registerRunRoutes(api, handlers)
+	registerUtilityRoutes(api, handlers)
+}
 
+func registerDaemonRoutes(api gin.IRouter, handlers *Handlers) {
 	daemon := api.Group("/daemon")
 	daemon.GET("/status", handlers.DaemonStatus)
 	daemon.GET("/health", handlers.DaemonHealth)
 	daemon.GET("/metrics", handlers.DaemonMetrics)
 	daemon.POST("/stop", handlers.StopDaemon)
+}
 
+func registerWorkspaceRoutes(api gin.IRouter, handlers *Handlers) {
 	workspaces := api.Group("/workspaces")
 	workspaces.POST("", handlers.RegisterWorkspace)
 	workspaces.GET("", handlers.ListWorkspaces)
@@ -25,7 +35,9 @@ func RegisterRoutes(router gin.IRouter, handlers *Handlers) {
 	workspaces.PATCH("/:id", handlers.UpdateWorkspace)
 	workspaces.DELETE("/:id", handlers.DeleteWorkspace)
 	workspaces.POST("/resolve", handlers.ResolveWorkspace)
+}
 
+func registerTaskRoutes(api gin.IRouter, handlers *Handlers) {
 	ui := api.Group("/ui")
 	ui.GET("/dashboard", handlers.GetDashboard)
 
@@ -42,6 +54,12 @@ func RegisterRoutes(router gin.IRouter, handlers *Handlers) {
 	tasks.POST("/:slug/runs", handlers.StartTaskRun)
 	tasks.POST("/:slug/archive", handlers.ArchiveTaskWorkflow)
 
+	taskRuns := api.Group("/task-runs")
+	taskRuns.POST("/multiple", handlers.StartTaskRunMultiple)
+	taskRuns.GET("/multiple/:run_id/snapshot", handlers.GetTaskRunMultipleSnapshot)
+}
+
+func registerReviewRoutes(api gin.IRouter, handlers *Handlers) {
 	reviews := api.Group("/reviews")
 	reviews.POST("/:slug/fetch", handlers.FetchReview)
 	reviews.POST("/:slug/watch", handlers.StartReviewWatch)
@@ -50,7 +68,9 @@ func RegisterRoutes(router gin.IRouter, handlers *Handlers) {
 	reviews.GET("/:slug/rounds/:round", handlers.GetReviewRound)
 	reviews.POST("/:slug/rounds/:round/runs", handlers.StartReviewRun)
 	reviews.GET("/:slug", handlers.GetLatestReview)
+}
 
+func registerRunRoutes(api gin.IRouter, handlers *Handlers) {
 	runs := api.Group("/runs")
 	runs.GET("", handlers.ListRuns)
 	runs.GET("/:run_id", handlers.GetRun)
@@ -59,7 +79,9 @@ func RegisterRoutes(router gin.IRouter, handlers *Handlers) {
 	runs.GET("/:run_id/events", handlers.ListRunEvents)
 	runs.GET("/:run_id/stream", handlers.StreamRun)
 	runs.POST("/:run_id/cancel", handlers.CancelRun)
+}
 
+func registerUtilityRoutes(api gin.IRouter, handlers *Handlers) {
 	api.POST("/sync", handlers.SyncWorkflow)
 	api.POST("/exec", handlers.StartExecRun)
 }

--- a/internal/api/httpapi/openapi_contract_test.go
+++ b/internal/api/httpapi/openapi_contract_test.go
@@ -59,6 +59,7 @@ func TestBrowserOpenAPIContractMatchesRegisteredBrowserRoutes(t *testing.T) {
 		"GET /api/runs/{run_id}/snapshot",
 		"GET /api/runs/{run_id}/transcript",
 		"GET /api/runs/{run_id}/stream",
+		"GET /api/task-runs/multiple/{run_id}/snapshot",
 		"GET /api/tasks",
 		"GET /api/tasks/{slug}",
 		"GET /api/tasks/{slug}/board",
@@ -72,6 +73,7 @@ func TestBrowserOpenAPIContractMatchesRegisteredBrowserRoutes(t *testing.T) {
 		"POST /api/reviews/{slug}/rounds/{round}/runs",
 		"POST /api/runs/{run_id}/cancel",
 		"POST /api/sync",
+		"POST /api/task-runs/multiple",
 		"POST /api/tasks/{slug}/archive",
 		"POST /api/tasks/{slug}/runs",
 		"POST /api/workspaces/resolve",
@@ -120,6 +122,7 @@ func TestBrowserOpenAPIContractKeepsWorkspaceContextAndProblemSemantics(t *testi
 		"GET /api/tasks/{slug}/items/{task_id}",
 		"GET /api/reviews/{slug}",
 		"POST /api/reviews/{slug}/watch",
+		"POST /api/task-runs/multiple",
 		"GET /api/reviews/{slug}/rounds/{round}",
 		"GET /api/reviews/{slug}/rounds/{round}/issues",
 		"GET /api/reviews/{slug}/rounds/{round}/issues/{issue_id}",
@@ -148,6 +151,7 @@ func TestBrowserOpenAPIContractKeepsWorkspaceContextAndProblemSemantics(t *testi
 
 	postBodies := map[string]string{
 		"POST /api/tasks/{slug}/runs":                  "#/components/schemas/TaskRunRequest",
+		"POST /api/task-runs/multiple":                 "#/components/schemas/TaskRunMultipleRequest",
 		"POST /api/tasks/{slug}/archive":               "#/components/schemas/WorkflowArchiveRequest",
 		"POST /api/reviews/{slug}/watch":               "#/components/schemas/ReviewWatchRequest",
 		"POST /api/reviews/{slug}/rounds/{round}/runs": "#/components/schemas/ReviewRunRequest",
@@ -170,6 +174,30 @@ func TestBrowserOpenAPIContractKeepsWorkspaceContextAndProblemSemantics(t *testi
 	taskRunSchema := getSchema(t, spec, "TaskRunRequest")
 	if schemaRequires(taskRunSchema, "workspace") {
 		t.Fatal("TaskRunRequest must not require workspace")
+	}
+	taskRunMultipleSchema := getSchema(t, spec, "TaskRunMultipleRequest")
+	if schemaRequires(taskRunMultipleSchema, "workspace") {
+		t.Fatal("TaskRunMultipleRequest must not require workspace")
+	}
+	if !schemaRequires(taskRunMultipleSchema, "slugs") {
+		t.Fatal("TaskRunMultipleRequest must require slugs")
+	}
+	taskRunMultipleProperties := getMap(t, taskRunMultipleSchema, "properties")
+	for _, field := range []string{"slugs", "mode", "presentation_mode", "runtime_overrides", "workspace"} {
+		if _, ok := taskRunMultipleProperties[field]; !ok {
+			t.Fatalf("TaskRunMultipleRequest must expose %s", field)
+		}
+	}
+	multiRunSnapshot := getSchema(t, spec, "TaskRunMultipleSnapshotResponse")
+	if !schemaRequires(multiRunSnapshot, "run") {
+		t.Fatal("TaskRunMultipleSnapshotResponse must require run")
+	}
+	multiRunSnapshotProperties := getMap(t, multiRunSnapshot, "properties")
+	if _, ok := multiRunSnapshotProperties["items"]; !ok {
+		t.Fatal("TaskRunMultipleSnapshotResponse must expose items")
+	}
+	if _, ok := getSchema(t, spec, "TaskRunMultipleItem")["properties"]; !ok {
+		t.Fatal("TaskRunMultipleItem must expose properties")
 	}
 	reviewRunSchema := getSchema(t, spec, "ReviewRunRequest")
 	if schemaRequires(reviewRunSchema, "workspace") {
@@ -217,6 +245,7 @@ func TestBrowserOpenAPIContractKeepsWorkspaceContextAndProblemSemantics(t *testi
 		"POST /api/tasks/{slug}/archive",
 		"POST /api/reviews/{slug}/watch",
 		"POST /api/reviews/{slug}/rounds/{round}/runs",
+		"POST /api/task-runs/multiple",
 		"POST /api/sync",
 		"POST /api/runs/{run_id}/cancel",
 		"POST /api/workspaces/resolve",

--- a/internal/api/httpapi/transport_integration_test.go
+++ b/internal/api/httpapi/transport_integration_test.go
@@ -1985,6 +1985,18 @@ func (f *fakeTaskService) StartRun(context.Context, string, string, core.TaskRun
 	return f.run, nil
 }
 
+func (f *fakeTaskService) StartRunMultiple(
+	context.Context,
+	string,
+	core.TaskRunMultipleRequest,
+) (core.Run, error) {
+	return f.run, nil
+}
+
+func (f *fakeTaskService) RunMultipleSnapshot(context.Context, string) (core.TaskRunMultipleSnapshot, error) {
+	return core.TaskRunMultipleSnapshot{Run: f.run}, nil
+}
+
 func (*fakeTaskService) Archive(context.Context, string, string, core.ArchiveRequest) (core.ArchiveResult, error) {
 	return core.ArchiveResult{Archived: true}, nil
 }
@@ -2122,6 +2134,18 @@ func (*capturingTaskService) Validate(context.Context, string, string) (core.Val
 
 func (*capturingTaskService) StartRun(context.Context, string, string, core.TaskRunRequest) (core.Run, error) {
 	return core.Run{}, nil
+}
+
+func (*capturingTaskService) StartRunMultiple(
+	context.Context,
+	string,
+	core.TaskRunMultipleRequest,
+) (core.Run, error) {
+	return core.Run{}, nil
+}
+
+func (*capturingTaskService) RunMultipleSnapshot(context.Context, string) (core.TaskRunMultipleSnapshot, error) {
+	return core.TaskRunMultipleSnapshot{}, nil
 }
 
 func (*capturingTaskService) Archive(context.Context, string, string, core.ArchiveRequest) (core.ArchiveResult, error) {

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -113,24 +113,26 @@ func TestNewTasksRunCommandDefaultsAttachModeToAuto(t *testing.T) {
 func TestNewTasksCommandRegistersRunMultiple(t *testing.T) {
 	t.Parallel()
 
-	cmd := newTasksCommand(nil, defaultCommandStateDefaults())
-	runMultiple, _, err := cmd.Find([]string{"run-multiple"})
-	if err != nil {
-		t.Fatalf("find run-multiple: %v", err)
-	}
-	if runMultiple.Name() != "run-multiple" {
-		t.Fatalf("expected run-multiple command, got %q", runMultiple.Name())
-	}
-	if runMultiple.Flags().Lookup("name") != nil {
-		t.Fatal("expected run-multiple to accept positional slugs instead of --name")
-	}
-	flag := runMultiple.Flags().Lookup("attach")
-	if flag == nil {
-		t.Fatal("expected run-multiple --attach flag")
-	}
-	if flag.DefValue != attachModeAuto {
-		t.Fatalf("expected --attach default %q, got %q", attachModeAuto, flag.DefValue)
-	}
+	t.Run("Should register run-multiple with correct flags", func(t *testing.T) {
+		cmd := newTasksCommand(nil, defaultCommandStateDefaults())
+		runMultiple, _, err := cmd.Find([]string{"run-multiple"})
+		if err != nil {
+			t.Fatalf("find run-multiple: %v", err)
+		}
+		if runMultiple.Name() != "run-multiple" {
+			t.Fatalf("expected run-multiple command, got %q", runMultiple.Name())
+		}
+		if runMultiple.Flags().Lookup("name") != nil {
+			t.Fatal("expected run-multiple to accept positional slugs instead of --name")
+		}
+		flag := runMultiple.Flags().Lookup("attach")
+		if flag == nil {
+			t.Fatal("expected run-multiple --attach flag")
+		}
+		if flag.DefValue != attachModeAuto {
+			t.Fatalf("expected --attach default %q, got %q", attachModeAuto, flag.DefValue)
+		}
+	})
 }
 
 func TestReviewsFixCommandDefaultsTUIToTrue(t *testing.T) {

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -110,6 +110,29 @@ func TestNewTasksRunCommandDefaultsAttachModeToAuto(t *testing.T) {
 	}
 }
 
+func TestNewTasksCommandRegistersRunMultiple(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTasksCommand(nil, defaultCommandStateDefaults())
+	runMultiple, _, err := cmd.Find([]string{"run-multiple"})
+	if err != nil {
+		t.Fatalf("find run-multiple: %v", err)
+	}
+	if runMultiple.Name() != "run-multiple" {
+		t.Fatalf("expected run-multiple command, got %q", runMultiple.Name())
+	}
+	if runMultiple.Flags().Lookup("name") != nil {
+		t.Fatal("expected run-multiple to accept positional slugs instead of --name")
+	}
+	flag := runMultiple.Flags().Lookup("attach")
+	if flag == nil {
+		t.Fatal("expected run-multiple --attach flag")
+	}
+	if flag.DefValue != attachModeAuto {
+		t.Fatalf("expected --attach default %q, got %q", attachModeAuto, flag.DefValue)
+	}
+}
+
 func TestReviewsFixCommandDefaultsTUIToTrue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -111,24 +111,28 @@ func TestNewTasksRunCommandDefaultsAttachModeToAuto(t *testing.T) {
 	}
 }
 
-func TestNewTasksCommandRegistersRunMultiple(t *testing.T) {
+func TestNewTasksCommandDoesNotRegisterRunMultiple(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should register run-multiple with correct flags", func(t *testing.T) {
+	t.Run("Should expose multiple execution through run flag", func(t *testing.T) {
 		cmd := newTasksCommand(nil, defaultCommandStateDefaults())
-		runMultiple, _, err := cmd.Find([]string{"run-multiple"})
+		found, _, err := cmd.Find([]string{"run-multiple"})
+		if err == nil && found.Name() == "run-multiple" {
+			t.Fatal("expected run-multiple command to be removed")
+		}
+		run, _, err := cmd.Find([]string{"run"})
 		if err != nil {
-			t.Fatalf("find run-multiple: %v", err)
+			t.Fatalf("find run: %v", err)
 		}
-		if runMultiple.Name() != "run-multiple" {
-			t.Fatalf("expected run-multiple command, got %q", runMultiple.Name())
+		if run.Flags().Lookup("name") == nil {
+			t.Fatal("expected run to preserve --name for single-task execution")
 		}
-		if runMultiple.Flags().Lookup("name") != nil {
-			t.Fatal("expected run-multiple to accept positional slugs instead of --name")
+		if run.Flags().Lookup("multiple") == nil {
+			t.Fatal("expected run --multiple flag")
 		}
-		flag := runMultiple.Flags().Lookup("attach")
+		flag := run.Flags().Lookup("attach")
 		if flag == nil {
-			t.Fatal("expected run-multiple --attach flag")
+			t.Fatal("expected run --attach flag")
 		}
 		if flag.DefValue != attachModeAuto {
 			t.Fatalf("expected --attach default %q, got %q", attachModeAuto, flag.DefValue)

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -549,7 +549,15 @@ func handleStartedTaskRunMultiple(
 	if run.PresentationMode == attachModeUI {
 		if err := attachStartedCLIRunUI(ctx, client, run.RunID); err != nil {
 			if errors.Is(err, errRunSettledBeforeUIAttach) {
-				return watchCLIRunUntilTerminalSuccess(ctx, cmd.OutOrStdout(), client, run.RunID)
+				if watchErr := watchCLIRunUntilTerminalSuccess(
+					ctx,
+					cmd.OutOrStdout(),
+					client,
+					run.RunID,
+				); watchErr != nil {
+					return mapDaemonCommandError(watchErr)
+				}
+				return nil
 			}
 			return mapDaemonCommandError(err)
 		}
@@ -561,7 +569,10 @@ func handleStartedTaskRunMultiple(
 	if run.PresentationMode != attachModeStream {
 		return nil
 	}
-	return watchCLIRunUntilTerminalSuccess(ctx, cmd.OutOrStdout(), client, run.RunID)
+	if err := watchCLIRunUntilTerminalSuccess(ctx, cmd.OutOrStdout(), client, run.RunID); err != nil {
+		return mapDaemonCommandError(err)
+	}
+	return nil
 }
 
 func writeStartedTaskRun(cmd *cobra.Command, run apicore.Run) error {
@@ -717,6 +728,11 @@ func (s *commandState) buildTaskRunRuntimeOverrides(cmd *cobra.Command) (json.Ra
 func mapDaemonCommandError(err error) error {
 	if err == nil {
 		return nil
+	}
+
+	var exitErr *commandExitError
+	if errors.As(err, &exitErr) {
+		return err
 	}
 
 	var remoteErr *apiclient.RemoteError

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -254,7 +254,6 @@ func newTasksCommand(dispatcher *kernel.Dispatcher, defaults commandStateDefault
 	cmd.AddCommand(
 		newTasksValidateCommand(),
 		newTasksRunCommandWithDefaults(dispatcher, defaults),
-		newTasksRunMultipleCommandWithDefaults(dispatcher, defaults),
 	)
 	return cmd
 }
@@ -269,8 +268,16 @@ func newTasksRunCommandWithDefaults(_ *kernel.Dispatcher, defaults commandStateD
 		Long: `Start a task workflow through the shared home-scoped daemon.
 
 The CLI resolves the workspace root and attach mode locally, ensures the daemon
-is running, and then sends the workflow request over the daemon transport.`,
+is running, and then sends the workflow request over the daemon transport.
+
+Use --multiple with one comma-separated slug list to start several task workflows
+through one daemon-owned parent run. V1 runs the queue in enqueued order;
+configured parallel mode prints a V2 worktree-isolation fallback message before
+sending enqueued execution to the daemon.`,
 		Example: `  compozy tasks run my-feature
+  compozy tasks run --multiple alpha,beta --stream
+  compozy tasks run --multiple alpha,beta --detach
+  compozy tasks run --multiple alpha,beta --ide codex --model gpt-5.5
   compozy tasks run my-feature --stream
   compozy tasks run my-feature --detach
   compozy tasks run --name my-feature --dry-run`,
@@ -283,30 +290,6 @@ is running, and then sends the workflow request over the daemon transport.`,
 	return cmd
 }
 
-func newTasksRunMultipleCommandWithDefaults(_ *kernel.Dispatcher, defaults commandStateDefaults) *cobra.Command {
-	state := newCommandStateWithDefaults(commandKindTasksRunMultiple, core.ModePRDTasks, defaults)
-	cmd := &cobra.Command{
-		Use:          "run-multiple [slugs]",
-		Short:        "Start a daemon-backed queue of task workflow runs",
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
-		Long: `Start multiple task workflows through one daemon-owned parent run.
-
-The command accepts one comma-separated positional slug list. V1 runs the queue
-in enqueued order; configured parallel mode prints a V2 worktree-isolation
-fallback message before sending enqueued execution to the daemon.`,
-		Example: `  compozy tasks run-multiple alpha,beta --stream
-  compozy tasks run-multiple alpha,beta --detach
-  compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return state.runTaskWorkflowsMultiple(cmd, args)
-		},
-	}
-
-	addTaskRunFlags(cmd, state, taskRunFlagOptions{})
-	return cmd
-}
-
 type taskRunFlagOptions struct {
 	includeName bool
 }
@@ -316,6 +299,12 @@ func addTaskRunFlags(cmd *cobra.Command, state *commandState, opts taskRunFlagOp
 	if opts.includeName {
 		cmd.Flags().StringVar(&state.name, "name", "", "Task workflow slug (defaults to the positional slug)")
 	}
+	cmd.Flags().StringVar(
+		&state.multiple,
+		"multiple",
+		"",
+		"Comma-separated task workflow slugs to run through one daemon-owned parent queue",
+	)
 	cmd.Flags().BoolVar(&state.includeCompleted, "include-completed", false, "Include completed tasks")
 	cmd.Flags().BoolVarP(
 		&state.recursive,
@@ -355,6 +344,10 @@ func addTaskRunFlags(cmd *cobra.Command, state *commandState, opts taskRunFlagOp
 }
 
 func (s *commandState) runTaskWorkflow(cmd *cobra.Command, args []string) error {
+	if commandFlagChanged(cmd, "multiple") {
+		return s.runTaskWorkflowsMultiple(cmd, args)
+	}
+
 	ctx, stop := signalCommandContext(cmd)
 	defer stop()
 
@@ -414,7 +407,7 @@ func (s *commandState) runTaskWorkflowsMultiple(cmd *cobra.Command, args []strin
 	ctx, stop := signalCommandContext(cmd)
 	defer stop()
 
-	slugs, err := resolveTaskWorkflowSlugList(args)
+	slugs, err := s.resolveTaskWorkflowSlugList(args)
 	if err != nil {
 		return withExitCode(1, err)
 	}
@@ -458,11 +451,14 @@ func (s *commandState) runTaskWorkflowsMultiple(cmd *cobra.Command, args []strin
 	return handleStartedTaskRunMultiple(ctx, cmd, client, run)
 }
 
-func resolveTaskWorkflowSlugList(args []string) ([]string, error) {
-	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
-		return nil, errors.New("workflow slug list is required; pass comma-separated slugs as the positional argument")
+func (s *commandState) resolveTaskWorkflowSlugList(args []string) ([]string, error) {
+	if len(args) > 0 || strings.TrimSpace(s.name) != "" {
+		return nil, errors.New("--multiple cannot be combined with a positional slug or --name")
 	}
-	slugs, err := taskscore.ParseCommaSeparatedSlugs(args[0])
+	if strings.TrimSpace(s.multiple) == "" {
+		return nil, errors.New("workflow slug list is required; pass comma-separated slugs to --multiple")
+	}
+	slugs, err := taskscore.ParseCommaSeparatedSlugs(s.multiple)
 	if err != nil {
 		return nil, fmt.Errorf("workflow slug list: %w", err)
 	}
@@ -508,7 +504,7 @@ func (s *commandState) resolveTaskRunMultipleMode(cmd *cobra.Command) (string, e
 			cmd.ErrOrStderr(),
 			"parallel multi-task execution is planned for V2 with git worktree isolation; running this queue in enqueued mode.",
 		); err != nil {
-			return "", fmt.Errorf("write run-multiple fallback message: %w", err)
+			return "", fmt.Errorf("write multi-run fallback message: %w", err)
 		}
 		return workspacecfg.TaskRunMultipleModeEnqueued, nil
 	default:

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -18,6 +18,8 @@ import (
 	core "github.com/compozy/compozy/internal/core"
 	"github.com/compozy/compozy/internal/core/kernel"
 	"github.com/compozy/compozy/internal/core/model"
+	taskscore "github.com/compozy/compozy/internal/core/tasks"
+	workspacecfg "github.com/compozy/compozy/internal/core/workspace"
 	"github.com/compozy/compozy/internal/daemon"
 	daemonlogger "github.com/compozy/compozy/internal/logger"
 	"github.com/spf13/cobra"
@@ -61,6 +63,8 @@ type daemonCommandClient interface {
 	GetReviewRound(context.Context, string, string, int) (apicore.ReviewRound, error)
 	ListReviewIssues(context.Context, string, string, int) ([]apicore.ReviewIssue, error)
 	StartTaskRun(context.Context, string, apicore.TaskRunRequest) (apicore.Run, error)
+	StartTaskRunMultiple(context.Context, apicore.TaskRunMultipleRequest) (apicore.Run, error)
+	GetTaskRunMultipleSnapshot(context.Context, string) (apicore.TaskRunMultipleSnapshot, error)
 	StartReviewRun(context.Context, string, string, int, apicore.ReviewRunRequest) (apicore.Run, error)
 	StartReviewWatch(context.Context, string, string, apicore.ReviewWatchRequest) (apicore.Run, error)
 	StartExecRun(context.Context, apicore.ExecRequest) (apicore.Run, error)
@@ -249,6 +253,7 @@ func newTasksCommand(dispatcher *kernel.Dispatcher, defaults commandStateDefault
 	cmd.AddCommand(
 		newTasksValidateCommand(),
 		newTasksRunCommandWithDefaults(dispatcher, defaults),
+		newTasksRunMultipleCommandWithDefaults(dispatcher, defaults),
 	)
 	return cmd
 }
@@ -273,8 +278,43 @@ is running, and then sends the workflow request over the daemon transport.`,
 		},
 	}
 
+	addTaskRunFlags(cmd, state, taskRunFlagOptions{includeName: true})
+	return cmd
+}
+
+func newTasksRunMultipleCommandWithDefaults(_ *kernel.Dispatcher, defaults commandStateDefaults) *cobra.Command {
+	state := newCommandStateWithDefaults(commandKindTasksRunMultiple, core.ModePRDTasks, defaults)
+	cmd := &cobra.Command{
+		Use:          "run-multiple [slugs]",
+		Short:        "Start a daemon-backed queue of task workflow runs",
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		Long: `Start multiple task workflows through one daemon-owned parent run.
+
+The command accepts one comma-separated positional slug list. V1 runs the queue
+in enqueued order; configured parallel mode prints a V2 worktree-isolation
+fallback message before sending enqueued execution to the daemon.`,
+		Example: `  compozy tasks run-multiple alpha,beta --stream
+  compozy tasks run-multiple alpha,beta --detach
+  compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return state.runTaskWorkflowsMultiple(cmd, args)
+		},
+	}
+
+	addTaskRunFlags(cmd, state, taskRunFlagOptions{})
+	return cmd
+}
+
+type taskRunFlagOptions struct {
+	includeName bool
+}
+
+func addTaskRunFlags(cmd *cobra.Command, state *commandState, opts taskRunFlagOptions) {
 	addCommonFlags(cmd, state, commonFlagOptions{})
-	cmd.Flags().StringVar(&state.name, "name", "", "Task workflow slug (defaults to the positional slug)")
+	if opts.includeName {
+		cmd.Flags().StringVar(&state.name, "name", "", "Task workflow slug (defaults to the positional slug)")
+	}
 	cmd.Flags().BoolVar(&state.includeCompleted, "include-completed", false, "Include completed tasks")
 	cmd.Flags().BoolVar(
 		&state.skipValidation,
@@ -302,7 +342,6 @@ is running, and then sends the workflow request over the daemon transport.`,
 		"task-runtime",
 		`Per-task runtime override rule for task runs (repeatable). Use key=value pairs such as type=frontend,ide=codex,model=gpt-5.5 or id=task_01,reasoning-effort=xhigh`,
 	)
-	return cmd
 }
 
 func (s *commandState) runTaskWorkflow(cmd *cobra.Command, args []string) error {
@@ -361,6 +400,116 @@ func (s *commandState) runTaskWorkflow(cmd *cobra.Command, args []string) error 
 	return handleStartedTaskRun(ctx, cmd, client, run)
 }
 
+func (s *commandState) runTaskWorkflowsMultiple(cmd *cobra.Command, args []string) error {
+	ctx, stop := signalCommandContext(cmd)
+	defer stop()
+
+	slugs, err := resolveTaskWorkflowSlugList(args)
+	if err != nil {
+		return withExitCode(1, err)
+	}
+	if err := s.applyWorkspaceDefaults(ctx, cmd); err != nil {
+		return withExitCode(2, fmt.Errorf("apply workspace defaults for %s: %w", cmd.CommandPath(), err))
+	}
+
+	s.explicitRuntime = captureExplicitRuntimeFlags(cmd)
+	if err := s.preflightTaskWorkflowSlugs(ctx, cmd, slugs); err != nil {
+		return err
+	}
+
+	presentationMode, err := s.resolveTaskPresentationMode(cmd)
+	if err != nil {
+		return withExitCode(1, err)
+	}
+	mode, err := s.resolveTaskRunMultipleMode(cmd)
+	if err != nil {
+		return withExitCode(2, err)
+	}
+	runtimeOverrides, err := s.buildTaskRunRuntimeOverrides(cmd)
+	if err != nil {
+		return withExitCode(2, err)
+	}
+
+	client, err := newCLIDaemonBootstrap().ensure(ctx)
+	if err != nil {
+		return withExitCode(2, err)
+	}
+
+	run, err := client.StartTaskRunMultiple(ctx, apicore.TaskRunMultipleRequest{
+		Workspace:        s.workspaceRoot,
+		Slugs:            slugs,
+		Mode:             mode,
+		PresentationMode: presentationMode,
+		RuntimeOverrides: runtimeOverrides,
+	})
+	if err != nil {
+		return mapDaemonCommandError(err)
+	}
+	return handleStartedTaskRunMultiple(ctx, cmd, client, run)
+}
+
+func resolveTaskWorkflowSlugList(args []string) ([]string, error) {
+	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
+		return nil, errors.New("workflow slug list is required; pass comma-separated slugs as the positional argument")
+	}
+	slugs, err := taskscore.ParseCommaSeparatedSlugs(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("workflow slug list: %w", err)
+	}
+	return slugs, nil
+}
+
+func (s *commandState) preflightTaskWorkflowSlugs(ctx context.Context, cmd *cobra.Command, slugs []string) error {
+	cfg, err := s.buildConfig()
+	if err != nil {
+		return withExitCode(2, err)
+	}
+
+	originalName := s.name
+	originalTasksDir := s.tasksDir
+	defer func() {
+		s.name = originalName
+		s.tasksDir = originalTasksDir
+	}()
+
+	for _, slug := range slugs {
+		resolvedTasksDir, err := resolveTaskWorkflowDir(s.workspaceRoot, slug, "")
+		if err != nil {
+			return withExitCode(2, err)
+		}
+		s.name = slug
+		s.tasksDir = resolvedTasksDir
+		cfg.Name = slug
+		cfg.TasksDir = resolvedTasksDir
+		if err := s.preflightTaskMetadata(ctx, cmd, cfg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *commandState) resolveTaskRunMultipleMode(cmd *cobra.Command) (string, error) {
+	mode := s.projectConfig.Tasks.Run.EffectiveRunMultipleMode()
+	switch mode {
+	case workspacecfg.TaskRunMultipleModeEnqueued:
+		return mode, nil
+	case workspacecfg.TaskRunMultipleModeParallel:
+		if _, err := fmt.Fprintln(
+			cmd.ErrOrStderr(),
+			"parallel multi-task execution is planned for V2 with git worktree isolation; running this queue in enqueued mode.",
+		); err != nil {
+			return "", fmt.Errorf("write run-multiple fallback message: %w", err)
+		}
+		return workspacecfg.TaskRunMultipleModeEnqueued, nil
+	default:
+		return "", fmt.Errorf("tasks.run.run_multiple_mode must be %q or %q (got %q)",
+			workspacecfg.TaskRunMultipleModeEnqueued,
+			workspacecfg.TaskRunMultipleModeParallel,
+			mode,
+		)
+	}
+}
+
 func handleStartedTaskRun(
 	ctx context.Context,
 	cmd *cobra.Command,
@@ -391,6 +540,30 @@ func handleStartedTaskRun(
 	return nil
 }
 
+func handleStartedTaskRunMultiple(
+	ctx context.Context,
+	cmd *cobra.Command,
+	client daemonCommandClient,
+	run apicore.Run,
+) error {
+	if run.PresentationMode == attachModeUI {
+		if err := attachStartedCLIRunUI(ctx, client, run.RunID); err != nil {
+			if errors.Is(err, errRunSettledBeforeUIAttach) {
+				return watchCLIRunUntilTerminalSuccess(ctx, cmd.OutOrStdout(), client, run.RunID)
+			}
+			return mapDaemonCommandError(err)
+		}
+		return nil
+	}
+	if err := writeStartedTaskRunMultiple(cmd, run); err != nil {
+		return err
+	}
+	if run.PresentationMode != attachModeStream {
+		return nil
+	}
+	return watchCLIRunUntilTerminalSuccess(ctx, cmd.OutOrStdout(), client, run.RunID)
+}
+
 func writeStartedTaskRun(cmd *cobra.Command, run apicore.Run) error {
 	if _, err := fmt.Fprintf(
 		cmd.OutOrStdout(),
@@ -399,6 +572,18 @@ func writeStartedTaskRun(cmd *cobra.Command, run apicore.Run) error {
 		run.PresentationMode,
 	); err != nil {
 		return withExitCode(2, fmt.Errorf("write task run summary: %w", err))
+	}
+	return nil
+}
+
+func writeStartedTaskRunMultiple(cmd *cobra.Command, run apicore.Run) error {
+	if _, err := fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"task multi-run started: %s (mode=%s)\n",
+		run.RunID,
+		run.PresentationMode,
+	); err != nil {
+		return withExitCode(2, fmt.Errorf("write task multi-run summary: %w", err))
 	}
 	return nil
 }

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -1036,7 +1036,7 @@ func (failingCLIWriter) Write([]byte) (int, error) {
 func TestResolveTaskRunMultipleMode(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default enqueued", func(t *testing.T) {
+	t.Run("Should default to enqueued", func(t *testing.T) {
 		t.Parallel()
 
 		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
@@ -1050,7 +1050,7 @@ func TestResolveTaskRunMultipleMode(t *testing.T) {
 		}
 	})
 
-	t.Run("parallel fallback", func(t *testing.T) {
+	t.Run("Should fallback to enqueued with warning", func(t *testing.T) {
 		t.Parallel()
 
 		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
@@ -1070,7 +1070,7 @@ func TestResolveTaskRunMultipleMode(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid internal value", func(t *testing.T) {
+	t.Run("Should return error for invalid internal value", func(t *testing.T) {
 		t.Parallel()
 
 		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
@@ -1081,7 +1081,7 @@ func TestResolveTaskRunMultipleMode(t *testing.T) {
 		}
 	})
 
-	t.Run("fallback write failure", func(t *testing.T) {
+	t.Run("Should surface write failure when fallback message cannot be written", func(t *testing.T) {
 		t.Parallel()
 
 		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -1039,7 +1039,7 @@ func TestResolveTaskRunMultipleMode(t *testing.T) {
 	t.Run("Should default to enqueued", func(t *testing.T) {
 		t.Parallel()
 
-		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
 		cmd := &cobra.Command{}
 		mode, err := state.resolveTaskRunMultipleMode(cmd)
 		if err != nil {
@@ -1053,7 +1053,7 @@ func TestResolveTaskRunMultipleMode(t *testing.T) {
 	t.Run("Should fallback to enqueued with warning", func(t *testing.T) {
 		t.Parallel()
 
-		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
 		state.projectConfig.Tasks.Run.RunMultipleMode = stringPointer("parallel")
 		cmd := &cobra.Command{}
 		var stderr bytes.Buffer
@@ -1073,7 +1073,7 @@ func TestResolveTaskRunMultipleMode(t *testing.T) {
 	t.Run("Should return error for invalid internal value", func(t *testing.T) {
 		t.Parallel()
 
-		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
 		state.projectConfig.Tasks.Run.RunMultipleMode = stringPointer("bogus")
 		_, err := state.resolveTaskRunMultipleMode(&cobra.Command{})
 		if err == nil || !strings.Contains(err.Error(), "tasks.run.run_multiple_mode") {
@@ -1084,12 +1084,12 @@ func TestResolveTaskRunMultipleMode(t *testing.T) {
 	t.Run("Should surface write failure when fallback message cannot be written", func(t *testing.T) {
 		t.Parallel()
 
-		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
 		state.projectConfig.Tasks.Run.RunMultipleMode = stringPointer("parallel")
 		cmd := &cobra.Command{}
 		cmd.SetErr(failingCLIWriter{})
 		_, err := state.resolveTaskRunMultipleMode(cmd)
-		if err == nil || !strings.Contains(err.Error(), "write run-multiple fallback message") {
+		if err == nil || !strings.Contains(err.Error(), "write multi-run fallback message") {
 			t.Fatalf("expected fallback write error, got %v", err)
 		}
 	})

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -20,6 +20,8 @@ import (
 	core "github.com/compozy/compozy/internal/core"
 	uipkg "github.com/compozy/compozy/internal/core/run/ui"
 	"github.com/compozy/compozy/internal/daemon"
+	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
+	"github.com/compozy/compozy/pkg/compozy/events/kinds"
 	"github.com/spf13/cobra"
 )
 
@@ -36,65 +38,71 @@ var (
 type daemonCommandContextKey string
 
 type stubDaemonCommandClient struct {
-	target          apiclient.Target
-	health          apicore.DaemonHealth
-	healthErr       error
-	healthCtx       context.Context
-	healthCalls     int
-	status          apicore.DaemonStatus
-	statusErr       error
-	statusCtx       context.Context
-	startCalls      int
-	startSlug       string
-	startRequest    apicore.TaskRunRequest
-	startRun        apicore.Run
-	startErr        error
-	cancelCtx       context.Context
-	cancelRunID     string
-	cancelCalls     int
-	cancelErr       error
-	stopCtx         context.Context
-	stopForce       bool
-	stopErr         error
-	workspaces      []apicore.Workspace
-	workspace       apicore.Workspace
-	workspaceErr    error
-	register        apicore.WorkspaceRegisterResult
-	registerErr     error
-	listErr         error
-	deleteRef       string
-	deleteErr       error
-	workflows       []apicore.WorkflowSummary
-	workflowsErr    error
-	archiveCalls    []string
-	archive         apicore.ArchiveResult
-	archiveBySlug   map[string]apicore.ArchiveResult
-	archiveErr      error
-	archiveErrors   map[string]error
-	syncRequest     apicore.SyncRequest
-	syncResult      apicore.SyncResult
-	syncErr         error
-	reviewFetch     apicore.ReviewFetchResult
-	reviewFetchErr  error
-	reviewLatest    apicore.ReviewSummary
-	reviewLatestErr error
-	reviewRound     apicore.ReviewRound
-	reviewRoundErr  error
-	reviewIssues    []apicore.ReviewIssue
-	reviewIssuesErr error
-	reviewRun       apicore.Run
-	reviewRunErr    error
-	reviewWatchRun  apicore.Run
-	reviewWatchErr  error
-	execRun         apicore.Run
-	execRunErr      error
-	runEventPage    apicore.RunEventPage
-	runEventPageErr error
-	snapshot        apicore.RunSnapshot
-	snapshotErr     error
-	snapshotFunc    func(context.Context, string) (apicore.RunSnapshot, error)
-	stream          apiclient.RunStream
-	streamErr       error
+	target               apiclient.Target
+	health               apicore.DaemonHealth
+	healthErr            error
+	healthCtx            context.Context
+	healthCalls          int
+	status               apicore.DaemonStatus
+	statusErr            error
+	statusCtx            context.Context
+	startCalls           int
+	startSlug            string
+	startRequest         apicore.TaskRunRequest
+	startRun             apicore.Run
+	startErr             error
+	startMultipleCalls   int
+	startMultipleRequest apicore.TaskRunMultipleRequest
+	startMultipleRun     apicore.Run
+	startMultipleErr     error
+	multiSnapshot        apicore.TaskRunMultipleSnapshot
+	multiSnapshotErr     error
+	cancelCtx            context.Context
+	cancelRunID          string
+	cancelCalls          int
+	cancelErr            error
+	stopCtx              context.Context
+	stopForce            bool
+	stopErr              error
+	workspaces           []apicore.Workspace
+	workspace            apicore.Workspace
+	workspaceErr         error
+	register             apicore.WorkspaceRegisterResult
+	registerErr          error
+	listErr              error
+	deleteRef            string
+	deleteErr            error
+	workflows            []apicore.WorkflowSummary
+	workflowsErr         error
+	archiveCalls         []string
+	archive              apicore.ArchiveResult
+	archiveBySlug        map[string]apicore.ArchiveResult
+	archiveErr           error
+	archiveErrors        map[string]error
+	syncRequest          apicore.SyncRequest
+	syncResult           apicore.SyncResult
+	syncErr              error
+	reviewFetch          apicore.ReviewFetchResult
+	reviewFetchErr       error
+	reviewLatest         apicore.ReviewSummary
+	reviewLatestErr      error
+	reviewRound          apicore.ReviewRound
+	reviewRoundErr       error
+	reviewIssues         []apicore.ReviewIssue
+	reviewIssuesErr      error
+	reviewRun            apicore.Run
+	reviewRunErr         error
+	reviewWatchRun       apicore.Run
+	reviewWatchErr       error
+	execRun              apicore.Run
+	execRunErr           error
+	runEventPage         apicore.RunEventPage
+	runEventPageErr      error
+	snapshot             apicore.RunSnapshot
+	snapshotErr          error
+	snapshotFunc         func(context.Context, string) (apicore.RunSnapshot, error)
+	stream               apiclient.RunStream
+	streamErr            error
 }
 
 func (c *stubDaemonCommandClient) Target() apiclient.Target {
@@ -311,6 +319,34 @@ func (c *stubDaemonCommandClient) StartTaskRun(
 		return apicore.Run{}, c.startErr
 	}
 	return c.startRun, nil
+}
+
+func (c *stubDaemonCommandClient) StartTaskRunMultiple(
+	_ context.Context,
+	req apicore.TaskRunMultipleRequest,
+) (apicore.Run, error) {
+	if c == nil {
+		return apicore.Run{}, errors.New("stub daemon client is required")
+	}
+	c.startMultipleCalls++
+	c.startMultipleRequest = req
+	if c.startMultipleErr != nil {
+		return apicore.Run{}, c.startMultipleErr
+	}
+	return c.startMultipleRun, nil
+}
+
+func (c *stubDaemonCommandClient) GetTaskRunMultipleSnapshot(
+	context.Context,
+	string,
+) (apicore.TaskRunMultipleSnapshot, error) {
+	if c == nil {
+		return apicore.TaskRunMultipleSnapshot{}, errors.New("stub daemon client is required")
+	}
+	if c.multiSnapshotErr != nil {
+		return apicore.TaskRunMultipleSnapshot{}, c.multiSnapshotErr
+	}
+	return c.multiSnapshot, nil
 }
 
 func (c *stubDaemonCommandClient) StartReviewRun(
@@ -989,6 +1025,224 @@ func decodeTaskRunOverrides(t *testing.T, raw json.RawMessage) daemonRuntimeOver
 		t.Fatalf("decode task run overrides: %v", err)
 	}
 	return payload
+}
+
+type failingCLIWriter struct{}
+
+func (failingCLIWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestResolveTaskRunMultipleMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default enqueued", func(t *testing.T) {
+		t.Parallel()
+
+		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		cmd := &cobra.Command{}
+		mode, err := state.resolveTaskRunMultipleMode(cmd)
+		if err != nil {
+			t.Fatalf("resolveTaskRunMultipleMode() error = %v", err)
+		}
+		if mode != "enqueued" {
+			t.Fatalf("mode = %q, want enqueued", mode)
+		}
+	})
+
+	t.Run("parallel fallback", func(t *testing.T) {
+		t.Parallel()
+
+		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		state.projectConfig.Tasks.Run.RunMultipleMode = stringPointer("parallel")
+		cmd := &cobra.Command{}
+		var stderr bytes.Buffer
+		cmd.SetErr(&stderr)
+		mode, err := state.resolveTaskRunMultipleMode(cmd)
+		if err != nil {
+			t.Fatalf("resolveTaskRunMultipleMode() error = %v", err)
+		}
+		if mode != "enqueued" {
+			t.Fatalf("mode = %q, want enqueued", mode)
+		}
+		if !containsAll(stderr.String(), "V2", "worktree isolation", "enqueued") {
+			t.Fatalf("fallback stderr = %q", stderr.String())
+		}
+	})
+
+	t.Run("invalid internal value", func(t *testing.T) {
+		t.Parallel()
+
+		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		state.projectConfig.Tasks.Run.RunMultipleMode = stringPointer("bogus")
+		_, err := state.resolveTaskRunMultipleMode(&cobra.Command{})
+		if err == nil || !strings.Contains(err.Error(), "tasks.run.run_multiple_mode") {
+			t.Fatalf("expected invalid mode error, got %v", err)
+		}
+	})
+
+	t.Run("fallback write failure", func(t *testing.T) {
+		t.Parallel()
+
+		state := newCommandState(commandKindTasksRunMultiple, core.ModePRDTasks)
+		state.projectConfig.Tasks.Run.RunMultipleMode = stringPointer("parallel")
+		cmd := &cobra.Command{}
+		cmd.SetErr(failingCLIWriter{})
+		_, err := state.resolveTaskRunMultipleMode(cmd)
+		if err == nil || !strings.Contains(err.Error(), "write run-multiple fallback message") {
+			t.Fatalf("expected fallback write error, got %v", err)
+		}
+	})
+}
+
+func TestRenderObservedTaskMultiLifecycle(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		kind    eventspkg.EventKind
+		payload kinds.TaskRunMultiplePayload
+		want    string
+	}{
+		{
+			name:    "queue started",
+			kind:    eventspkg.EventKindTaskRunMultipleStarted,
+			payload: kinds.TaskRunMultiplePayload{Mode: "enqueued", Slugs: []string{"alpha", "beta"}, Total: 2},
+			want:    "task queue started | mode=enqueued total=2\n",
+		},
+		{
+			name:    "item queued",
+			kind:    eventspkg.EventKindTaskRunMultipleItemQueued,
+			payload: kinds.TaskRunMultiplePayload{Slug: "alpha", Index: 0, Total: 2, Status: "queued"},
+			want:    "task[1/2] alpha queued\n",
+		},
+		{
+			name: "child started",
+			kind: eventspkg.EventKindTaskRunMultipleChildStarted,
+			payload: kinds.TaskRunMultiplePayload{
+				Slug:       "alpha",
+				Index:      0,
+				Total:      2,
+				Status:     "running",
+				ChildRunID: "child-alpha",
+			},
+			want: "task[1/2] alpha running | run=child-alpha\n",
+		},
+		{
+			name: "child completed",
+			kind: eventspkg.EventKindTaskRunMultipleChildCompleted,
+			payload: kinds.TaskRunMultiplePayload{
+				Slug:       "alpha",
+				Index:      0,
+				Total:      2,
+				Status:     "completed",
+				ChildRunID: "child-alpha",
+			},
+			want: "task[1/2] alpha completed | run=child-alpha\n",
+		},
+		{
+			name: "child failed",
+			kind: eventspkg.EventKindTaskRunMultipleChildFailed,
+			payload: kinds.TaskRunMultiplePayload{
+				Slug:       "alpha",
+				Index:      0,
+				Total:      2,
+				Status:     "failed",
+				ChildRunID: "child-alpha",
+				Error:      "forced failure",
+			},
+			want: "task[1/2] alpha failed | run=child-alpha | forced failure\n",
+		},
+		{
+			name: "item canceled",
+			kind: eventspkg.EventKindTaskRunMultipleItemCanceled,
+			payload: kinds.TaskRunMultiplePayload{
+				Slug:   "beta",
+				Index:  1,
+				Total:  2,
+				Status: "canceled",
+				Error:  "parent failed",
+			},
+			want: "task[2/2] beta canceled | parent failed\n",
+		},
+		{
+			name:    "queue completed",
+			kind:    eventspkg.EventKindTaskRunMultipleQueueCompleted,
+			payload: kinds.TaskRunMultiplePayload{Total: 2},
+			want:    "task queue completed | total=2\n",
+		},
+		{
+			name:    "queue canceled",
+			kind:    eventspkg.EventKindTaskRunMultipleQueueCanceled,
+			payload: kinds.TaskRunMultiplePayload{Error: "stop requested"},
+			want:    "task queue canceled | stop requested\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := json.Marshal(tc.payload)
+			if err != nil {
+				t.Fatalf("marshal payload: %v", err)
+			}
+			got := renderObservedRunEvent(eventspkg.Event{
+				Kind:    tc.kind,
+				Payload: raw,
+			})
+			if got != tc.want {
+				t.Fatalf("renderObservedRunEvent() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderObservedTaskMultiLifecycleFallbacks(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		kind eventspkg.EventKind
+		want string
+	}{
+		{
+			name: "queue started",
+			kind: eventspkg.EventKindTaskRunMultipleStarted,
+			want: "task queue started\n",
+		},
+		{
+			name: "item failed",
+			kind: eventspkg.EventKindTaskRunMultipleChildFailed,
+			want: "task failed\n",
+		},
+		{
+			name: "queue completed",
+			kind: eventspkg.EventKindTaskRunMultipleQueueCompleted,
+			want: "task queue completed\n",
+		},
+		{
+			name: "queue canceled",
+			kind: eventspkg.EventKindTaskRunMultipleQueueCanceled,
+			want: "task queue canceled\n",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := renderObservedRunEvent(eventspkg.Event{
+				Kind:    tc.kind,
+				Payload: []byte("{"),
+			})
+			if got != tc.want {
+				t.Fatalf("renderObservedRunEvent() = %q, want %q", got, tc.want)
+			}
+		})
+	}
 }
 
 func TestDaemonStartCommandDetachedReturnsReadyStatus(t *testing.T) {

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -1105,19 +1105,19 @@ func TestRenderObservedTaskMultiLifecycle(t *testing.T) {
 		want    string
 	}{
 		{
-			name:    "queue started",
+			name:    "Should render queue started",
 			kind:    eventspkg.EventKindTaskRunMultipleStarted,
 			payload: kinds.TaskRunMultiplePayload{Mode: "enqueued", Slugs: []string{"alpha", "beta"}, Total: 2},
 			want:    "task queue started | mode=enqueued total=2\n",
 		},
 		{
-			name:    "item queued",
+			name:    "Should render item queued",
 			kind:    eventspkg.EventKindTaskRunMultipleItemQueued,
 			payload: kinds.TaskRunMultiplePayload{Slug: "alpha", Index: 0, Total: 2, Status: "queued"},
 			want:    "task[1/2] alpha queued\n",
 		},
 		{
-			name: "child started",
+			name: "Should render child started",
 			kind: eventspkg.EventKindTaskRunMultipleChildStarted,
 			payload: kinds.TaskRunMultiplePayload{
 				Slug:       "alpha",
@@ -1129,7 +1129,7 @@ func TestRenderObservedTaskMultiLifecycle(t *testing.T) {
 			want: "task[1/2] alpha running | run=child-alpha\n",
 		},
 		{
-			name: "child completed",
+			name: "Should render child completed",
 			kind: eventspkg.EventKindTaskRunMultipleChildCompleted,
 			payload: kinds.TaskRunMultiplePayload{
 				Slug:       "alpha",
@@ -1141,7 +1141,7 @@ func TestRenderObservedTaskMultiLifecycle(t *testing.T) {
 			want: "task[1/2] alpha completed | run=child-alpha\n",
 		},
 		{
-			name: "child failed",
+			name: "Should render child failed",
 			kind: eventspkg.EventKindTaskRunMultipleChildFailed,
 			payload: kinds.TaskRunMultiplePayload{
 				Slug:       "alpha",
@@ -1154,7 +1154,7 @@ func TestRenderObservedTaskMultiLifecycle(t *testing.T) {
 			want: "task[1/2] alpha failed | run=child-alpha | forced failure\n",
 		},
 		{
-			name: "item canceled",
+			name: "Should render item canceled",
 			kind: eventspkg.EventKindTaskRunMultipleItemCanceled,
 			payload: kinds.TaskRunMultiplePayload{
 				Slug:   "beta",
@@ -1166,13 +1166,13 @@ func TestRenderObservedTaskMultiLifecycle(t *testing.T) {
 			want: "task[2/2] beta canceled | parent failed\n",
 		},
 		{
-			name:    "queue completed",
+			name:    "Should render queue completed",
 			kind:    eventspkg.EventKindTaskRunMultipleQueueCompleted,
 			payload: kinds.TaskRunMultiplePayload{Total: 2},
 			want:    "task queue completed | total=2\n",
 		},
 		{
-			name:    "queue canceled",
+			name:    "Should render queue canceled",
 			kind:    eventspkg.EventKindTaskRunMultipleQueueCanceled,
 			payload: kinds.TaskRunMultiplePayload{Error: "stop requested"},
 			want:    "task queue canceled | stop requested\n",
@@ -1208,22 +1208,22 @@ func TestRenderObservedTaskMultiLifecycleFallbacks(t *testing.T) {
 		want string
 	}{
 		{
-			name: "queue started",
+			name: "Should render queue started fallback",
 			kind: eventspkg.EventKindTaskRunMultipleStarted,
 			want: "task queue started\n",
 		},
 		{
-			name: "item failed",
+			name: "Should render item failed fallback",
 			kind: eventspkg.EventKindTaskRunMultipleChildFailed,
 			want: "task failed\n",
 		},
 		{
-			name: "queue completed",
+			name: "Should render queue completed fallback",
 			kind: eventspkg.EventKindTaskRunMultipleQueueCompleted,
 			want: "task queue completed\n",
 		},
 		{
-			name: "queue canceled",
+			name: "Should render queue canceled fallback",
 			kind: eventspkg.EventKindTaskRunMultipleQueueCanceled,
 			want: "task queue canceled\n",
 		},

--- a/internal/cli/daemon_exec_test_helpers_test.go
+++ b/internal/cli/daemon_exec_test_helpers_test.go
@@ -35,6 +35,11 @@ var _ daemonCommandClient = (*inProcessDaemonCommandClient)(nil)
 
 func installInProcessCLIDaemonBootstrap(t *testing.T) {
 	t.Helper()
+	installInProcessCLIDaemonBootstrapWithConfig(t, daemon.RunManagerConfig{})
+}
+
+func installInProcessCLIDaemonBootstrapWithConfig(t *testing.T, cfg daemon.RunManagerConfig) {
+	t.Helper()
 
 	prepareInProcessCLIDaemonHome(t)
 
@@ -57,11 +62,14 @@ func installInProcessCLIDaemonBootstrap(t *testing.T) {
 		_ = db.Close()
 	})
 
-	manager, err := daemon.NewRunManager(daemon.RunManagerConfig{
-		GlobalDB:             db,
-		LifecycleContext:     ctx,
-		ShutdownDrainTimeout: time.Second,
-	})
+	cfg.GlobalDB = db
+	if cfg.LifecycleContext == nil {
+		cfg.LifecycleContext = ctx
+	}
+	if cfg.ShutdownDrainTimeout == 0 {
+		cfg.ShutdownDrainTimeout = time.Second
+	}
+	manager, err := daemon.NewRunManager(cfg)
 	if err != nil {
 		t.Fatalf("daemon.NewRunManager() error = %v", err)
 	}
@@ -324,6 +332,20 @@ func (c *inProcessDaemonCommandClient) StartTaskRun(
 	req apicore.TaskRunRequest,
 ) (apicore.Run, error) {
 	return c.manager.StartTaskRun(ctx, req.Workspace, slug, req)
+}
+
+func (c *inProcessDaemonCommandClient) StartTaskRunMultiple(
+	ctx context.Context,
+	req apicore.TaskRunMultipleRequest,
+) (apicore.Run, error) {
+	return c.manager.StartTaskRunMultiple(ctx, req.Workspace, req)
+}
+
+func (c *inProcessDaemonCommandClient) GetTaskRunMultipleSnapshot(
+	ctx context.Context,
+	runID string,
+) (apicore.TaskRunMultipleSnapshot, error) {
+	return c.manager.RunMultipleSnapshot(ctx, runID)
 }
 
 func (c *inProcessDaemonCommandClient) StartReviewRun(

--- a/internal/cli/daemon_exec_test_helpers_test.go
+++ b/internal/cli/daemon_exec_test_helpers_test.go
@@ -40,7 +40,14 @@ func installInProcessCLIDaemonBootstrap(t *testing.T) {
 
 func installInProcessCLIDaemonBootstrapWithConfig(t *testing.T, cfg daemon.RunManagerConfig) {
 	t.Helper()
+	_ = installInProcessCLIDaemonBootstrapWithConfigClient(t, cfg)
+}
 
+func installInProcessCLIDaemonBootstrapWithConfigClient(
+	t *testing.T,
+	cfg daemon.RunManagerConfig,
+) *inProcessDaemonCommandClient {
+	t.Helper()
 	prepareInProcessCLIDaemonHome(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -81,11 +88,13 @@ func installInProcessCLIDaemonBootstrapWithConfig(t *testing.T, cfg daemon.RunMa
 		}
 	})
 
-	installTestCLIReadyDaemonBootstrap(t, &inProcessDaemonCommandClient{
+	client := &inProcessDaemonCommandClient{
 		globalDB: db,
 		manager:  manager,
 		target:   apiclient.Target{SocketPath: "in-process://daemon"},
-	})
+	}
+	installTestCLIReadyDaemonBootstrap(t, client)
+	return client
 }
 
 func prepareInProcessCLIDaemonHome(t *testing.T) {

--- a/internal/cli/extensions_bootstrap.go
+++ b/internal/cli/extensions_bootstrap.go
@@ -72,8 +72,7 @@ func (s *commandState) requiresDeclarativeAssetBootstrap() bool {
 	case commandKindFetchReviews,
 		commandKindFixReviews,
 		commandKindExec,
-		commandKindTasksRun,
-		commandKindTasksRunMultiple:
+		commandKindTasksRun:
 		return true
 	default:
 		return false

--- a/internal/cli/extensions_bootstrap.go
+++ b/internal/cli/extensions_bootstrap.go
@@ -69,7 +69,11 @@ func (s *commandState) requiresDeclarativeAssetBootstrap() bool {
 	}
 
 	switch s.kind {
-	case commandKindFetchReviews, commandKindFixReviews, commandKindExec, commandKindTasksRun:
+	case commandKindFetchReviews,
+		commandKindFixReviews,
+		commandKindExec,
+		commandKindTasksRun,
+		commandKindTasksRunMultiple:
 		return true
 	default:
 		return false

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,14 +18,13 @@ import (
 type commandKind string
 
 const (
-	commandKindFetchReviews     commandKind = "reviews fetch"
-	commandKindFixReviews       commandKind = "reviews fix"
-	commandKindWatchReviews     commandKind = "reviews watch"
-	commandKindExec             commandKind = "exec"
-	commandKindArchive          commandKind = "archive"
-	commandKindTasksRun         commandKind = "tasks run"
-	commandKindTasksRunMultiple commandKind = "tasks run-multiple"
-	commandKindSync             commandKind = "sync"
+	commandKindFetchReviews commandKind = "reviews fetch"
+	commandKindFixReviews   commandKind = "reviews fix"
+	commandKindWatchReviews commandKind = "reviews watch"
+	commandKindExec         commandKind = "exec"
+	commandKindArchive      commandKind = "archive"
+	commandKindTasksRun     commandKind = "tasks run"
+	commandKindSync         commandKind = "sync"
 )
 
 var validateRootDispatcher = kernel.ValidateDefaultRegistry

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,13 +18,14 @@ import (
 type commandKind string
 
 const (
-	commandKindFetchReviews commandKind = "reviews fetch"
-	commandKindFixReviews   commandKind = "reviews fix"
-	commandKindWatchReviews commandKind = "reviews watch"
-	commandKindExec         commandKind = "exec"
-	commandKindArchive      commandKind = "archive"
-	commandKindTasksRun     commandKind = "tasks run"
-	commandKindSync         commandKind = "sync"
+	commandKindFetchReviews     commandKind = "reviews fetch"
+	commandKindFixReviews       commandKind = "reviews fix"
+	commandKindWatchReviews     commandKind = "reviews watch"
+	commandKindExec             commandKind = "exec"
+	commandKindArchive          commandKind = "archive"
+	commandKindTasksRun         commandKind = "tasks run"
+	commandKindTasksRunMultiple commandKind = "tasks run-multiple"
+	commandKindSync             commandKind = "sync"
 )
 
 var validateRootDispatcher = kernel.ValidateDefaultRegistry

--- a/internal/cli/root_command_execution_test.go
+++ b/internal/cli/root_command_execution_test.go
@@ -1170,6 +1170,335 @@ func TestTasksRunCommandPositionalSlugSkipsInteractiveFormWithoutTTY(t *testing.
 	}
 }
 
+func TestTasksRunMultipleCommandDetachSendsOrderedSlugs(t *testing.T) {
+	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+		[]string{
+			"status: pending",
+			"title: Alpha Task",
+			"type: backend",
+			"complexity: low",
+		},
+		"# Task 1: Alpha Task",
+	))
+	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+	withWorkingDir(t, workspaceRoot)
+
+	readyClient := &stubDaemonCommandClient{
+		target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
+		health: apicore.DaemonHealth{Ready: true},
+		startMultipleRun: apicore.Run{
+			RunID:            "run-task-multi-001",
+			Mode:             "task_multi",
+			Status:           "running",
+			PresentationMode: attachModeDetach,
+			StartedAt:        time.Date(2026, 4, 17, 13, 5, 45, 0, time.UTC),
+		},
+	}
+	installTestCLIReadyDaemonBootstrap(t, readyClient)
+
+	defaults := allowBundledSkillsForExecutionTests()
+	defaults.isInteractive = func() bool { return false }
+	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+	stdout, stderr, err := executeCommandCapturingProcessIO(
+		t,
+		cmd,
+		nil,
+		"tasks",
+		"run-multiple",
+		"alpha,beta",
+		"--detach",
+		"--dry-run",
+		"--include-completed",
+	)
+	if err != nil {
+		t.Fatalf("execute tasks run-multiple detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if readyClient.startCalls != 0 {
+		t.Fatalf("StartTaskRun calls = %d, want 0", readyClient.startCalls)
+	}
+	if readyClient.startMultipleCalls != 1 {
+		t.Fatalf("StartTaskRunMultiple calls = %d, want 1", readyClient.startMultipleCalls)
+	}
+	if !slices.Equal(readyClient.startMultipleRequest.Slugs, []string{"alpha", "beta"}) {
+		t.Fatalf("unexpected multi-run slugs: %#v", readyClient.startMultipleRequest.Slugs)
+	}
+	resolvedWorkspaceRoot, err := filepath.EvalSymlinks(workspaceRoot)
+	if err != nil {
+		t.Fatalf("resolve workspace root symlinks: %v", err)
+	}
+	if readyClient.startMultipleRequest.Workspace != resolvedWorkspaceRoot {
+		t.Fatalf("workspace = %q, want %q", readyClient.startMultipleRequest.Workspace, resolvedWorkspaceRoot)
+	}
+	if readyClient.startMultipleRequest.Mode != "enqueued" {
+		t.Fatalf("mode = %q, want enqueued", readyClient.startMultipleRequest.Mode)
+	}
+	if readyClient.startMultipleRequest.PresentationMode != attachModeDetach {
+		t.Fatalf("presentation mode = %q, want detach", readyClient.startMultipleRequest.PresentationMode)
+	}
+	overrides := decodeTaskRunOverrides(t, readyClient.startMultipleRequest.RuntimeOverrides)
+	if overrides.DryRun == nil || !*overrides.DryRun {
+		t.Fatalf("expected dry-run runtime override, got %#v", overrides.DryRun)
+	}
+	if overrides.IncludeCompleted == nil || !*overrides.IncludeCompleted {
+		t.Fatalf("expected include-completed runtime override, got %#v", overrides.IncludeCompleted)
+	}
+	if !strings.Contains(stderr, "preflight=ok") {
+		t.Fatalf("expected preflight success log on stderr, got %q", stderr)
+	}
+	if got := stdout; got != "task multi-run started: run-task-multi-001 (mode=detach)\n" {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}
+
+func TestTasksRunMultipleCommandRejectsInvalidSlugListsBeforeDaemon(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing",
+			args: []string{"tasks", "run-multiple"},
+			want: "workflow slug list is required",
+		},
+		{
+			name: "empty entry",
+			args: []string{"tasks", "run-multiple", "alpha,,beta"},
+			want: "task slug at position 2 cannot be empty",
+		},
+		{
+			name: "duplicate",
+			args: []string{"tasks", "run-multiple", "alpha,beta,alpha"},
+			want: "duplicate task slug \"alpha\"",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
+				resolveHomePaths: func() (compozyconfig.HomePaths, error) {
+					t.Fatal("daemon bootstrap should not run for invalid slug input")
+					return compozyconfig.HomePaths{}, nil
+				},
+			})
+
+			defaults := allowBundledSkillsForExecutionTests()
+			defaults.isInteractive = func() bool { return false }
+			cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+			stdout, stderr, err := executeCommandCapturingProcessIO(t, cmd, nil, tc.args...)
+			if err == nil {
+				t.Fatalf("expected slug validation error\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+			}
+			var exitErr *commandExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+				t.Fatalf("expected exit code 1, got %v", err)
+			}
+			if stdout != "" {
+				t.Fatalf("expected no stdout, got %q", stdout)
+			}
+			if !strings.Contains(stderr, tc.want) {
+				t.Fatalf("stderr = %q, want %q", stderr, tc.want)
+			}
+		})
+	}
+}
+
+func TestTasksRunMultipleCommandParallelConfigFallsBackToEnqueued(t *testing.T) {
+	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+		[]string{
+			"status: pending",
+			"title: Alpha Task",
+			"type: backend",
+			"complexity: low",
+		},
+		"# Task 1: Alpha Task",
+	))
+	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+	writeCLIWorkspaceConfig(t, workspaceRoot, `
+[tasks.run]
+run_multiple_mode = "parallel"
+`)
+	withWorkingDir(t, workspaceRoot)
+
+	readyClient := &stubDaemonCommandClient{
+		target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
+		health: apicore.DaemonHealth{Ready: true},
+		startMultipleRun: apicore.Run{
+			RunID:            "run-task-multi-parallel",
+			Mode:             "task_multi",
+			Status:           "running",
+			PresentationMode: attachModeDetach,
+			StartedAt:        time.Date(2026, 4, 17, 13, 7, 0, 0, time.UTC),
+		},
+	}
+	installTestCLIReadyDaemonBootstrap(t, readyClient)
+
+	defaults := allowBundledSkillsForExecutionTests()
+	defaults.isInteractive = func() bool { return false }
+	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+	stdout, stderr, err := executeCommandCapturingProcessIO(
+		t,
+		cmd,
+		nil,
+		"tasks",
+		"run-multiple",
+		"alpha,beta",
+		"--detach",
+	)
+	if err != nil {
+		t.Fatalf("execute tasks run-multiple parallel fallback: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if readyClient.startMultipleRequest.Mode != "enqueued" {
+		t.Fatalf("mode = %q, want enqueued fallback", readyClient.startMultipleRequest.Mode)
+	}
+	if !containsAll(stderr, "V2", "worktree isolation", "enqueued") {
+		t.Fatalf("expected fallback message mentioning V2 and worktree isolation, got %q", stderr)
+	}
+	if !strings.Contains(stdout, "task multi-run started: run-task-multi-parallel") {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+}
+
+func TestTasksRunCommandStillCallsSingleRunClient(t *testing.T) {
+	workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
+	writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+		[]string{
+			"status: pending",
+			"title: Demo Task",
+			"type: backend",
+			"complexity: low",
+		},
+		"# Task 1: Demo Task",
+	))
+	withWorkingDir(t, workspaceRoot)
+
+	readyClient := &stubDaemonCommandClient{
+		target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
+		health: apicore.DaemonHealth{Ready: true},
+		startRun: apicore.Run{
+			RunID:            "run-task-single-stable",
+			Mode:             string(core.ModePRDTasks),
+			Status:           "running",
+			PresentationMode: attachModeDetach,
+			StartedAt:        time.Date(2026, 4, 17, 13, 7, 30, 0, time.UTC),
+		},
+	}
+	installTestCLIReadyDaemonBootstrap(t, readyClient)
+
+	defaults := allowBundledSkillsForExecutionTests()
+	defaults.isInteractive = func() bool { return false }
+	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+	stdout, stderr, err := executeCommandCapturingProcessIO(t, cmd, nil, "tasks", "run", "demo", "--detach")
+	if err != nil {
+		t.Fatalf("execute tasks run detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if readyClient.startCalls != 1 {
+		t.Fatalf("StartTaskRun calls = %d, want 1", readyClient.startCalls)
+	}
+	if readyClient.startMultipleCalls != 0 {
+		t.Fatalf("StartTaskRunMultiple calls = %d, want 0", readyClient.startMultipleCalls)
+	}
+	if readyClient.startSlug != "demo" {
+		t.Fatalf("single-run slug = %q, want demo", readyClient.startSlug)
+	}
+	if !strings.Contains(stdout, "task run started: run-task-single-stable (mode=detach)") {
+		t.Fatalf("unexpected stdout: %q", stdout)
+	}
+}
+
+func TestTasksRunMultipleCommandInProcessDetachStartsParentRun(t *testing.T) {
+	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+		[]string{
+			"status: pending",
+			"title: Alpha Task",
+			"type: backend",
+			"complexity: low",
+		},
+		"# Task 1: Alpha Task",
+	))
+	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+	withWorkingDir(t, workspaceRoot)
+
+	defaults := allowBundledSkillsForExecutionTests()
+	defaults.isInteractive = func() bool { return false }
+	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+	stdout, stderr, err := executeDaemonBackedCommandCapturingProcessIO(
+		t,
+		cmd,
+		nil,
+		"tasks",
+		"run-multiple",
+		"alpha,beta",
+		"--detach",
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf("execute in-process tasks run-multiple detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "preflight=ok") {
+		t.Fatalf("expected preflight success log on stderr, got %q", stderr)
+	}
+	if !containsAll(stdout, "task multi-run started:", "(mode=detach)") {
+		t.Fatalf("expected parent run id in detach stdout, got %q", stdout)
+	}
+}
+
+func TestTasksRunMultipleCommandStreamReturnsNonZeroOnParentFailure(t *testing.T) {
+	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+		[]string{
+			"status: pending",
+			"title: Alpha Task",
+			"type: backend",
+			"complexity: low",
+		},
+		"# Task 1: Alpha Task",
+	))
+	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+	withWorkingDir(t, workspaceRoot)
+
+	installInProcessCLIDaemonBootstrapWithConfig(t, daemon.RunManagerConfig{
+		Execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
+			return errors.New("forced child failure")
+		},
+	})
+
+	defaults := allowBundledSkillsForExecutionTests()
+	defaults.isInteractive = func() bool { return false }
+	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+	stdout, stderr, err := executeCommandCapturingProcessIO(
+		t,
+		cmd,
+		nil,
+		"tasks",
+		"run-multiple",
+		"alpha,beta",
+		"--stream",
+		"--dry-run",
+	)
+	if err == nil {
+		t.Fatalf("expected stream failure exit\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+	var exitErr *commandExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1 for failed parent, got %v", err)
+	}
+	if !containsAll(
+		stdout,
+		"task multi-run started:",
+		"task queue started",
+		"task[1/2] alpha",
+		"failed",
+		"forced child failure",
+		"run failed",
+	) {
+		t.Fatalf("expected parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
+	}
+}
+
 func TestTasksRunCommandNoFlagsUsesInteractiveForm(t *testing.T) {
 	workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
 	writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(

--- a/internal/cli/root_command_execution_test.go
+++ b/internal/cli/root_command_execution_test.go
@@ -1408,7 +1408,7 @@ func TestTasksRunCommandStillCallsSingleRunClient(t *testing.T) {
 	}
 }
 
-func TestTasksRunMultipleCommandInProcessDetachStartsParentRun(t *testing.T) {
+func TestTasksRunMultipleCommandInProcessStreamReconstructsParentQueueState(t *testing.T) {
 	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
 	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
 		[]string{
@@ -1422,27 +1422,111 @@ func TestTasksRunMultipleCommandInProcessDetachStartsParentRun(t *testing.T) {
 	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
 	withWorkingDir(t, workspaceRoot)
 
+	client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{})
+
 	defaults := allowBundledSkillsForExecutionTests()
 	defaults.isInteractive = func() bool { return false }
 	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-	stdout, stderr, err := executeDaemonBackedCommandCapturingProcessIO(
+	stdout, stderr, err := executeCommandCapturingProcessIO(
 		t,
 		cmd,
 		nil,
 		"tasks",
 		"run-multiple",
 		"alpha,beta",
-		"--detach",
+		"--stream",
 		"--dry-run",
 	)
 	if err != nil {
-		t.Fatalf("execute in-process tasks run-multiple detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		t.Fatalf("execute in-process tasks run-multiple stream: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
 	if !strings.Contains(stderr, "preflight=ok") {
 		t.Fatalf("expected preflight success log on stderr, got %q", stderr)
 	}
-	if !containsAll(stdout, "task multi-run started:", "(mode=detach)") {
-		t.Fatalf("expected parent run id in detach stdout, got %q", stdout)
+	if !containsAll(
+		stdout,
+		"task multi-run started:",
+		"task queue started | mode=enqueued total=2",
+		"task[1/2] alpha queued",
+		"task[2/2] beta queued",
+		"task[1/2] alpha completed",
+		"task[2/2] beta completed",
+		"task queue completed | total=2",
+	) {
+		t.Fatalf("expected complete parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
+	}
+
+	runID := taskMultiRunIDFromCLIOutput(t, stdout)
+	snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
+	}
+	assertTaskMultiSnapshotItemsForCLI(t, snapshot, []string{"alpha", "beta"})
+}
+
+func TestTasksRunMultipleCommandInProcessParallelConfigStreamsEnqueuedQueue(t *testing.T) {
+	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+		[]string{
+			"status: pending",
+			"title: Alpha Task",
+			"type: backend",
+			"complexity: low",
+		},
+		"# Task 1: Alpha Task",
+	))
+	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+	writeCLIWorkspaceConfig(t, workspaceRoot, `
+[tasks.run]
+run_multiple_mode = "parallel"
+`)
+	withWorkingDir(t, workspaceRoot)
+
+	client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{})
+
+	defaults := allowBundledSkillsForExecutionTests()
+	defaults.isInteractive = func() bool { return false }
+	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+	stdout, stderr, err := executeCommandCapturingProcessIO(
+		t,
+		cmd,
+		nil,
+		"tasks",
+		"run-multiple",
+		"alpha,beta",
+		"--stream",
+		"--dry-run",
+	)
+	if err != nil {
+		t.Fatalf(
+			"execute in-process tasks run-multiple parallel stream: %v\nstdout:\n%s\nstderr:\n%s",
+			err,
+			stdout,
+			stderr,
+		)
+	}
+	if !containsAll(stderr, "V2", "worktree isolation", "enqueued") {
+		t.Fatalf("expected fallback message mentioning V2 and worktree isolation, got %q", stderr)
+	}
+	if !containsAll(
+		stdout,
+		"task queue started | mode=enqueued total=2",
+		"task[1/2] alpha completed",
+		"task[2/2] beta completed",
+	) {
+		t.Fatalf("expected enqueued parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
+	}
+
+	runID := taskMultiRunIDFromCLIOutput(t, stdout)
+	snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
+	}
+	assertTaskMultiSnapshotItemsForCLI(t, snapshot, []string{"alpha", "beta"})
+
+	started := taskMultiStartedPayloadForCLI(t, client, runID)
+	if started.Mode != "enqueued" {
+		t.Fatalf("task.multi.started mode = %q, want enqueued", started.Mode)
 	}
 }
 
@@ -2653,6 +2737,82 @@ func decodeExecJSONLEvents(t *testing.T, stdout string) []map[string]any {
 		events = append(events, payload)
 	}
 	return events
+}
+
+func taskMultiRunIDFromCLIOutput(t *testing.T, stdout string) string {
+	t.Helper()
+
+	const prefix = "task multi-run started: "
+	for _, line := range strings.Split(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, prefix) {
+			continue
+		}
+		runPart := strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
+		runID, _, ok := strings.Cut(runPart, " ")
+		if !ok || strings.TrimSpace(runID) == "" {
+			t.Fatalf("parse task multi-run id from line %q", line)
+		}
+		return runID
+	}
+	t.Fatalf("task multi-run start line not found in output:\n%s", stdout)
+	return ""
+}
+
+func assertTaskMultiSnapshotItemsForCLI(
+	t *testing.T,
+	snapshot apicore.TaskRunMultipleSnapshot,
+	wantSlugs []string,
+) {
+	t.Helper()
+
+	if snapshot.Run.Mode != "task_multi" {
+		t.Fatalf("snapshot parent mode = %q, want task_multi", snapshot.Run.Mode)
+	}
+	if snapshot.Run.Status != "completed" {
+		t.Fatalf("snapshot parent status = %q, want completed", snapshot.Run.Status)
+	}
+	if len(snapshot.Items) != len(wantSlugs) {
+		t.Fatalf("snapshot item count = %d, want %d: %#v", len(snapshot.Items), len(wantSlugs), snapshot.Items)
+	}
+	gotSlugs := make([]string, 0, len(snapshot.Items))
+	for _, item := range snapshot.Items {
+		gotSlugs = append(gotSlugs, item.Slug)
+		if item.Status != "completed" {
+			t.Fatalf("snapshot item %q status = %q, want completed", item.Slug, item.Status)
+		}
+		if strings.TrimSpace(item.RunID) == "" {
+			t.Fatalf("snapshot item %q is missing child run id", item.Slug)
+		}
+	}
+	if !slices.Equal(gotSlugs, wantSlugs) {
+		t.Fatalf("snapshot slugs = %#v, want %#v", gotSlugs, wantSlugs)
+	}
+}
+
+func taskMultiStartedPayloadForCLI(
+	t *testing.T,
+	client *inProcessDaemonCommandClient,
+	runID string,
+) kinds.TaskRunMultiplePayload {
+	t.Helper()
+
+	page, err := client.ListRunEvents(context.Background(), runID, apicore.StreamCursor{}, 100)
+	if err != nil {
+		t.Fatalf("ListRunEvents(%q) error = %v", runID, err)
+	}
+	for _, event := range page.Events {
+		if event.Kind != eventspkg.EventKindTaskRunMultipleStarted {
+			continue
+		}
+		var payload kinds.TaskRunMultiplePayload
+		if err := json.Unmarshal(event.Payload, &payload); err != nil {
+			t.Fatalf("decode %s payload: %v", event.Kind, err)
+		}
+		return payload
+	}
+	t.Fatalf("%s event not found for run %q", eventspkg.EventKindTaskRunMultipleStarted, runID)
+	return kinds.TaskRunMultiplePayload{}
 }
 
 func withWorkingDir(t *testing.T, dir string) {

--- a/internal/cli/root_command_execution_test.go
+++ b/internal/cli/root_command_execution_test.go
@@ -1258,17 +1258,17 @@ func TestTasksRunMultipleCommandRejectsInvalidSlugListsBeforeDaemon(t *testing.T
 		want string
 	}{
 		{
-			name: "missing",
+			name: "Should return error for missing slug",
 			args: []string{"tasks", "run-multiple"},
 			want: "workflow slug list is required",
 		},
 		{
-			name: "empty entry",
+			name: "Should return error for empty entry",
 			args: []string{"tasks", "run-multiple", "alpha,,beta"},
 			want: "task slug at position 2 cannot be empty",
 		},
 		{
-			name: "duplicate",
+			name: "Should return error for duplicate slug",
 			args: []string{"tasks", "run-multiple", "alpha,beta,alpha"},
 			want: "duplicate task slug \"alpha\"",
 		},

--- a/internal/cli/root_command_execution_test.go
+++ b/internal/cli/root_command_execution_test.go
@@ -1171,421 +1171,453 @@ func TestTasksRunCommandPositionalSlugSkipsInteractiveFormWithoutTTY(t *testing.
 }
 
 func TestTasksRunMultipleCommandDetachSendsOrderedSlugs(t *testing.T) {
-	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
-	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
-		[]string{
-			"status: pending",
-			"title: Alpha Task",
-			"type: backend",
-			"complexity: low",
-		},
-		"# Task 1: Alpha Task",
-	))
-	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
-	withWorkingDir(t, workspaceRoot)
+	t.Run("Should send ordered slugs for detached multi-run", func(t *testing.T) {
+		t.Parallel()
 
-	readyClient := &stubDaemonCommandClient{
-		target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
-		health: apicore.DaemonHealth{Ready: true},
-		startMultipleRun: apicore.Run{
-			RunID:            "run-task-multi-001",
-			Mode:             "task_multi",
-			Status:           "running",
-			PresentationMode: attachModeDetach,
-			StartedAt:        time.Date(2026, 4, 17, 13, 5, 45, 0, time.UTC),
-		},
-	}
-	installTestCLIReadyDaemonBootstrap(t, readyClient)
+		workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+		writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Alpha Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Alpha Task",
+		))
+		writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+		withWorkingDir(t, workspaceRoot)
 
-	defaults := allowBundledSkillsForExecutionTests()
-	defaults.isInteractive = func() bool { return false }
-	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-	stdout, stderr, err := executeCommandCapturingProcessIO(
-		t,
-		cmd,
-		nil,
-		"tasks",
-		"run",
-		"--multiple",
-		"alpha,beta",
-		"--detach",
-		"--dry-run",
-		"--include-completed",
-	)
-	if err != nil {
-		t.Fatalf("execute tasks run --multiple detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
-	}
-	if readyClient.startCalls != 0 {
-		t.Fatalf("StartTaskRun calls = %d, want 0", readyClient.startCalls)
-	}
-	if readyClient.startMultipleCalls != 1 {
-		t.Fatalf("StartTaskRunMultiple calls = %d, want 1", readyClient.startMultipleCalls)
-	}
-	if !slices.Equal(readyClient.startMultipleRequest.Slugs, []string{"alpha", "beta"}) {
-		t.Fatalf("unexpected multi-run slugs: %#v", readyClient.startMultipleRequest.Slugs)
-	}
-	resolvedWorkspaceRoot, err := filepath.EvalSymlinks(workspaceRoot)
-	if err != nil {
-		t.Fatalf("resolve workspace root symlinks: %v", err)
-	}
-	if readyClient.startMultipleRequest.Workspace != resolvedWorkspaceRoot {
-		t.Fatalf("workspace = %q, want %q", readyClient.startMultipleRequest.Workspace, resolvedWorkspaceRoot)
-	}
-	if readyClient.startMultipleRequest.Mode != "enqueued" {
-		t.Fatalf("mode = %q, want enqueued", readyClient.startMultipleRequest.Mode)
-	}
-	if readyClient.startMultipleRequest.PresentationMode != attachModeDetach {
-		t.Fatalf("presentation mode = %q, want detach", readyClient.startMultipleRequest.PresentationMode)
-	}
-	overrides := decodeTaskRunOverrides(t, readyClient.startMultipleRequest.RuntimeOverrides)
-	if overrides.DryRun == nil || !*overrides.DryRun {
-		t.Fatalf("expected dry-run runtime override, got %#v", overrides.DryRun)
-	}
-	if overrides.IncludeCompleted == nil || !*overrides.IncludeCompleted {
-		t.Fatalf("expected include-completed runtime override, got %#v", overrides.IncludeCompleted)
-	}
-	if !strings.Contains(stderr, "preflight=ok") {
-		t.Fatalf("expected preflight success log on stderr, got %q", stderr)
-	}
-	if got := stdout; got != "task multi-run started: run-task-multi-001 (mode=detach)\n" {
-		t.Fatalf("unexpected stdout: %q", got)
-	}
+		readyClient := &stubDaemonCommandClient{
+			target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
+			health: apicore.DaemonHealth{Ready: true},
+			startMultipleRun: apicore.Run{
+				RunID:            "run-task-multi-001",
+				Mode:             "task_multi",
+				Status:           "running",
+				PresentationMode: attachModeDetach,
+				StartedAt:        time.Date(2026, 4, 17, 13, 5, 45, 0, time.UTC),
+			},
+		}
+		installTestCLIReadyDaemonBootstrap(t, readyClient)
+
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(
+			t,
+			cmd,
+			nil,
+			"tasks",
+			"run",
+			"--multiple",
+			"alpha,beta",
+			"--detach",
+			"--dry-run",
+			"--include-completed",
+		)
+		if err != nil {
+			t.Fatalf("execute tasks run --multiple detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if readyClient.startCalls != 0 {
+			t.Fatalf("StartTaskRun calls = %d, want 0", readyClient.startCalls)
+		}
+		if readyClient.startMultipleCalls != 1 {
+			t.Fatalf("StartTaskRunMultiple calls = %d, want 1", readyClient.startMultipleCalls)
+		}
+		if !slices.Equal(readyClient.startMultipleRequest.Slugs, []string{"alpha", "beta"}) {
+			t.Fatalf("unexpected multi-run slugs: %#v", readyClient.startMultipleRequest.Slugs)
+		}
+		resolvedWorkspaceRoot, err := filepath.EvalSymlinks(workspaceRoot)
+		if err != nil {
+			t.Fatalf("resolve workspace root symlinks: %v", err)
+		}
+		if readyClient.startMultipleRequest.Workspace != resolvedWorkspaceRoot {
+			t.Fatalf("workspace = %q, want %q", readyClient.startMultipleRequest.Workspace, resolvedWorkspaceRoot)
+		}
+		if readyClient.startMultipleRequest.Mode != "enqueued" {
+			t.Fatalf("mode = %q, want enqueued", readyClient.startMultipleRequest.Mode)
+		}
+		if readyClient.startMultipleRequest.PresentationMode != attachModeDetach {
+			t.Fatalf("presentation mode = %q, want detach", readyClient.startMultipleRequest.PresentationMode)
+		}
+		overrides := decodeTaskRunOverrides(t, readyClient.startMultipleRequest.RuntimeOverrides)
+		if overrides.DryRun == nil || !*overrides.DryRun {
+			t.Fatalf("expected dry-run runtime override, got %#v", overrides.DryRun)
+		}
+		if overrides.IncludeCompleted == nil || !*overrides.IncludeCompleted {
+			t.Fatalf("expected include-completed runtime override, got %#v", overrides.IncludeCompleted)
+		}
+		if !strings.Contains(stderr, "preflight=ok") {
+			t.Fatalf("expected preflight success log on stderr, got %q", stderr)
+		}
+		if got := stdout; got != "task multi-run started: run-task-multi-001 (mode=detach)\n" {
+			t.Fatalf("unexpected stdout: %q", got)
+		}
+	})
 }
 
 func TestTasksRunMultipleCommandRejectsInvalidSlugListsBeforeDaemon(t *testing.T) {
-	cases := []struct {
-		name string
-		args []string
-		want string
-	}{
-		{
-			name: "Should return error for missing slug",
-			args: []string{"tasks", "run", "--multiple", ""},
-			want: "workflow slug list is required",
-		},
-		{
-			name: "Should return error for empty entry",
-			args: []string{"tasks", "run", "--multiple", "alpha,,beta"},
-			want: "task slug at position 2 cannot be empty",
-		},
-		{
-			name: "Should return error for duplicate slug",
-			args: []string{"tasks", "run", "--multiple", "alpha,beta,alpha"},
-			want: "duplicate task slug \"alpha\"",
-		},
-	}
+	t.Run("Should reject invalid slug lists before daemon", func(t *testing.T) {
+		t.Parallel()
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
-				resolveHomePaths: func() (compozyconfig.HomePaths, error) {
-					t.Fatal("daemon bootstrap should not run for invalid slug input")
-					return compozyconfig.HomePaths{}, nil
-				},
+		cases := []struct {
+			name string
+			args []string
+			want string
+		}{
+			{
+				name: "Should return error for missing slug",
+				args: []string{"tasks", "run", "--multiple", ""},
+				want: "workflow slug list is required",
+			},
+			{
+				name: "Should return error for empty entry",
+				args: []string{"tasks", "run", "--multiple", "alpha,,beta"},
+				want: "task slug at position 2 cannot be empty",
+			},
+			{
+				name: "Should return error for duplicate slug",
+				args: []string{"tasks", "run", "--multiple", "alpha,beta,alpha"},
+				want: "duplicate task slug \"alpha\"",
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
+					resolveHomePaths: func() (compozyconfig.HomePaths, error) {
+						t.Fatal("daemon bootstrap should not run for invalid slug input")
+						return compozyconfig.HomePaths{}, nil
+					},
+				})
+
+				defaults := allowBundledSkillsForExecutionTests()
+				defaults.isInteractive = func() bool { return false }
+				cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+				stdout, stderr, err := executeCommandCapturingProcessIO(t, cmd, nil, tc.args...)
+				if err == nil {
+					t.Fatalf("expected slug validation error\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+				}
+				var exitErr *commandExitError
+				if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+					t.Fatalf("expected exit code 1, got %v", err)
+				}
+				if stdout != "" {
+					t.Fatalf("expected no stdout, got %q", stdout)
+				}
+				if !strings.Contains(stderr, tc.want) {
+					t.Fatalf("stderr = %q, want %q", stderr, tc.want)
+				}
 			})
-
-			defaults := allowBundledSkillsForExecutionTests()
-			defaults.isInteractive = func() bool { return false }
-			cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-			stdout, stderr, err := executeCommandCapturingProcessIO(t, cmd, nil, tc.args...)
-			if err == nil {
-				t.Fatalf("expected slug validation error\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-			}
-			var exitErr *commandExitError
-			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
-				t.Fatalf("expected exit code 1, got %v", err)
-			}
-			if stdout != "" {
-				t.Fatalf("expected no stdout, got %q", stdout)
-			}
-			if !strings.Contains(stderr, tc.want) {
-				t.Fatalf("stderr = %q, want %q", stderr, tc.want)
-			}
-		})
-	}
+		}
+	})
 }
 
 func TestTasksRunMultipleCommandParallelConfigFallsBackToEnqueued(t *testing.T) {
-	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
-	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
-		[]string{
-			"status: pending",
-			"title: Alpha Task",
-			"type: backend",
-			"complexity: low",
-		},
-		"# Task 1: Alpha Task",
-	))
-	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
-	writeCLIWorkspaceConfig(t, workspaceRoot, `
+	t.Run("Should fall back parallel config to enqueued", func(t *testing.T) {
+		t.Parallel()
+
+		workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+		writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Alpha Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Alpha Task",
+		))
+		writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+		writeCLIWorkspaceConfig(t, workspaceRoot, `
 [tasks.run]
 run_multiple_mode = "parallel"
 `)
-	withWorkingDir(t, workspaceRoot)
+		withWorkingDir(t, workspaceRoot)
 
-	readyClient := &stubDaemonCommandClient{
-		target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
-		health: apicore.DaemonHealth{Ready: true},
-		startMultipleRun: apicore.Run{
-			RunID:            "run-task-multi-parallel",
-			Mode:             "task_multi",
-			Status:           "running",
-			PresentationMode: attachModeDetach,
-			StartedAt:        time.Date(2026, 4, 17, 13, 7, 0, 0, time.UTC),
-		},
-	}
-	installTestCLIReadyDaemonBootstrap(t, readyClient)
+		readyClient := &stubDaemonCommandClient{
+			target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
+			health: apicore.DaemonHealth{Ready: true},
+			startMultipleRun: apicore.Run{
+				RunID:            "run-task-multi-parallel",
+				Mode:             "task_multi",
+				Status:           "running",
+				PresentationMode: attachModeDetach,
+				StartedAt:        time.Date(2026, 4, 17, 13, 7, 0, 0, time.UTC),
+			},
+		}
+		installTestCLIReadyDaemonBootstrap(t, readyClient)
 
-	defaults := allowBundledSkillsForExecutionTests()
-	defaults.isInteractive = func() bool { return false }
-	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-	stdout, stderr, err := executeCommandCapturingProcessIO(
-		t,
-		cmd,
-		nil,
-		"tasks",
-		"run",
-		"--multiple",
-		"alpha,beta",
-		"--detach",
-	)
-	if err != nil {
-		t.Fatalf("execute tasks run --multiple parallel fallback: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
-	}
-	if readyClient.startMultipleRequest.Mode != "enqueued" {
-		t.Fatalf("mode = %q, want enqueued fallback", readyClient.startMultipleRequest.Mode)
-	}
-	if !containsAll(stderr, "V2", "worktree isolation", "enqueued") {
-		t.Fatalf("expected fallback message mentioning V2 and worktree isolation, got %q", stderr)
-	}
-	if !strings.Contains(stdout, "task multi-run started: run-task-multi-parallel") {
-		t.Fatalf("unexpected stdout: %q", stdout)
-	}
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(
+			t,
+			cmd,
+			nil,
+			"tasks",
+			"run",
+			"--multiple",
+			"alpha,beta",
+			"--detach",
+		)
+		if err != nil {
+			t.Fatalf(
+				"execute tasks run --multiple parallel fallback: %v\nstdout:\n%s\nstderr:\n%s",
+				err,
+				stdout,
+				stderr,
+			)
+		}
+		if readyClient.startMultipleRequest.Mode != "enqueued" {
+			t.Fatalf("mode = %q, want enqueued fallback", readyClient.startMultipleRequest.Mode)
+		}
+		if !containsAll(stderr, "V2", "worktree isolation", "enqueued") {
+			t.Fatalf("expected fallback message mentioning V2 and worktree isolation, got %q", stderr)
+		}
+		if !strings.Contains(stdout, "task multi-run started: run-task-multi-parallel") {
+			t.Fatalf("unexpected stdout: %q", stdout)
+		}
+	})
 }
 
 func TestTasksRunCommandStillCallsSingleRunClient(t *testing.T) {
-	workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
-	writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
-		[]string{
-			"status: pending",
-			"title: Demo Task",
-			"type: backend",
-			"complexity: low",
-		},
-		"# Task 1: Demo Task",
-	))
-	withWorkingDir(t, workspaceRoot)
+	t.Run("Should still call single run client", func(t *testing.T) {
+		t.Parallel()
 
-	readyClient := &stubDaemonCommandClient{
-		target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
-		health: apicore.DaemonHealth{Ready: true},
-		startRun: apicore.Run{
-			RunID:            "run-task-single-stable",
-			Mode:             string(core.ModePRDTasks),
-			Status:           "running",
-			PresentationMode: attachModeDetach,
-			StartedAt:        time.Date(2026, 4, 17, 13, 7, 30, 0, time.UTC),
-		},
-	}
-	installTestCLIReadyDaemonBootstrap(t, readyClient)
+		workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
+		writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Demo Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Demo Task",
+		))
+		withWorkingDir(t, workspaceRoot)
 
-	defaults := allowBundledSkillsForExecutionTests()
-	defaults.isInteractive = func() bool { return false }
-	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-	stdout, stderr, err := executeCommandCapturingProcessIO(t, cmd, nil, "tasks", "run", "demo", "--detach")
-	if err != nil {
-		t.Fatalf("execute tasks run detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
-	}
-	if readyClient.startCalls != 1 {
-		t.Fatalf("StartTaskRun calls = %d, want 1", readyClient.startCalls)
-	}
-	if readyClient.startMultipleCalls != 0 {
-		t.Fatalf("StartTaskRunMultiple calls = %d, want 0", readyClient.startMultipleCalls)
-	}
-	if readyClient.startSlug != "demo" {
-		t.Fatalf("single-run slug = %q, want demo", readyClient.startSlug)
-	}
-	if !strings.Contains(stdout, "task run started: run-task-single-stable (mode=detach)") {
-		t.Fatalf("unexpected stdout: %q", stdout)
-	}
+		readyClient := &stubDaemonCommandClient{
+			target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
+			health: apicore.DaemonHealth{Ready: true},
+			startRun: apicore.Run{
+				RunID:            "run-task-single-stable",
+				Mode:             string(core.ModePRDTasks),
+				Status:           "running",
+				PresentationMode: attachModeDetach,
+				StartedAt:        time.Date(2026, 4, 17, 13, 7, 30, 0, time.UTC),
+			},
+		}
+		installTestCLIReadyDaemonBootstrap(t, readyClient)
+
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(t, cmd, nil, "tasks", "run", "demo", "--detach")
+		if err != nil {
+			t.Fatalf("execute tasks run detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if readyClient.startCalls != 1 {
+			t.Fatalf("StartTaskRun calls = %d, want 1", readyClient.startCalls)
+		}
+		if readyClient.startMultipleCalls != 0 {
+			t.Fatalf("StartTaskRunMultiple calls = %d, want 0", readyClient.startMultipleCalls)
+		}
+		if readyClient.startSlug != "demo" {
+			t.Fatalf("single-run slug = %q, want demo", readyClient.startSlug)
+		}
+		if !strings.Contains(stdout, "task run started: run-task-single-stable (mode=detach)") {
+			t.Fatalf("unexpected stdout: %q", stdout)
+		}
+	})
 }
 
 func TestTasksRunMultipleCommandInProcessStreamReconstructsParentQueueState(t *testing.T) {
-	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
-	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
-		[]string{
-			"status: pending",
-			"title: Alpha Task",
-			"type: backend",
-			"complexity: low",
-		},
-		"# Task 1: Alpha Task",
-	))
-	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
-	withWorkingDir(t, workspaceRoot)
+	t.Run("Should reconstruct parent queue state while streaming in process", func(t *testing.T) {
+		workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+		writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Alpha Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Alpha Task",
+		))
+		writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+		withWorkingDir(t, workspaceRoot)
 
-	client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{})
+		client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{})
 
-	defaults := allowBundledSkillsForExecutionTests()
-	defaults.isInteractive = func() bool { return false }
-	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-	stdout, stderr, err := executeCommandCapturingProcessIO(
-		t,
-		cmd,
-		nil,
-		"tasks",
-		"run",
-		"--multiple",
-		"alpha,beta",
-		"--stream",
-		"--dry-run",
-	)
-	if err != nil {
-		t.Fatalf("execute in-process tasks run --multiple stream: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
-	}
-	if !strings.Contains(stderr, "preflight=ok") {
-		t.Fatalf("expected preflight success log on stderr, got %q", stderr)
-	}
-	if !containsAll(
-		stdout,
-		"task multi-run started:",
-		"task queue started | mode=enqueued total=2",
-		"task[1/2] alpha queued",
-		"task[2/2] beta queued",
-		"task[1/2] alpha completed",
-		"task[2/2] beta completed",
-		"task queue completed | total=2",
-	) {
-		t.Fatalf("expected complete parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
-	}
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(
+			t,
+			cmd,
+			nil,
+			"tasks",
+			"run",
+			"--multiple",
+			"alpha,beta",
+			"--stream",
+			"--dry-run",
+		)
+		if err != nil {
+			t.Fatalf(
+				"execute in-process tasks run --multiple stream: %v\nstdout:\n%s\nstderr:\n%s",
+				err,
+				stdout,
+				stderr,
+			)
+		}
+		if !strings.Contains(stderr, "preflight=ok") {
+			t.Fatalf("expected preflight success log on stderr, got %q", stderr)
+		}
+		if !containsAll(
+			stdout,
+			"task multi-run started:",
+			"task queue started | mode=enqueued total=2",
+			"task[1/2] alpha queued",
+			"task[2/2] beta queued",
+			"task[1/2] alpha completed",
+			"task[2/2] beta completed",
+			"task queue completed | total=2",
+		) {
+			t.Fatalf("expected complete parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
+		}
 
-	runID := taskMultiRunIDFromCLIOutput(t, stdout)
-	snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
-	if err != nil {
-		t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
-	}
-	assertTaskMultiSnapshotItemsForCLI(t, snapshot, []string{"alpha", "beta"})
+		runID := taskMultiRunIDFromCLIOutput(t, stdout)
+		snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
+		}
+		assertTaskMultiSnapshotItemsForCLI(t, snapshot, []string{"alpha", "beta"})
+	})
 }
 
 func TestTasksRunMultipleCommandInProcessParallelConfigStreamsEnqueuedQueue(t *testing.T) {
-	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
-	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
-		[]string{
-			"status: pending",
-			"title: Alpha Task",
-			"type: backend",
-			"complexity: low",
-		},
-		"# Task 1: Alpha Task",
-	))
-	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
-	writeCLIWorkspaceConfig(t, workspaceRoot, `
+	t.Run("Should stream enqueued queue for in-process parallel config fallback", func(t *testing.T) {
+		workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+		writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Alpha Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Alpha Task",
+		))
+		writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+		writeCLIWorkspaceConfig(t, workspaceRoot, `
 [tasks.run]
 run_multiple_mode = "parallel"
 `)
-	withWorkingDir(t, workspaceRoot)
+		withWorkingDir(t, workspaceRoot)
 
-	client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{})
+		client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{})
 
-	defaults := allowBundledSkillsForExecutionTests()
-	defaults.isInteractive = func() bool { return false }
-	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-	stdout, stderr, err := executeCommandCapturingProcessIO(
-		t,
-		cmd,
-		nil,
-		"tasks",
-		"run",
-		"--multiple",
-		"alpha,beta",
-		"--stream",
-		"--dry-run",
-	)
-	if err != nil {
-		t.Fatalf(
-			"execute in-process tasks run --multiple parallel stream: %v\nstdout:\n%s\nstderr:\n%s",
-			err,
-			stdout,
-			stderr,
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(
+			t,
+			cmd,
+			nil,
+			"tasks",
+			"run",
+			"--multiple",
+			"alpha,beta",
+			"--stream",
+			"--dry-run",
 		)
-	}
-	if !containsAll(stderr, "V2", "worktree isolation", "enqueued") {
-		t.Fatalf("expected fallback message mentioning V2 and worktree isolation, got %q", stderr)
-	}
-	if !containsAll(
-		stdout,
-		"task queue started | mode=enqueued total=2",
-		"task[1/2] alpha completed",
-		"task[2/2] beta completed",
-	) {
-		t.Fatalf("expected enqueued parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
-	}
+		if err != nil {
+			t.Fatalf(
+				"execute in-process tasks run --multiple parallel stream: %v\nstdout:\n%s\nstderr:\n%s",
+				err,
+				stdout,
+				stderr,
+			)
+		}
+		if !containsAll(stderr, "V2", "worktree isolation", "enqueued") {
+			t.Fatalf("expected fallback message mentioning V2 and worktree isolation, got %q", stderr)
+		}
+		if !containsAll(
+			stdout,
+			"task queue started | mode=enqueued total=2",
+			"task[1/2] alpha completed",
+			"task[2/2] beta completed",
+		) {
+			t.Fatalf("expected enqueued parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
+		}
 
-	runID := taskMultiRunIDFromCLIOutput(t, stdout)
-	snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
-	if err != nil {
-		t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
-	}
-	assertTaskMultiSnapshotItemsForCLI(t, snapshot, []string{"alpha", "beta"})
+		runID := taskMultiRunIDFromCLIOutput(t, stdout)
+		snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
+		}
+		assertTaskMultiSnapshotItemsForCLI(t, snapshot, []string{"alpha", "beta"})
 
-	started := taskMultiStartedPayloadForCLI(t, client, runID)
-	if started.Mode != "enqueued" {
-		t.Fatalf("task.multi.started mode = %q, want enqueued", started.Mode)
-	}
+		started := taskMultiStartedPayloadForCLI(t, client, runID)
+		if started.Mode != "enqueued" {
+			t.Fatalf("task.multi.started mode = %q, want enqueued", started.Mode)
+		}
+	})
 }
 
 func TestTasksRunMultipleCommandStreamReturnsNonZeroOnParentFailure(t *testing.T) {
-	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
-	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
-		[]string{
-			"status: pending",
-			"title: Alpha Task",
-			"type: backend",
-			"complexity: low",
-		},
-		"# Task 1: Alpha Task",
-	))
-	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
-	withWorkingDir(t, workspaceRoot)
+	t.Run("Should return non-zero when streamed parent fails", func(t *testing.T) {
+		workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+		writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Alpha Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Alpha Task",
+		))
+		writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+		withWorkingDir(t, workspaceRoot)
 
-	installInProcessCLIDaemonBootstrapWithConfig(t, daemon.RunManagerConfig{
-		Execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
-			return errors.New("forced child failure")
-		},
+		installInProcessCLIDaemonBootstrapWithConfig(t, daemon.RunManagerConfig{
+			Execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
+				return errors.New("forced child failure")
+			},
+		})
+
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(
+			t,
+			cmd,
+			nil,
+			"tasks",
+			"run",
+			"--multiple",
+			"alpha,beta",
+			"--stream",
+			"--dry-run",
+		)
+		if err == nil {
+			t.Fatalf("expected stream failure exit\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+		}
+		var exitErr *commandExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			t.Fatalf("expected exit code 1 for failed parent, got %v", err)
+		}
+		if !containsAll(
+			stdout,
+			"task multi-run started:",
+			"task queue started",
+			"task[1/2] alpha",
+			"failed",
+			"forced child failure",
+			"run failed",
+		) {
+			t.Fatalf("expected parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
+		}
 	})
-
-	defaults := allowBundledSkillsForExecutionTests()
-	defaults.isInteractive = func() bool { return false }
-	cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-	stdout, stderr, err := executeCommandCapturingProcessIO(
-		t,
-		cmd,
-		nil,
-		"tasks",
-		"run",
-		"--multiple",
-		"alpha,beta",
-		"--stream",
-		"--dry-run",
-	)
-	if err == nil {
-		t.Fatalf("expected stream failure exit\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
-	}
-	var exitErr *commandExitError
-	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
-		t.Fatalf("expected exit code 1 for failed parent, got %v", err)
-	}
-	if !containsAll(
-		stdout,
-		"task multi-run started:",
-		"task queue started",
-		"task[1/2] alpha",
-		"failed",
-		"forced child failure",
-		"run failed",
-	) {
-		t.Fatalf("expected parent queue stream output, got %q\nstderr:\n%s", stdout, stderr)
-	}
 }
 
 func TestTasksRunCommandNoFlagsUsesInteractiveForm(t *testing.T) {

--- a/internal/cli/root_command_execution_test.go
+++ b/internal/cli/root_command_execution_test.go
@@ -1205,14 +1205,15 @@ func TestTasksRunMultipleCommandDetachSendsOrderedSlugs(t *testing.T) {
 		cmd,
 		nil,
 		"tasks",
-		"run-multiple",
+		"run",
+		"--multiple",
 		"alpha,beta",
 		"--detach",
 		"--dry-run",
 		"--include-completed",
 	)
 	if err != nil {
-		t.Fatalf("execute tasks run-multiple detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		t.Fatalf("execute tasks run --multiple detach: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
 	if readyClient.startCalls != 0 {
 		t.Fatalf("StartTaskRun calls = %d, want 0", readyClient.startCalls)
@@ -1259,17 +1260,17 @@ func TestTasksRunMultipleCommandRejectsInvalidSlugListsBeforeDaemon(t *testing.T
 	}{
 		{
 			name: "Should return error for missing slug",
-			args: []string{"tasks", "run-multiple"},
+			args: []string{"tasks", "run", "--multiple", ""},
 			want: "workflow slug list is required",
 		},
 		{
 			name: "Should return error for empty entry",
-			args: []string{"tasks", "run-multiple", "alpha,,beta"},
+			args: []string{"tasks", "run", "--multiple", "alpha,,beta"},
 			want: "task slug at position 2 cannot be empty",
 		},
 		{
 			name: "Should return error for duplicate slug",
-			args: []string{"tasks", "run-multiple", "alpha,beta,alpha"},
+			args: []string{"tasks", "run", "--multiple", "alpha,beta,alpha"},
 			want: "duplicate task slug \"alpha\"",
 		},
 	}
@@ -1343,12 +1344,13 @@ run_multiple_mode = "parallel"
 		cmd,
 		nil,
 		"tasks",
-		"run-multiple",
+		"run",
+		"--multiple",
 		"alpha,beta",
 		"--detach",
 	)
 	if err != nil {
-		t.Fatalf("execute tasks run-multiple parallel fallback: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		t.Fatalf("execute tasks run --multiple parallel fallback: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
 	if readyClient.startMultipleRequest.Mode != "enqueued" {
 		t.Fatalf("mode = %q, want enqueued fallback", readyClient.startMultipleRequest.Mode)
@@ -1432,13 +1434,14 @@ func TestTasksRunMultipleCommandInProcessStreamReconstructsParentQueueState(t *t
 		cmd,
 		nil,
 		"tasks",
-		"run-multiple",
+		"run",
+		"--multiple",
 		"alpha,beta",
 		"--stream",
 		"--dry-run",
 	)
 	if err != nil {
-		t.Fatalf("execute in-process tasks run-multiple stream: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		t.Fatalf("execute in-process tasks run --multiple stream: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
 	}
 	if !strings.Contains(stderr, "preflight=ok") {
 		t.Fatalf("expected preflight success log on stderr, got %q", stderr)
@@ -1492,14 +1495,15 @@ run_multiple_mode = "parallel"
 		cmd,
 		nil,
 		"tasks",
-		"run-multiple",
+		"run",
+		"--multiple",
 		"alpha,beta",
 		"--stream",
 		"--dry-run",
 	)
 	if err != nil {
 		t.Fatalf(
-			"execute in-process tasks run-multiple parallel stream: %v\nstdout:\n%s\nstderr:\n%s",
+			"execute in-process tasks run --multiple parallel stream: %v\nstdout:\n%s\nstderr:\n%s",
 			err,
 			stdout,
 			stderr,
@@ -1558,7 +1562,8 @@ func TestTasksRunMultipleCommandStreamReturnsNonZeroOnParentFailure(t *testing.T
 		cmd,
 		nil,
 		"tasks",
-		"run-multiple",
+		"run",
+		"--multiple",
 		"alpha,beta",
 		"--stream",
 		"--dry-run",

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -451,58 +451,60 @@ func TestTasksRunHelpShowsDaemonTaskFlagsOnly(t *testing.T) {
 }
 
 func TestTasksRunMultipleHelpShowsExamplesAndSharedTaskFlags(t *testing.T) {
-	t.Parallel()
+	t.Run("Should show examples and shared task flags in help output", func(t *testing.T) {
+		t.Parallel()
 
-	cmd := findNestedCommand(t, NewRootCommand(), "tasks", "run-multiple [slugs]")
-	if cmd.Flags().Lookup("name") != nil {
-		t.Fatal("expected tasks run-multiple to omit --name")
-	}
-
-	output, err := executeRootCommand("tasks", "run-multiple", "--help")
-	if err != nil {
-		t.Fatalf("execute tasks run-multiple help: %v", err)
-	}
-
-	required := []string{
-		"compozy tasks run-multiple alpha,beta --stream",
-		"compozy tasks run-multiple alpha,beta --detach",
-		"compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5",
-		"one comma-separated positional slug list",
-		"configured parallel mode prints a V2 worktree-isolation",
-		"--attach",
-		"--detach",
-		"--stream",
-		"--ui",
-		"--include-completed",
-		"--skip-validation",
-		"--force",
-		"--task-runtime",
-	}
-	for _, snippet := range required {
-		if !strings.Contains(output, snippet) {
-			t.Fatalf("expected tasks run-multiple help to include %q\noutput:\n%s", snippet, output)
+		cmd := findNestedCommand(t, NewRootCommand(), "tasks", "run-multiple [slugs]")
+		if cmd.Flags().Lookup("name") != nil {
+			t.Fatal("expected tasks run-multiple to omit --name")
 		}
-	}
 
-	forbidden := []string{
-		"--name",
-		"--pr",
-		"--provider",
-		"--reviews-dir",
-		"--batch-size",
-		"--concurrent",
-		"--format",
-		"--grouped",
-		"--include-resolved",
-		"--tasks-dir",
-		"--form ",
-		"--tui",
-	}
-	for _, snippet := range forbidden {
-		if strings.Contains(output, snippet) {
-			t.Fatalf("expected tasks run-multiple help to omit %q\noutput:\n%s", snippet, output)
+		output, err := executeRootCommand("tasks", "run-multiple", "--help")
+		if err != nil {
+			t.Fatalf("execute tasks run-multiple help: %v", err)
 		}
-	}
+
+		required := []string{
+			"compozy tasks run-multiple alpha,beta --stream",
+			"compozy tasks run-multiple alpha,beta --detach",
+			"compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5",
+			"one comma-separated positional slug list",
+			"configured parallel mode prints a V2 worktree-isolation",
+			"--attach",
+			"--detach",
+			"--stream",
+			"--ui",
+			"--include-completed",
+			"--skip-validation",
+			"--force",
+			"--task-runtime",
+		}
+		for _, snippet := range required {
+			if !strings.Contains(output, snippet) {
+				t.Fatalf("expected tasks run-multiple help to include %q\noutput:\n%s", snippet, output)
+			}
+		}
+
+		forbidden := []string{
+			"--name",
+			"--pr",
+			"--provider",
+			"--reviews-dir",
+			"--batch-size",
+			"--concurrent",
+			"--format",
+			"--grouped",
+			"--include-resolved",
+			"--tasks-dir",
+			"--form ",
+			"--tui",
+		}
+		for _, snippet := range forbidden {
+			if strings.Contains(output, snippet) {
+				t.Fatalf("expected tasks run-multiple help to omit %q\noutput:\n%s", snippet, output)
+			}
+		}
+	})
 }
 
 func TestExecHelpShowsExecFlagsOnly(t *testing.T) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -450,6 +450,61 @@ func TestTasksRunHelpShowsDaemonTaskFlagsOnly(t *testing.T) {
 	}
 }
 
+func TestTasksRunMultipleHelpShowsExamplesAndSharedTaskFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := findNestedCommand(t, NewRootCommand(), "tasks", "run-multiple [slugs]")
+	if cmd.Flags().Lookup("name") != nil {
+		t.Fatal("expected tasks run-multiple to omit --name")
+	}
+
+	output, err := executeRootCommand("tasks", "run-multiple", "--help")
+	if err != nil {
+		t.Fatalf("execute tasks run-multiple help: %v", err)
+	}
+
+	required := []string{
+		"compozy tasks run-multiple alpha,beta --stream",
+		"compozy tasks run-multiple alpha,beta --detach",
+		"compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5",
+		"one comma-separated positional slug list",
+		"configured parallel mode prints a V2 worktree-isolation",
+		"--attach",
+		"--detach",
+		"--stream",
+		"--ui",
+		"--include-completed",
+		"--skip-validation",
+		"--force",
+		"--task-runtime",
+	}
+	for _, snippet := range required {
+		if !strings.Contains(output, snippet) {
+			t.Fatalf("expected tasks run-multiple help to include %q\noutput:\n%s", snippet, output)
+		}
+	}
+
+	forbidden := []string{
+		"--name",
+		"--pr",
+		"--provider",
+		"--reviews-dir",
+		"--batch-size",
+		"--concurrent",
+		"--format",
+		"--grouped",
+		"--include-resolved",
+		"--tasks-dir",
+		"--form ",
+		"--tui",
+	}
+	for _, snippet := range forbidden {
+		if strings.Contains(output, snippet) {
+			t.Fatalf("expected tasks run-multiple help to omit %q\noutput:\n%s", snippet, output)
+		}
+	}
+}
+
 func TestExecHelpShowsExecFlagsOnly(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -450,26 +450,30 @@ func TestTasksRunHelpShowsDaemonTaskFlagsOnly(t *testing.T) {
 	}
 }
 
-func TestTasksRunMultipleHelpShowsExamplesAndSharedTaskFlags(t *testing.T) {
-	t.Run("Should show examples and shared task flags in help output", func(t *testing.T) {
+func TestTasksRunHelpShowsMultipleExamplesAndSharedTaskFlags(t *testing.T) {
+	t.Run("Should show multiple examples and shared task flags in help output", func(t *testing.T) {
 		t.Parallel()
 
-		cmd := findNestedCommand(t, NewRootCommand(), "tasks", "run-multiple [slugs]")
-		if cmd.Flags().Lookup("name") != nil {
-			t.Fatal("expected tasks run-multiple to omit --name")
+		cmd := findNestedCommand(t, NewRootCommand(), "tasks", "run [slug]")
+		if cmd.Flags().Lookup("name") == nil {
+			t.Fatal("expected tasks run to preserve --name")
+		}
+		if cmd.Flags().Lookup("multiple") == nil {
+			t.Fatal("expected tasks run to include --multiple")
 		}
 
-		output, err := executeRootCommand("tasks", "run-multiple", "--help")
+		output, err := executeRootCommand("tasks", "run", "--help")
 		if err != nil {
-			t.Fatalf("execute tasks run-multiple help: %v", err)
+			t.Fatalf("execute tasks run help: %v", err)
 		}
 
 		required := []string{
-			"compozy tasks run-multiple alpha,beta --stream",
-			"compozy tasks run-multiple alpha,beta --detach",
-			"compozy tasks run-multiple alpha,beta --ide codex --model gpt-5.5",
-			"one comma-separated positional slug list",
+			"compozy tasks run --multiple alpha,beta --stream",
+			"compozy tasks run --multiple alpha,beta --detach",
+			"compozy tasks run --multiple alpha,beta --ide codex --model gpt-5.5",
+			"one comma-separated slug list",
 			"configured parallel mode prints a V2 worktree-isolation",
+			"--multiple",
 			"--attach",
 			"--detach",
 			"--stream",
@@ -481,12 +485,11 @@ func TestTasksRunMultipleHelpShowsExamplesAndSharedTaskFlags(t *testing.T) {
 		}
 		for _, snippet := range required {
 			if !strings.Contains(output, snippet) {
-				t.Fatalf("expected tasks run-multiple help to include %q\noutput:\n%s", snippet, output)
+				t.Fatalf("expected tasks run help to include %q\noutput:\n%s", snippet, output)
 			}
 		}
 
 		forbidden := []string{
-			"--name",
 			"--pr",
 			"--provider",
 			"--reviews-dir",
@@ -501,7 +504,7 @@ func TestTasksRunMultipleHelpShowsExamplesAndSharedTaskFlags(t *testing.T) {
 		}
 		for _, snippet := range forbidden {
 			if strings.Contains(output, snippet) {
-				t.Fatalf("expected tasks run-multiple help to omit %q\noutput:\n%s", snippet, output)
+				t.Fatalf("expected tasks run help to omit %q\noutput:\n%s", snippet, output)
 			}
 		}
 	})

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -246,5 +246,5 @@ func (s *commandState) preflightTaskMetadata(ctx context.Context, cmd *cobra.Com
 }
 
 func isTaskRunCommandKind(kind commandKind) bool {
-	return kind == commandKindTasksRun || kind == commandKindTasksRunMultiple
+	return kind == commandKindTasksRun
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -210,7 +210,7 @@ func isReusableAgentValidationText(err error) bool {
 }
 
 func (s *commandState) preflightTaskMetadata(ctx context.Context, cmd *cobra.Command, cfg core.Config) error {
-	if s.kind != commandKindTasksRun || cfg.Mode != core.ModePRDTasks {
+	if !isTaskRunCommandKind(s.kind) || cfg.Mode != core.ModePRDTasks {
 		return nil
 	}
 
@@ -242,4 +242,8 @@ func (s *commandState) preflightTaskMetadata(ctx context.Context, cmd *cobra.Com
 		return withExitCode(1, fmt.Errorf("task validation failed"))
 	}
 	return nil
+}
+
+func isTaskRunCommandKind(kind commandKind) bool {
+	return kind == commandKindTasksRun || kind == commandKindTasksRunMultiple
 }

--- a/internal/cli/run_observe.go
+++ b/internal/cli/run_observe.go
@@ -310,7 +310,96 @@ func defaultWatchCLIRun(ctx context.Context, dst io.Writer, client daemonCommand
 	return nil
 }
 
+func watchCLIRunUntilTerminalSuccess(
+	ctx context.Context,
+	dst io.Writer,
+	client daemonCommandClient,
+	runID string,
+) error {
+	if dst == nil {
+		dst = io.Discard
+	}
+
+	eventsCh, errsCh := runspkg.WatchRemote(ctx, cliRemoteWatchClient{daemon: client}, runID)
+	for eventsCh != nil || errsCh != nil {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err, ok := <-errsCh:
+			if !ok {
+				errsCh = nil
+				continue
+			}
+			if err != nil {
+				return mapDaemonCommandError(err)
+			}
+		case event, ok := <-eventsCh:
+			if !ok {
+				eventsCh = nil
+				continue
+			}
+			done, err := writeObservedEventAndCheckTerminal(ctx, dst, client, runID, event)
+			if err != nil || done {
+				return err
+			}
+		}
+	}
+
+	return currentTerminalRunSuccess(ctx, client, runID)
+}
+
+func writeObservedEventAndCheckTerminal(
+	ctx context.Context,
+	dst io.Writer,
+	client daemonCommandClient,
+	runID string,
+	event eventspkg.Event,
+) (bool, error) {
+	line := renderObservedRunEvent(event)
+	if strings.TrimSpace(line) != "" {
+		if _, err := io.WriteString(dst, line); err != nil {
+			return false, withExitCode(2, fmt.Errorf("write run watch output: %w", err))
+		}
+	}
+	if !isTerminalDaemonEvent(event.Kind) {
+		return false, nil
+	}
+	terminal, err := waitForTerminalDaemonRunSnapshot(ctx, client, runID)
+	if err != nil {
+		return false, mapDaemonCommandError(err)
+	}
+	return true, terminalRunSuccessError(terminal)
+}
+
+func currentTerminalRunSuccess(ctx context.Context, client daemonCommandClient, runID string) error {
+	snapshot, err := client.GetRunSnapshot(ctx, runID)
+	if err != nil {
+		return mapDaemonCommandError(err)
+	}
+	if isTerminalDaemonRun(snapshot.Run.Status) {
+		return terminalRunSuccessError(snapshot.Run)
+	}
+	return nil
+}
+
+func terminalRunSuccessError(run apicore.Run) error {
+	if !isTerminalFailureStatus(run) {
+		return nil
+	}
+	status := strings.TrimSpace(run.Status)
+	message := strings.TrimSpace(run.ErrorText)
+	if message == "" {
+		message = fmt.Sprintf("run ended with status %s", status)
+	} else {
+		message = fmt.Sprintf("run ended with status %s: %s", status, message)
+	}
+	return withExitCode(1, errors.New(message))
+}
+
 func renderObservedRunEvent(event eventspkg.Event) string {
+	if line, handled := renderObservedTaskMultiLifecycle(event); handled {
+		return line
+	}
 	if line, handled := renderObservedRunLifecycle(event); handled {
 		return line
 	}
@@ -321,6 +410,91 @@ func renderObservedRunEvent(event eventspkg.Event) string {
 		return line
 	}
 	return ""
+}
+
+func renderObservedTaskMultiLifecycle(event eventspkg.Event) (string, bool) {
+	switch event.Kind {
+	case eventspkg.EventKindTaskRunMultipleStarted:
+		payload, ok := decodeObservedPayload[kinds.TaskRunMultiplePayload](event)
+		if !ok {
+			return "task queue started\n", true
+		}
+		total := payload.Total
+		if total <= 0 {
+			total = len(payload.Slugs)
+		}
+		return fmt.Sprintf(
+			"task queue started | mode=%s total=%d\n",
+			firstNonEmpty(payload.Mode, "enqueued"),
+			total,
+		), true
+	case eventspkg.EventKindTaskRunMultipleItemQueued:
+		return renderObservedTaskMultiItem(event, "queued")
+	case eventspkg.EventKindTaskRunMultipleChildStarted:
+		return renderObservedTaskMultiItem(event, "started")
+	case eventspkg.EventKindTaskRunMultipleChildCompleted:
+		return renderObservedTaskMultiItem(event, "completed")
+	case eventspkg.EventKindTaskRunMultipleChildFailed:
+		return renderObservedTaskMultiItem(event, "failed")
+	case eventspkg.EventKindTaskRunMultipleItemCanceled:
+		return renderObservedTaskMultiItem(event, "canceled")
+	case eventspkg.EventKindTaskRunMultipleQueueCompleted:
+		payload, ok := decodeObservedPayload[kinds.TaskRunMultiplePayload](event)
+		if !ok {
+			return "task queue completed\n", true
+		}
+		return fmt.Sprintf("task queue completed | total=%d\n", payload.Total), true
+	case eventspkg.EventKindTaskRunMultipleQueueCanceled:
+		payload, ok := decodeObservedPayload[kinds.TaskRunMultiplePayload](event)
+		if !ok {
+			return "task queue canceled\n", true
+		}
+		if message := strings.TrimSpace(payload.Error); message != "" {
+			return fmt.Sprintf("task queue canceled | %s\n", message), true
+		}
+		return "task queue canceled\n", true
+	default:
+		return "", false
+	}
+}
+
+func renderObservedTaskMultiItem(event eventspkg.Event, fallbackStatus string) (string, bool) {
+	payload, ok := decodeObservedPayload[kinds.TaskRunMultiplePayload](event)
+	if !ok {
+		return fmt.Sprintf("task %s\n", fallbackStatus), true
+	}
+	status := firstNonEmpty(payload.Status, fallbackStatus)
+	label := observedTaskMultiLabel(payload)
+	childRunID := strings.TrimSpace(payload.ChildRunID)
+	message := strings.TrimSpace(payload.Error)
+	switch {
+	case childRunID != "" && message != "":
+		return fmt.Sprintf("%s %s | run=%s | %s\n", label, status, childRunID, message), true
+	case childRunID != "":
+		return fmt.Sprintf("%s %s | run=%s\n", label, status, childRunID), true
+	case message != "":
+		return fmt.Sprintf("%s %s | %s\n", label, status, message), true
+	default:
+		return fmt.Sprintf("%s %s\n", label, status), true
+	}
+}
+
+func observedTaskMultiLabel(payload kinds.TaskRunMultiplePayload) string {
+	slug := strings.TrimSpace(payload.Slug)
+	index := payload.Index + 1
+	if index <= 0 {
+		index = 1
+	}
+	if payload.Total > 0 {
+		if slug != "" {
+			return fmt.Sprintf("task[%d/%d] %s", index, payload.Total, slug)
+		}
+		return fmt.Sprintf("task[%d/%d]", index, payload.Total)
+	}
+	if slug != "" {
+		return fmt.Sprintf("task[%d] %s", index, slug)
+	}
+	return fmt.Sprintf("task[%d]", index)
 }
 
 func isTerminalObservedRunStatus(status string) bool {

--- a/internal/cli/run_observe.go
+++ b/internal/cli/run_observe.go
@@ -19,10 +19,11 @@ import (
 )
 
 var (
-	attachCLIRunUI         = newAttachCLIRunUI()
-	attachStartedCLIRunUI  = newAttachStartedCLIRunUI()
-	watchCLIRun            = defaultWatchCLIRun
-	openCLIRemoteUISession = uipkg.AttachRemote
+	attachCLIRunUI                 = newAttachCLIRunUI()
+	attachStartedCLIRunUI          = newAttachStartedCLIRunUI()
+	watchCLIRun                    = defaultWatchCLIRun
+	openCLIRemoteUISession         = uipkg.AttachRemote
+	openCLIRemoteMultiRunUISession = uipkg.AttachRemoteMultiple
 )
 
 var errRunSettledBeforeUIAttach = errors.New("run settled before ui attach")
@@ -31,6 +32,7 @@ const (
 	defaultUIAttachSnapshotTimeout      = 300 * time.Millisecond
 	defaultUIAttachSnapshotPollInterval = 10 * time.Millisecond
 	defaultOwnedRunCancelTimeout        = 5 * time.Second
+	daemonRunModeTaskMulti              = "task_multi"
 )
 
 type cliRunObserveConfig struct {
@@ -114,12 +116,9 @@ func attachRemoteCLIRunUI(
 	cancelOwnedRunOnExit bool,
 	cfg cliRunObserveConfig,
 ) error {
-	trimmedRunID := strings.TrimSpace(runID)
-	if client == nil {
-		return errors.New("daemon client is required")
-	}
-	if trimmedRunID == "" {
-		return errors.New("run id is required")
+	trimmedRunID, err := normalizeRemoteRunRequest(client, runID)
+	if err != nil {
+		return err
 	}
 
 	snapshot, err := loadUIAttachSnapshot(
@@ -131,6 +130,9 @@ func attachRemoteCLIRunUI(
 	)
 	if err != nil {
 		return err
+	}
+	if isTaskMultiRunSnapshot(snapshot) {
+		return attachRemoteCLIMultiRunUI(ctx, client, trimmedRunID, cancelOwnedRunOnExit, cfg)
 	}
 	if runSnapshotSettledBeforeUIAttach(snapshot) {
 		return errRunSettledBeforeUIAttach
@@ -149,14 +151,77 @@ func attachRemoteCLIRunUI(
 	if err != nil {
 		return err
 	}
-	var cancelRequested atomic.Bool
-	if cancelOwnedRunOnExit {
-		session.SetQuitHandler(func(uipkg.QuitRequest) {
-			cancelRequested.Store(true)
-			session.Shutdown()
-		})
-	}
+	return waitRemoteCLIRunUI(ctx, client, trimmedRunID, session, cancelOwnedRunOnExit, cfg.ownedRunCancelTimeout)
+}
 
+func normalizeRemoteRunRequest(client daemonCommandClient, runID string) (string, error) {
+	trimmedRunID := strings.TrimSpace(runID)
+	if client == nil {
+		return "", errors.New("daemon client is required")
+	}
+	if trimmedRunID == "" {
+		return "", errors.New("run id is required")
+	}
+	return trimmedRunID, nil
+}
+
+func isTaskMultiRunSnapshot(snapshot apicore.RunSnapshot) bool {
+	return snapshot.Run.Mode == daemonRunModeTaskMulti
+}
+
+func attachRemoteCLIMultiRunUI(
+	ctx context.Context,
+	client daemonCommandClient,
+	runID string,
+	cancelOwnedRunOnExit bool,
+	cfg cliRunObserveConfig,
+) error {
+	parentSnapshot, err := loadUIAttachTaskRunMultipleSnapshot(
+		ctx,
+		client,
+		runID,
+		cfg.attachSnapshotTimeout,
+		cfg.attachSnapshotPollInterval,
+	)
+	if err != nil {
+		return err
+	}
+	session, err := openCLIRemoteMultiRunUISession(ctx, uipkg.RemoteMultiRunAttachOptions{
+		Snapshot:     parentSnapshot,
+		OwnerSession: cancelOwnedRunOnExit,
+		LoadSnapshot: func(loadCtx context.Context) (apicore.TaskRunMultipleSnapshot, error) {
+			return client.GetTaskRunMultipleSnapshot(loadCtx, runID)
+		},
+		LoadChildSnapshot: func(loadCtx context.Context, childRunID string) (apicore.RunSnapshot, error) {
+			return client.GetRunSnapshot(loadCtx, childRunID)
+		},
+		OpenParentStream: func(streamCtx context.Context, after apicore.StreamCursor) (apiclient.RunStream, error) {
+			return client.OpenRunStream(streamCtx, runID, after)
+		},
+		OpenChildStream: func(
+			streamCtx context.Context,
+			childRunID string,
+			after apicore.StreamCursor,
+		) (apiclient.RunStream, error) {
+			return client.OpenRunStream(streamCtx, childRunID, after)
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return waitRemoteCLIRunUI(ctx, client, runID, session, cancelOwnedRunOnExit, cfg.ownedRunCancelTimeout)
+}
+
+func waitRemoteCLIRunUI(
+	ctx context.Context,
+	client daemonCommandClient,
+	runID string,
+	session uipkg.Session,
+	cancelOwnedRunOnExit bool,
+	cancelTimeout time.Duration,
+) error {
+	var cancelRequested atomic.Bool
+	installRemoteUIQuitHandler(session, cancelOwnedRunOnExit, &cancelRequested)
 	done := make(chan struct{})
 	go func() {
 		select {
@@ -175,7 +240,7 @@ func attachRemoteCLIRunUI(
 		return waitErr
 	}
 	if cancelOwnedRunOnExit && cancelRequested.Load() {
-		if err := cancelOwnedDaemonRun(ctx, client, trimmedRunID, cfg.ownedRunCancelTimeout); err != nil {
+		if err := cancelOwnedDaemonRun(ctx, client, runID, cancelTimeout); err != nil {
 			return err
 		}
 	}
@@ -183,6 +248,16 @@ func attachRemoteCLIRunUI(
 		return nil
 	}
 	return nil
+}
+
+func installRemoteUIQuitHandler(session uipkg.Session, cancelOwnedRunOnExit bool, cancelRequested *atomic.Bool) {
+	if !cancelOwnedRunOnExit {
+		return
+	}
+	session.SetQuitHandler(func(uipkg.QuitRequest) {
+		cancelRequested.Store(true)
+		session.Shutdown()
+	})
 }
 
 func cancelOwnedDaemonRun(
@@ -204,6 +279,46 @@ func cancelOwnedDaemonRun(
 		return fmt.Errorf("cancel daemon run after ui exit: %w", err)
 	}
 	return nil
+}
+
+func loadUIAttachTaskRunMultipleSnapshot(
+	ctx context.Context,
+	client daemonCommandClient,
+	runID string,
+	timeout time.Duration,
+	pollInterval time.Duration,
+) (apicore.TaskRunMultipleSnapshot, error) {
+	snapshot, err := client.GetTaskRunMultipleSnapshot(ctx, runID)
+	if err != nil {
+		return apicore.TaskRunMultipleSnapshot{}, err
+	}
+	if len(snapshot.Items) > 0 || isTerminalObservedRunStatus(snapshot.Run.Status) ||
+		timeout <= 0 || pollInterval <= 0 {
+		return snapshot, nil
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return snapshot, ctx.Err()
+		case <-timer.C:
+			return snapshot, nil
+		case <-ticker.C:
+			snapshot, err = client.GetTaskRunMultipleSnapshot(ctx, runID)
+			if err != nil {
+				return apicore.TaskRunMultipleSnapshot{}, err
+			}
+			if len(snapshot.Items) > 0 || isTerminalObservedRunStatus(snapshot.Run.Status) {
+				return snapshot, nil
+			}
+		}
+	}
 }
 
 func loadUIAttachSnapshot(

--- a/internal/cli/run_observe.go
+++ b/internal/cli/run_observe.go
@@ -558,7 +558,10 @@ func renderObservedTaskMultiLifecycle(event eventspkg.Event) (string, bool) {
 		if !ok {
 			return "task queue completed\n", true
 		}
-		return fmt.Sprintf("task queue completed | total=%d\n", payload.Total), true
+		if payload.Total > 0 {
+			return fmt.Sprintf("task queue completed | total=%d\n", payload.Total), true
+		}
+		return "task queue completed\n", true
 	case eventspkg.EventKindTaskRunMultipleQueueCanceled:
 		payload, ok := decodeObservedPayload[kinds.TaskRunMultiplePayload](event)
 		if !ok {

--- a/internal/cli/skills_preflight.go
+++ b/internal/cli/skills_preflight.go
@@ -267,7 +267,7 @@ func ensureBundledSkillsCurrent(
 }
 
 func (s *commandState) requiresBundledSkillPreflight() bool {
-	return s.kind == commandKindTasksRun || s.kind == commandKindFixReviews || s.kind == commandKindWatchReviews
+	return isTaskRunCommandKind(s.kind) || s.kind == commandKindFixReviews || s.kind == commandKindWatchReviews
 }
 
 func buildMissingSkillError(commandPath, agentName string, result requiredSkillState) error {

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -21,6 +21,7 @@ import (
 type workflowIdentity struct {
 	pr         string
 	name       string
+	multiple   string
 	provider   string
 	round      int
 	nitpicks   bool
@@ -372,7 +373,7 @@ func (s *commandState) enableExecutableExtensions() bool {
 	}
 
 	switch s.kind {
-	case commandKindTasksRun, commandKindTasksRunMultiple, commandKindFixReviews, commandKindWatchReviews:
+	case commandKindTasksRun, commandKindFixReviews, commandKindWatchReviews:
 		return true
 	case commandKindExec:
 		return s.extensionsEnabled
@@ -428,7 +429,7 @@ func (s *commandState) isWorkflowExecutionCommand() bool {
 		return false
 	}
 	switch s.kind {
-	case commandKindTasksRun, commandKindTasksRunMultiple, commandKindFixReviews, commandKindWatchReviews:
+	case commandKindTasksRun, commandKindFixReviews, commandKindWatchReviews:
 		return true
 	default:
 		return false
@@ -440,7 +441,7 @@ func (s *commandState) hasConfiguredWorkflowTUI() bool {
 		return false
 	}
 	switch s.kind {
-	case commandKindTasksRun, commandKindTasksRunMultiple:
+	case commandKindTasksRun:
 		return s.projectConfig.Tasks.Run.TUI != nil
 	case commandKindFixReviews:
 		return s.projectConfig.FixReviews.TUI != nil

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -370,7 +370,7 @@ func (s *commandState) enableExecutableExtensions() bool {
 	}
 
 	switch s.kind {
-	case commandKindTasksRun, commandKindFixReviews, commandKindWatchReviews:
+	case commandKindTasksRun, commandKindTasksRunMultiple, commandKindFixReviews, commandKindWatchReviews:
 		return true
 	case commandKindExec:
 		return s.extensionsEnabled
@@ -426,7 +426,7 @@ func (s *commandState) isWorkflowExecutionCommand() bool {
 		return false
 	}
 	switch s.kind {
-	case commandKindTasksRun, commandKindFixReviews, commandKindWatchReviews:
+	case commandKindTasksRun, commandKindTasksRunMultiple, commandKindFixReviews, commandKindWatchReviews:
 		return true
 	default:
 		return false
@@ -438,7 +438,7 @@ func (s *commandState) hasConfiguredWorkflowTUI() bool {
 		return false
 	}
 	switch s.kind {
-	case commandKindTasksRun:
+	case commandKindTasksRun, commandKindTasksRunMultiple:
 		return s.projectConfig.Tasks.Run.TUI != nil
 	case commandKindFixReviews:
 		return s.projectConfig.FixReviews.TUI != nil

--- a/internal/cli/testdata/tasks_run_help.golden
+++ b/internal/cli/testdata/tasks_run_help.golden
@@ -3,11 +3,19 @@ Start a task workflow through the shared home-scoped daemon.
 The CLI resolves the workspace root and attach mode locally, ensures the daemon
 is running, and then sends the workflow request over the daemon transport.
 
+Use --multiple with one comma-separated slug list to start several task workflows
+through one daemon-owned parent run. V1 runs the queue in enqueued order;
+configured parallel mode prints a V2 worktree-isolation fallback message before
+sending enqueued execution to the daemon.
+
 Usage:
   compozy tasks run [slug] [flags]
 
 Examples:
   compozy tasks run my-feature
+  compozy tasks run --multiple alpha,beta --stream
+  compozy tasks run --multiple alpha,beta --detach
+  compozy tasks run --multiple alpha,beta --ide codex --model gpt-5.5
   compozy tasks run my-feature --stream
   compozy tasks run my-feature --detach
   compozy tasks run --name my-feature --dry-run
@@ -25,6 +33,7 @@ Flags:
       --include-completed                Include completed tasks
       --max-retries int                  Retry execution-stage ACP failures or timeouts up to N times before marking them failed
       --model string                     Model to use. Leave empty to use the selected runtime default.
+      --multiple string                  Comma-separated task workflow slugs to run through one daemon-owned parent queue
       --name string                      Task workflow slug (defaults to the positional slug)
       --reasoning-effort string          Reasoning effort for runtimes that support bootstrap reasoning flags (low, medium, high, xhigh). (default "medium")
   -r, --recursive                        Recursively discover task_NNN.md files in subdirectories. Skips dot-, underscore-prefixed, reviews-*, adrs, and memory directories. Note: DB sync and extension Host API still operate on the slug root only.

--- a/internal/cli/validate_tasks_test.go
+++ b/internal/cli/validate_tasks_test.go
@@ -337,6 +337,25 @@ func makeValidateTasksWorkspace(t *testing.T, name string) (string, string) {
 	return root, tasksDir
 }
 
+func writeTaskWorkflowForCLI(t *testing.T, workspaceRoot string, slug string) string {
+	t.Helper()
+
+	tasksDir := filepath.Join(workspaceRoot, ".compozy", "tasks", slug)
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatalf("mkdir task workflow %s: %v", slug, err)
+	}
+	writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+		[]string{
+			"status: pending",
+			"title: " + slug + " Task",
+			"type: backend",
+			"complexity: low",
+		},
+		"# Task 1: "+slug+" Task",
+	))
+	return tasksDir
+}
+
 func cliTaskMarkdown(frontMatter []string, h1 string) string {
 	lines := []string{"---"}
 	lines = append(lines, frontMatter...)

--- a/internal/cli/workspace_config.go
+++ b/internal/cli/workspace_config.go
@@ -127,7 +127,7 @@ func (s *commandState) applyProjectConfig(cmd *cobra.Command, cfg workspace.Proj
 	)
 
 	switch s.kind {
-	case commandKindTasksRun:
+	case commandKindTasksRun, commandKindTasksRunMultiple:
 		applyConfig(cmd, "attach", cfg.Runs.DefaultAttachMode, func(val string) { s.attachMode = val })
 		applyConfig(cmd, "format", cfg.Tasks.Run.OutputFormat, func(val string) { s.outputFormat = val })
 		applyConfig(cmd, "tui", cfg.Tasks.Run.TUI, func(val bool) { s.tui = val })

--- a/internal/cli/workspace_config.go
+++ b/internal/cli/workspace_config.go
@@ -127,7 +127,7 @@ func (s *commandState) applyProjectConfig(cmd *cobra.Command, cfg workspace.Proj
 	)
 
 	switch s.kind {
-	case commandKindTasksRun, commandKindTasksRunMultiple:
+	case commandKindTasksRun:
 		s.applyTasksRunConfig(cmd, cfg)
 	case commandKindFixReviews:
 		applyConfig(cmd, "format", cfg.FixReviews.OutputFormat, func(val string) { s.outputFormat = val })

--- a/internal/core/run/ui/multi_remote.go
+++ b/internal/core/run/ui/multi_remote.go
@@ -478,10 +478,10 @@ func (m *multiRunModel) handleKey(v tea.KeyPressMsg) tea.Cmd {
 	switch strings.ToLower(v.String()) {
 	case keyCtrlC, "q":
 		return m.handleQuitKey()
-	case "[", "shift+left":
+	case keyLeft, "h":
 		m.moveActiveTab(-1)
 		return nil
-	case "]", "shift+right":
+	case keyRight, "l":
 		m.moveActiveTab(1)
 		return nil
 	default:
@@ -509,10 +509,10 @@ func (m *multiRunModel) handleQuitKey() tea.Cmd {
 
 func (m *multiRunModel) handleQuitDialogKey(v tea.KeyPressMsg) tea.Cmd {
 	switch strings.ToLower(v.String()) {
-	case "left", "h", keyShiftTab:
+	case keyLeft, "h", keyShiftTab:
 		m.quitDialog.Move(-1)
 		return nil
-	case "right", "l", keyTab:
+	case keyRight, "l", keyTab:
 		m.quitDialog.Move(1)
 		return nil
 	case keyEnter, "q", keyCtrlC:
@@ -787,7 +787,7 @@ func (m *multiRunModel) renderTabs() string {
 		chunks = append(chunks, style.Render(truncateString(label, 32)))
 	}
 	left := renderGap(bg, 1) + strings.Join(chunks, renderGap(bg, 1))
-	hint := renderKeycap("[/]", bg) + renderGap(bg, 1) + renderStyledOnBackground(styleMutedText, bg, "TABS")
+	hint := renderKeycap("←→/hl", bg) + renderGap(bg, 1) + renderStyledOnBackground(styleMutedText, bg, "TABS")
 	gap := max(m.width-lipgloss.Width(left)-lipgloss.Width(hint)-1, 1)
 	line := renderOwnedLineKnownOwned(m.width, bg, left+renderGap(bg, gap)+hint)
 	separator := renderOwnedLineKnownOwned(

--- a/internal/core/run/ui/multi_remote.go
+++ b/internal/core/run/ui/multi_remote.go
@@ -373,18 +373,14 @@ func followRemoteMultiRunChild(
 	cursor apicore.StreamCursor,
 	bootstrap bool,
 ) {
-	if bootstrap {
-		if opts.LoadChildSnapshot == nil {
-			return
-		}
+	if bootstrap && opts.LoadChildSnapshot != nil {
 		snapshot, err := opts.LoadChildSnapshot(ctx, runID)
-		if err != nil {
-			return
-		}
-		session.Enqueue(multiRunChildBootstrapMsg{RunID: runID, Snapshot: snapshot})
-		cursor = streamCursorOrZero(snapshot.NextCursor)
-		if isTerminalRunStatus(snapshot.Run.Status) {
-			return
+		if err == nil {
+			session.Enqueue(multiRunChildBootstrapMsg{RunID: runID, Snapshot: snapshot})
+			cursor = streamCursorOrZero(snapshot.NextCursor)
+			if isTerminalRunStatus(snapshot.Run.Status) {
+				return
+			}
 		}
 	}
 	if opts.OpenChildStream == nil {

--- a/internal/core/run/ui/multi_remote.go
+++ b/internal/core/run/ui/multi_remote.go
@@ -357,12 +357,12 @@ type multiRunParentSession struct {
 }
 
 func (s multiRunParentSession) Enqueue(msg any) {
+	s.Session.Enqueue(msg)
 	if ev, ok := msg.(events.Event); ok {
 		if childRunID := childRunIDFromTaskMultiEvent(ev); childRunID != "" && s.observeChild != nil {
 			s.observeChild(childRunID, apicore.StreamCursor{}, true)
 		}
 	}
-	s.Session.Enqueue(msg)
 }
 
 func followRemoteMultiRunChild(

--- a/internal/core/run/ui/multi_remote.go
+++ b/internal/core/run/ui/multi_remote.go
@@ -1,0 +1,1238 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image/color"
+	"strings"
+	"sync"
+	"time"
+
+	apiclient "github.com/compozy/compozy/internal/api/client"
+	apicore "github.com/compozy/compozy/internal/api/core"
+	"github.com/compozy/compozy/pkg/compozy/events"
+	"github.com/compozy/compozy/pkg/compozy/events/kinds"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+const (
+	multiRunTabsHeight = 2
+
+	taskMultiStatusQueued    = "queued"
+	taskMultiStatusRunning   = "running"
+	taskMultiStatusCompleted = "completed"
+	taskMultiStatusFailed    = "failed"
+	taskMultiStatusCanceled  = "canceled"
+)
+
+var (
+	setupRemoteMultiRunUISession = newMultiRunController
+	newMultiRunTeaProgram        = defaultNewMultiRunTeaProgram
+)
+
+// RemoteMultiRunAttachOptions configures a daemon-backed multi-run UI attach session.
+type RemoteMultiRunAttachOptions struct {
+	Snapshot          apicore.TaskRunMultipleSnapshot
+	Config            *config
+	OwnerSession      bool
+	LoadSnapshot      func(context.Context) (apicore.TaskRunMultipleSnapshot, error)
+	LoadChildSnapshot func(context.Context, string) (apicore.RunSnapshot, error)
+	OpenParentStream  func(context.Context, apicore.StreamCursor) (apiclient.RunStream, error)
+	OpenChildStream   func(context.Context, string, apicore.StreamCursor) (apiclient.RunStream, error)
+}
+
+type multiRunTab struct {
+	slug       string
+	status     string
+	runID      string
+	errorText  string
+	child      *uiModel
+	translator *uiEventTranslator
+	terminal   bool
+}
+
+type multiRunModel struct {
+	parentRun  apicore.Run
+	tabs       []multiRunTab
+	activeTab  int
+	width      int
+	height     int
+	cfg        *config
+	quitDialog quitDialogState
+	shutdown   shutdownState
+	onQuit     func(uiQuitRequest)
+	now        time.Time
+}
+
+type multiRunController struct {
+	model         *multiRunModel
+	prog          *tea.Program
+	done          chan error
+	quitHandler   func(uiQuitRequest)
+	quitHandlerMu sync.RWMutex
+	ctx           context.Context
+	cancel        context.CancelFunc
+	workers       sync.WaitGroup
+	shutdownOnce  sync.Once
+}
+
+type multiRunChildBootstrapMsg struct {
+	RunID    string
+	Snapshot apicore.RunSnapshot
+}
+
+type multiRunChildEventMsg struct {
+	RunID string
+	Event events.Event
+}
+
+type remoteWorkerSession interface {
+	Session
+	StartRemoteWorker(func(context.Context))
+}
+
+type initialMultiRunChild struct {
+	runID    string
+	cursor   apicore.StreamCursor
+	terminal bool
+}
+
+// AttachRemoteMultiple boots the tabbed Bubble Tea cockpit from a daemon-owned parent run snapshot.
+func AttachRemoteMultiple(ctx context.Context, opts RemoteMultiRunAttachOptions) (Session, error) {
+	mdl, initialChildren, err := newRemoteMultiRunModel(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	session := setupRemoteMultiRunUISession(ctx, mdl)
+	if session == nil {
+		return nil, errors.New("remote multi-run ui session is required")
+	}
+
+	observedChildren := make(map[string]struct{}, len(initialChildren))
+	var observedMu sync.Mutex
+	observeChild := func(runID string, cursor apicore.StreamCursor, bootstrap bool) {
+		trimmedRunID := strings.TrimSpace(runID)
+		if trimmedRunID == "" {
+			return
+		}
+		observedMu.Lock()
+		if _, ok := observedChildren[trimmedRunID]; ok {
+			observedMu.Unlock()
+			return
+		}
+		observedChildren[trimmedRunID] = struct{}{}
+		observedMu.Unlock()
+
+		startRemoteWorker(session, func(workerCtx context.Context) {
+			followRemoteMultiRunChild(workerCtx, session, opts, trimmedRunID, cursor, bootstrap)
+		})
+	}
+
+	for _, child := range initialChildren {
+		observeChild(child.runID, child.cursor, false)
+	}
+	if opts.OpenParentStream != nil && !isTerminalRunStatus(opts.Snapshot.Run.Status) {
+		stream, err := opts.OpenParentStream(ctx, apicore.StreamCursor{})
+		if err != nil {
+			session.Shutdown()
+			return nil, fmt.Errorf("open remote multi-run parent stream: %w", err)
+		}
+		startRemoteWorker(session, func(workerCtx context.Context) {
+			followRemoteMultiRunParent(workerCtx, session, opts, stream, observeChild)
+		})
+	}
+	return session, nil
+}
+
+func newRemoteMultiRunModel(
+	ctx context.Context,
+	opts RemoteMultiRunAttachOptions,
+) (*multiRunModel, []initialMultiRunChild, error) {
+	cfg := opts.Config
+	if cfg == nil {
+		cfg = &config{}
+	}
+	localCfg := *cfg
+	localCfg.DetachOnly = !opts.OwnerSession
+	localCfg.DaemonOwned = true
+
+	mdl := &multiRunModel{
+		parentRun:  opts.Snapshot.Run,
+		width:      120,
+		height:     40,
+		cfg:        &localCfg,
+		quitDialog: newQuitDialogState(),
+		now:        time.Now(),
+	}
+	children := make([]initialMultiRunChild, 0, len(opts.Snapshot.Items))
+	for _, item := range opts.Snapshot.Items {
+		tab := newMultiRunTab(item)
+		if tab.runID != "" && opts.LoadChildSnapshot != nil {
+			snapshot, err := opts.LoadChildSnapshot(ctx, tab.runID)
+			if err != nil {
+				return nil, nil, fmt.Errorf("load child run snapshot %s: %w", tab.runID, err)
+			}
+			tab.applyChildSnapshot(snapshot, mdl.cfg, mdl.childWidth(), mdl.childHeight())
+			children = append(children, initialMultiRunChild{
+				runID:    tab.runID,
+				cursor:   streamCursorOrZero(snapshot.NextCursor),
+				terminal: isTerminalRunStatus(snapshot.Run.Status),
+			})
+		}
+		mdl.tabs = append(mdl.tabs, tab)
+	}
+	mdl.activeTab = mdl.initialActiveTab()
+	return mdl, nonTerminalInitialChildren(children), nil
+}
+
+func nonTerminalInitialChildren(children []initialMultiRunChild) []initialMultiRunChild {
+	result := make([]initialMultiRunChild, 0, len(children))
+	for _, child := range children {
+		if !child.terminal {
+			result = append(result, child)
+		}
+	}
+	return result
+}
+
+func newMultiRunTab(item apicore.TaskRunMultipleItem) multiRunTab {
+	status := strings.TrimSpace(item.Status)
+	if status == "" {
+		status = taskMultiStatusQueued
+	}
+	return multiRunTab{
+		slug:       strings.TrimSpace(item.Slug),
+		status:     status,
+		runID:      strings.TrimSpace(item.RunID),
+		errorText:  strings.TrimSpace(item.ErrorText),
+		translator: newUIEventTranslator(),
+		terminal:   isTerminalTaskMultiStatus(status),
+	}
+}
+
+func newMultiRunController(ctx context.Context, mdl *multiRunModel) remoteWorkerSession {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sessionCtx, cancel := context.WithCancel(ctx)
+	if mdl == nil {
+		mdl = &multiRunModel{
+			width:      120,
+			height:     40,
+			cfg:        &config{},
+			quitDialog: newQuitDialogState(),
+			now:        time.Now(),
+		}
+	}
+	ctrl := &multiRunController{
+		model:  mdl,
+		done:   make(chan error, 1),
+		ctx:    sessionCtx,
+		cancel: cancel,
+	}
+	mdl.onQuit = ctrl.requestQuit
+	ctrl.prog = newMultiRunTeaProgram(mdl)
+	go func() {
+		_, runErr := ctrl.prog.Run()
+		if runErr != nil {
+			ctrl.done <- runErr
+		}
+		close(ctrl.done)
+	}()
+	return ctrl
+}
+
+func defaultNewMultiRunTeaProgram(mdl tea.Model) *tea.Program {
+	return tea.NewProgram(mdl, tea.WithoutSignalHandler())
+}
+
+func (c *multiRunController) Enqueue(msg any) {
+	if c == nil || c.prog == nil {
+		return
+	}
+	c.prog.Send(msg)
+}
+
+func (c *multiRunController) SetQuitHandler(fn func(uiQuitRequest)) {
+	if c == nil {
+		return
+	}
+	c.quitHandlerMu.Lock()
+	defer c.quitHandlerMu.Unlock()
+	c.quitHandler = fn
+}
+
+func (c *multiRunController) requestQuit(req uiQuitRequest) {
+	c.quitHandlerMu.RLock()
+	fn := c.quitHandler
+	c.quitHandlerMu.RUnlock()
+	if fn != nil {
+		fn(req)
+	}
+}
+
+func (c *multiRunController) CloseEvents() {}
+
+func (c *multiRunController) Shutdown() {
+	if c == nil {
+		return
+	}
+	c.shutdownOnce.Do(func() {
+		if c.cancel != nil {
+			c.cancel()
+		}
+		if c.prog != nil {
+			c.prog.Quit()
+		}
+	})
+}
+
+func (c *multiRunController) Wait() error {
+	if c == nil {
+		return nil
+	}
+	err, ok := <-c.done
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.workers.Wait()
+	if !ok {
+		return nil
+	}
+	return err
+}
+
+func (c *multiRunController) StartRemoteWorker(fn func(context.Context)) {
+	if c == nil || fn == nil {
+		return
+	}
+	c.workers.Add(1)
+	go func() {
+		defer c.workers.Done()
+		fn(c.ctx)
+	}()
+}
+
+func startRemoteWorker(session remoteWorkerSession, fn func(context.Context)) {
+	if fn == nil {
+		return
+	}
+	session.StartRemoteWorker(fn)
+}
+
+func followRemoteMultiRunParent(
+	ctx context.Context,
+	session Session,
+	opts RemoteMultiRunAttachOptions,
+	stream apiclient.RunStream,
+	observeChild func(string, apicore.StreamCursor, bool),
+) {
+	parentSession := multiRunParentSession{
+		Session:      session,
+		observeChild: observeChild,
+	}
+	followOpts := RemoteAttachOptions{
+		LoadSnapshot: func(loadCtx context.Context) (apicore.RunSnapshot, error) {
+			if opts.LoadSnapshot == nil {
+				return apicore.RunSnapshot{Run: opts.Snapshot.Run}, nil
+			}
+			snapshot, err := opts.LoadSnapshot(loadCtx)
+			if err != nil {
+				return apicore.RunSnapshot{}, err
+			}
+			return apicore.RunSnapshot{Run: snapshot.Run}, nil
+		},
+		OpenStream: opts.OpenParentStream,
+	}
+	followRemoteRun(ctx, parentSession, followOpts, stream, apicore.StreamCursor{})
+}
+
+type multiRunParentSession struct {
+	Session
+	observeChild func(string, apicore.StreamCursor, bool)
+}
+
+func (s multiRunParentSession) Enqueue(msg any) {
+	if ev, ok := msg.(events.Event); ok {
+		if childRunID := childRunIDFromTaskMultiEvent(ev); childRunID != "" && s.observeChild != nil {
+			s.observeChild(childRunID, apicore.StreamCursor{}, true)
+		}
+	}
+	s.Session.Enqueue(msg)
+}
+
+func followRemoteMultiRunChild(
+	ctx context.Context,
+	session Session,
+	opts RemoteMultiRunAttachOptions,
+	runID string,
+	cursor apicore.StreamCursor,
+	bootstrap bool,
+) {
+	if bootstrap {
+		if opts.LoadChildSnapshot == nil {
+			return
+		}
+		snapshot, err := opts.LoadChildSnapshot(ctx, runID)
+		if err != nil {
+			return
+		}
+		session.Enqueue(multiRunChildBootstrapMsg{RunID: runID, Snapshot: snapshot})
+		cursor = streamCursorOrZero(snapshot.NextCursor)
+		if isTerminalRunStatus(snapshot.Run.Status) {
+			return
+		}
+	}
+	if opts.OpenChildStream == nil {
+		return
+	}
+	stream, err := opts.OpenChildStream(ctx, runID, cursor)
+	if err != nil {
+		return
+	}
+	followRemoteRun(ctx, multiRunChildSession{Session: session, runID: runID}, RemoteAttachOptions{
+		LoadSnapshot: func(loadCtx context.Context) (apicore.RunSnapshot, error) {
+			if opts.LoadChildSnapshot == nil {
+				return apicore.RunSnapshot{}, nil
+			}
+			return opts.LoadChildSnapshot(loadCtx, runID)
+		},
+		OpenStream: func(streamCtx context.Context, after apicore.StreamCursor) (apiclient.RunStream, error) {
+			return opts.OpenChildStream(streamCtx, runID, after)
+		},
+	}, stream, cursor)
+}
+
+type multiRunChildSession struct {
+	Session
+	runID string
+}
+
+func (s multiRunChildSession) Enqueue(msg any) {
+	if ev, ok := msg.(events.Event); ok {
+		s.Session.Enqueue(multiRunChildEventMsg{RunID: s.runID, Event: ev})
+		return
+	}
+	s.Session.Enqueue(msg)
+}
+
+func childRunIDFromTaskMultiEvent(ev events.Event) string {
+	switch ev.Kind {
+	case events.EventKindTaskRunMultipleChildStarted,
+		events.EventKindTaskRunMultipleChildCompleted,
+		events.EventKindTaskRunMultipleChildFailed,
+		events.EventKindTaskRunMultipleItemCanceled:
+		payload, ok := decodeTaskMultiPayload(ev)
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(payload.ChildRunID)
+	default:
+		return ""
+	}
+}
+
+func (m *multiRunModel) Init() tea.Cmd {
+	if child := m.activeChild(); child != nil {
+		return child.Init()
+	}
+	return nil
+}
+
+func (m *multiRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch value := msg.(type) {
+	case tea.KeyPressMsg:
+		return m, m.handleKey(value)
+	case tea.WindowSizeMsg:
+		m.handleWindowSize(value)
+		return m, nil
+	case clockTickMsg:
+		return m, m.handleClockTick(value)
+	case spinnerTickMsg:
+		return m, m.handleSpinnerTick(value)
+	case events.Event:
+		m.handleParentEvent(value)
+		return m, nil
+	case multiRunChildBootstrapMsg:
+		m.handleChildBootstrap(value)
+		return m, nil
+	case multiRunChildEventMsg:
+		return m, m.handleChildEvent(value)
+	default:
+		if child := m.activeChild(); child != nil {
+			_, cmd := child.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+}
+
+func (m *multiRunModel) handleKey(v tea.KeyPressMsg) tea.Cmd {
+	if m.quitDialog.Active {
+		return m.handleQuitDialogKey(v)
+	}
+	switch strings.ToLower(v.String()) {
+	case keyCtrlC, "q":
+		return m.handleQuitKey()
+	case "[", "shift+left":
+		m.moveActiveTab(-1)
+		return nil
+	case "]", "shift+right":
+		m.moveActiveTab(1)
+		return nil
+	default:
+		if child := m.activeChild(); child != nil {
+			_, cmd := child.Update(v)
+			return cmd
+		}
+		return nil
+	}
+}
+
+func (m *multiRunModel) handleQuitKey() tea.Cmd {
+	if m.cfg != nil && m.cfg.DetachOnly {
+		return tea.Quit
+	}
+	if m.isQueueComplete() {
+		return tea.Quit
+	}
+	if !m.shutdown.Active() {
+		m.quitDialog.Open()
+		return nil
+	}
+	return m.requestQueueStopFromQuit()
+}
+
+func (m *multiRunModel) handleQuitDialogKey(v tea.KeyPressMsg) tea.Cmd {
+	switch strings.ToLower(v.String()) {
+	case "left", "h", keyShiftTab:
+		m.quitDialog.Move(-1)
+		return nil
+	case "right", "l", keyTab:
+		m.quitDialog.Move(1)
+		return nil
+	case keyEnter, "q", keyCtrlC:
+		return m.confirmQuitDialog()
+	case keyEscape:
+		m.quitDialog.Close()
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (m *multiRunModel) confirmQuitDialog() tea.Cmd {
+	selected := m.quitDialog.Selected
+	m.quitDialog.Close()
+	switch selected {
+	case quitDialogActionClose:
+		return tea.Quit
+	case quitDialogActionStop:
+		return m.requestQueueStopFromQuit()
+	default:
+		return nil
+	}
+}
+
+func (m *multiRunModel) requestQueueStopFromQuit() tea.Cmd {
+	req, ok := m.nextQuitRequest()
+	if !ok {
+		return nil
+	}
+	m.markCancelableTabsCanceled("stop requested")
+	if m.onQuit == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		m.onQuit(req)
+		return drainMsg{}
+	}
+}
+
+func (m *multiRunModel) nextQuitRequest() (uiQuitRequest, bool) {
+	now := time.Now()
+	m.now = now
+	switch m.shutdown.Phase {
+	case shutdownPhaseIdle:
+		m.shutdown = shutdownState{
+			Phase:       shutdownPhaseDraining,
+			Source:      shutdownSourceUI,
+			RequestedAt: now,
+			DeadlineAt:  now.Add(gracefulShutdownTimeout),
+		}
+		return uiQuitRequestDrain, true
+	case shutdownPhaseDraining:
+		m.shutdown = shutdownState{
+			Phase:       shutdownPhaseForcing,
+			Source:      shutdownSourceUI,
+			RequestedAt: now,
+		}
+		return uiQuitRequestForce, true
+	default:
+		return uiQuitRequestDrain, false
+	}
+}
+
+func (m *multiRunModel) markCancelableTabsCanceled(message string) {
+	for idx := range m.tabs {
+		switch m.tabs[idx].status {
+		case "", taskMultiStatusQueued, taskMultiStatusRunning:
+			m.tabs[idx].status = taskMultiStatusCanceled
+			m.tabs[idx].terminal = true
+			if strings.TrimSpace(m.tabs[idx].errorText) == "" {
+				m.tabs[idx].errorText = message
+			}
+		}
+	}
+}
+
+func (m *multiRunModel) handleWindowSize(v tea.WindowSizeMsg) {
+	m.width = v.Width
+	m.height = v.Height
+	for idx := range m.tabs {
+		if m.tabs[idx].child != nil {
+			m.resizeChild(m.tabs[idx].child)
+		}
+	}
+}
+
+func (m *multiRunModel) handleClockTick(v clockTickMsg) tea.Cmd {
+	if !v.at.IsZero() {
+		m.now = v.at
+	}
+	if child := m.activeChild(); child != nil {
+		return child.handleClockTick(v)
+	}
+	return nil
+}
+
+func (m *multiRunModel) handleSpinnerTick(v spinnerTickMsg) tea.Cmd {
+	if child := m.activeChild(); child != nil {
+		return child.handleSpinnerTick(v)
+	}
+	return nil
+}
+
+func (m *multiRunModel) handleParentEvent(ev events.Event) {
+	switch ev.Kind {
+	case events.EventKindTaskRunMultipleStarted:
+		m.applyTaskMultiStarted(ev)
+	case events.EventKindTaskRunMultipleItemQueued,
+		events.EventKindTaskRunMultipleChildStarted,
+		events.EventKindTaskRunMultipleChildCompleted,
+		events.EventKindTaskRunMultipleChildFailed,
+		events.EventKindTaskRunMultipleItemCanceled:
+		m.applyTaskMultiItem(ev)
+	case events.EventKindTaskRunMultipleQueueCompleted:
+		m.parentRun.Status = remoteRunStatusCompleted
+		m.quitDialog.Close()
+		m.shutdown = shutdownState{}
+	case events.EventKindTaskRunMultipleQueueCanceled:
+		m.parentRun.Status = remoteRunStatusCanceled
+		m.applyTaskMultiQueueCanceled(ev)
+		m.quitDialog.Close()
+	case events.EventKindRunCompleted:
+		m.parentRun.Status = remoteRunStatusCompleted
+		m.quitDialog.Close()
+	case events.EventKindRunFailed:
+		m.parentRun.Status = remoteRunStatusFailed
+		m.quitDialog.Close()
+	case events.EventKindRunCancelled:
+		m.parentRun.Status = remoteRunStatusCanceled
+		m.quitDialog.Close()
+	default:
+		return
+	}
+}
+
+func (m *multiRunModel) applyTaskMultiStarted(ev events.Event) {
+	payload, ok := decodeTaskMultiPayload(ev)
+	if !ok {
+		return
+	}
+	if payload.Status != "" {
+		m.parentRun.Status = payload.Status
+	}
+	for _, slug := range payload.Slugs {
+		m.ensureTab(strings.TrimSpace(slug))
+	}
+	if m.activeTab < 0 || m.activeTab >= len(m.tabs) {
+		m.activeTab = m.initialActiveTab()
+	}
+}
+
+func (m *multiRunModel) applyTaskMultiItem(ev events.Event) {
+	payload, ok := decodeTaskMultiPayload(ev)
+	if !ok {
+		return
+	}
+	idx := m.ensureTabForPayload(payload)
+	if idx < 0 || idx >= len(m.tabs) {
+		return
+	}
+	tab := &m.tabs[idx]
+	if payload.Status != "" {
+		tab.status = strings.TrimSpace(payload.Status)
+	}
+	if childRunID := strings.TrimSpace(payload.ChildRunID); childRunID != "" {
+		tab.runID = childRunID
+	}
+	if errorText := strings.TrimSpace(payload.Error); errorText != "" {
+		tab.errorText = errorText
+	}
+	tab.terminal = isTerminalTaskMultiStatus(tab.status)
+	if idx == m.activeTab && tab.terminal {
+		m.advanceActiveTabAfterTerminal()
+	}
+}
+
+func (m *multiRunModel) applyTaskMultiQueueCanceled(ev events.Event) {
+	payload, ok := decodeTaskMultiPayload(ev)
+	if !ok {
+		return
+	}
+	message := strings.TrimSpace(payload.Error)
+	for idx := range m.tabs {
+		if !isTerminalTaskMultiStatus(m.tabs[idx].status) {
+			m.tabs[idx].status = taskMultiStatusCanceled
+			m.tabs[idx].terminal = true
+			if m.tabs[idx].errorText == "" {
+				m.tabs[idx].errorText = message
+			}
+		}
+	}
+}
+
+func (m *multiRunModel) handleChildBootstrap(msg multiRunChildBootstrapMsg) {
+	idx := m.findTabByRunID(msg.RunID)
+	if idx < 0 {
+		return
+	}
+	m.tabs[idx].applyChildSnapshot(msg.Snapshot, m.cfg, m.childWidth(), m.childHeight())
+	if status := taskMultiStatusFromRunStatus(msg.Snapshot.Run.Status); status != "" {
+		m.tabs[idx].status = status
+		m.tabs[idx].terminal = isTerminalTaskMultiStatus(status)
+	}
+}
+
+func (m *multiRunModel) handleChildEvent(msg multiRunChildEventMsg) tea.Cmd {
+	idx := m.findTabByRunID(msg.RunID)
+	if idx < 0 {
+		return nil
+	}
+	tab := &m.tabs[idx]
+	if tab.child == nil {
+		tab.child = newPlaceholderChildModel(tab.slug, m.cfg, m.childWidth(), m.childHeight())
+	}
+	if tab.translator == nil {
+		tab.translator = newUIEventTranslator()
+	}
+	var cmd tea.Cmd
+	for _, uiMsg := range tab.translator.translateMessages(msg.Event) {
+		if nextCmd := applyChildUIMsg(tab, uiMsg); nextCmd != nil && idx == m.activeTab {
+			cmd = nextCmd
+		}
+	}
+	if status := taskMultiStatusFromChildRunEvent(msg.Event.Kind); status != "" {
+		tab.status = status
+		tab.terminal = isTerminalTaskMultiStatus(status)
+	}
+	if idx == m.activeTab && tab.terminal {
+		m.advanceActiveTabAfterTerminal()
+	}
+	return cmd
+}
+
+func (m *multiRunModel) View() tea.View {
+	if m.quitDialog.Active {
+		return m.renderQuitDialogView()
+	}
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		m.renderTabs(),
+		m.renderActiveTabContent(),
+	)
+	return m.renderRoot(content)
+}
+
+func (m *multiRunModel) renderRoot(content string) tea.View {
+	v := tea.NewView(rootScreenStyle(m.width, m.height).Render(content))
+	v.AltScreen = true
+	v.MouseMode = tea.MouseModeCellMotion
+	return v
+}
+
+func (m *multiRunModel) renderTabs() string {
+	bg := colorBgBase
+	chunks := make([]string, 0, len(m.tabs))
+	for idx := range m.tabs {
+		tab := m.tabs[idx]
+		label := fmt.Sprintf(
+			"%d %s %s",
+			idx+1,
+			firstNonEmpty(tab.slug, tab.runID, "workflow"),
+			strings.ToUpper(tab.status),
+		)
+		style := lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(colorBgSurface).
+			Foreground(multiRunStatusColor(tab.status))
+		if idx == m.activeTab {
+			style = style.Bold(true).Background(colorAccent).Foreground(colorBgBase)
+		}
+		chunks = append(chunks, style.Render(truncateString(label, 32)))
+	}
+	left := renderGap(bg, 1) + strings.Join(chunks, renderGap(bg, 1))
+	hint := renderKeycap("[/]", bg) + renderGap(bg, 1) + renderStyledOnBackground(styleMutedText, bg, "TABS")
+	gap := max(m.width-lipgloss.Width(left)-lipgloss.Width(hint)-1, 1)
+	line := renderOwnedLineKnownOwned(m.width, bg, left+renderGap(bg, gap)+hint)
+	separator := renderOwnedLineKnownOwned(
+		m.width,
+		bg,
+		renderStyledOnBackground(styleSeparator, bg, strings.Repeat("─", m.width)),
+	)
+	return line + "\n" + separator
+}
+
+func (m *multiRunModel) renderActiveTabContent() string {
+	tab := m.activeTabState()
+	if tab == nil {
+		return m.renderQueuedTabContent(nil)
+	}
+	if tab.child == nil {
+		return m.renderQueuedTabContent(tab)
+	}
+	m.resizeChild(tab.child)
+	return tab.child.View().Content
+}
+
+func (m *multiRunModel) renderQueuedTabContent(tab *multiRunTab) string {
+	width := max(m.width, 1)
+	height := max(m.childHeight(), 1)
+	panelWidth := max(width-4, 20)
+	innerStyle := techPanelStyle(panelWidth, multiRunStatusColor(tabStatus(tab))).Padding(1, 2)
+	innerWidth := max(panelWidth-innerStyle.GetHorizontalFrameSize(), 1)
+	slug := "workflow"
+	status := taskMultiStatusQueued
+	errText := ""
+	if tab != nil {
+		slug = firstNonEmpty(tab.slug, tab.runID, "workflow")
+		status = tabStatus(tab)
+		errText = strings.TrimSpace(tab.errorText)
+	}
+	lines := []string{
+		renderOwnedLineKnownOwned(innerWidth, colorBgSurface, renderTechLabel("queue."+status, colorBgSurface)),
+		renderOwnedLineKnownOwned(innerWidth, colorBgSurface, ""),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			colorBgSurface,
+			renderStyledOnBackground(styleBodyText, colorBgSurface, truncateString(slug, innerWidth)),
+		),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			colorBgSurface,
+			renderStyledOnBackground(
+				styleMutedText,
+				colorBgSurface,
+				truncateString("Child run has not started yet.", innerWidth),
+			),
+		),
+	}
+	if errText != "" {
+		lines = append(lines, renderOwnedLineKnownOwned(
+			innerWidth,
+			colorBgSurface,
+			renderStyledOnBackground(styleMutedText, colorBgSurface, truncateString(errText, innerWidth)),
+		))
+	}
+	panel := innerStyle.Render(strings.Join(lines, "\n"))
+	return lipgloss.Place(
+		width,
+		height,
+		lipgloss.Center,
+		lipgloss.Center,
+		panel,
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(colorBgBase)),
+	)
+}
+
+func (m *multiRunModel) renderQuitDialogView() tea.View {
+	panel := m.renderQuitDialogPanel()
+	content := lipgloss.Place(
+		max(m.width, 1),
+		max(m.height, 1),
+		lipgloss.Center,
+		lipgloss.Center,
+		panel,
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(colorBgBase)),
+	)
+	return m.renderRoot(content)
+}
+
+func (m *multiRunModel) renderQuitDialogPanel() string {
+	availableWidth := max(m.width-4, 1)
+	panelWidth := min(availableWidth, quitDialogMaxWidth)
+	panelStyle := techPanelStyle(panelWidth, colorBorderFocus).Padding(1, 2)
+	innerWidth := max(panelWidth-panelStyle.GetHorizontalFrameSize(), 1)
+	bg := colorBgSurface
+	lines := []string{
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				lipgloss.NewStyle().Bold(true).Foreground(colorAccentDeep),
+				bg,
+				truncateString("Leave Active Queue?", innerWidth),
+			),
+		),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(styleBodyText, bg, truncateString("This queue is still active.", innerWidth)),
+		),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				styleMutedText,
+				bg,
+				truncateString("Close the TUI and keep queued work running.", innerWidth),
+			),
+		),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				styleMutedText,
+				bg,
+				truncateString("Choose Stop Run to cancel active and queued work.", innerWidth),
+			),
+		),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedBlock(innerWidth, bg, m.renderQuitDialogActions(innerWidth, bg)),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				styleDimText,
+				bg,
+				truncateString("[enter/q] confirm  [tab/left/right] choice  [esc] back", innerWidth),
+			),
+		),
+	}
+	return panelStyle.Render(strings.Join(lines, "\n"))
+}
+
+func (m *multiRunModel) renderQuitDialogActions(width int, bg color.Color) string {
+	actions := []string{
+		m.renderQuitDialogAction("Close TUI", quitDialogActionClose),
+		m.renderQuitDialogAction("Stop Run", quitDialogActionStop),
+		m.renderQuitDialogAction("Cancel", quitDialogActionCancel),
+	}
+	if width < 44 {
+		return strings.Join(actions, "\n")
+	}
+	return strings.Join(actions, renderGap(bg, 1))
+}
+
+func (m *multiRunModel) renderQuitDialogAction(label string, action quitDialogAction) string {
+	baseStyle := lipgloss.NewStyle().Bold(true).Padding(0, 1)
+	if m.quitDialog.Selected == action {
+		return baseStyle.Foreground(colorBgSurface).Background(colorAccent).Render(label)
+	}
+	return baseStyle.Foreground(colorFgBright).Background(colorBgBase).Render(label)
+}
+
+func (m *multiRunModel) activeChild() *uiModel {
+	tab := m.activeTabState()
+	if tab == nil {
+		return nil
+	}
+	return tab.child
+}
+
+func (m *multiRunModel) activeTabState() *multiRunTab {
+	if m == nil || m.activeTab < 0 || m.activeTab >= len(m.tabs) {
+		return nil
+	}
+	return &m.tabs[m.activeTab]
+}
+
+func (m *multiRunModel) moveActiveTab(delta int) {
+	if len(m.tabs) == 0 {
+		return
+	}
+	if child := m.activeChild(); child != nil {
+		child.persistSelectedViewportState()
+	}
+	next := (m.activeTab + delta + len(m.tabs)) % len(m.tabs)
+	m.activeTab = next
+	if child := m.activeChild(); child != nil {
+		m.resizeChild(child)
+		child.refreshViewportContent()
+	}
+}
+
+func (m *multiRunModel) advanceActiveTabAfterTerminal() {
+	if len(m.tabs) == 0 {
+		return
+	}
+	for idx := m.activeTab + 1; idx < len(m.tabs); idx++ {
+		if !isTerminalTaskMultiStatus(m.tabs[idx].status) {
+			m.activeTab = idx
+			return
+		}
+	}
+	for idx := range m.tabs {
+		if !isTerminalTaskMultiStatus(m.tabs[idx].status) {
+			m.activeTab = idx
+			return
+		}
+	}
+}
+
+func (m *multiRunModel) initialActiveTab() int {
+	for idx := range m.tabs {
+		if m.tabs[idx].status == taskMultiStatusRunning {
+			return idx
+		}
+	}
+	for idx := range m.tabs {
+		if !isTerminalTaskMultiStatus(m.tabs[idx].status) {
+			return idx
+		}
+	}
+	return 0
+}
+
+func (m *multiRunModel) ensureTab(slug string) int {
+	trimmed := strings.TrimSpace(slug)
+	for idx := range m.tabs {
+		if m.tabs[idx].slug == trimmed {
+			return idx
+		}
+	}
+	m.tabs = append(m.tabs, multiRunTab{
+		slug:       trimmed,
+		status:     taskMultiStatusQueued,
+		translator: newUIEventTranslator(),
+	})
+	return len(m.tabs) - 1
+}
+
+func (m *multiRunModel) ensureTabForPayload(payload kinds.TaskRunMultiplePayload) int {
+	if payload.Index >= 0 && payload.Index < len(m.tabs) {
+		return payload.Index
+	}
+	if slug := strings.TrimSpace(payload.Slug); slug != "" {
+		return m.ensureTab(slug)
+	}
+	if childRunID := strings.TrimSpace(payload.ChildRunID); childRunID != "" {
+		if idx := m.findTabByRunID(childRunID); idx >= 0 {
+			return idx
+		}
+	}
+	return -1
+}
+
+func (m *multiRunModel) findTabByRunID(runID string) int {
+	trimmed := strings.TrimSpace(runID)
+	if trimmed == "" {
+		return -1
+	}
+	for idx := range m.tabs {
+		if m.tabs[idx].runID == trimmed {
+			return idx
+		}
+	}
+	return -1
+}
+
+func (m *multiRunModel) isQueueComplete() bool {
+	if isTerminalRunStatus(m.parentRun.Status) {
+		return true
+	}
+	if len(m.tabs) == 0 {
+		return false
+	}
+	for idx := range m.tabs {
+		if !isTerminalTaskMultiStatus(m.tabs[idx].status) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *multiRunModel) resizeChild(child *uiModel) {
+	if child == nil {
+		return
+	}
+	child.handleWindowSize(tea.WindowSizeMsg{
+		Width:  m.childWidth(),
+		Height: m.childHeight(),
+	})
+}
+
+func (m *multiRunModel) childWidth() int {
+	return max(m.width, 1)
+}
+
+func (m *multiRunModel) childHeight() int {
+	return max(m.height-multiRunTabsHeight, 1)
+}
+
+func (t *multiRunTab) applyChildSnapshot(snapshot apicore.RunSnapshot, cfg *config, width int, height int) {
+	t.runID = firstNonEmpty(t.runID, snapshot.Run.RunID)
+	t.child = childModelFromRunSnapshot(snapshot, cfg, width, height)
+	t.translator = newUIEventTranslator()
+	for idx := range t.child.jobs {
+		t.translator.hydrateSessionView(idx, t.child.jobs[idx].snapshot)
+	}
+}
+
+func childModelFromRunSnapshot(snapshot apicore.RunSnapshot, cfg *config, width int, height int) *uiModel {
+	jobs, msgs := remoteSnapshotBootstrap(snapshot)
+	if len(jobs) == 0 {
+		jobs = []job{{
+			SafeName:  firstNonEmpty(snapshot.Run.WorkflowSlug, snapshot.Run.RunID, "workflow"),
+			TaskTitle: firstNonEmpty(snapshot.Run.WorkflowSlug, "Starting workflow"),
+		}}
+	}
+	mdl := newUIModel(len(jobs))
+	mdl.cfg = cfg
+	mdl.handleWindowSize(tea.WindowSizeMsg{Width: width, Height: height})
+	applyBootstrapJobsToModel(mdl, jobs)
+	for _, msg := range msgs {
+		mdl.applyUIMsg(msg)
+	}
+	return mdl
+}
+
+func newPlaceholderChildModel(slug string, cfg *config, width int, height int) *uiModel {
+	return childModelFromRunSnapshot(apicore.RunSnapshot{
+		Run: apicore.Run{
+			RunID:        slug,
+			WorkflowSlug: slug,
+			Status:       remoteRunStatusRunning,
+		},
+	}, cfg, width, height)
+}
+
+func applyBootstrapJobsToModel(mdl *uiModel, jobs []job) {
+	for idx := range jobs {
+		jb := jobs[idx]
+		totalIssues := 0
+		for _, items := range jb.Groups {
+			totalIssues += len(items)
+		}
+		codeFileLabel := jb.CodeFileLabel()
+		if len(jb.CodeFiles) > 3 {
+			codeFileLabel = fmt.Sprintf("%s and %d more", strings.Join(jb.CodeFiles[:3], ", "), len(jb.CodeFiles)-3)
+		}
+		mdl.applyUIMsg(jobQueuedMsg{
+			Index:           idx,
+			CodeFile:        codeFileLabel,
+			CodeFiles:       append([]string(nil), jb.CodeFiles...),
+			Issues:          totalIssues,
+			TaskTitle:       jb.TaskTitle,
+			TaskType:        jb.TaskType,
+			SafeName:        jb.SafeName,
+			IDE:             jb.IDE,
+			Model:           jb.Model,
+			ReasoningEffort: jb.ReasoningEffort,
+			OutLog:          jb.OutLog,
+			ErrLog:          jb.ErrLog,
+			OutBuffer:       jb.OutBuffer,
+			ErrBuffer:       jb.ErrBuffer,
+		})
+	}
+}
+
+func applyChildUIMsg(tab *multiRunTab, msg uiMsg) tea.Cmd {
+	if tab == nil || tab.child == nil {
+		return nil
+	}
+	if update, ok := msg.(jobUpdateMsg); ok && update.HydrateTranslator {
+		if tab.translator == nil {
+			tab.translator = newUIEventTranslator()
+		}
+		tab.translator.hydrateSessionView(update.Index, update.Snapshot)
+	}
+	return tab.child.applyUIMsg(msg)
+}
+
+func tabStatus(tab *multiRunTab) string {
+	if tab == nil {
+		return taskMultiStatusQueued
+	}
+	if status := strings.TrimSpace(tab.status); status != "" {
+		return status
+	}
+	return taskMultiStatusQueued
+}
+
+func isTerminalTaskMultiStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case taskMultiStatusCompleted, taskMultiStatusFailed, taskMultiStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func taskMultiStatusFromRunStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case remoteRunStatusRunning, remoteRunStatusRetrying:
+		return taskMultiStatusRunning
+	case remoteRunStatusCompleted:
+		return taskMultiStatusCompleted
+	case remoteRunStatusFailed, remoteRunStatusCrashed:
+		return taskMultiStatusFailed
+	case remoteRunStatusCanceled:
+		return taskMultiStatusCanceled
+	default:
+		return ""
+	}
+}
+
+func taskMultiStatusFromChildRunEvent(kind events.EventKind) string {
+	switch kind {
+	case events.EventKindRunCompleted:
+		return taskMultiStatusCompleted
+	case events.EventKindRunFailed:
+		return taskMultiStatusFailed
+	case events.EventKindRunCancelled:
+		return taskMultiStatusCanceled
+	default:
+		return ""
+	}
+}
+
+func multiRunStatusColor(status string) color.Color {
+	switch strings.TrimSpace(status) {
+	case taskMultiStatusRunning:
+		return colorAccentAlt
+	case taskMultiStatusCompleted:
+		return colorSuccess
+	case taskMultiStatusFailed:
+		return colorError
+	case taskMultiStatusCanceled:
+		return colorWarning
+	default:
+		return colorMuted
+	}
+}
+
+func decodeTaskMultiPayload(ev events.Event) (kinds.TaskRunMultiplePayload, bool) {
+	var payload kinds.TaskRunMultiplePayload
+	if err := json.Unmarshal(ev.Payload, &payload); err != nil {
+		return kinds.TaskRunMultiplePayload{}, false
+	}
+	return payload, true
+}

--- a/internal/core/run/ui/multi_remote_test.go
+++ b/internal/core/run/ui/multi_remote_test.go
@@ -707,6 +707,41 @@ func TestMultiRunChildEventCreatesPlaceholderAndMapsTerminalRunStatus(t *testing
 	}
 }
 
+func TestFollowRemoteMultiRunChildFallsBackToStreamWhenBootstrapSnapshotFails(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	session := newRecordingMultiRunSession(context.Background(), mdl)
+	streamOpened := false
+	now := time.Date(2026, 4, 17, 13, 0, 0, 0, time.UTC)
+
+	followRemoteMultiRunChild(context.Background(), session, RemoteMultiRunAttachOptions{
+		LoadChildSnapshot: func(context.Context, string) (apicore.RunSnapshot, error) {
+			return apicore.RunSnapshot{}, errors.New("snapshot unavailable")
+		},
+		OpenChildStream: func(_ context.Context, runID string, _ apicore.StreamCursor) (apiclient.RunStream, error) {
+			if runID != "run-alpha" {
+				t.Fatalf("unexpected child stream run id %q", runID)
+			}
+			streamOpened = true
+			return newBufferedClientRunStream(apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+				t,
+				eventspkg.EventKindRunCompleted,
+				kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
+			), 1, now)}), nil
+		},
+	}, "run-alpha", apicore.StreamCursor{}, true)
+
+	if !streamOpened {
+		t.Fatal("expected child stream to open after bootstrap snapshot failure")
+	}
+	session.withModel(func(mdl *multiRunModel) {
+		if got := mdl.tabs[0].status; got != taskMultiStatusCompleted {
+			t.Fatalf("alpha status = %q, want completed", got)
+		}
+	})
+}
+
 func TestMultiRunUpdateRoutesResizeTicksParentAndChildMessages(t *testing.T) {
 	t.Parallel()
 
@@ -785,24 +820,42 @@ func TestMultiRunStatusHelpersCoverAllStatuses(t *testing.T) {
 			t.Fatalf("expected color for status %q", status)
 		}
 	}
-	for _, status := range []string{
-		remoteRunStatusRunning,
-		remoteRunStatusRetrying,
-		remoteRunStatusCompleted,
-		remoteRunStatusFailed,
-		remoteRunStatusCrashed,
-		remoteRunStatusCanceled,
-		"pending",
-	} {
-		_ = taskMultiStatusFromRunStatus(status)
+	runStatusCases := []struct {
+		input string
+		want  string
+	}{
+		{input: remoteRunStatusRunning, want: taskMultiStatusRunning},
+		{input: remoteRunStatusRetrying, want: taskMultiStatusRunning},
+		{input: remoteRunStatusCompleted, want: taskMultiStatusCompleted},
+		{input: remoteRunStatusFailed, want: taskMultiStatusFailed},
+		{input: remoteRunStatusCrashed, want: taskMultiStatusFailed},
+		{input: remoteRunStatusCanceled, want: taskMultiStatusCanceled},
+		{input: "pending", want: ""},
 	}
-	for _, kind := range []eventspkg.EventKind{
-		eventspkg.EventKindRunCompleted,
-		eventspkg.EventKindRunFailed,
-		eventspkg.EventKindRunCancelled,
-		eventspkg.EventKindJobQueued,
-	} {
-		_ = taskMultiStatusFromChildRunEvent(kind)
+	for _, tc := range runStatusCases {
+		tc := tc
+		t.Run("Should map run status "+tc.input, func(t *testing.T) {
+			if got := taskMultiStatusFromRunStatus(tc.input); got != tc.want {
+				t.Fatalf("taskMultiStatusFromRunStatus(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+	childEventCases := []struct {
+		input eventspkg.EventKind
+		want  string
+	}{
+		{input: eventspkg.EventKindRunCompleted, want: taskMultiStatusCompleted},
+		{input: eventspkg.EventKindRunFailed, want: taskMultiStatusFailed},
+		{input: eventspkg.EventKindRunCancelled, want: taskMultiStatusCanceled},
+		{input: eventspkg.EventKindJobQueued, want: ""},
+	}
+	for _, tc := range childEventCases {
+		tc := tc
+		t.Run("Should map child event "+string(tc.input), func(t *testing.T) {
+			if got := taskMultiStatusFromChildRunEvent(tc.input); got != tc.want {
+				t.Fatalf("taskMultiStatusFromChildRunEvent(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/core/run/ui/multi_remote_test.go
+++ b/internal/core/run/ui/multi_remote_test.go
@@ -21,457 +21,479 @@ import (
 func TestMultiRunInitialSnapshotRendersQueuedTabsInOrder(t *testing.T) {
 	t.Parallel()
 
-	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
-		Snapshot: apicore.TaskRunMultipleSnapshot{
-			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
-			Items: []apicore.TaskRunMultipleItem{
-				{Slug: "alpha", Status: taskMultiStatusQueued},
-				{Slug: "beta", Status: taskMultiStatusQueued},
-				{Slug: "gamma", Status: taskMultiStatusQueued},
+	t.Run("Should render queued tabs in request order", func(t *testing.T) {
+		mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+			Snapshot: apicore.TaskRunMultipleSnapshot{
+				Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+				Items: []apicore.TaskRunMultipleItem{
+					{Slug: "alpha", Status: taskMultiStatusQueued},
+					{Slug: "beta", Status: taskMultiStatusQueued},
+					{Slug: "gamma", Status: taskMultiStatusQueued},
+				},
 			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
-	}
-	mdl.handleWindowSize(tea.WindowSizeMsg{Width: 120, Height: 30})
+		})
+		if err != nil {
+			t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+		}
+		mdl.handleWindowSize(tea.WindowSizeMsg{Width: 120, Height: 30})
 
-	view := mdl.View().Content
-	alpha := strings.Index(view, "alpha QUEUED")
-	beta := strings.Index(view, "beta QUEUED")
-	gamma := strings.Index(view, "gamma QUEUED")
-	if alpha < 0 || beta < 0 || gamma < 0 {
-		t.Fatalf("expected queued tabs for alpha, beta, gamma, got %q", view)
-	}
-	if alpha >= beta || beta >= gamma {
-		t.Fatalf("expected queued tabs in request order, got alpha=%d beta=%d gamma=%d", alpha, beta, gamma)
-	}
-	if !strings.Contains(view, "Child run has not started yet.") {
-		t.Fatalf("expected queued active tab message, got %q", view)
-	}
+		view := mdl.View().Content
+		alpha := strings.Index(view, "alpha QUEUED")
+		beta := strings.Index(view, "beta QUEUED")
+		gamma := strings.Index(view, "gamma QUEUED")
+		if alpha < 0 || beta < 0 || gamma < 0 {
+			t.Fatalf("expected queued tabs for alpha, beta, gamma, got %q", view)
+		}
+		if alpha >= beta || beta >= gamma {
+			t.Fatalf("expected queued tabs in request order, got alpha=%d beta=%d gamma=%d", alpha, beta, gamma)
+		}
+		if !strings.Contains(view, "Child run has not started yet.") {
+			t.Fatalf("expected queued active tab message, got %q", view)
+		}
+	})
 }
 
 func TestMultiRunChildStartUpdatesOnlyTargetTabState(t *testing.T) {
 	t.Parallel()
 
-	alphaSnapshot := childSnapshotForTest(t, "run-alpha", "alpha", remoteRunStatusRunning, "alpha transcript")
-	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
-		Snapshot: apicore.TaskRunMultipleSnapshot{
-			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
-			Items: []apicore.TaskRunMultipleItem{
-				{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
-				{Slug: "beta", Status: taskMultiStatusQueued},
+	t.Run("Should update only the target tab when a child starts", func(t *testing.T) {
+		alphaSnapshot := childSnapshotForTest(t, "run-alpha", "alpha", remoteRunStatusRunning, "alpha transcript")
+		mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+			Snapshot: apicore.TaskRunMultipleSnapshot{
+				Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+				Items: []apicore.TaskRunMultipleItem{
+					{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
+					{Slug: "beta", Status: taskMultiStatusQueued},
+				},
 			},
-		},
-		LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
-			if runID != "run-alpha" {
-				t.Fatalf("unexpected child snapshot run id %q", runID)
-			}
-			return alphaSnapshot, nil
-		},
+			LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
+				if runID != "run-alpha" {
+					t.Fatalf("unexpected child snapshot run id %q", runID)
+				}
+				return alphaSnapshot, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+		}
+		alphaEntries := append([]TranscriptEntry(nil), mdl.tabs[0].child.jobs[0].snapshot.Entries...)
+
+		mdl.handleParentEvent(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindTaskRunMultipleChildStarted,
+			kinds.TaskRunMultiplePayload{
+				Slug:       "beta",
+				Index:      1,
+				Total:      2,
+				Status:     taskMultiStatusRunning,
+				ChildRunID: "run-beta",
+			},
+		))
+
+		if got := mdl.tabs[1].status; got != taskMultiStatusRunning {
+			t.Fatalf("expected beta running, got %q", got)
+		}
+		if got := mdl.tabs[1].runID; got != "run-beta" {
+			t.Fatalf("expected beta child run id, got %q", got)
+		}
+		if !reflect.DeepEqual(alphaEntries, mdl.tabs[0].child.jobs[0].snapshot.Entries) {
+			t.Fatalf("alpha transcript changed after beta start: %#v", mdl.tabs[0].child.jobs[0].snapshot.Entries)
+		}
 	})
-	if err != nil {
-		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
-	}
-	alphaEntries := append([]TranscriptEntry(nil), mdl.tabs[0].child.jobs[0].snapshot.Entries...)
-
-	mdl.handleParentEvent(mustRuntimeEventUITest(
-		t,
-		eventspkg.EventKindTaskRunMultipleChildStarted,
-		kinds.TaskRunMultiplePayload{
-			Slug:       "beta",
-			Index:      1,
-			Total:      2,
-			Status:     taskMultiStatusRunning,
-			ChildRunID: "run-beta",
-		},
-	))
-
-	if got := mdl.tabs[1].status; got != taskMultiStatusRunning {
-		t.Fatalf("expected beta running, got %q", got)
-	}
-	if got := mdl.tabs[1].runID; got != "run-beta" {
-		t.Fatalf("expected beta child run id, got %q", got)
-	}
-	if !reflect.DeepEqual(alphaEntries, mdl.tabs[0].child.jobs[0].snapshot.Entries) {
-		t.Fatalf("alpha transcript changed after beta start: %#v", mdl.tabs[0].child.jobs[0].snapshot.Entries)
-	}
 }
 
 func TestMultiRunCompletedTabRemainsNavigableAfterActiveAdvances(t *testing.T) {
 	t.Parallel()
 
-	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
-		Snapshot: apicore.TaskRunMultipleSnapshot{
-			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
-			Items: []apicore.TaskRunMultipleItem{
-				{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
-				{Slug: "beta", Status: taskMultiStatusQueued},
-				{Slug: "gamma", Status: taskMultiStatusQueued},
+	t.Run("Should keep completed tab navigable after active tab advances", func(t *testing.T) {
+		mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+			Snapshot: apicore.TaskRunMultipleSnapshot{
+				Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+				Items: []apicore.TaskRunMultipleItem{
+					{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
+					{Slug: "beta", Status: taskMultiStatusQueued},
+					{Slug: "gamma", Status: taskMultiStatusQueued},
+				},
 			},
-		},
-		LoadChildSnapshot: func(context.Context, string) (apicore.RunSnapshot, error) {
-			return childSnapshotForTest(t, "run-alpha", "alpha", remoteRunStatusRunning, "alpha transcript"), nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
-	}
-
-	mdl.handleParentEvent(mustRuntimeEventUITest(
-		t,
-		eventspkg.EventKindTaskRunMultipleChildCompleted,
-		kinds.TaskRunMultiplePayload{
-			Slug:       "alpha",
-			Index:      0,
-			Total:      3,
-			Status:     taskMultiStatusCompleted,
-			ChildRunID: "run-alpha",
-		},
-	))
-
-	if got := mdl.activeTab; got != 1 {
-		t.Fatalf("expected active tab to advance to beta, got %d", got)
-	}
-	if mdl.tabs[0].child == nil {
-		t.Fatal("expected completed alpha child view to remain available")
-	}
-	mdl.moveActiveTab(-1)
-	if got := mdl.activeTab; got != 0 {
-		t.Fatalf("expected alpha completed tab to remain navigable, got active %d", got)
-	}
-}
-
-func TestMultiRunTabNavigationDoesNotCycleChildPaneFocus(t *testing.T) {
-	t.Parallel()
-
-	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
-		Snapshot: apicore.TaskRunMultipleSnapshot{
-			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
-			Items: []apicore.TaskRunMultipleItem{
-				{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
-				{Slug: "beta", Status: taskMultiStatusRunning, RunID: "run-beta"},
+			LoadChildSnapshot: func(context.Context, string) (apicore.RunSnapshot, error) {
+				return childSnapshotForTest(t, "run-alpha", "alpha", remoteRunStatusRunning, "alpha transcript"), nil
 			},
-		},
-		LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
-			return childSnapshotForTest(
-				t,
-				runID,
-				strings.TrimPrefix(runID, "run-"),
-				remoteRunStatusRunning,
-				runID+" transcript",
-			), nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
-	}
-	mdl.tabs[0].child.focusedPane = uiPaneTimeline
-
-	cmd := mdl.handleKey(keyCode(tea.KeyRight))
-	if cmd != nil {
-		t.Fatalf("expected tab navigation to stay local, got command %T", cmd())
-	}
-	if got := mdl.activeTab; got != 1 {
-		t.Fatalf("expected active tab beta, got %d", got)
-	}
-	if got := mdl.tabs[0].child.focusedPane; got != uiPaneTimeline {
-		t.Fatalf("expected alpha child focus to remain timeline, got %s", got)
-	}
-	if got := mdl.tabs[1].child.focusedPane; got != uiPaneJobs {
-		t.Fatalf("expected beta child focus to remain jobs, got %s", got)
-	}
-}
-
-func TestMultiRunTabNavigationUsesHorizontalKeys(t *testing.T) {
-	t.Parallel()
-
-	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
-		Snapshot: apicore.TaskRunMultipleSnapshot{
-			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
-			Items: []apicore.TaskRunMultipleItem{
-				{Slug: "alpha", Status: taskMultiStatusQueued},
-				{Slug: "beta", Status: taskMultiStatusQueued},
-				{Slug: "gamma", Status: taskMultiStatusQueued},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
-	}
-
-	mdl.handleKey(keyCode(tea.KeyRight))
-	if got := mdl.activeTab; got != 1 {
-		t.Fatalf("expected right arrow to move to beta tab, got %d", got)
-	}
-	mdl.handleKey(keyText("l"))
-	if got := mdl.activeTab; got != 2 {
-		t.Fatalf("expected l to move to gamma tab, got %d", got)
-	}
-	mdl.handleKey(keyCode(tea.KeyLeft))
-	if got := mdl.activeTab; got != 1 {
-		t.Fatalf("expected left arrow to move back to beta tab, got %d", got)
-	}
-	mdl.handleKey(keyText("h"))
-	if got := mdl.activeTab; got != 0 {
-		t.Fatalf("expected h to move back to alpha tab, got %d", got)
-	}
-
-	view := mdl.renderTabs()
-	if !strings.Contains(view, "←→/HL") || !strings.Contains(view, "TABS") {
-		t.Fatalf("expected tab help to advertise horizontal navigation, got %q", view)
-	}
-}
-
-func TestMultiRunCloseTUIDoesNotRequestParentCancel(t *testing.T) {
-	t.Parallel()
-
-	mdl := multiRunModelForQuitTest()
-	var quitRequests []uiQuitRequest
-	mdl.onQuit = func(req uiQuitRequest) {
-		quitRequests = append(quitRequests, req)
-	}
-
-	if cmd := mdl.handleKey(keyText("q")); cmd != nil {
-		t.Fatalf("expected q to open quit dialog, got %T", cmd())
-	}
-	cmd := mdl.handleKey(keyCode(tea.KeyEnter))
-	if cmd == nil {
-		t.Fatal("expected Close TUI confirmation to return quit command")
-	}
-	if _, ok := cmd().(tea.QuitMsg); !ok {
-		t.Fatalf("expected Close TUI to quit, got %T", cmd())
-	}
-	if len(quitRequests) != 0 {
-		t.Fatalf("expected Close TUI not to request parent cancel, got %#v", quitRequests)
-	}
-}
-
-func TestMultiRunStopRunRequestsParentCancelOnceAndMarksQueuedCanceled(t *testing.T) {
-	t.Parallel()
-
-	mdl := multiRunModelForQuitTest()
-	var quitRequests []uiQuitRequest
-	mdl.onQuit = func(req uiQuitRequest) {
-		quitRequests = append(quitRequests, req)
-	}
-
-	mdl.handleKey(keyText("q"))
-	mdl.handleKey(keyText(keyRight))
-	cmd := mdl.handleKey(keyCode(tea.KeyEnter))
-	if cmd == nil {
-		t.Fatal("expected Stop Run confirmation to return command")
-	}
-	if _, ok := cmd().(drainMsg); !ok {
-		t.Fatalf("expected Stop Run command to drain, got %T", cmd())
-	}
-	if got := len(quitRequests); got != 1 {
-		t.Fatalf("expected one parent cancel request, got %d", got)
-	}
-	if quitRequests[0] != uiQuitRequestDrain {
-		t.Fatalf("expected drain quit request, got %v", quitRequests[0])
-	}
-	for idx, tab := range mdl.tabs {
-		if got := tab.status; got != taskMultiStatusCanceled {
-			t.Fatalf("tab %d status = %q, want canceled", idx, got)
+		})
+		if err != nil {
+			t.Fatalf("newRemoteMultiRunModel() error = %v", err)
 		}
-	}
-}
 
-func TestMultiRunQuitKeyDetachAndCompletedQueueCloseImmediately(t *testing.T) {
-	t.Parallel()
-
-	detachOnly := multiRunModelForQuitTest()
-	detachOnly.cfg.DetachOnly = true
-	cmd := detachOnly.handleKey(keyText("q"))
-	if cmd == nil {
-		t.Fatal("expected detach-only queue to quit immediately")
-	}
-	if _, ok := cmd().(tea.QuitMsg); !ok {
-		t.Fatalf("expected detach-only quit command, got %T", cmd())
-	}
-
-	completed := multiRunModelForQuitTest()
-	completed.parentRun.Status = remoteRunStatusCompleted
-	cmd = completed.handleKey(keyText("q"))
-	if cmd == nil {
-		t.Fatal("expected completed queue to quit immediately")
-	}
-	if _, ok := cmd().(tea.QuitMsg); !ok {
-		t.Fatalf("expected completed queue quit command, got %T", cmd())
-	}
-}
-
-func TestMultiRunQuitDialogNavigationEscapeAndForceEscalation(t *testing.T) {
-	t.Parallel()
-
-	mdl := multiRunModelForQuitTest()
-	var quitRequests []uiQuitRequest
-	mdl.onQuit = func(req uiQuitRequest) {
-		quitRequests = append(quitRequests, req)
-	}
-
-	mdl.handleKey(keyText("q"))
-	mdl.handleKey(keyText(keyLeft))
-	if got := mdl.quitDialog.Selected; got != quitDialogActionCancel {
-		t.Fatalf("expected left from default to wrap to cancel, got %v", got)
-	}
-	if cmd := mdl.handleKey(keyText("esc")); cmd != nil {
-		t.Fatalf("expected escape to close dialog locally, got %T", cmd())
-	}
-	if mdl.quitDialog.Active {
-		t.Fatal("expected escape to close quit dialog")
-	}
-
-	mdl.shutdown = shutdownState{Phase: shutdownPhaseDraining}
-	cmd := mdl.handleKey(keyText("q"))
-	if cmd == nil {
-		t.Fatal("expected q during draining to escalate")
-	}
-	if _, ok := cmd().(drainMsg); !ok {
-		t.Fatalf("expected force escalation drain message, got %T", cmd())
-	}
-	if got := quitRequests[len(quitRequests)-1]; got != uiQuitRequestForce {
-		t.Fatalf("expected force quit request, got %v", got)
-	}
-}
-
-func TestMultiRunPayloadFallbacksAndQueueCompletion(t *testing.T) {
-	t.Parallel()
-
-	mdl := multiRunModelForQuitTest()
-	mdl.handleParentEvent(mustRuntimeEventUITest(
-		t,
-		eventspkg.EventKindTaskRunMultipleChildStarted,
-		kinds.TaskRunMultiplePayload{
-			Slug:       "beta",
-			Index:      99,
-			Status:     taskMultiStatusRunning,
-			ChildRunID: "run-beta",
-		},
-	))
-	if got := mdl.tabs[1].runID; got != "run-beta" {
-		t.Fatalf("expected slug fallback to update beta run id, got %q", got)
-	}
-	mdl.handleParentEvent(mustRuntimeEventUITest(
-		t,
-		eventspkg.EventKindTaskRunMultipleQueueCompleted,
-		kinds.TaskRunMultiplePayload{Status: taskMultiStatusCompleted, Total: 2},
-	))
-	if got := mdl.parentRun.Status; got != remoteRunStatusCompleted {
-		t.Fatalf("parent status = %q, want completed", got)
-	}
-	if !mdl.isQueueComplete() {
-		t.Fatal("expected terminal parent to mark queue complete")
-	}
-}
-
-func TestAttachRemoteMultipleFollowsParentAndChildStreams(t *testing.T) {
-	originalSetup := setupRemoteMultiRunUISession
-	defer func() {
-		setupRemoteMultiRunUISession = originalSetup
-	}()
-
-	var session *recordingMultiRunSession
-	setupRemoteMultiRunUISession = func(ctx context.Context, mdl *multiRunModel) remoteWorkerSession {
-		session = newRecordingMultiRunSession(ctx, mdl)
-		return session
-	}
-
-	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
-	parentStream := newBufferedClientRunStream(
-		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
-			t,
-			eventspkg.EventKindTaskRunMultipleChildStarted,
-			kinds.TaskRunMultiplePayload{
-				Slug:       "alpha",
-				Index:      0,
-				Total:      2,
-				Status:     taskMultiStatusRunning,
-				ChildRunID: "run-alpha",
-			},
-		), 1, now)},
-		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+		mdl.handleParentEvent(mustRuntimeEventUITest(
 			t,
 			eventspkg.EventKindTaskRunMultipleChildCompleted,
 			kinds.TaskRunMultiplePayload{
 				Slug:       "alpha",
 				Index:      0,
-				Total:      2,
+				Total:      3,
 				Status:     taskMultiStatusCompleted,
 				ChildRunID: "run-alpha",
 			},
-		), 2, now.Add(time.Second))},
-		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
-			t,
-			eventspkg.EventKindRunCompleted,
-			kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
-		), 3, now.Add(2*time.Second))},
-	)
-	childStream := newBufferedClientRunStream(
-		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
-			t,
-			eventspkg.EventKindJobQueued,
-			kinds.JobQueuedPayload{Index: 0, TaskTitle: "Alpha child", SafeName: "alpha-child"},
-		), 1, now)},
-		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
-			t,
-			eventspkg.EventKindJobStarted,
-			kinds.JobStartedPayload{JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 1, MaxAttempts: 1}},
-		), 2, now.Add(time.Second))},
-		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
-			t,
-			eventspkg.EventKindRunCompleted,
-			kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
-		), 3, now.Add(2*time.Second))},
-	)
+		))
 
-	attached, err := AttachRemoteMultiple(context.Background(), RemoteMultiRunAttachOptions{
-		Snapshot: apicore.TaskRunMultipleSnapshot{
-			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
-			Items: []apicore.TaskRunMultipleItem{
-				{Slug: "alpha", Status: taskMultiStatusQueued},
-				{Slug: "beta", Status: taskMultiStatusQueued},
-			},
-		},
-		LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
-			return apicore.RunSnapshot{
-				Run: apicore.Run{RunID: runID, WorkflowSlug: "alpha", Status: remoteRunStatusRunning},
-			}, nil
-		},
-		OpenParentStream: func(context.Context, apicore.StreamCursor) (apiclient.RunStream, error) {
-			return parentStream, nil
-		},
-		OpenChildStream: func(_ context.Context, runID string, _ apicore.StreamCursor) (apiclient.RunStream, error) {
-			if runID != "run-alpha" {
-				t.Fatalf("unexpected child stream run id %q", runID)
-			}
-			return childStream, nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("AttachRemoteMultiple() error = %v", err)
-	}
-	if attached == nil {
-		t.Fatal("expected attached multi-run session")
-	}
-	if err := session.Wait(); err != nil {
-		t.Fatalf("recording session wait: %v", err)
-	}
-
-	session.withModel(func(mdl *multiRunModel) {
-		if got := mdl.tabs[0].status; got != taskMultiStatusCompleted {
-			t.Fatalf("alpha status = %q, want completed", got)
-		}
-		if got := mdl.tabs[0].runID; got != "run-alpha" {
-			t.Fatalf("alpha run id = %q, want run-alpha", got)
+		if got := mdl.activeTab; got != 1 {
+			t.Fatalf("expected active tab to advance to beta, got %d", got)
 		}
 		if mdl.tabs[0].child == nil {
-			t.Fatal("expected alpha child model")
+			t.Fatal("expected completed alpha child view to remain available")
 		}
-		if got := mdl.tabs[0].child.jobs[0].taskTitle; got != "Alpha child" {
-			t.Fatalf("alpha child title = %q, want Alpha child", got)
+		mdl.moveActiveTab(-1)
+		if got := mdl.activeTab; got != 0 {
+			t.Fatalf("expected alpha completed tab to remain navigable, got active %d", got)
 		}
+	})
+}
+
+func TestMultiRunTabNavigationDoesNotCycleChildPaneFocus(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should change tabs without cycling child pane focus", func(t *testing.T) {
+		mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+			Snapshot: apicore.TaskRunMultipleSnapshot{
+				Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+				Items: []apicore.TaskRunMultipleItem{
+					{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
+					{Slug: "beta", Status: taskMultiStatusRunning, RunID: "run-beta"},
+				},
+			},
+			LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
+				return childSnapshotForTest(
+					t,
+					runID,
+					strings.TrimPrefix(runID, "run-"),
+					remoteRunStatusRunning,
+					runID+" transcript",
+				), nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+		}
+		mdl.tabs[0].child.focusedPane = uiPaneTimeline
+
+		cmd := mdl.handleKey(keyCode(tea.KeyRight))
+		if cmd != nil {
+			t.Fatalf("expected tab navigation to stay local, got command %T", cmd())
+		}
+		if got := mdl.activeTab; got != 1 {
+			t.Fatalf("expected active tab beta, got %d", got)
+		}
+		if got := mdl.tabs[0].child.focusedPane; got != uiPaneTimeline {
+			t.Fatalf("expected alpha child focus to remain timeline, got %s", got)
+		}
+		if got := mdl.tabs[1].child.focusedPane; got != uiPaneJobs {
+			t.Fatalf("expected beta child focus to remain jobs, got %s", got)
+		}
+	})
+}
+
+func TestMultiRunTabNavigationUsesHorizontalKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should navigate tabs with horizontal keys", func(t *testing.T) {
+		mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+			Snapshot: apicore.TaskRunMultipleSnapshot{
+				Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+				Items: []apicore.TaskRunMultipleItem{
+					{Slug: "alpha", Status: taskMultiStatusQueued},
+					{Slug: "beta", Status: taskMultiStatusQueued},
+					{Slug: "gamma", Status: taskMultiStatusQueued},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+		}
+
+		mdl.handleKey(keyCode(tea.KeyRight))
+		if got := mdl.activeTab; got != 1 {
+			t.Fatalf("expected right arrow to move to beta tab, got %d", got)
+		}
+		mdl.handleKey(keyText("l"))
+		if got := mdl.activeTab; got != 2 {
+			t.Fatalf("expected l to move to gamma tab, got %d", got)
+		}
+		mdl.handleKey(keyCode(tea.KeyLeft))
+		if got := mdl.activeTab; got != 1 {
+			t.Fatalf("expected left arrow to move back to beta tab, got %d", got)
+		}
+		mdl.handleKey(keyText("h"))
+		if got := mdl.activeTab; got != 0 {
+			t.Fatalf("expected h to move back to alpha tab, got %d", got)
+		}
+
+		view := mdl.renderTabs()
+		if !strings.Contains(view, "←→/HL") || !strings.Contains(view, "TABS") {
+			t.Fatalf("expected tab help to advertise horizontal navigation, got %q", view)
+		}
+	})
+}
+
+func TestMultiRunCloseTUIDoesNotRequestParentCancel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should quit without requesting parent cancel when closing TUI", func(t *testing.T) {
+		mdl := multiRunModelForQuitTest()
+		var quitRequests []uiQuitRequest
+		mdl.onQuit = func(req uiQuitRequest) {
+			quitRequests = append(quitRequests, req)
+		}
+
+		if cmd := mdl.handleKey(keyText("q")); cmd != nil {
+			t.Fatalf("expected q to open quit dialog, got %T", cmd())
+		}
+		cmd := mdl.handleKey(keyCode(tea.KeyEnter))
+		if cmd == nil {
+			t.Fatal("expected Close TUI confirmation to return quit command")
+		}
+		if _, ok := cmd().(tea.QuitMsg); !ok {
+			t.Fatalf("expected Close TUI to quit, got %T", cmd())
+		}
+		if len(quitRequests) != 0 {
+			t.Fatalf("expected Close TUI not to request parent cancel, got %#v", quitRequests)
+		}
+	})
+}
+
+func TestMultiRunStopRunRequestsParentCancelOnceAndMarksQueuedCanceled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should request parent cancel once and mark queued tabs canceled", func(t *testing.T) {
+		mdl := multiRunModelForQuitTest()
+		var quitRequests []uiQuitRequest
+		mdl.onQuit = func(req uiQuitRequest) {
+			quitRequests = append(quitRequests, req)
+		}
+
+		mdl.handleKey(keyText("q"))
+		mdl.handleKey(keyText(keyRight))
+		cmd := mdl.handleKey(keyCode(tea.KeyEnter))
+		if cmd == nil {
+			t.Fatal("expected Stop Run confirmation to return command")
+		}
+		if _, ok := cmd().(drainMsg); !ok {
+			t.Fatalf("expected Stop Run command to drain, got %T", cmd())
+		}
+		if got := len(quitRequests); got != 1 {
+			t.Fatalf("expected one parent cancel request, got %d", got)
+		}
+		if quitRequests[0] != uiQuitRequestDrain {
+			t.Fatalf("expected drain quit request, got %v", quitRequests[0])
+		}
+		for idx, tab := range mdl.tabs {
+			if got := tab.status; got != taskMultiStatusCanceled {
+				t.Fatalf("tab %d status = %q, want canceled", idx, got)
+			}
+		}
+	})
+}
+
+func TestMultiRunQuitKeyDetachAndCompletedQueueCloseImmediately(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should close immediately for detach-only and completed queues", func(t *testing.T) {
+		detachOnly := multiRunModelForQuitTest()
+		detachOnly.cfg.DetachOnly = true
+		cmd := detachOnly.handleKey(keyText("q"))
+		if cmd == nil {
+			t.Fatal("expected detach-only queue to quit immediately")
+		}
+		if _, ok := cmd().(tea.QuitMsg); !ok {
+			t.Fatalf("expected detach-only quit command, got %T", cmd())
+		}
+
+		completed := multiRunModelForQuitTest()
+		completed.parentRun.Status = remoteRunStatusCompleted
+		cmd = completed.handleKey(keyText("q"))
+		if cmd == nil {
+			t.Fatal("expected completed queue to quit immediately")
+		}
+		if _, ok := cmd().(tea.QuitMsg); !ok {
+			t.Fatalf("expected completed queue quit command, got %T", cmd())
+		}
+	})
+}
+
+func TestMultiRunQuitDialogNavigationEscapeAndForceEscalation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should support quit dialog navigation escape and force escalation", func(t *testing.T) {
+		mdl := multiRunModelForQuitTest()
+		var quitRequests []uiQuitRequest
+		mdl.onQuit = func(req uiQuitRequest) {
+			quitRequests = append(quitRequests, req)
+		}
+
+		mdl.handleKey(keyText("q"))
+		mdl.handleKey(keyText(keyLeft))
+		if got := mdl.quitDialog.Selected; got != quitDialogActionCancel {
+			t.Fatalf("expected left from default to wrap to cancel, got %v", got)
+		}
+		if cmd := mdl.handleKey(keyText("esc")); cmd != nil {
+			t.Fatalf("expected escape to close dialog locally, got %T", cmd())
+		}
+		if mdl.quitDialog.Active {
+			t.Fatal("expected escape to close quit dialog")
+		}
+
+		mdl.shutdown = shutdownState{Phase: shutdownPhaseDraining}
+		cmd := mdl.handleKey(keyText("q"))
+		if cmd == nil {
+			t.Fatal("expected q during draining to escalate")
+		}
+		if _, ok := cmd().(drainMsg); !ok {
+			t.Fatalf("expected force escalation drain message, got %T", cmd())
+		}
+		if got := quitRequests[len(quitRequests)-1]; got != uiQuitRequestForce {
+			t.Fatalf("expected force quit request, got %v", got)
+		}
+	})
+}
+
+func TestMultiRunPayloadFallbacksAndQueueCompletion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should apply payload fallbacks and mark queue completion", func(t *testing.T) {
+		mdl := multiRunModelForQuitTest()
+		mdl.handleParentEvent(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindTaskRunMultipleChildStarted,
+			kinds.TaskRunMultiplePayload{
+				Slug:       "beta",
+				Index:      99,
+				Status:     taskMultiStatusRunning,
+				ChildRunID: "run-beta",
+			},
+		))
+		if got := mdl.tabs[1].runID; got != "run-beta" {
+			t.Fatalf("expected slug fallback to update beta run id, got %q", got)
+		}
+		mdl.handleParentEvent(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindTaskRunMultipleQueueCompleted,
+			kinds.TaskRunMultiplePayload{Status: taskMultiStatusCompleted, Total: 2},
+		))
+		if got := mdl.parentRun.Status; got != remoteRunStatusCompleted {
+			t.Fatalf("parent status = %q, want completed", got)
+		}
+		if !mdl.isQueueComplete() {
+			t.Fatal("expected terminal parent to mark queue complete")
+		}
+	})
+}
+
+func TestAttachRemoteMultipleFollowsParentAndChildStreams(t *testing.T) {
+	t.Run("Should follow both parent and child event streams", func(t *testing.T) {
+		originalSetup := setupRemoteMultiRunUISession
+		defer func() {
+			setupRemoteMultiRunUISession = originalSetup
+		}()
+
+		var session *recordingMultiRunSession
+		setupRemoteMultiRunUISession = func(ctx context.Context, mdl *multiRunModel) remoteWorkerSession {
+			session = newRecordingMultiRunSession(ctx, mdl)
+			return session
+		}
+
+		now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+		parentStream := newBufferedClientRunStream(
+			apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+				t,
+				eventspkg.EventKindTaskRunMultipleChildStarted,
+				kinds.TaskRunMultiplePayload{
+					Slug:       "alpha",
+					Index:      0,
+					Total:      2,
+					Status:     taskMultiStatusRunning,
+					ChildRunID: "run-alpha",
+				},
+			), 1, now)},
+			apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+				t,
+				eventspkg.EventKindTaskRunMultipleChildCompleted,
+				kinds.TaskRunMultiplePayload{
+					Slug:       "alpha",
+					Index:      0,
+					Total:      2,
+					Status:     taskMultiStatusCompleted,
+					ChildRunID: "run-alpha",
+				},
+			), 2, now.Add(time.Second))},
+			apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+				t,
+				eventspkg.EventKindRunCompleted,
+				kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
+			), 3, now.Add(2*time.Second))},
+		)
+		childStream := newBufferedClientRunStream(
+			apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+				t,
+				eventspkg.EventKindJobQueued,
+				kinds.JobQueuedPayload{Index: 0, TaskTitle: "Alpha child", SafeName: "alpha-child"},
+			), 1, now)},
+			apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+				t,
+				eventspkg.EventKindJobStarted,
+				kinds.JobStartedPayload{JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 1, MaxAttempts: 1}},
+			), 2, now.Add(time.Second))},
+			apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+				t,
+				eventspkg.EventKindRunCompleted,
+				kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
+			), 3, now.Add(2*time.Second))},
+		)
+
+		attached, err := AttachRemoteMultiple(context.Background(), RemoteMultiRunAttachOptions{
+			Snapshot: apicore.TaskRunMultipleSnapshot{
+				Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+				Items: []apicore.TaskRunMultipleItem{
+					{Slug: "alpha", Status: taskMultiStatusQueued},
+					{Slug: "beta", Status: taskMultiStatusQueued},
+				},
+			},
+			LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
+				return apicore.RunSnapshot{
+					Run: apicore.Run{RunID: runID, WorkflowSlug: "alpha", Status: remoteRunStatusRunning},
+				}, nil
+			},
+			OpenParentStream: func(context.Context, apicore.StreamCursor) (apiclient.RunStream, error) {
+				return parentStream, nil
+			},
+			OpenChildStream: func(_ context.Context, runID string, _ apicore.StreamCursor) (apiclient.RunStream, error) {
+				if runID != "run-alpha" {
+					t.Fatalf("unexpected child stream run id %q", runID)
+				}
+				return childStream, nil
+			},
+		})
+		if err != nil {
+			t.Fatalf("AttachRemoteMultiple() error = %v", err)
+		}
+		if attached == nil {
+			t.Fatal("expected attached multi-run session")
+		}
+		if err := session.Wait(); err != nil {
+			t.Fatalf("recording session wait: %v", err)
+		}
+
+		session.withModel(func(mdl *multiRunModel) {
+			if got := mdl.tabs[0].status; got != taskMultiStatusCompleted {
+				t.Fatalf("alpha status = %q, want completed", got)
+			}
+			if got := mdl.tabs[0].runID; got != "run-alpha" {
+				t.Fatalf("alpha run id = %q, want run-alpha", got)
+			}
+			if mdl.tabs[0].child == nil {
+				t.Fatal("expected alpha child model")
+			}
+			if got := mdl.tabs[0].child.jobs[0].taskTitle; got != "Alpha child" {
+				t.Fatalf("alpha child title = %q, want Alpha child", got)
+			}
+		})
 	})
 }
 

--- a/internal/core/run/ui/multi_remote_test.go
+++ b/internal/core/run/ui/multi_remote_test.go
@@ -1,0 +1,872 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	apiclient "github.com/compozy/compozy/internal/api/client"
+	apicore "github.com/compozy/compozy/internal/api/core"
+	"github.com/compozy/compozy/internal/core/model"
+	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
+	"github.com/compozy/compozy/pkg/compozy/events/kinds"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestMultiRunInitialSnapshotRendersQueuedTabsInOrder(t *testing.T) {
+	t.Parallel()
+
+	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{
+				{Slug: "alpha", Status: taskMultiStatusQueued},
+				{Slug: "beta", Status: taskMultiStatusQueued},
+				{Slug: "gamma", Status: taskMultiStatusQueued},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+	}
+	mdl.handleWindowSize(tea.WindowSizeMsg{Width: 120, Height: 30})
+
+	view := mdl.View().Content
+	alpha := strings.Index(view, "alpha QUEUED")
+	beta := strings.Index(view, "beta QUEUED")
+	gamma := strings.Index(view, "gamma QUEUED")
+	if alpha < 0 || beta < 0 || gamma < 0 {
+		t.Fatalf("expected queued tabs for alpha, beta, gamma, got %q", view)
+	}
+	if alpha >= beta || beta >= gamma {
+		t.Fatalf("expected queued tabs in request order, got alpha=%d beta=%d gamma=%d", alpha, beta, gamma)
+	}
+	if !strings.Contains(view, "Child run has not started yet.") {
+		t.Fatalf("expected queued active tab message, got %q", view)
+	}
+}
+
+func TestMultiRunChildStartUpdatesOnlyTargetTabState(t *testing.T) {
+	t.Parallel()
+
+	alphaSnapshot := childSnapshotForTest(t, "run-alpha", "alpha", remoteRunStatusRunning, "alpha transcript")
+	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{
+				{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
+				{Slug: "beta", Status: taskMultiStatusQueued},
+			},
+		},
+		LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
+			if runID != "run-alpha" {
+				t.Fatalf("unexpected child snapshot run id %q", runID)
+			}
+			return alphaSnapshot, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+	}
+	alphaEntries := append([]TranscriptEntry(nil), mdl.tabs[0].child.jobs[0].snapshot.Entries...)
+
+	mdl.handleParentEvent(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleChildStarted,
+		kinds.TaskRunMultiplePayload{
+			Slug:       "beta",
+			Index:      1,
+			Total:      2,
+			Status:     taskMultiStatusRunning,
+			ChildRunID: "run-beta",
+		},
+	))
+
+	if got := mdl.tabs[1].status; got != taskMultiStatusRunning {
+		t.Fatalf("expected beta running, got %q", got)
+	}
+	if got := mdl.tabs[1].runID; got != "run-beta" {
+		t.Fatalf("expected beta child run id, got %q", got)
+	}
+	if !reflect.DeepEqual(alphaEntries, mdl.tabs[0].child.jobs[0].snapshot.Entries) {
+		t.Fatalf("alpha transcript changed after beta start: %#v", mdl.tabs[0].child.jobs[0].snapshot.Entries)
+	}
+}
+
+func TestMultiRunCompletedTabRemainsNavigableAfterActiveAdvances(t *testing.T) {
+	t.Parallel()
+
+	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{
+				{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
+				{Slug: "beta", Status: taskMultiStatusQueued},
+				{Slug: "gamma", Status: taskMultiStatusQueued},
+			},
+		},
+		LoadChildSnapshot: func(context.Context, string) (apicore.RunSnapshot, error) {
+			return childSnapshotForTest(t, "run-alpha", "alpha", remoteRunStatusRunning, "alpha transcript"), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+	}
+
+	mdl.handleParentEvent(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleChildCompleted,
+		kinds.TaskRunMultiplePayload{
+			Slug:       "alpha",
+			Index:      0,
+			Total:      3,
+			Status:     taskMultiStatusCompleted,
+			ChildRunID: "run-alpha",
+		},
+	))
+
+	if got := mdl.activeTab; got != 1 {
+		t.Fatalf("expected active tab to advance to beta, got %d", got)
+	}
+	if mdl.tabs[0].child == nil {
+		t.Fatal("expected completed alpha child view to remain available")
+	}
+	mdl.moveActiveTab(-1)
+	if got := mdl.activeTab; got != 0 {
+		t.Fatalf("expected alpha completed tab to remain navigable, got active %d", got)
+	}
+}
+
+func TestMultiRunTabNavigationDoesNotCycleChildPaneFocus(t *testing.T) {
+	t.Parallel()
+
+	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{
+				{Slug: "alpha", Status: taskMultiStatusRunning, RunID: "run-alpha"},
+				{Slug: "beta", Status: taskMultiStatusRunning, RunID: "run-beta"},
+			},
+		},
+		LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
+			return childSnapshotForTest(
+				t,
+				runID,
+				strings.TrimPrefix(runID, "run-"),
+				remoteRunStatusRunning,
+				runID+" transcript",
+			), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+	}
+	mdl.tabs[0].child.focusedPane = uiPaneTimeline
+
+	cmd := mdl.handleKey(keyText("]"))
+	if cmd != nil {
+		t.Fatalf("expected tab navigation to stay local, got command %T", cmd())
+	}
+	if got := mdl.activeTab; got != 1 {
+		t.Fatalf("expected active tab beta, got %d", got)
+	}
+	if got := mdl.tabs[0].child.focusedPane; got != uiPaneTimeline {
+		t.Fatalf("expected alpha child focus to remain timeline, got %s", got)
+	}
+	if got := mdl.tabs[1].child.focusedPane; got != uiPaneJobs {
+		t.Fatalf("expected beta child focus to remain jobs, got %s", got)
+	}
+}
+
+func TestMultiRunCloseTUIDoesNotRequestParentCancel(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	var quitRequests []uiQuitRequest
+	mdl.onQuit = func(req uiQuitRequest) {
+		quitRequests = append(quitRequests, req)
+	}
+
+	if cmd := mdl.handleKey(keyText("q")); cmd != nil {
+		t.Fatalf("expected q to open quit dialog, got %T", cmd())
+	}
+	cmd := mdl.handleKey(keyCode(tea.KeyEnter))
+	if cmd == nil {
+		t.Fatal("expected Close TUI confirmation to return quit command")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("expected Close TUI to quit, got %T", cmd())
+	}
+	if len(quitRequests) != 0 {
+		t.Fatalf("expected Close TUI not to request parent cancel, got %#v", quitRequests)
+	}
+}
+
+func TestMultiRunStopRunRequestsParentCancelOnceAndMarksQueuedCanceled(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	var quitRequests []uiQuitRequest
+	mdl.onQuit = func(req uiQuitRequest) {
+		quitRequests = append(quitRequests, req)
+	}
+
+	mdl.handleKey(keyText("q"))
+	mdl.handleKey(keyText("right"))
+	cmd := mdl.handleKey(keyCode(tea.KeyEnter))
+	if cmd == nil {
+		t.Fatal("expected Stop Run confirmation to return command")
+	}
+	if _, ok := cmd().(drainMsg); !ok {
+		t.Fatalf("expected Stop Run command to drain, got %T", cmd())
+	}
+	if got := len(quitRequests); got != 1 {
+		t.Fatalf("expected one parent cancel request, got %d", got)
+	}
+	if quitRequests[0] != uiQuitRequestDrain {
+		t.Fatalf("expected drain quit request, got %v", quitRequests[0])
+	}
+	for idx, tab := range mdl.tabs {
+		if got := tab.status; got != taskMultiStatusCanceled {
+			t.Fatalf("tab %d status = %q, want canceled", idx, got)
+		}
+	}
+}
+
+func TestMultiRunQuitKeyDetachAndCompletedQueueCloseImmediately(t *testing.T) {
+	t.Parallel()
+
+	detachOnly := multiRunModelForQuitTest()
+	detachOnly.cfg.DetachOnly = true
+	cmd := detachOnly.handleKey(keyText("q"))
+	if cmd == nil {
+		t.Fatal("expected detach-only queue to quit immediately")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("expected detach-only quit command, got %T", cmd())
+	}
+
+	completed := multiRunModelForQuitTest()
+	completed.parentRun.Status = remoteRunStatusCompleted
+	cmd = completed.handleKey(keyText("q"))
+	if cmd == nil {
+		t.Fatal("expected completed queue to quit immediately")
+	}
+	if _, ok := cmd().(tea.QuitMsg); !ok {
+		t.Fatalf("expected completed queue quit command, got %T", cmd())
+	}
+}
+
+func TestMultiRunQuitDialogNavigationEscapeAndForceEscalation(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	var quitRequests []uiQuitRequest
+	mdl.onQuit = func(req uiQuitRequest) {
+		quitRequests = append(quitRequests, req)
+	}
+
+	mdl.handleKey(keyText("q"))
+	mdl.handleKey(keyText("left"))
+	if got := mdl.quitDialog.Selected; got != quitDialogActionCancel {
+		t.Fatalf("expected left from default to wrap to cancel, got %v", got)
+	}
+	if cmd := mdl.handleKey(keyText("esc")); cmd != nil {
+		t.Fatalf("expected escape to close dialog locally, got %T", cmd())
+	}
+	if mdl.quitDialog.Active {
+		t.Fatal("expected escape to close quit dialog")
+	}
+
+	mdl.shutdown = shutdownState{Phase: shutdownPhaseDraining}
+	cmd := mdl.handleKey(keyText("q"))
+	if cmd == nil {
+		t.Fatal("expected q during draining to escalate")
+	}
+	if _, ok := cmd().(drainMsg); !ok {
+		t.Fatalf("expected force escalation drain message, got %T", cmd())
+	}
+	if got := quitRequests[len(quitRequests)-1]; got != uiQuitRequestForce {
+		t.Fatalf("expected force quit request, got %v", got)
+	}
+}
+
+func TestMultiRunPayloadFallbacksAndQueueCompletion(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	mdl.handleParentEvent(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleChildStarted,
+		kinds.TaskRunMultiplePayload{
+			Slug:       "beta",
+			Index:      99,
+			Status:     taskMultiStatusRunning,
+			ChildRunID: "run-beta",
+		},
+	))
+	if got := mdl.tabs[1].runID; got != "run-beta" {
+		t.Fatalf("expected slug fallback to update beta run id, got %q", got)
+	}
+	mdl.handleParentEvent(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleQueueCompleted,
+		kinds.TaskRunMultiplePayload{Status: taskMultiStatusCompleted, Total: 2},
+	))
+	if got := mdl.parentRun.Status; got != remoteRunStatusCompleted {
+		t.Fatalf("parent status = %q, want completed", got)
+	}
+	if !mdl.isQueueComplete() {
+		t.Fatal("expected terminal parent to mark queue complete")
+	}
+}
+
+func TestAttachRemoteMultipleFollowsParentAndChildStreams(t *testing.T) {
+	originalSetup := setupRemoteMultiRunUISession
+	defer func() {
+		setupRemoteMultiRunUISession = originalSetup
+	}()
+
+	var session *recordingMultiRunSession
+	setupRemoteMultiRunUISession = func(ctx context.Context, mdl *multiRunModel) remoteWorkerSession {
+		session = newRecordingMultiRunSession(ctx, mdl)
+		return session
+	}
+
+	now := time.Date(2026, 5, 17, 12, 0, 0, 0, time.UTC)
+	parentStream := newBufferedClientRunStream(
+		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindTaskRunMultipleChildStarted,
+			kinds.TaskRunMultiplePayload{
+				Slug:       "alpha",
+				Index:      0,
+				Total:      2,
+				Status:     taskMultiStatusRunning,
+				ChildRunID: "run-alpha",
+			},
+		), 1, now)},
+		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindTaskRunMultipleChildCompleted,
+			kinds.TaskRunMultiplePayload{
+				Slug:       "alpha",
+				Index:      0,
+				Total:      2,
+				Status:     taskMultiStatusCompleted,
+				ChildRunID: "run-alpha",
+			},
+		), 2, now.Add(time.Second))},
+		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindRunCompleted,
+			kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
+		), 3, now.Add(2*time.Second))},
+	)
+	childStream := newBufferedClientRunStream(
+		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindJobQueued,
+			kinds.JobQueuedPayload{Index: 0, TaskTitle: "Alpha child", SafeName: "alpha-child"},
+		), 1, now)},
+		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindJobStarted,
+			kinds.JobStartedPayload{JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 1, MaxAttempts: 1}},
+		), 2, now.Add(time.Second))},
+		apiclient.RunStreamItem{Event: eventPointer(mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindRunCompleted,
+			kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
+		), 3, now.Add(2*time.Second))},
+	)
+
+	attached, err := AttachRemoteMultiple(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{
+				{Slug: "alpha", Status: taskMultiStatusQueued},
+				{Slug: "beta", Status: taskMultiStatusQueued},
+			},
+		},
+		LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
+			return apicore.RunSnapshot{
+				Run: apicore.Run{RunID: runID, WorkflowSlug: "alpha", Status: remoteRunStatusRunning},
+			}, nil
+		},
+		OpenParentStream: func(context.Context, apicore.StreamCursor) (apiclient.RunStream, error) {
+			return parentStream, nil
+		},
+		OpenChildStream: func(_ context.Context, runID string, _ apicore.StreamCursor) (apiclient.RunStream, error) {
+			if runID != "run-alpha" {
+				t.Fatalf("unexpected child stream run id %q", runID)
+			}
+			return childStream, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("AttachRemoteMultiple() error = %v", err)
+	}
+	if attached == nil {
+		t.Fatal("expected attached multi-run session")
+	}
+	if err := session.Wait(); err != nil {
+		t.Fatalf("recording session wait: %v", err)
+	}
+
+	session.withModel(func(mdl *multiRunModel) {
+		if got := mdl.tabs[0].status; got != taskMultiStatusCompleted {
+			t.Fatalf("alpha status = %q, want completed", got)
+		}
+		if got := mdl.tabs[0].runID; got != "run-alpha" {
+			t.Fatalf("alpha run id = %q, want run-alpha", got)
+		}
+		if mdl.tabs[0].child == nil {
+			t.Fatal("expected alpha child model")
+		}
+		if got := mdl.tabs[0].child.jobs[0].taskTitle; got != "Alpha child" {
+			t.Fatalf("alpha child title = %q, want Alpha child", got)
+		}
+	})
+}
+
+func TestRemoteMultiRunReattachRestoresCompletedActiveAndQueuedTabs(t *testing.T) {
+	t.Parallel()
+
+	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{
+				{Slug: "alpha", Status: taskMultiStatusCompleted, RunID: "run-alpha"},
+				{Slug: "beta", Status: taskMultiStatusRunning, RunID: "run-beta"},
+				{Slug: "gamma", Status: taskMultiStatusQueued},
+			},
+		},
+		LoadChildSnapshot: func(_ context.Context, runID string) (apicore.RunSnapshot, error) {
+			switch runID {
+			case "run-alpha":
+				return childSnapshotForTest(t, runID, "alpha", remoteRunStatusCompleted, "alpha done"), nil
+			case "run-beta":
+				return childSnapshotForTest(t, runID, "beta", remoteRunStatusRunning, "beta work"), nil
+			default:
+				t.Fatalf("unexpected child snapshot run id %q", runID)
+				return apicore.RunSnapshot{}, nil
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+	}
+
+	if got := mdl.activeTab; got != 1 {
+		t.Fatalf("expected active tab to restore running beta, got %d", got)
+	}
+	if mdl.tabs[0].child == nil || mdl.tabs[1].child == nil {
+		t.Fatalf("expected completed and running child models, got %#v", mdl.tabs)
+	}
+	if mdl.tabs[2].child != nil {
+		t.Fatal("expected queued gamma tab to have no child model yet")
+	}
+	if got := mdl.tabs[0].child.jobs[0].snapshot.Entries[0].Preview; got != "alpha done" {
+		t.Fatalf("expected alpha transcript restored, got %q", got)
+	}
+	if got := mdl.tabs[1].child.jobs[0].snapshot.Entries[0].Preview; got != "beta work" {
+		t.Fatalf("expected beta transcript restored, got %q", got)
+	}
+}
+
+func TestMultiRunControllerLifecycleCoversSessionMethods(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	done := make(chan error)
+	close(done)
+	ctx, cancel := context.WithCancel(context.Background())
+	ctrl := &multiRunController{model: mdl, done: done, ctx: ctx, cancel: cancel}
+	quitCalls := 0
+	ctrl.SetQuitHandler(func(uiQuitRequest) {
+		quitCalls++
+	})
+	ctrl.requestQuit(uiQuitRequestDrain)
+	ctrl.Enqueue(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleStarted,
+		kinds.TaskRunMultiplePayload{Slugs: []string{"alpha", "beta"}, Total: 2, Status: taskMultiStatusRunning},
+	))
+	ctrl.StartRemoteWorker(func(context.Context) {})
+	ctrl.CloseEvents()
+	ctrl.Shutdown()
+	if err := ctrl.Wait(); err != nil {
+		t.Fatalf("multi-run controller wait: %v", err)
+	}
+	if quitCalls != 1 {
+		t.Fatalf("quit handler calls = %d, want 1", quitCalls)
+	}
+}
+
+func TestNewMultiRunControllerRunsWithInjectedProgram(t *testing.T) {
+	originalProgram := newMultiRunTeaProgram
+	defer func() {
+		newMultiRunTeaProgram = originalProgram
+	}()
+	newMultiRunTeaProgram = func(mdl tea.Model) *tea.Program {
+		return tea.NewProgram(mdl, tea.WithoutSignalHandler(), tea.WithoutRenderer(), tea.WithInput(nil))
+	}
+
+	session := newMultiRunController(context.Background(), multiRunModelForQuitTest())
+	ctrl, ok := session.(*multiRunController)
+	if !ok {
+		t.Fatalf("expected multiRunController, got %T", session)
+	}
+	ctrl.Enqueue(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleStarted,
+		kinds.TaskRunMultiplePayload{Slugs: []string{"alpha", "beta"}, Total: 2, Status: taskMultiStatusRunning},
+	))
+	ctrl.Shutdown()
+	if err := ctrl.Wait(); err != nil {
+		t.Fatalf("multi-run controller wait: %v", err)
+	}
+}
+
+func TestMultiRunQuitDialogRenderAndCancelAction(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	mdl.handleKey(keyText("q"))
+	if !mdl.quitDialog.Active {
+		t.Fatal("expected quit dialog to open")
+	}
+	view := mdl.View().Content
+	if !strings.Contains(view, "Leave Active Queue?") || !strings.Contains(view, "Stop Run") {
+		t.Fatalf("expected queue quit dialog, got %q", view)
+	}
+
+	mdl.handleKey(keyText("right"))
+	mdl.handleKey(keyText("right"))
+	if got := mdl.quitDialog.Selected; got != quitDialogActionCancel {
+		t.Fatalf("expected cancel action selected, got %v", got)
+	}
+	if cmd := mdl.handleKey(keyCode(tea.KeyEnter)); cmd != nil {
+		t.Fatalf("expected Cancel action to return to UI without command, got %T", cmd())
+	}
+	if mdl.quitDialog.Active {
+		t.Fatal("expected Cancel action to close dialog")
+	}
+	if mdl.shutdown.Active() {
+		t.Fatalf("expected Cancel action not to start shutdown, got %#v", mdl.shutdown)
+	}
+}
+
+func TestMultiRunParentStartedAndQueueCanceledEvents(t *testing.T) {
+	t.Parallel()
+
+	mdl := &multiRunModel{
+		parentRun:  apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+		width:      120,
+		height:     30,
+		cfg:        &config{},
+		quitDialog: newQuitDialogState(),
+	}
+	mdl.handleParentEvent(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleStarted,
+		kinds.TaskRunMultiplePayload{
+			Status: taskMultiStatusRunning,
+			Slugs:  []string{"alpha", "beta"},
+			Total:  2,
+		},
+	))
+	if len(mdl.tabs) != 2 {
+		t.Fatalf("expected started event to create two tabs, got %#v", mdl.tabs)
+	}
+	mdl.handleParentEvent(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindTaskRunMultipleQueueCanceled,
+		kinds.TaskRunMultiplePayload{Status: taskMultiStatusCanceled, Error: "stop requested"},
+	))
+	for idx, tab := range mdl.tabs {
+		if tab.status != taskMultiStatusCanceled || tab.errorText != "stop requested" {
+			t.Fatalf("tab %d after queue cancel = %#v", idx, tab)
+		}
+	}
+	if got := mdl.parentRun.Status; got != remoteRunStatusCanceled {
+		t.Fatalf("parent status = %q, want canceled", got)
+	}
+}
+
+func TestMultiRunChildEventCreatesPlaceholderAndMapsTerminalRunStatus(t *testing.T) {
+	t.Parallel()
+
+	mdl := &multiRunModel{
+		parentRun:  apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+		width:      120,
+		height:     30,
+		cfg:        &config{},
+		quitDialog: newQuitDialogState(),
+		tabs: []multiRunTab{{
+			slug:       "alpha",
+			status:     taskMultiStatusRunning,
+			runID:      "run-alpha",
+			translator: newUIEventTranslator(),
+		}},
+	}
+
+	mdl.handleChildEvent(multiRunChildEventMsg{
+		RunID: "run-alpha",
+		Event: mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindJobQueued,
+			kinds.JobQueuedPayload{Index: 0, SafeName: "alpha-job", TaskTitle: "Alpha"},
+		),
+	})
+	if mdl.tabs[0].child == nil {
+		t.Fatal("expected child event to create placeholder child model")
+	}
+	if got := mdl.tabs[0].child.jobs[0].taskTitle; got != "Alpha" {
+		t.Fatalf("child task title = %q, want Alpha", got)
+	}
+
+	mdl.handleChildEvent(multiRunChildEventMsg{
+		RunID: "run-alpha",
+		Event: mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindRunFailed,
+			kinds.RunFailedPayload{Error: "child failed"},
+		),
+	})
+	if got := mdl.tabs[0].status; got != taskMultiStatusFailed {
+		t.Fatalf("child terminal status = %q, want failed", got)
+	}
+}
+
+func TestMultiRunUpdateRoutesResizeTicksParentAndChildMessages(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	if _, cmd := mdl.Update(tea.WindowSizeMsg{Width: 100, Height: 28}); cmd != nil {
+		t.Fatalf("expected resize to stay local, got %T", cmd())
+	}
+	if got := mdl.tabs[0].child.width; got != 100 {
+		t.Fatalf("child width = %d, want 100", got)
+	}
+	mdl.Update(clockTickMsg{at: time.Now()})
+	mdl.Update(spinnerTickMsg{at: time.Now()})
+	mdl.Update(multiRunChildBootstrapMsg{
+		RunID:    "run-alpha",
+		Snapshot: childSnapshotForTest(t, "run-alpha", "alpha", remoteRunStatusCompleted, "done"),
+	})
+	if got := mdl.tabs[0].status; got != taskMultiStatusCompleted {
+		t.Fatalf("bootstrap status = %q, want completed", got)
+	}
+	mdl.Update(mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindRunFailed,
+		kinds.RunFailedPayload{Error: "parent failed"},
+	))
+	if got := mdl.parentRun.Status; got != remoteRunStatusFailed {
+		t.Fatalf("parent status = %q, want failed", got)
+	}
+}
+
+func TestAttachRemoteMultipleReturnsSetupAndParentStreamErrors(t *testing.T) {
+	originalSetup := setupRemoteMultiRunUISession
+	defer func() {
+		setupRemoteMultiRunUISession = originalSetup
+	}()
+
+	setupRemoteMultiRunUISession = func(context.Context, *multiRunModel) remoteWorkerSession {
+		return nil
+	}
+	_, err := AttachRemoteMultiple(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "remote multi-run ui session is required") {
+		t.Fatalf("AttachRemoteMultiple nil setup error = %v", err)
+	}
+
+	setupRemoteMultiRunUISession = func(ctx context.Context, mdl *multiRunModel) remoteWorkerSession {
+		return newRecordingMultiRunSession(ctx, mdl)
+	}
+	_, err = AttachRemoteMultiple(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+		},
+		OpenParentStream: func(context.Context, apicore.StreamCursor) (apiclient.RunStream, error) {
+			return nil, context.Canceled
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AttachRemoteMultiple stream error = %v, want context.Canceled wrapper", err)
+	}
+}
+
+func TestMultiRunStatusHelpersCoverAllStatuses(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{
+		taskMultiStatusQueued,
+		taskMultiStatusRunning,
+		taskMultiStatusCompleted,
+		taskMultiStatusFailed,
+		taskMultiStatusCanceled,
+		"unknown",
+	} {
+		if multiRunStatusColor(status) == nil {
+			t.Fatalf("expected color for status %q", status)
+		}
+	}
+	for _, status := range []string{
+		remoteRunStatusRunning,
+		remoteRunStatusRetrying,
+		remoteRunStatusCompleted,
+		remoteRunStatusFailed,
+		remoteRunStatusCrashed,
+		remoteRunStatusCanceled,
+		"pending",
+	} {
+		_ = taskMultiStatusFromRunStatus(status)
+	}
+	for _, kind := range []eventspkg.EventKind{
+		eventspkg.EventKindRunCompleted,
+		eventspkg.EventKindRunFailed,
+		eventspkg.EventKindRunCancelled,
+		eventspkg.EventKindJobQueued,
+	} {
+		_ = taskMultiStatusFromChildRunEvent(kind)
+	}
+}
+
+func TestMultiRunNilAndNarrowHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	var nilController *multiRunController
+	nilController.SetQuitHandler(nil)
+	nilController.StartRemoteWorker(nil)
+	nilController.Shutdown()
+
+	var nilModel *multiRunModel
+	if nilModel.activeChild() != nil {
+		t.Fatal("expected nil model active child to be nil")
+	}
+
+	mdl := multiRunModelForQuitTest()
+	if got := tabStatus(nil); got != taskMultiStatusQueued {
+		t.Fatalf("nil tab status = %q, want queued", got)
+	}
+	if actions := mdl.renderQuitDialogActions(20, colorBgSurface); !strings.Contains(actions, "\n") {
+		t.Fatalf("expected narrow quit actions to stack vertically, got %q", actions)
+	}
+	mdl.activeTab = -1
+	if mdl.activeTabState() != nil {
+		t.Fatal("expected invalid active tab to return nil")
+	}
+	mdl.resizeChild(nil)
+}
+
+func multiRunModelForQuitTest() *multiRunModel {
+	mdl := &multiRunModel{
+		parentRun:  apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+		width:      120,
+		height:     30,
+		cfg:        &config{},
+		quitDialog: newQuitDialogState(),
+		now:        time.Now(),
+		tabs: []multiRunTab{
+			{slug: "alpha", status: taskMultiStatusRunning, runID: "run-alpha", translator: newUIEventTranslator()},
+			{slug: "beta", status: taskMultiStatusQueued, translator: newUIEventTranslator()},
+		},
+	}
+	mdl.tabs[0].child = childModelFromRunSnapshot(apicore.RunSnapshot{
+		Run: apicore.Run{RunID: "run-alpha", WorkflowSlug: "alpha", Status: remoteRunStatusRunning},
+	}, mdl.cfg, mdl.childWidth(), mdl.childHeight())
+	return mdl
+}
+
+func childSnapshotForTest(
+	t *testing.T,
+	runID string,
+	slug string,
+	status string,
+	preview string,
+) apicore.RunSnapshot {
+	t.Helper()
+	return apicore.RunSnapshot{
+		Run: apicore.Run{RunID: runID, WorkflowSlug: slug, Status: status},
+		Jobs: []apicore.RunJobState{{
+			Index:  0,
+			JobID:  slug + "-job",
+			Status: status,
+			Summary: &apicore.RunJobSummary{
+				TaskTitle: slug,
+				SafeName:  slug,
+				Session: apiSessionSnapshot(buildSnapshotWithEntries(t, TranscriptEntry{
+					ID:      slug + "-entry",
+					Kind:    transcriptEntryAssistantMessage,
+					Title:   "Assistant",
+					Preview: preview,
+					Blocks:  []model.ContentBlock{mustContentBlockUITest(t, model.TextBlock{Text: preview})},
+				})),
+			},
+		}},
+	}
+}
+
+type recordingMultiRunSession struct {
+	mu          sync.Mutex
+	model       *multiRunModel
+	ctx         context.Context
+	cancel      context.CancelFunc
+	workers     sync.WaitGroup
+	quitHandler func(uiQuitRequest)
+}
+
+func newRecordingMultiRunSession(parent context.Context, mdl *multiRunModel) *recordingMultiRunSession {
+	ctx, cancel := context.WithCancel(parent)
+	mdl.onQuit = func(uiQuitRequest) {}
+	return &recordingMultiRunSession{model: mdl, ctx: ctx, cancel: cancel}
+}
+
+func (s *recordingMultiRunSession) Enqueue(msg any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.model.Update(msg)
+}
+
+func (s *recordingMultiRunSession) SetQuitHandler(fn func(uiQuitRequest)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.quitHandler = fn
+}
+
+func (s *recordingMultiRunSession) CloseEvents() {}
+
+func (s *recordingMultiRunSession) Shutdown() {
+	s.cancel()
+}
+
+func (s *recordingMultiRunSession) Wait() error {
+	s.workers.Wait()
+	return nil
+}
+
+func (s *recordingMultiRunSession) StartRemoteWorker(fn func(context.Context)) {
+	s.workers.Add(1)
+	go func() {
+		defer s.workers.Done()
+		fn(s.ctx)
+	}()
+}
+
+func (s *recordingMultiRunSession) withModel(fn func(*multiRunModel)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fn(s.model)
+}

--- a/internal/core/run/ui/multi_remote_test.go
+++ b/internal/core/run/ui/multi_remote_test.go
@@ -168,7 +168,7 @@ func TestMultiRunTabNavigationDoesNotCycleChildPaneFocus(t *testing.T) {
 	}
 	mdl.tabs[0].child.focusedPane = uiPaneTimeline
 
-	cmd := mdl.handleKey(keyText("]"))
+	cmd := mdl.handleKey(keyCode(tea.KeyRight))
 	if cmd != nil {
 		t.Fatalf("expected tab navigation to stay local, got command %T", cmd())
 	}
@@ -180,6 +180,46 @@ func TestMultiRunTabNavigationDoesNotCycleChildPaneFocus(t *testing.T) {
 	}
 	if got := mdl.tabs[1].child.focusedPane; got != uiPaneJobs {
 		t.Fatalf("expected beta child focus to remain jobs, got %s", got)
+	}
+}
+
+func TestMultiRunTabNavigationUsesHorizontalKeys(t *testing.T) {
+	t.Parallel()
+
+	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run: apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{
+				{Slug: "alpha", Status: taskMultiStatusQueued},
+				{Slug: "beta", Status: taskMultiStatusQueued},
+				{Slug: "gamma", Status: taskMultiStatusQueued},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+	}
+
+	mdl.handleKey(keyCode(tea.KeyRight))
+	if got := mdl.activeTab; got != 1 {
+		t.Fatalf("expected right arrow to move to beta tab, got %d", got)
+	}
+	mdl.handleKey(keyText("l"))
+	if got := mdl.activeTab; got != 2 {
+		t.Fatalf("expected l to move to gamma tab, got %d", got)
+	}
+	mdl.handleKey(keyCode(tea.KeyLeft))
+	if got := mdl.activeTab; got != 1 {
+		t.Fatalf("expected left arrow to move back to beta tab, got %d", got)
+	}
+	mdl.handleKey(keyText("h"))
+	if got := mdl.activeTab; got != 0 {
+		t.Fatalf("expected h to move back to alpha tab, got %d", got)
+	}
+
+	view := mdl.renderTabs()
+	if !strings.Contains(view, "←→/HL") || !strings.Contains(view, "TABS") {
+		t.Fatalf("expected tab help to advertise horizontal navigation, got %q", view)
 	}
 }
 
@@ -217,7 +257,7 @@ func TestMultiRunStopRunRequestsParentCancelOnceAndMarksQueuedCanceled(t *testin
 	}
 
 	mdl.handleKey(keyText("q"))
-	mdl.handleKey(keyText("right"))
+	mdl.handleKey(keyText(keyRight))
 	cmd := mdl.handleKey(keyCode(tea.KeyEnter))
 	if cmd == nil {
 		t.Fatal("expected Stop Run confirmation to return command")
@@ -272,7 +312,7 @@ func TestMultiRunQuitDialogNavigationEscapeAndForceEscalation(t *testing.T) {
 	}
 
 	mdl.handleKey(keyText("q"))
-	mdl.handleKey(keyText("left"))
+	mdl.handleKey(keyText(keyLeft))
 	if got := mdl.quitDialog.Selected; got != quitDialogActionCancel {
 		t.Fatalf("expected left from default to wrap to cancel, got %v", got)
 	}
@@ -547,8 +587,8 @@ func TestMultiRunQuitDialogRenderAndCancelAction(t *testing.T) {
 		t.Fatalf("expected queue quit dialog, got %q", view)
 	}
 
-	mdl.handleKey(keyText("right"))
-	mdl.handleKey(keyText("right"))
+	mdl.handleKey(keyText(keyRight))
+	mdl.handleKey(keyText(keyRight))
 	if got := mdl.quitDialog.Selected; got != quitDialogActionCancel {
 		t.Fatalf("expected cancel action selected, got %v", got)
 	}

--- a/internal/core/run/ui/update.go
+++ b/internal/core/run/ui/update.go
@@ -21,6 +21,8 @@ const (
 	keyTab      = "tab"
 	keyShiftTab = "shift+tab"
 	keyEnter    = "enter"
+	keyLeft     = "left"
+	keyRight    = "right"
 )
 
 var setSidebarViewportContent = func(vp *viewport.Model, content string) {
@@ -189,10 +191,10 @@ func (m *uiModel) requestRunStopFromQuit() tea.Cmd {
 
 func (m *uiModel) handleQuitDialogKey(v tea.KeyPressMsg) tea.Cmd {
 	switch strings.ToLower(v.String()) {
-	case "left", "h", keyShiftTab:
+	case keyLeft, "h", keyShiftTab:
 		m.quitDialog.Move(-1)
 		return nil
-	case "right", "l", keyTab:
+	case keyRight, "l", keyTab:
 		m.quitDialog.Move(1)
 		return nil
 	case keyEnter, "q", keyCtrlC:

--- a/internal/core/run/ui/update.go
+++ b/internal/core/run/ui/update.go
@@ -18,6 +18,9 @@ const (
 	keyEnd      = "end"
 	keyCtrlC    = "ctrl+c"
 	keyEscape   = "esc"
+	keyTab      = "tab"
+	keyShiftTab = "shift+tab"
+	keyEnter    = "enter"
 )
 
 var setSidebarViewportContent = func(vp *viewport.Model, content string) {
@@ -125,13 +128,13 @@ func (m *uiModel) handleKey(v tea.KeyPressMsg) tea.Cmd {
 		return m.handleSummaryToggle()
 	case keyEscape:
 		return m.handleEscape()
-	case "tab":
+	case keyTab:
 		m.cycleFocusedPane(1)
 		return nil
-	case "shift+tab":
+	case keyShiftTab:
 		m.cycleFocusedPane(-1)
 		return nil
-	case "enter":
+	case keyEnter:
 		m.toggleSelectedEntryExpansion()
 		return nil
 	case "up", "k":
@@ -186,13 +189,13 @@ func (m *uiModel) requestRunStopFromQuit() tea.Cmd {
 
 func (m *uiModel) handleQuitDialogKey(v tea.KeyPressMsg) tea.Cmd {
 	switch strings.ToLower(v.String()) {
-	case "left", "h", "shift+tab":
+	case "left", "h", keyShiftTab:
 		m.quitDialog.Move(-1)
 		return nil
-	case "right", "l", "tab":
+	case "right", "l", keyTab:
 		m.quitDialog.Move(1)
 		return nil
-	case "enter", "q", keyCtrlC:
+	case keyEnter, "q", keyCtrlC:
 		return m.confirmQuitDialog()
 	case keyEscape:
 		m.closeQuitDialog()

--- a/internal/core/run/ui/update_test.go
+++ b/internal/core/run/ui/update_test.go
@@ -81,7 +81,7 @@ func TestHandleKeyQuitDialogExplicitlyStopsRun(t *testing.T) {
 	if !m.quitDialog.Active {
 		t.Fatal("expected active run quit to open the quit dialog")
 	}
-	if cmd := m.handleKey(keyText("right")); cmd != nil {
+	if cmd := m.handleKey(keyText(keyRight)); cmd != nil {
 		t.Fatalf("expected action selection to stay local to the dialog, got %T", cmd())
 	}
 	if got := m.quitDialog.Selected; got != quitDialogActionStop {
@@ -357,6 +357,38 @@ func TestMoveFocusedSelectionNavigatesTimelineEntries(t *testing.T) {
 	m.handleKey(keyCode(tea.KeyUp))
 	if got := m.jobs[0].selectedEntry; got != 0 {
 		t.Fatalf("expected up to restore timeline selection, got %d", got)
+	}
+}
+
+func TestVerticalKeysNavigateFocusedJobs(t *testing.T) {
+	t.Parallel()
+
+	m := newUIModel(3)
+	m.jobs = []uiJob{
+		{safeName: "job-1"},
+		{safeName: "job-2"},
+		{safeName: "job-3"},
+	}
+	m.focusedPane = uiPaneJobs
+
+	m.handleKey(keyCode(tea.KeyDown))
+	if got := m.selectedJob; got != 1 {
+		t.Fatalf("expected down to move job selection forward, got %d", got)
+	}
+
+	m.handleKey(keyText("j"))
+	if got := m.selectedJob; got != 2 {
+		t.Fatalf("expected j to move job selection forward, got %d", got)
+	}
+
+	m.handleKey(keyCode(tea.KeyUp))
+	if got := m.selectedJob; got != 1 {
+		t.Fatalf("expected up to move job selection backward, got %d", got)
+	}
+
+	m.handleKey(keyText("k"))
+	if got := m.selectedJob; got != 0 {
+		t.Fatalf("expected k to move job selection backward, got %d", got)
 	}
 }
 

--- a/internal/core/run/ui/update_test.go
+++ b/internal/core/run/ui/update_test.go
@@ -313,7 +313,7 @@ func TestPaneNavigationCyclesVisiblePanes(t *testing.T) {
 		t.Fatalf("expected second tab to wrap focus back to jobs, got %s", got)
 	}
 
-	m.handleKey(keyText("shift+tab"))
+	m.handleKey(keyText(keyShiftTab))
 	if got := m.focusedPane; got != uiPaneTimeline {
 		t.Fatalf("expected shift+tab to move focus back to timeline, got %s", got)
 	}

--- a/internal/core/run/ui/update_test.go
+++ b/internal/core/run/ui/update_test.go
@@ -363,32 +363,56 @@ func TestMoveFocusedSelectionNavigatesTimelineEntries(t *testing.T) {
 func TestVerticalKeysNavigateFocusedJobs(t *testing.T) {
 	t.Parallel()
 
-	m := newUIModel(3)
-	m.jobs = []uiJob{
-		{safeName: "job-1"},
-		{safeName: "job-2"},
-		{safeName: "job-3"},
+	cases := []struct {
+		name         string
+		initial      int
+		key          tea.KeyPressMsg
+		wantSelected int
+	}{
+		{
+			name:         "Should move job selection forward with down arrow",
+			key:          keyCode(tea.KeyDown),
+			wantSelected: 1,
+		},
+		{
+			name:         "Should move job selection forward with j",
+			initial:      1,
+			key:          keyText("j"),
+			wantSelected: 2,
+		},
+		{
+			name:         "Should move job selection backward with up arrow",
+			initial:      2,
+			key:          keyCode(tea.KeyUp),
+			wantSelected: 1,
+		},
+		{
+			name:         "Should move job selection backward with k",
+			initial:      1,
+			key:          keyText("k"),
+			wantSelected: 0,
+		},
 	}
-	m.focusedPane = uiPaneJobs
 
-	m.handleKey(keyCode(tea.KeyDown))
-	if got := m.selectedJob; got != 1 {
-		t.Fatalf("expected down to move job selection forward, got %d", got)
-	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	m.handleKey(keyText("j"))
-	if got := m.selectedJob; got != 2 {
-		t.Fatalf("expected j to move job selection forward, got %d", got)
-	}
+			m := newUIModel(3)
+			m.jobs = []uiJob{
+				{safeName: "job-1"},
+				{safeName: "job-2"},
+				{safeName: "job-3"},
+			}
+			m.focusedPane = uiPaneJobs
+			m.selectedJob = tc.initial
 
-	m.handleKey(keyCode(tea.KeyUp))
-	if got := m.selectedJob; got != 1 {
-		t.Fatalf("expected up to move job selection backward, got %d", got)
-	}
-
-	m.handleKey(keyText("k"))
-	if got := m.selectedJob; got != 0 {
-		t.Fatalf("expected k to move job selection backward, got %d", got)
+			m.handleKey(tc.key)
+			if got := m.selectedJob; got != tc.wantSelected {
+				t.Fatalf("selectedJob = %d, want %d", got, tc.wantSelected)
+			}
+		})
 	}
 }
 

--- a/internal/core/run/ui/view.go
+++ b/internal/core/run/ui/view.go
@@ -159,12 +159,12 @@ func (m *uiModel) renderHelp() string {
 	case uiPaneJobs:
 		pairs = append(pairs,
 			renderKeycap("↑↓/jk", bg)+renderGap(bg, 1)+renderStyledOnBackground(styleMutedText, bg, "JOB"),
-			renderKeycap("tab", bg)+renderGap(bg, 1)+renderStyledOnBackground(styleMutedText, bg, "FOCUS"),
+			renderKeycap(keyTab, bg)+renderGap(bg, 1)+renderStyledOnBackground(styleMutedText, bg, "FOCUS"),
 		)
 	case uiPaneTimeline:
 		pairs = append(pairs,
 			renderKeycap("↑↓/jk", bg)+renderGap(bg, 1)+renderStyledOnBackground(styleMutedText, bg, "ENTRY"),
-			renderKeycap("enter", bg)+renderGap(bg, 1)+renderStyledOnBackground(styleMutedText, bg, "EXPAND"),
+			renderKeycap(keyEnter, bg)+renderGap(bg, 1)+renderStyledOnBackground(styleMutedText, bg, "EXPAND"),
 			renderKeycap("pg/home/end", bg)+renderGap(bg, 1)+renderStyledOnBackground(styleMutedText, bg, "SCROLL"),
 		)
 	}

--- a/internal/core/run/ui/view_test.go
+++ b/internal/core/run/ui/view_test.go
@@ -803,6 +803,21 @@ func TestActiveRunHelpUsesExitLabel(t *testing.T) {
 	}
 }
 
+func TestJobPaneHelpUsesVerticalNavigation(t *testing.T) {
+	t.Parallel()
+
+	m := newPopulatedUIModelForTest(t, tea.WindowSizeMsg{Width: 120, Height: 30})
+	m.focusedPane = uiPaneJobs
+
+	help := m.renderHelp()
+	if !strings.Contains(help, "↑↓/JK") {
+		t.Fatalf("expected job help to advertise vertical navigation, got %q", help)
+	}
+	if strings.Contains(help, "←→/HL") {
+		t.Fatalf("expected job help not to advertise horizontal navigation, got %q", help)
+	}
+}
+
 func TestQuitDialogViewContainsChoices(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/run/ui/view_test.go
+++ b/internal/core/run/ui/view_test.go
@@ -806,16 +806,18 @@ func TestActiveRunHelpUsesExitLabel(t *testing.T) {
 func TestJobPaneHelpUsesVerticalNavigation(t *testing.T) {
 	t.Parallel()
 
-	m := newPopulatedUIModelForTest(t, tea.WindowSizeMsg{Width: 120, Height: 30})
-	m.focusedPane = uiPaneJobs
+	t.Run("Should advertise vertical navigation for job pane", func(t *testing.T) {
+		m := newPopulatedUIModelForTest(t, tea.WindowSizeMsg{Width: 120, Height: 30})
+		m.focusedPane = uiPaneJobs
 
-	help := m.renderHelp()
-	if !strings.Contains(help, "↑↓/JK") {
-		t.Fatalf("expected job help to advertise vertical navigation, got %q", help)
-	}
-	if strings.Contains(help, "←→/HL") {
-		t.Fatalf("expected job help not to advertise horizontal navigation, got %q", help)
-	}
+		help := m.renderHelp()
+		if !strings.Contains(help, "↑↓/JK") {
+			t.Fatalf("expected job help to advertise vertical navigation, got %q", help)
+		}
+		if strings.Contains(help, "←→/HL") {
+			t.Fatalf("expected job help not to advertise horizontal navigation, got %q", help)
+		}
+	})
 }
 
 func TestQuitDialogViewContainsChoices(t *testing.T) {

--- a/internal/core/tasks/slug_list.go
+++ b/internal/core/tasks/slug_list.go
@@ -1,0 +1,24 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ParseCommaSeparatedSlugs(input string) ([]string, error) {
+	parts := strings.Split(input, ",")
+	slugs := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for idx, raw := range parts {
+		slug := strings.TrimSpace(raw)
+		if slug == "" {
+			return nil, fmt.Errorf("task slug at position %d cannot be empty", idx+1)
+		}
+		if _, exists := seen[slug]; exists {
+			return nil, fmt.Errorf("duplicate task slug %q", slug)
+		}
+		seen[slug] = struct{}{}
+		slugs = append(slugs, slug)
+	}
+	return slugs, nil
+}

--- a/internal/core/tasks/slug_list_test.go
+++ b/internal/core/tasks/slug_list_test.go
@@ -6,52 +6,58 @@ import (
 	"testing"
 )
 
-func TestParseCommaSeparatedSlugsPreservesOrder(t *testing.T) {
+func TestParseCommaSeparatedSlugs(t *testing.T) {
 	t.Parallel()
 
-	got, err := ParseCommaSeparatedSlugs("alpha,beta,gamma")
-	if err != nil {
-		t.Fatalf("parse slugs: %v", err)
+	cases := []struct {
+		name             string
+		input            string
+		want             []string
+		wantErrSubstring string
+	}{
+		{
+			name:  "Should preserve slug order",
+			input: "alpha,beta,gamma",
+			want:  []string{"alpha", "beta", "gamma"},
+		},
+		{
+			name:  "Should trim slug entries",
+			input: "alpha, beta ,gamma",
+			want:  []string{"alpha", "beta", "gamma"},
+		},
+		{
+			name:             "Should reject empty entries",
+			input:            "alpha,,beta",
+			wantErrSubstring: "position 2 cannot be empty",
+		},
+		{
+			name:             "Should reject duplicate slugs",
+			input:            "alpha, beta ,alpha",
+			wantErrSubstring: `duplicate task slug "alpha"`,
+		},
 	}
-	want := []string{"alpha", "beta", "gamma"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("unexpected slugs\nwant: %#v\ngot:  %#v", want, got)
-	}
-}
 
-func TestParseCommaSeparatedSlugsTrimsEntries(t *testing.T) {
-	t.Parallel()
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := ParseCommaSeparatedSlugs("alpha, beta ,gamma")
-	if err != nil {
-		t.Fatalf("parse slugs: %v", err)
-	}
-	want := []string{"alpha", "beta", "gamma"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("unexpected slugs\nwant: %#v\ngot:  %#v", want, got)
-	}
-}
-
-func TestParseCommaSeparatedSlugsRejectsEmptyEntries(t *testing.T) {
-	t.Parallel()
-
-	_, err := ParseCommaSeparatedSlugs("alpha,,beta")
-	if err == nil {
-		t.Fatal("expected empty slug error")
-	}
-	if !strings.Contains(err.Error(), "position 2 cannot be empty") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestParseCommaSeparatedSlugsRejectsDuplicates(t *testing.T) {
-	t.Parallel()
-
-	_, err := ParseCommaSeparatedSlugs("alpha, beta ,alpha")
-	if err == nil {
-		t.Fatal("expected duplicate slug error")
-	}
-	if !strings.Contains(err.Error(), `duplicate task slug "alpha"`) {
-		t.Fatalf("unexpected error: %v", err)
+			got, err := ParseCommaSeparatedSlugs(tc.input)
+			if tc.wantErrSubstring != "" {
+				if err == nil {
+					t.Fatal("expected parse error")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse slugs: %v", err)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("unexpected slugs\nwant: %#v\ngot:  %#v", tc.want, got)
+			}
+		})
 	}
 }

--- a/internal/core/tasks/slug_list_test.go
+++ b/internal/core/tasks/slug_list_test.go
@@ -1,0 +1,57 @@
+package tasks
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestParseCommaSeparatedSlugsPreservesOrder(t *testing.T) {
+	t.Parallel()
+
+	got, err := ParseCommaSeparatedSlugs("alpha,beta,gamma")
+	if err != nil {
+		t.Fatalf("parse slugs: %v", err)
+	}
+	want := []string{"alpha", "beta", "gamma"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected slugs\nwant: %#v\ngot:  %#v", want, got)
+	}
+}
+
+func TestParseCommaSeparatedSlugsTrimsEntries(t *testing.T) {
+	t.Parallel()
+
+	got, err := ParseCommaSeparatedSlugs("alpha, beta ,gamma")
+	if err != nil {
+		t.Fatalf("parse slugs: %v", err)
+	}
+	want := []string{"alpha", "beta", "gamma"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected slugs\nwant: %#v\ngot:  %#v", want, got)
+	}
+}
+
+func TestParseCommaSeparatedSlugsRejectsEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCommaSeparatedSlugs("alpha,,beta")
+	if err == nil {
+		t.Fatal("expected empty slug error")
+	}
+	if !strings.Contains(err.Error(), "position 2 cannot be empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseCommaSeparatedSlugsRejectsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseCommaSeparatedSlugs("alpha, beta ,alpha")
+	if err == nil {
+		t.Fatal("expected duplicate slug error")
+	}
+	if !strings.Contains(err.Error(), `duplicate task slug "alpha"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/core/workspace/config_merge.go
+++ b/internal/core/workspace/config_merge.go
@@ -82,6 +82,7 @@ func buildEffectiveTaskRunConfig(
 			workspaceDefaults.OutputFormat,
 			workspace.OutputFormat,
 		),
+		RunMultipleMode:  cloneOptionalValue(preferOverlay(global.RunMultipleMode, workspace.RunMultipleMode)),
 		TUI:              cloneOptionalValue(preferOverlay(global.TUI, workspace.TUI)),
 		TaskRuntimeRules: mergeTaskRunRuntimeRules(global.TaskRuntimeRules, workspace.TaskRuntimeRules),
 	}

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -480,6 +480,20 @@ func TestLoadConfigDefaultsTaskRunMultipleModeToEnqueued(t *testing.T) {
 	})
 }
 
+func TestTaskRunConfigEffectiveRunMultipleMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should treat whitespace-only run_multiple_mode as missing", func(t *testing.T) {
+		t.Parallel()
+
+		mode := "   "
+		cfg := TaskRunConfig{RunMultipleMode: &mode}
+		if got := cfg.EffectiveRunMultipleMode(); got != TaskRunMultipleModeEnqueued {
+			t.Fatalf("EffectiveRunMultipleMode() = %q, want %q", got, TaskRunMultipleModeEnqueued)
+		}
+	})
+}
+
 func TestLoadConfigRejectsInvalidTaskRunMultipleMode(t *testing.T) {
 	t.Run("Should reject invalid run_multiple_mode", func(t *testing.T) {
 		t.Parallel()

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -1572,10 +1572,12 @@ func loadConfigWithIsolatedHome(t *testing.T, workspaceRoot string) (ProjectConf
 func stubWorkspaceUserHomeDir(t *testing.T, fn func() (string, error)) {
 	t.Helper()
 
+	workspaceUserHomeDirMu.Lock()
 	original := osUserHomeDir
 	osUserHomeDir = fn
 	t.Cleanup(func() {
 		osUserHomeDir = original
+		workspaceUserHomeDirMu.Unlock()
 	})
 }
 

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -6,9 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 )
+
+var workspaceUserHomeDirMu sync.Mutex
 
 func TestDiscoverFindsNearestWorkspaceRoot(t *testing.T) {
 	t.Parallel()
@@ -387,14 +390,15 @@ func TestLoadConfigParsesTaskRunMultipleMode(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run("Should parse run_multiple_mode="+tc.name, func(t *testing.T) {
-			isolateWorkspaceConfigHome(t)
+			t.Parallel()
+
 			root := t.TempDir()
 			writeWorkspaceConfig(t, root, `
 [tasks.run]
 run_multiple_mode = "`+tc.mode+`"
 `)
 
-			cfg, _, err := LoadConfig(context.Background(), root)
+			cfg, _, err := loadConfigWithIsolatedHome(t, root)
 			if err != nil {
 				t.Fatalf("load config: %v", err)
 			}
@@ -408,13 +412,14 @@ run_multiple_mode = "`+tc.mode+`"
 
 func TestLoadConfigDefaultsTaskRunMultipleModeToEnqueued(t *testing.T) {
 	t.Run("Should default run_multiple_mode to enqueued", func(t *testing.T) {
-		isolateWorkspaceConfigHome(t)
+		t.Parallel()
+
 		root := t.TempDir()
 		if err := os.MkdirAll(filepath.Join(root, ".compozy"), 0o755); err != nil {
 			t.Fatalf("mkdir .compozy: %v", err)
 		}
 
-		cfg, _, err := LoadConfig(context.Background(), root)
+		cfg, _, err := loadConfigWithIsolatedHome(t, root)
 		if err != nil {
 			t.Fatalf("load config: %v", err)
 		}
@@ -429,14 +434,15 @@ func TestLoadConfigDefaultsTaskRunMultipleModeToEnqueued(t *testing.T) {
 
 func TestLoadConfigRejectsInvalidTaskRunMultipleMode(t *testing.T) {
 	t.Run("Should reject invalid run_multiple_mode", func(t *testing.T) {
-		isolateWorkspaceConfigHome(t)
+		t.Parallel()
+
 		root := t.TempDir()
 		writeWorkspaceConfig(t, root, `
 [tasks.run]
 run_multiple_mode = "invalid"
 `)
 
-		_, _, err := LoadConfig(context.Background(), root)
+		_, _, err := loadConfigWithIsolatedHome(t, root)
 		if err == nil {
 			t.Fatal("expected invalid tasks.run.run_multiple_mode error")
 		}
@@ -448,14 +454,15 @@ run_multiple_mode = "invalid"
 
 func TestLoadConfigAcceptsTaskRunMultipleModeAndRejectsUnknownTaskRunKeys(t *testing.T) {
 	t.Run("Should accept run_multiple_mode", func(t *testing.T) {
-		isolateWorkspaceConfigHome(t)
+		t.Parallel()
+
 		root := t.TempDir()
 		writeWorkspaceConfig(t, root, `
 [tasks.run]
 run_multiple_mode = "enqueued"
 `)
 
-		cfg, _, err := LoadConfig(context.Background(), root)
+		cfg, _, err := loadConfigWithIsolatedHome(t, root)
 		if err != nil {
 			t.Fatalf("load config: %v", err)
 		}
@@ -468,14 +475,15 @@ run_multiple_mode = "enqueued"
 	})
 
 	t.Run("Should reject unknown task-run key", func(t *testing.T) {
-		isolateWorkspaceConfigHome(t)
+		t.Parallel()
+
 		root := t.TempDir()
 		writeWorkspaceConfig(t, root, `
 [tasks.run]
 unknown_task_run_key = true
 `)
 
-		_, _, err := LoadConfig(context.Background(), root)
+		_, _, err := loadConfigWithIsolatedHome(t, root)
 		if err == nil {
 			t.Fatal("expected unknown tasks.run key error")
 		}
@@ -1541,6 +1549,24 @@ func isolateWorkspaceConfigHome(t *testing.T) string {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
 	return homeDir
+}
+
+func loadConfigWithIsolatedHome(t *testing.T, workspaceRoot string) (ProjectConfig, string, error) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	workspaceUserHomeDirMu.Lock()
+	defer workspaceUserHomeDirMu.Unlock()
+
+	original := osUserHomeDir
+	osUserHomeDir = func() (string, error) {
+		return homeDir, nil
+	}
+	defer func() {
+		osUserHomeDir = original
+	}()
+
+	return LoadConfig(context.Background(), workspaceRoot)
 }
 
 func stubWorkspaceUserHomeDir(t *testing.T, fn func() (string, error)) {

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -375,6 +375,111 @@ output_format = "json"
 	}
 }
 
+func TestLoadConfigParsesTaskRunMultipleMode(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+	}{
+		{name: "enqueued", mode: TaskRunMultipleModeEnqueued},
+		{name: "parallel", mode: TaskRunMultipleModeParallel},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateWorkspaceConfigHome(t)
+			root := t.TempDir()
+			writeWorkspaceConfig(t, root, `
+[tasks.run]
+run_multiple_mode = "`+tc.mode+`"
+`)
+
+			cfg, _, err := LoadConfig(context.Background(), root)
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+			assertOptionalString(t, "tasks.run.run_multiple_mode", cfg.Tasks.Run.RunMultipleMode, ptrString(tc.mode))
+			if got := cfg.Tasks.Run.EffectiveRunMultipleMode(); got != tc.mode {
+				t.Fatalf("expected effective run_multiple_mode %q, got %q", tc.mode, got)
+			}
+		})
+	}
+}
+
+func TestLoadConfigDefaultsTaskRunMultipleModeToEnqueued(t *testing.T) {
+	isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".compozy"), 0o755); err != nil {
+		t.Fatalf("mkdir .compozy: %v", err)
+	}
+
+	cfg, _, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Tasks.Run.RunMultipleMode != nil {
+		t.Fatalf("expected unset run_multiple_mode pointer, got %#v", cfg.Tasks.Run.RunMultipleMode)
+	}
+	if got := cfg.Tasks.Run.EffectiveRunMultipleMode(); got != TaskRunMultipleModeEnqueued {
+		t.Fatalf("expected default run_multiple_mode %q, got %q", TaskRunMultipleModeEnqueued, got)
+	}
+}
+
+func TestLoadConfigRejectsInvalidTaskRunMultipleMode(t *testing.T) {
+	isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, `
+[tasks.run]
+run_multiple_mode = "invalid"
+`)
+
+	_, _, err := LoadConfig(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected invalid tasks.run.run_multiple_mode error")
+	}
+	if !strings.Contains(err.Error(), "tasks.run.run_multiple_mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigAcceptsTaskRunMultipleModeAndRejectsUnknownTaskRunKeys(t *testing.T) {
+	t.Run("accepts run_multiple_mode", func(t *testing.T) {
+		isolateWorkspaceConfigHome(t)
+		root := t.TempDir()
+		writeWorkspaceConfig(t, root, `
+[tasks.run]
+run_multiple_mode = "enqueued"
+`)
+
+		cfg, _, err := LoadConfig(context.Background(), root)
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		assertOptionalString(
+			t,
+			"tasks.run.run_multiple_mode",
+			cfg.Tasks.Run.RunMultipleMode,
+			ptrString(TaskRunMultipleModeEnqueued),
+		)
+	})
+
+	t.Run("rejects unknown task-run key", func(t *testing.T) {
+		isolateWorkspaceConfigHome(t)
+		root := t.TempDir()
+		writeWorkspaceConfig(t, root, `
+[tasks.run]
+unknown_task_run_key = true
+`)
+
+		_, _, err := LoadConfig(context.Background(), root)
+		if err == nil {
+			t.Fatal("expected unknown tasks.run key error")
+		}
+		if !strings.Contains(err.Error(), "decode workspace config") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestLoadConfigAcceptsRawJSONExecOutputFormat(t *testing.T) {
 	t.Parallel()
 
@@ -1197,6 +1302,7 @@ access_mode = "default"
 
 [tasks.run]
 include_completed = false
+run_multiple_mode = "enqueued"
 `)
 	writeWorkspaceConfig(t, root, `
 [defaults]
@@ -1204,6 +1310,7 @@ model = "gpt-5.5"
 
 [tasks.run]
 include_completed = true
+run_multiple_mode = "parallel"
 `)
 
 	cfg, path, err := LoadConfig(context.Background(), root)
@@ -1222,6 +1329,12 @@ include_completed = true
 	if cfg.Tasks.Run.IncludeCompleted == nil || !*cfg.Tasks.Run.IncludeCompleted {
 		t.Fatalf("expected workspace tasks.run.include_completed override, got %#v", cfg.Tasks.Run.IncludeCompleted)
 	}
+	assertOptionalString(
+		t,
+		"tasks.run.run_multiple_mode",
+		cfg.Tasks.Run.RunMultipleMode,
+		ptrString(TaskRunMultipleModeParallel),
+	)
 }
 
 func TestLoadConfigKeepsWorkspaceDefaultsAheadOfGlobalCommandOverrides(t *testing.T) {

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -385,7 +385,8 @@ func TestLoadConfigParsesTaskRunMultipleMode(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+		tc := tc
+		t.Run("Should parse run_multiple_mode="+tc.name, func(t *testing.T) {
 			isolateWorkspaceConfigHome(t)
 			root := t.TempDir()
 			writeWorkspaceConfig(t, root, `
@@ -406,43 +407,47 @@ run_multiple_mode = "`+tc.mode+`"
 }
 
 func TestLoadConfigDefaultsTaskRunMultipleModeToEnqueued(t *testing.T) {
-	isolateWorkspaceConfigHome(t)
-	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".compozy"), 0o755); err != nil {
-		t.Fatalf("mkdir .compozy: %v", err)
-	}
+	t.Run("Should default run_multiple_mode to enqueued", func(t *testing.T) {
+		isolateWorkspaceConfigHome(t)
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".compozy"), 0o755); err != nil {
+			t.Fatalf("mkdir .compozy: %v", err)
+		}
 
-	cfg, _, err := LoadConfig(context.Background(), root)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
-	}
-	if cfg.Tasks.Run.RunMultipleMode != nil {
-		t.Fatalf("expected unset run_multiple_mode pointer, got %#v", cfg.Tasks.Run.RunMultipleMode)
-	}
-	if got := cfg.Tasks.Run.EffectiveRunMultipleMode(); got != TaskRunMultipleModeEnqueued {
-		t.Fatalf("expected default run_multiple_mode %q, got %q", TaskRunMultipleModeEnqueued, got)
-	}
+		cfg, _, err := LoadConfig(context.Background(), root)
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		if cfg.Tasks.Run.RunMultipleMode != nil {
+			t.Fatalf("expected unset run_multiple_mode pointer, got %#v", cfg.Tasks.Run.RunMultipleMode)
+		}
+		if got := cfg.Tasks.Run.EffectiveRunMultipleMode(); got != TaskRunMultipleModeEnqueued {
+			t.Fatalf("expected default run_multiple_mode %q, got %q", TaskRunMultipleModeEnqueued, got)
+		}
+	})
 }
 
 func TestLoadConfigRejectsInvalidTaskRunMultipleMode(t *testing.T) {
-	isolateWorkspaceConfigHome(t)
-	root := t.TempDir()
-	writeWorkspaceConfig(t, root, `
+	t.Run("Should reject invalid run_multiple_mode", func(t *testing.T) {
+		isolateWorkspaceConfigHome(t)
+		root := t.TempDir()
+		writeWorkspaceConfig(t, root, `
 [tasks.run]
 run_multiple_mode = "invalid"
 `)
 
-	_, _, err := LoadConfig(context.Background(), root)
-	if err == nil {
-		t.Fatal("expected invalid tasks.run.run_multiple_mode error")
-	}
-	if !strings.Contains(err.Error(), "tasks.run.run_multiple_mode") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+		_, _, err := LoadConfig(context.Background(), root)
+		if err == nil {
+			t.Fatal("expected invalid tasks.run.run_multiple_mode error")
+		}
+		if !strings.Contains(err.Error(), "tasks.run.run_multiple_mode") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestLoadConfigAcceptsTaskRunMultipleModeAndRejectsUnknownTaskRunKeys(t *testing.T) {
-	t.Run("accepts run_multiple_mode", func(t *testing.T) {
+	t.Run("Should accept run_multiple_mode", func(t *testing.T) {
 		isolateWorkspaceConfigHome(t)
 		root := t.TempDir()
 		writeWorkspaceConfig(t, root, `
@@ -462,7 +467,7 @@ run_multiple_mode = "enqueued"
 		)
 	})
 
-	t.Run("rejects unknown task-run key", func(t *testing.T) {
+	t.Run("Should reject unknown task-run key", func(t *testing.T) {
 		isolateWorkspaceConfigHome(t)
 		root := t.TempDir()
 		writeWorkspaceConfig(t, root, `

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -1,6 +1,15 @@
 package workspace
 
-import "github.com/compozy/compozy/internal/core/model"
+import (
+	"strings"
+
+	"github.com/compozy/compozy/internal/core/model"
+)
+
+const (
+	TaskRunMultipleModeEnqueued = "enqueued"
+	TaskRunMultipleModeParallel = "parallel"
+)
 
 type Context struct {
 	Root                string
@@ -41,8 +50,16 @@ type DefaultsConfig RuntimeOverrides
 type TaskRunConfig struct {
 	IncludeCompleted *bool                    `toml:"include_completed"`
 	OutputFormat     *string                  `toml:"output_format"`
+	RunMultipleMode  *string                  `toml:"run_multiple_mode"`
 	TUI              *bool                    `toml:"tui"`
 	TaskRuntimeRules *[]model.TaskRuntimeRule `toml:"task_runtime_rules"`
+}
+
+func (cfg TaskRunConfig) EffectiveRunMultipleMode() string {
+	if cfg.RunMultipleMode == nil {
+		return TaskRunMultipleModeEnqueued
+	}
+	return strings.TrimSpace(*cfg.RunMultipleMode)
 }
 
 type TasksConfig struct {

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -60,7 +60,11 @@ func (cfg TaskRunConfig) EffectiveRunMultipleMode() string {
 	if cfg.RunMultipleMode == nil {
 		return TaskRunMultipleModeEnqueued
 	}
-	return strings.TrimSpace(*cfg.RunMultipleMode)
+	mode := strings.TrimSpace(*cfg.RunMultipleMode)
+	if mode == "" {
+		return TaskRunMultipleModeEnqueued
+	}
+	return mode
 }
 
 type TasksConfig struct {

--- a/internal/core/workspace/config_validate.go
+++ b/internal/core/workspace/config_validate.go
@@ -90,6 +90,12 @@ func validateTaskRun(scope string, defaults DefaultsConfig, cfg TaskRunConfig) e
 	if err := validateWorkflowTUI(scope, "tasks.run", defaults, cfg.OutputFormat, cfg.TUI); err != nil {
 		return err
 	}
+	if err := validateTaskRunMultipleMode(
+		configFieldName(scope, "tasks.run.run_multiple_mode"),
+		cfg.RunMultipleMode,
+	); err != nil {
+		return err
+	}
 	return validateTaskRunRuntimeRules(scope, cfg.TaskRuntimeRules)
 }
 
@@ -314,6 +320,26 @@ func validateAttachModeValue(field string, value *string) error {
 			"ui",
 			"stream",
 			"detach",
+			strings.TrimSpace(*value),
+		)
+	}
+}
+
+func validateTaskRunMultipleMode(field string, value *string) error {
+	if value == nil {
+		return nil
+	}
+	switch strings.TrimSpace(*value) {
+	case "":
+		return fmt.Errorf("%s cannot be empty", field)
+	case TaskRunMultipleModeEnqueued, TaskRunMultipleModeParallel:
+		return nil
+	default:
+		return fmt.Errorf(
+			"%s must be %q or %q (got %q)",
+			field,
+			TaskRunMultipleModeEnqueued,
+			TaskRunMultipleModeParallel,
 			strings.TrimSpace(*value),
 		)
 	}

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -716,9 +716,11 @@ func (m *RunManager) OpenStream(
 
 // Cancel requests cancellation for one active run.
 func (m *RunManager) Cancel(ctx context.Context, runID string) error {
+	trimmedRunID := strings.TrimSpace(runID)
 	listCtx := detachContext(ctx)
-	row, err := m.globalDB.GetRun(listCtx, strings.TrimSpace(runID))
+	row, err := m.globalDB.GetRun(listCtx, trimmedRunID)
 	if err != nil {
+		m.cancelActiveRun(trimmedRunID)
 		return err
 	}
 	if isTerminalRunStatus(row.Status) {
@@ -733,6 +735,16 @@ func (m *RunManager) Cancel(ctx context.Context, runID string) error {
 		active.cancel()
 	}
 	return nil
+}
+
+func (m *RunManager) cancelActiveRun(runID string) {
+	active := m.getActive(runID)
+	if active == nil {
+		return
+	}
+	if active.markCancelRequested() {
+		active.cancel()
+	}
 }
 
 func (m *RunManager) prepareTaskStart(
@@ -759,10 +771,6 @@ func (m *RunManager) prepareTaskStart(
 	if err := requireDirectory(tasksDir); err != nil {
 		return globaldb.Workspace{}, nil, nil, "", err
 	}
-	if err := m.rejectCompletedTaskWorkflow(ctx, workflowID, tasksDir, workflowSlug); err != nil {
-		return globaldb.Workspace{}, nil, nil, "", err
-	}
-
 	runtimeCfg := &model.RuntimeConfig{
 		WorkspaceRoot:              workspaceRow.RootDir,
 		Name:                       strings.TrimSpace(workflowSlug),
@@ -781,6 +789,11 @@ func (m *RunManager) prepareTaskStart(
 	applyTaskProjectConfig(runtimeCfg, projectCfg.Tasks.Run)
 	if err := applyRuntimeOverrideInput(runtimeCfg, overrides); err != nil {
 		return globaldb.Workspace{}, nil, nil, "", err
+	}
+	if !runtimeCfg.IncludeCompleted {
+		if err := m.rejectCompletedTaskWorkflow(ctx, workflowID, tasksDir, workflowSlug); err != nil {
+			return globaldb.Workspace{}, nil, nil, "", err
+		}
 	}
 	runtimeCfg.ApplyDefaults()
 	runtimeCfg.TUI = false

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	runModeTask        = "task"
+	runModeTaskMulti   = "task_multi"
 	runModeReview      = "review"
 	runModeReviewWatch = "review_watch"
 	runModeExec        = "exec"
@@ -54,6 +55,7 @@ const (
 	defaultStreamPageLimit    = 256
 	cancelRequestedByDaemon   = "daemon"
 	completedNoWorkSummary    = "no work"
+	taskMultiRunName          = "task-multi"
 
 	maxImplicitRunIDAllocationAttempts = 8
 )
@@ -132,6 +134,7 @@ type activeRun struct {
 	watcher        *workflowWatcher
 	reviewWatch    *preparedReviewWatch
 	reviewWatchKey *reviewWatchKey
+	taskMulti      *preparedTaskMulti
 
 	stateMu         sync.RWMutex
 	cancelRequested bool
@@ -182,6 +185,7 @@ type startRunSpec struct {
 	runtimeCfg       *model.RuntimeConfig
 	reviewWatch      *preparedReviewWatch
 	reviewWatchKey   *reviewWatchKey
+	taskMulti        *preparedTaskMulti
 }
 
 type terminalState struct {
@@ -1381,6 +1385,7 @@ func newActiveRun(
 		workflowRoot:   strings.TrimSpace(spec.workflowRoot),
 		reviewWatch:    spec.reviewWatch,
 		reviewWatchKey: cloneReviewWatchKey(spec.reviewWatchKey),
+		taskMulti:      spec.taskMulti,
 	}
 }
 
@@ -1445,6 +1450,10 @@ func (m *RunManager) runAsync(active *activeRun, row globaldb.Run, runtimeCfg *m
 
 	if active.mode == runModeReviewWatch {
 		m.executeReviewWatchRun(active, row)
+		return
+	}
+	if active.mode == runModeTaskMulti {
+		m.executeTaskMultiRun(active, row)
 		return
 	}
 	if runtimeCfg.Mode == model.ExecutionModeExec {

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -101,6 +101,36 @@ func TestRunManagerRejectsCompletedTaskWorkflowBeforeCreatingRun(t *testing.T) {
 	}
 }
 
+func TestRunManagerIncludeCompletedStartsCompletedTaskWorkflow(t *testing.T) {
+	seenIncludeCompleted := make(chan bool, 1)
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+			seenIncludeCompleted <- cfg.IncludeCompleted
+			return nil
+		},
+	})
+	env.writeWorkflowFile(t, env.workflowSlug, "task_01.md", daemonTaskBody("completed", "Done task"))
+
+	const runID = "task-run-include-completed"
+	run := env.startTaskRun(
+		t,
+		runID,
+		rawJSON(t, `{"run_id":"`+runID+`","include_completed":true}`),
+	)
+	if !waitForBool(t, seenIncludeCompleted) {
+		t.Fatal("execute saw IncludeCompleted=false, want true")
+	}
+	terminal := waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusCompleted
+	})
+	if terminal.EndedAt == nil {
+		t.Fatal("EndedAt = nil, want terminal timestamp")
+	}
+}
+
 func TestRunManagerCancelTaskRunMirrorsTerminalStateAndIsIdempotent(t *testing.T) {
 	started := make(chan string, 1)
 	env := newRunManagerTestEnv(t, runManagerTestDeps{
@@ -2922,6 +2952,38 @@ func waitForString(t *testing.T, ch <-chan string, want string) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out waiting for %q", want)
 	}
+}
+
+func waitForBool(t *testing.T, ch <-chan bool) bool {
+	t.Helper()
+
+	select {
+	case got := <-ch:
+		return got
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for bool")
+	}
+	return false
+}
+
+func waitForClosed(t *testing.T, ch <-chan struct{}, label string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+func requireActiveRun(t *testing.T, manager *RunManager, runID string) *activeRun {
+	t.Helper()
+
+	active := manager.getActive(runID)
+	if active == nil {
+		t.Fatalf("active run %q = nil", runID)
+	}
+	return active
 }
 
 func waitForCondition(t *testing.T, timeout time.Duration, label string, fn func() bool) {

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -102,33 +102,35 @@ func TestRunManagerRejectsCompletedTaskWorkflowBeforeCreatingRun(t *testing.T) {
 }
 
 func TestRunManagerIncludeCompletedStartsCompletedTaskWorkflow(t *testing.T) {
-	seenIncludeCompleted := make(chan bool, 1)
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
-			return &model.SolvePreparation{}, nil
-		},
-		execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
-			seenIncludeCompleted <- cfg.IncludeCompleted
-			return nil
-		},
-	})
-	env.writeWorkflowFile(t, env.workflowSlug, "task_01.md", daemonTaskBody("completed", "Done task"))
+	t.Run("Should include completed tasks when include_completed is true", func(t *testing.T) {
+		seenIncludeCompleted := make(chan bool, 1)
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+				seenIncludeCompleted <- cfg.IncludeCompleted
+				return nil
+			},
+		})
+		env.writeWorkflowFile(t, env.workflowSlug, "task_01.md", daemonTaskBody("completed", "Done task"))
 
-	const runID = "task-run-include-completed"
-	run := env.startTaskRun(
-		t,
-		runID,
-		rawJSON(t, `{"run_id":"`+runID+`","include_completed":true}`),
-	)
-	if !waitForBool(t, seenIncludeCompleted) {
-		t.Fatal("execute saw IncludeCompleted=false, want true")
-	}
-	terminal := waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusCompleted
+		const runID = "task-run-include-completed"
+		run := env.startTaskRun(
+			t,
+			runID,
+			rawJSON(t, `{"run_id":"`+runID+`","include_completed":true}`),
+		)
+		if !waitForBool(t, seenIncludeCompleted) {
+			t.Fatal("execute saw IncludeCompleted=false, want true")
+		}
+		terminal := waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCompleted
+		})
+		if terminal.EndedAt == nil {
+			t.Fatal("EndedAt = nil, want terminal timestamp")
+		}
 	})
-	if terminal.EndedAt == nil {
-		t.Fatal("EndedAt = nil, want terminal timestamp")
-	}
 }
 
 func TestRunManagerCancelTaskRunMirrorsTerminalStateAndIsIdempotent(t *testing.T) {

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	daemonMetricModes          = []string{runModeExec, runModeReview, runModeTask}
+	daemonMetricModes          = []string{runModeExec, runModeReview, runModeTask, runModeTaskMulti}
 	daemonTerminalMetricStatus = []string{runStatusCancelled, runStatusCompleted, runStatusCrashed, runStatusFailed}
 )
 

--- a/internal/daemon/task_multi.go
+++ b/internal/daemon/task_multi.go
@@ -359,6 +359,10 @@ func (m *RunManager) runTaskMultiChildAt(
 	}
 	childRow, err := m.waitForTaskMultiChild(active.ctx, childRun.RunID)
 	if err != nil {
+		var childCancelErr error
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			childCancelErr = m.Cancel(detachContext(context.Background()), childRun.RunID)
+		}
 		emitErr := m.emitTaskMultiItemEvent(
 			active,
 			eventspkg.EventKindTaskRunMultipleItemCanceled,
@@ -370,7 +374,7 @@ func (m *RunManager) runTaskMultiChildAt(
 			err.Error(),
 		)
 		cancelErr := m.cancelTaskMultiQueuedItems(active, prepared.items, index+1, total, err)
-		return errors.Join(err, emitErr, cancelErr)
+		return errors.Join(err, childCancelErr, emitErr, cancelErr)
 	}
 	if err := m.finishTaskMultiChild(active, item, index, total, childRow); err != nil {
 		return err
@@ -388,13 +392,17 @@ func (m *RunManager) runTaskMultiChildAt(
 		}
 		return cause
 	}
-	return fmt.Errorf(
+	childErr := fmt.Errorf(
 		"task multi child run %s for %s ended with status %s: %s",
 		childRow.RunID,
 		item.slug,
 		childRow.Status,
 		childRow.ErrorText,
 	)
+	if emitErr := m.cancelTaskMultiQueuedItems(active, prepared.items, index+1, total, childErr); emitErr != nil {
+		return errors.Join(childErr, emitErr)
+	}
+	return childErr
 }
 
 func (m *RunManager) startTaskMultiChild(
@@ -483,12 +491,16 @@ func (m *RunManager) finishTaskMultiChild(
 }
 
 func (m *RunManager) waitForTaskMultiChild(ctx context.Context, runID string) (globaldb.Run, error) {
+	trimmedRunID := strings.TrimSpace(runID)
 	ticker := time.NewTicker(taskMultiChildPollInterval)
 	defer ticker.Stop()
 
 	for {
-		row, err := m.globalDB.GetRun(detachContext(ctx), strings.TrimSpace(runID))
-		if err == nil && isTerminalRunStatus(row.Status) {
+		row, err := m.globalDB.GetRun(detachContext(ctx), trimmedRunID)
+		if err != nil {
+			return globaldb.Run{}, fmt.Errorf("load child run %s: %w", trimmedRunID, err)
+		}
+		if isTerminalRunStatus(row.Status) {
 			return row, nil
 		}
 		select {

--- a/internal/daemon/task_multi.go
+++ b/internal/daemon/task_multi.go
@@ -1,0 +1,659 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	apicore "github.com/compozy/compozy/internal/api/core"
+	"github.com/compozy/compozy/internal/core/model"
+	taskscore "github.com/compozy/compozy/internal/core/tasks"
+	workspacecfg "github.com/compozy/compozy/internal/core/workspace"
+	"github.com/compozy/compozy/internal/store/globaldb"
+	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
+	"github.com/compozy/compozy/pkg/compozy/events/kinds"
+)
+
+const (
+	taskMultiItemStatusQueued    = "queued"
+	taskMultiItemStatusRunning   = "running"
+	taskMultiItemStatusCompleted = "completed"
+	taskMultiItemStatusFailed    = "failed"
+	taskMultiItemStatusCanceled  = "canceled"
+
+	taskMultiChildPollInterval = 100 * time.Millisecond
+)
+
+type preparedTaskMulti struct {
+	workspace        globaldb.Workspace
+	mode             string
+	presentationMode string
+	items            []preparedTaskMultiItem
+}
+
+type preparedTaskMultiItem struct {
+	slug         string
+	workflowID   *string
+	workflowRoot string
+	runtimeCfg   *model.RuntimeConfig
+}
+
+type taskMultiSnapshotBuilder struct {
+	items []apicore.TaskRunMultipleItem
+	index map[string]int
+}
+
+// StartTaskRunMultiple starts one daemon-owned parent for an ordered task queue.
+func (m *RunManager) StartTaskRunMultiple(
+	ctx context.Context,
+	workspaceRef string,
+	req apicore.TaskRunMultipleRequest,
+) (apicore.Run, error) {
+	slugs, err := normalizeTaskMultiSlugs(req.Slugs)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	mode, err := resolveTaskMultiMode(req.Mode)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	childOverrides, err := taskMultiChildRuntimeOverrides(req.RuntimeOverrides)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	prepared, err := m.prepareTaskMultiStart(detachContext(ctx), workspaceRef, slugs, mode, req, childOverrides)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	runtimeCfg, err := taskMultiParentRuntimeConfig(req.RuntimeOverrides, prepared.workspace.RootDir)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	return m.startRun(ctx, startRunSpec{
+		workspace:        prepared.workspace,
+		mode:             runModeTaskMulti,
+		presentationMode: prepared.presentationMode,
+		runtimeCfg:       runtimeCfg,
+		taskMulti:        prepared,
+	})
+}
+
+// RunMultipleSnapshot reconstructs the ordered child state for a parent multi-run.
+func (m *RunManager) RunMultipleSnapshot(ctx context.Context, runID string) (apicore.TaskRunMultipleSnapshot, error) {
+	listCtx := detachContext(ctx)
+	row, err := m.globalDB.GetRun(listCtx, strings.TrimSpace(runID))
+	if err != nil {
+		return apicore.TaskRunMultipleSnapshot{}, err
+	}
+	if row.Mode != runModeTaskMulti {
+		return apicore.TaskRunMultipleSnapshot{}, apicore.NewProblem(
+			http.StatusUnprocessableEntity,
+			"run_not_task_multi",
+			"run is not a multi-task parent",
+			map[string]any{"run_id": row.RunID, "mode": row.Mode},
+			nil,
+		)
+	}
+	runView, err := m.toCoreRun(listCtx, row, "")
+	if err != nil {
+		return apicore.TaskRunMultipleSnapshot{}, err
+	}
+
+	lease, err := m.acquireRunDB(listCtx, row.RunID)
+	if err != nil {
+		return apicore.TaskRunMultipleSnapshot{}, err
+	}
+	defer func() {
+		_ = lease.Close()
+	}()
+	eventRows, err := lease.DB().ListEvents(listCtx, 0, 0)
+	if err != nil {
+		return apicore.TaskRunMultipleSnapshot{}, err
+	}
+	builder := newTaskMultiSnapshotBuilder()
+	for _, event := range eventRows.Events {
+		if err := builder.applyEvent(event); err != nil {
+			return apicore.TaskRunMultipleSnapshot{}, err
+		}
+	}
+	return apicore.TaskRunMultipleSnapshot{
+		Run:   runView,
+		Items: builder.snapshotItems(),
+	}, nil
+}
+
+func (m *RunManager) prepareTaskMultiStart(
+	ctx context.Context,
+	workspaceRef string,
+	slugs []string,
+	mode string,
+	req apicore.TaskRunMultipleRequest,
+	childOverrides json.RawMessage,
+) (*preparedTaskMulti, error) {
+	items := make([]preparedTaskMultiItem, 0, len(slugs))
+	var workspaceRow globaldb.Workspace
+	var presentationMode string
+	for idx, slug := range slugs {
+		row, workflowID, runtimeCfg, childPresentationMode, err := m.prepareTaskStart(
+			ctx,
+			workspaceRef,
+			slug,
+			apicore.TaskRunRequest{
+				Workspace:        req.Workspace,
+				PresentationMode: req.PresentationMode,
+				RuntimeOverrides: childOverrides,
+			},
+		)
+		if err != nil {
+			return nil, err
+		}
+		if idx == 0 {
+			workspaceRow = row
+			presentationMode = childPresentationMode
+		}
+		items = append(items, preparedTaskMultiItem{
+			slug:         strings.TrimSpace(slug),
+			workflowID:   cloneStringPtr(workflowID),
+			workflowRoot: strings.TrimSpace(runtimeCfg.TasksDir),
+			runtimeCfg:   runtimeCfg,
+		})
+	}
+	if len(items) == 0 {
+		return nil, taskMultiValidationProblem("slugs_required", "slugs is required", "slugs")
+	}
+	if strings.TrimSpace(presentationMode) == "" {
+		var err error
+		presentationMode, err = normalizePresentationMode(req.PresentationMode)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &preparedTaskMulti{
+		workspace:        workspaceRow,
+		mode:             mode,
+		presentationMode: presentationMode,
+		items:            items,
+	}, nil
+}
+
+func taskMultiParentRuntimeConfig(raw json.RawMessage, workspaceRoot string) (*model.RuntimeConfig, error) {
+	overrides, err := parseRuntimeOverrides(raw)
+	if err != nil {
+		return nil, err
+	}
+	runtimeCfg := &model.RuntimeConfig{
+		WorkspaceRoot: strings.TrimSpace(workspaceRoot),
+		Name:          taskMultiRunName,
+		Mode:          model.ExecutionModePRDTasks,
+		DaemonOwned:   true,
+	}
+	if overrides.RunID != nil {
+		runtimeCfg.RunID = strings.TrimSpace(*overrides.RunID)
+	}
+	runtimeCfg.ApplyDefaults()
+	runtimeCfg.TUI = false
+	runtimeCfg.EnableExecutableExtensions = false
+	return runtimeCfg, nil
+}
+
+func taskMultiChildRuntimeOverrides(raw json.RawMessage) (json.RawMessage, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
+	}
+	if _, err := parseRuntimeOverrides(raw); err != nil {
+		return nil, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return nil, apicore.NewProblem(
+			http.StatusUnprocessableEntity,
+			"invalid_runtime_overrides",
+			fmt.Sprintf("runtime_overrides: %v", err),
+			nil,
+			err,
+		)
+	}
+	delete(fields, "run_id")
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	encoded, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("marshal child runtime overrides: %w", err)
+	}
+	return encoded, nil
+}
+
+func normalizeTaskMultiSlugs(values []string) ([]string, error) {
+	slugs, err := taskscore.ParseCommaSeparatedSlugs(strings.Join(values, ","))
+	if err != nil {
+		return nil, apicore.NewProblem(
+			http.StatusUnprocessableEntity,
+			"invalid_task_slugs",
+			err.Error(),
+			map[string]any{"field": "slugs"},
+			err,
+		)
+	}
+	return slugs, nil
+}
+
+func resolveTaskMultiMode(raw string) (string, error) {
+	switch strings.TrimSpace(raw) {
+	case "", workspacecfg.TaskRunMultipleModeEnqueued, workspacecfg.TaskRunMultipleModeParallel:
+		return workspacecfg.TaskRunMultipleModeEnqueued, nil
+	default:
+		return "", taskMultiValidationProblem(
+			"invalid_run_multiple_mode",
+			"run_multiple mode must be enqueued or parallel",
+			"mode",
+		)
+	}
+}
+
+func taskMultiValidationProblem(code string, message string, field string) error {
+	return apicore.NewProblem(
+		http.StatusUnprocessableEntity,
+		code,
+		message,
+		map[string]any{"field": field},
+		nil,
+	)
+}
+
+func (m *RunManager) executeTaskMultiRun(active *activeRun, row globaldb.Run) {
+	scope := active.scope
+	var fallback terminalState
+
+	if err := context.Cause(active.ctx); err != nil {
+		fallback = cancelledTerminalState(err)
+		m.finishRun(active, row, fallback)
+		return
+	}
+	if err := startScopeRuntime(active.ctx, scope); err != nil {
+		fallback = fallbackTerminalState(scope.RunArtifacts(), err, active.cancelWasRequested())
+		m.finishRun(active, row, fallback)
+		return
+	}
+
+	row.Status = runStatusRunning
+	updated, err := m.globalDB.UpdateRun(detachContext(active.ctx), row)
+	if err != nil {
+		fallback = failedTerminalState(scope.RunArtifacts(), err)
+		m.finishRun(active, row, fallback)
+		return
+	}
+	row = updated
+	m.publishRunWorkspaceEvent(active.ctx, row, active.workflowSlug, apicore.WorkspaceEventKindRunStatusChanged)
+
+	err = m.runTaskMultiCoordinator(active)
+	fallback = fallbackTerminalState(scope.RunArtifacts(), err, active.cancelWasRequested())
+	if err == nil {
+		fallback = completedTerminalState(scope.RunArtifacts(), "multi-task queue completed")
+	}
+	m.finishRun(active, row, fallback)
+}
+
+func (m *RunManager) runTaskMultiCoordinator(active *activeRun) error {
+	if active == nil || active.taskMulti == nil {
+		return errors.New("task multi run is not configured")
+	}
+	prepared := active.taskMulti
+	total := len(prepared.items)
+	if err := m.emitTaskMultiEvent(active, eventspkg.EventKindTaskRunMultipleStarted, kinds.TaskRunMultiplePayload{
+		Mode:   prepared.mode,
+		Status: runStatusRunning,
+		Slugs:  preparedTaskMultiSlugs(prepared.items),
+		Total:  total,
+	}); err != nil {
+		return err
+	}
+	for idx, item := range prepared.items {
+		if err := m.emitTaskMultiItemEvent(
+			active,
+			eventspkg.EventKindTaskRunMultipleItemQueued,
+			item,
+			idx,
+			total,
+			taskMultiItemStatusQueued,
+			"",
+			"",
+		); err != nil {
+			return err
+		}
+	}
+	for idx, item := range prepared.items {
+		if err := context.Cause(active.ctx); err != nil {
+			if emitErr := m.cancelTaskMultiQueuedItems(active, prepared.items, idx, total, err); emitErr != nil {
+				return errors.Join(err, emitErr)
+			}
+			return err
+		}
+		if err := m.runTaskMultiChildAt(active, prepared, item, idx, total); err != nil {
+			return err
+		}
+	}
+	return m.emitTaskMultiEvent(active, eventspkg.EventKindTaskRunMultipleQueueCompleted, kinds.TaskRunMultiplePayload{
+		Mode:   prepared.mode,
+		Status: runStatusCompleted,
+		Slugs:  preparedTaskMultiSlugs(prepared.items),
+		Total:  total,
+	})
+}
+
+func (m *RunManager) runTaskMultiChildAt(
+	active *activeRun,
+	prepared *preparedTaskMulti,
+	item preparedTaskMultiItem,
+	index int,
+	total int,
+) error {
+	childRun, err := m.startTaskMultiChild(active, prepared, item, index, total)
+	if err != nil {
+		return err
+	}
+	childRow, err := m.waitForTaskMultiChild(active.ctx, childRun.RunID)
+	if err != nil {
+		emitErr := m.emitTaskMultiItemEvent(
+			active,
+			eventspkg.EventKindTaskRunMultipleItemCanceled,
+			item,
+			index,
+			total,
+			taskMultiItemStatusCanceled,
+			childRun.RunID,
+			err.Error(),
+		)
+		cancelErr := m.cancelTaskMultiQueuedItems(active, prepared.items, index+1, total, err)
+		return errors.Join(err, emitErr, cancelErr)
+	}
+	if err := m.finishTaskMultiChild(active, item, index, total, childRow); err != nil {
+		return err
+	}
+	if childRow.Status == runStatusCompleted {
+		return nil
+	}
+	if childRow.Status == runStatusCancelled && active.cancelWasRequested() {
+		cause := context.Cause(active.ctx)
+		if cause == nil {
+			cause = context.Canceled
+		}
+		if emitErr := m.cancelTaskMultiQueuedItems(active, prepared.items, index+1, total, cause); emitErr != nil {
+			return errors.Join(cause, emitErr)
+		}
+		return cause
+	}
+	return fmt.Errorf(
+		"task multi child run %s for %s ended with status %s: %s",
+		childRow.RunID,
+		item.slug,
+		childRow.Status,
+		childRow.ErrorText,
+	)
+}
+
+func (m *RunManager) startTaskMultiChild(
+	active *activeRun,
+	prepared *preparedTaskMulti,
+	item preparedTaskMultiItem,
+	index int,
+	total int,
+) (apicore.Run, error) {
+	runtimeCfg := item.runtimeCfg.Clone()
+	if runtimeCfg == nil {
+		return apicore.Run{}, errors.New("task multi child runtime config is required")
+	}
+	runtimeCfg.ParentRunID = active.runID
+	childRun, err := m.startRun(active.ctx, startRunSpec{
+		workspace:        prepared.workspace,
+		workflowID:       cloneStringPtr(item.workflowID),
+		workflowSlug:     item.slug,
+		workflowRoot:     item.workflowRoot,
+		mode:             runModeTask,
+		presentationMode: prepared.presentationMode,
+		parentRunID:      active.runID,
+		runtimeCfg:       runtimeCfg,
+	})
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	if err := m.emitTaskMultiItemEvent(
+		active,
+		eventspkg.EventKindTaskRunMultipleChildStarted,
+		item,
+		index,
+		total,
+		taskMultiItemStatusRunning,
+		childRun.RunID,
+		"",
+	); err != nil {
+		cancelErr := m.Cancel(detachContext(context.Background()), childRun.RunID)
+		return apicore.Run{}, errors.Join(err, cancelErr)
+	}
+	return childRun, nil
+}
+
+func (m *RunManager) finishTaskMultiChild(
+	active *activeRun,
+	item preparedTaskMultiItem,
+	index int,
+	total int,
+	childRow globaldb.Run,
+) error {
+	switch childRow.Status {
+	case runStatusCompleted:
+		return m.emitTaskMultiItemEvent(
+			active,
+			eventspkg.EventKindTaskRunMultipleChildCompleted,
+			item,
+			index,
+			total,
+			taskMultiItemStatusCompleted,
+			childRow.RunID,
+			"",
+		)
+	case runStatusCancelled:
+		return m.emitTaskMultiItemEvent(
+			active,
+			eventspkg.EventKindTaskRunMultipleItemCanceled,
+			item,
+			index,
+			total,
+			taskMultiItemStatusCanceled,
+			childRow.RunID,
+			childRow.ErrorText,
+		)
+	default:
+		return m.emitTaskMultiItemEvent(
+			active,
+			eventspkg.EventKindTaskRunMultipleChildFailed,
+			item,
+			index,
+			total,
+			taskMultiItemStatusFailed,
+			childRow.RunID,
+			childRow.ErrorText,
+		)
+	}
+}
+
+func (m *RunManager) waitForTaskMultiChild(ctx context.Context, runID string) (globaldb.Run, error) {
+	ticker := time.NewTicker(taskMultiChildPollInterval)
+	defer ticker.Stop()
+
+	for {
+		row, err := m.globalDB.GetRun(detachContext(ctx), strings.TrimSpace(runID))
+		if err == nil && isTerminalRunStatus(row.Status) {
+			return row, nil
+		}
+		select {
+		case <-ctx.Done():
+			if cancelErr := m.Cancel(detachContext(context.Background()), runID); cancelErr != nil {
+				return globaldb.Run{}, errors.Join(ctx.Err(), fmt.Errorf("cancel child run %s: %w", runID, cancelErr))
+			}
+			return globaldb.Run{}, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (m *RunManager) cancelTaskMultiQueuedItems(
+	active *activeRun,
+	items []preparedTaskMultiItem,
+	startIndex int,
+	total int,
+	cause error,
+) error {
+	var err error
+	for idx := startIndex; idx < len(items); idx++ {
+		item := items[idx]
+		err = errors.Join(err, m.emitTaskMultiItemEvent(
+			active,
+			eventspkg.EventKindTaskRunMultipleItemCanceled,
+			item,
+			idx,
+			total,
+			taskMultiItemStatusCanceled,
+			"",
+			errorString(cause),
+		))
+	}
+	err = errors.Join(
+		err,
+		m.emitTaskMultiEvent(active, eventspkg.EventKindTaskRunMultipleQueueCanceled, kinds.TaskRunMultiplePayload{
+			Mode:   active.taskMulti.mode,
+			Status: taskMultiItemStatusCanceled,
+			Slugs:  preparedTaskMultiSlugs(items),
+			Total:  total,
+			Error:  errorString(cause),
+		}),
+	)
+	return err
+}
+
+func (m *RunManager) emitTaskMultiItemEvent(
+	active *activeRun,
+	kind eventspkg.EventKind,
+	item preparedTaskMultiItem,
+	index int,
+	total int,
+	status string,
+	childRunID string,
+	errorText string,
+) error {
+	return m.emitTaskMultiEvent(active, kind, kinds.TaskRunMultiplePayload{
+		Slug:       item.slug,
+		Index:      index,
+		Total:      total,
+		Status:     status,
+		ChildRunID: strings.TrimSpace(childRunID),
+		Error:      strings.TrimSpace(errorText),
+	})
+}
+
+func (m *RunManager) emitTaskMultiEvent(
+	active *activeRun,
+	kind eventspkg.EventKind,
+	payload kinds.TaskRunMultiplePayload,
+) error {
+	if active == nil || active.scope == nil || active.scope.RunJournal() == nil {
+		return nil
+	}
+	payload.RunID = active.runID
+	if payload.Mode == "" && active.taskMulti != nil {
+		payload.Mode = active.taskMulti.mode
+	}
+	if err := submitSyntheticEvent(
+		detachContext(active.ctx),
+		active.scope.RunJournal(),
+		active.runID,
+		kind,
+		payload,
+	); err != nil {
+		return err
+	}
+	m.publishWorkspaceEvent(active.ctx, apicore.WorkspaceEvent{
+		WorkspaceID: active.workspaceID,
+		RunID:       active.runID,
+		Mode:        active.mode,
+		Status:      runStatusRunning,
+		Kind:        apicore.WorkspaceEventKindRunStatusChanged,
+	})
+	return nil
+}
+
+func preparedTaskMultiSlugs(items []preparedTaskMultiItem) []string {
+	slugs := make([]string, 0, len(items))
+	for _, item := range items {
+		slugs = append(slugs, item.slug)
+	}
+	return slugs
+}
+
+func newTaskMultiSnapshotBuilder() *taskMultiSnapshotBuilder {
+	return &taskMultiSnapshotBuilder{
+		index: make(map[string]int),
+	}
+}
+
+func (b *taskMultiSnapshotBuilder) applyEvent(event eventspkg.Event) error {
+	switch event.Kind {
+	case eventspkg.EventKindTaskRunMultipleStarted:
+		payload, err := decodeTaskMultiPayload(event)
+		if err != nil {
+			return err
+		}
+		for _, slug := range payload.Slugs {
+			b.ensureItem(slug).Status = taskMultiItemStatusQueued
+		}
+	case eventspkg.EventKindTaskRunMultipleItemQueued,
+		eventspkg.EventKindTaskRunMultipleChildStarted,
+		eventspkg.EventKindTaskRunMultipleChildCompleted,
+		eventspkg.EventKindTaskRunMultipleChildFailed,
+		eventspkg.EventKindTaskRunMultipleItemCanceled:
+		payload, err := decodeTaskMultiPayload(event)
+		if err != nil {
+			return err
+		}
+		item := b.ensureItem(payload.Slug)
+		item.Status = strings.TrimSpace(payload.Status)
+		if childRunID := strings.TrimSpace(payload.ChildRunID); childRunID != "" {
+			item.RunID = childRunID
+		}
+		if errorText := strings.TrimSpace(payload.Error); errorText != "" {
+			item.ErrorText = errorText
+		}
+	}
+	return nil
+}
+
+func decodeTaskMultiPayload(event eventspkg.Event) (kinds.TaskRunMultiplePayload, error) {
+	var payload kinds.TaskRunMultiplePayload
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		return kinds.TaskRunMultiplePayload{}, fmt.Errorf("daemon: decode %s payload: %w", event.Kind, err)
+	}
+	return payload, nil
+}
+
+func (b *taskMultiSnapshotBuilder) ensureItem(slug string) *apicore.TaskRunMultipleItem {
+	trimmed := strings.TrimSpace(slug)
+	if idx, ok := b.index[trimmed]; ok {
+		return &b.items[idx]
+	}
+	b.items = append(b.items, apicore.TaskRunMultipleItem{
+		Slug:   trimmed,
+		Status: taskMultiItemStatusQueued,
+	})
+	idx := len(b.items) - 1
+	b.index[trimmed] = idx
+	return &b.items[idx]
+}
+
+func (b *taskMultiSnapshotBuilder) snapshotItems() []apicore.TaskRunMultipleItem {
+	return append([]apicore.TaskRunMultipleItem(nil), b.items...)
+}

--- a/internal/daemon/task_multi.go
+++ b/internal/daemon/task_multi.go
@@ -245,8 +245,10 @@ func normalizeTaskMultiSlugs(values []string) ([]string, error) {
 
 func resolveTaskMultiMode(raw string) (string, error) {
 	switch strings.TrimSpace(raw) {
-	case "", workspacecfg.TaskRunMultipleModeEnqueued, workspacecfg.TaskRunMultipleModeParallel:
+	case "", workspacecfg.TaskRunMultipleModeEnqueued:
 		return workspacecfg.TaskRunMultipleModeEnqueued, nil
+	case workspacecfg.TaskRunMultipleModeParallel:
+		return workspacecfg.TaskRunMultipleModeParallel, nil
 	default:
 		return "", taskMultiValidationProblem(
 			"invalid_run_multiple_mode",
@@ -361,7 +363,7 @@ func (m *RunManager) runTaskMultiChildAt(
 	if err != nil {
 		var childCancelErr error
 		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-			childCancelErr = m.Cancel(detachContext(context.Background()), childRun.RunID)
+			childCancelErr = m.Cancel(detachContext(active.ctx), childRun.RunID)
 		}
 		emitErr := m.emitTaskMultiItemEvent(
 			active,
@@ -440,7 +442,7 @@ func (m *RunManager) startTaskMultiChild(
 		childRun.RunID,
 		"",
 	); err != nil {
-		cancelErr := m.Cancel(detachContext(context.Background()), childRun.RunID)
+		cancelErr := m.Cancel(detachContext(active.ctx), childRun.RunID)
 		return apicore.Run{}, errors.Join(err, cancelErr)
 	}
 	return childRun, nil
@@ -505,7 +507,7 @@ func (m *RunManager) waitForTaskMultiChild(ctx context.Context, runID string) (g
 		}
 		select {
 		case <-ctx.Done():
-			if cancelErr := m.Cancel(detachContext(context.Background()), runID); cancelErr != nil {
+			if cancelErr := m.Cancel(detachContext(ctx), runID); cancelErr != nil {
 				return globaldb.Run{}, errors.Join(ctx.Err(), fmt.Errorf("cancel child run %s: %w", runID, cancelErr))
 			}
 			return globaldb.Run{}, ctx.Err()

--- a/internal/daemon/task_multi.go
+++ b/internal/daemon/task_multi.go
@@ -248,11 +248,15 @@ func resolveTaskMultiMode(raw string) (string, error) {
 	case "", workspacecfg.TaskRunMultipleModeEnqueued:
 		return workspacecfg.TaskRunMultipleModeEnqueued, nil
 	case workspacecfg.TaskRunMultipleModeParallel:
-		return workspacecfg.TaskRunMultipleModeParallel, nil
+		return "", taskMultiValidationProblem(
+			"unsupported_run_multiple_mode",
+			"parallel run_multiple mode is not supported by the daemon; use enqueued",
+			"mode",
+		)
 	default:
 		return "", taskMultiValidationProblem(
 			"invalid_run_multiple_mode",
-			"run_multiple mode must be enqueued or parallel",
+			"run_multiple mode must be enqueued",
 			"mode",
 		)
 	}
@@ -357,7 +361,18 @@ func (m *RunManager) runTaskMultiChildAt(
 ) error {
 	childRun, err := m.startTaskMultiChild(active, prepared, item, index, total)
 	if err != nil {
-		return err
+		emitErr := m.emitTaskMultiItemEvent(
+			active,
+			eventspkg.EventKindTaskRunMultipleChildFailed,
+			item,
+			index,
+			total,
+			taskMultiItemStatusFailed,
+			"",
+			err.Error(),
+		)
+		cancelErr := m.cancelTaskMultiQueuedItems(active, prepared.items, index+1, total, err)
+		return errors.Join(err, emitErr, cancelErr)
 	}
 	childRow, err := m.waitForTaskMultiChild(active.ctx, childRun.RunID)
 	if err != nil {

--- a/internal/daemon/task_multi_test.go
+++ b/internal/daemon/task_multi_test.go
@@ -1,0 +1,405 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apicore "github.com/compozy/compozy/internal/api/core"
+	"github.com/compozy/compozy/internal/core/model"
+	"github.com/compozy/compozy/internal/store/globaldb"
+	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
+)
+
+func TestRunManagerTaskRunMultipleRunsChildrenSequentially(t *testing.T) {
+	started := make(chan string, 2)
+	releaseAlpha := make(chan struct{})
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		buildRunID: taskMultiRunIDBuilder("task-multi-sequential"),
+		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+			started <- cfg.Name + ":" + cfg.RunID
+			if cfg.Name != "alpha" {
+				return nil
+			}
+			select {
+			case <-releaseAlpha:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+	writeTaskMultiWorkflow(t, env, "alpha", "pending")
+	writeTaskMultiWorkflow(t, env, "beta", "pending")
+
+	parent := startTaskMultiRun(t, env, "task-multi-sequential", []string{"alpha", "beta"})
+	if parent.Mode != runModeTaskMulti {
+		t.Fatalf("parent mode = %q, want %q", parent.Mode, runModeTaskMulti)
+	}
+	waitForString(t, started, "alpha:child-alpha")
+	waitForCondition(t, 5*time.Second, "task_multi active-run accounting", func() bool {
+		counts := env.manager.ActiveRunCountsByMode()
+		return env.manager.ActiveRunCount() == 2 && counts[runModeTaskMulti] == 1 && counts[runModeTask] == 1
+	})
+	assertNoTaskMultiStart(t, started, "beta before alpha completes")
+
+	close(releaseAlpha)
+	waitForString(t, started, "beta:child-beta")
+	parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusCompleted
+	})
+	if parentRow.Mode != runModeTaskMulti {
+		t.Fatalf("parent row mode = %q, want %q", parentRow.Mode, runModeTaskMulti)
+	}
+
+	alpha := requireTaskMultiChildRow(t, env, "child-alpha", parent.RunID, runStatusCompleted)
+	beta := requireTaskMultiChildRow(t, env, "child-beta", parent.RunID, runStatusCompleted)
+	if alpha.Mode != runModeTask || beta.Mode != runModeTask {
+		t.Fatalf("child modes = %q/%q, want %q", alpha.Mode, beta.Mode, runModeTask)
+	}
+
+	runs, err := env.manager.List(context.Background(), apicore.RunListQuery{Workspace: env.workspaceRoot, Limit: 10})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(runs) != 3 {
+		t.Fatalf("run count = %d, want parent plus two children", len(runs))
+	}
+	if !hasRunMode(runs, runModeTaskMulti) {
+		t.Fatalf("runs missing %q mode: %#v", runModeTaskMulti, runs)
+	}
+
+	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+	if err != nil {
+		t.Fatalf("RunMultipleSnapshot() error = %v", err)
+	}
+	wantItems := []apicore.TaskRunMultipleItem{
+		{Slug: "alpha", Status: taskMultiItemStatusCompleted, RunID: "child-alpha"},
+		{Slug: "beta", Status: taskMultiItemStatusCompleted, RunID: "child-beta"},
+	}
+	assertTaskMultiItems(t, snapshot.Items, wantItems)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleStarted)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemQueued)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleChildStarted)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleChildCompleted)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCompleted)
+}
+
+func TestRunManagerTaskRunMultipleStopsOnFirstChildFailure(t *testing.T) {
+	var betaStarted bool
+	var mu sync.Mutex
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		buildRunID: taskMultiRunIDBuilder("task-multi-failure"),
+		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+			if cfg.Name == "beta" {
+				mu.Lock()
+				betaStarted = true
+				mu.Unlock()
+				return nil
+			}
+			return errors.New("alpha failed")
+		},
+	})
+	writeTaskMultiWorkflow(t, env, "alpha", "pending")
+	writeTaskMultiWorkflow(t, env, "beta", "pending")
+
+	parent := startTaskMultiRun(t, env, "task-multi-failure", []string{"alpha", "beta"})
+	parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusFailed
+	})
+	if !strings.Contains(parentRow.ErrorText, "alpha failed") {
+		t.Fatalf("parent error = %q, want child failure text", parentRow.ErrorText)
+	}
+	requireTaskMultiChildRow(t, env, "child-alpha", parent.RunID, runStatusFailed)
+	if _, err := env.globalDB.GetRun(context.Background(), "child-beta"); !errors.Is(err, globaldb.ErrRunNotFound) {
+		t.Fatalf("GetRun(child-beta) error = %v, want ErrRunNotFound", err)
+	}
+	mu.Lock()
+	started := betaStarted
+	mu.Unlock()
+	if started {
+		t.Fatal("beta child started after first child failed")
+	}
+
+	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+	if err != nil {
+		t.Fatalf("RunMultipleSnapshot() error = %v", err)
+	}
+	wantItems := []apicore.TaskRunMultipleItem{
+		{Slug: "alpha", Status: taskMultiItemStatusFailed, RunID: "child-alpha", ErrorText: "alpha failed"},
+		{Slug: "beta", Status: taskMultiItemStatusQueued},
+	}
+	assertTaskMultiItems(t, snapshot.Items, wantItems)
+}
+
+func TestRunManagerTaskRunMultipleCancellationCancelsActiveAndQueuedChildren(t *testing.T) {
+	started := make(chan string, 1)
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		buildRunID: taskMultiRunIDBuilder("task-multi-cancel"),
+		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+			started <- cfg.Name + ":" + cfg.RunID
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	writeTaskMultiWorkflow(t, env, "alpha", "pending")
+	writeTaskMultiWorkflow(t, env, "beta", "pending")
+
+	parent := startTaskMultiRun(t, env, "task-multi-cancel", []string{"alpha", "beta"})
+	waitForString(t, started, "alpha:child-alpha")
+	if err := env.manager.Cancel(context.Background(), parent.RunID); err != nil {
+		t.Fatalf("Cancel(parent) error = %v", err)
+	}
+
+	waitForRun(t, env.globalDB, "child-alpha", func(row globaldb.Run) bool {
+		return row.Status == runStatusCancelled
+	})
+	parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusCancelled
+	})
+	if parentRow.EndedAt == nil {
+		t.Fatal("parent EndedAt = nil, want terminal timestamp")
+	}
+	if _, err := env.globalDB.GetRun(context.Background(), "child-beta"); !errors.Is(err, globaldb.ErrRunNotFound) {
+		t.Fatalf("GetRun(child-beta) error = %v, want ErrRunNotFound", err)
+	}
+
+	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+	if err != nil {
+		t.Fatalf("RunMultipleSnapshot() error = %v", err)
+	}
+	wantItems := []apicore.TaskRunMultipleItem{
+		{Slug: "alpha", Status: taskMultiItemStatusCanceled, RunID: "child-alpha"},
+		{Slug: "beta", Status: taskMultiItemStatusCanceled},
+	}
+	assertTaskMultiItems(t, snapshot.Items, wantItems)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemCanceled)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCanceled)
+}
+
+func TestRunManagerTaskRunMultiplePreflightRejectsInvalidInputBeforeParentRun(t *testing.T) {
+	t.Run("Should reject unsupported mode", func(t *testing.T) {
+		env := newRunManagerTestEnv(t, runManagerTestDeps{buildRunID: taskMultiRunIDBuilder("task-multi-invalid-mode")})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+
+		_, err := env.manager.StartTaskRunMultiple(
+			context.Background(),
+			env.workspaceRoot,
+			apicore.TaskRunMultipleRequest{
+				Workspace:        env.workspaceRoot,
+				Slugs:            []string{"alpha"},
+				Mode:             "unsupported",
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: rawJSON(t, `{"run_id":"task-multi-invalid-mode"}`),
+			},
+		)
+		assertProblemStatus(t, err, http.StatusUnprocessableEntity)
+		if _, err := env.globalDB.GetRun(
+			context.Background(),
+			"task-multi-invalid-mode",
+		); !errors.Is(
+			err,
+			globaldb.ErrRunNotFound,
+		) {
+			t.Fatalf("GetRun(task-multi-invalid-mode) error = %v, want ErrRunNotFound", err)
+		}
+	})
+
+	t.Run("Should reject duplicate slugs", func(t *testing.T) {
+		env := newRunManagerTestEnv(t, runManagerTestDeps{buildRunID: taskMultiRunIDBuilder("task-multi-duplicate")})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+
+		_, err := env.manager.StartTaskRunMultiple(
+			context.Background(),
+			env.workspaceRoot,
+			apicore.TaskRunMultipleRequest{
+				Workspace:        env.workspaceRoot,
+				Slugs:            []string{"alpha", "alpha"},
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: rawJSON(t, `{"run_id":"task-multi-duplicate"}`),
+			},
+		)
+		assertProblemStatus(t, err, http.StatusUnprocessableEntity)
+		if _, err := env.globalDB.GetRun(
+			context.Background(),
+			"task-multi-duplicate",
+		); !errors.Is(
+			err,
+			globaldb.ErrRunNotFound,
+		) {
+			t.Fatalf("GetRun(task-multi-duplicate) error = %v, want ErrRunNotFound", err)
+		}
+	})
+
+	t.Run("Should reject completed workflow before creating parent", func(t *testing.T) {
+		env := newRunManagerTestEnv(t, runManagerTestDeps{buildRunID: taskMultiRunIDBuilder("task-multi-completed")})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+		writeTaskMultiWorkflow(t, env, "beta", "completed")
+
+		_, err := env.manager.StartTaskRunMultiple(
+			context.Background(),
+			env.workspaceRoot,
+			apicore.TaskRunMultipleRequest{
+				Workspace:        env.workspaceRoot,
+				Slugs:            []string{"alpha", "beta"},
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: rawJSON(t, `{"run_id":"task-multi-completed"}`),
+			},
+		)
+		assertProblemStatus(t, err, http.StatusConflict)
+		if _, err := env.globalDB.GetRun(
+			context.Background(),
+			"task-multi-completed",
+		); !errors.Is(
+			err,
+			globaldb.ErrRunNotFound,
+		) {
+			t.Fatalf("GetRun(task-multi-completed) error = %v, want ErrRunNotFound", err)
+		}
+	})
+}
+
+func TestRunManagerTaskRunMultipleSnapshotRejectsNonParentRun(t *testing.T) {
+	env := newRunManagerTestEnv(t, runManagerTestDeps{})
+
+	run := env.startTaskRun(t, "task-run-not-multi", nil)
+	waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+		return isTerminalRunStatus(row.Status)
+	})
+
+	_, err := env.manager.RunMultipleSnapshot(context.Background(), run.RunID)
+	assertProblemStatus(t, err, http.StatusUnprocessableEntity)
+}
+
+func TestRunManagerTaskRunMultipleParentRuntimeStartFailureDoesNotStartChildren(t *testing.T) {
+	var childStarted atomic.Bool
+	runtimeManager := &stubRuntimeManager{startErr: errors.New("runtime failed to start")}
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		buildRunID:   taskMultiRunIDBuilder("task-multi-parent-start-failure"),
+		openRunScope: newTestOpenRunScope(runtimeManager),
+		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
+			childStarted.Store(true)
+			return nil
+		},
+	})
+	writeTaskMultiWorkflow(t, env, "alpha", "pending")
+
+	parent := startTaskMultiRun(t, env, "task-multi-parent-start-failure", []string{"alpha"})
+	row := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusFailed
+	})
+	if !strings.Contains(row.ErrorText, "runtime failed to start") {
+		t.Fatalf("parent error = %q, want runtime failure", row.ErrorText)
+	}
+	if childStarted.Load() {
+		t.Fatal("child started after parent runtime start failure")
+	}
+	if _, err := env.globalDB.GetRun(context.Background(), "child-alpha"); !errors.Is(err, globaldb.ErrRunNotFound) {
+		t.Fatalf("GetRun(child-alpha) error = %v, want ErrRunNotFound", err)
+	}
+}
+
+func writeTaskMultiWorkflow(t *testing.T, env *runManagerTestEnv, slug string, status string) {
+	t.Helper()
+	env.writeWorkflowFile(t, slug, "task_01.md", daemonTaskBody(status, "Task "+slug))
+}
+
+func startTaskMultiRun(t *testing.T, env *runManagerTestEnv, runID string, slugs []string) apicore.Run {
+	t.Helper()
+	run, err := env.manager.StartTaskRunMultiple(
+		context.Background(),
+		env.workspaceRoot,
+		apicore.TaskRunMultipleRequest{
+			Workspace:        env.workspaceRoot,
+			Slugs:            slugs,
+			Mode:             "parallel",
+			PresentationMode: defaultPresentationMode,
+			RuntimeOverrides: rawJSON(t, fmt.Sprintf(`{"run_id":%q}`, runID)),
+		},
+	)
+	if err != nil {
+		t.Fatalf("StartTaskRunMultiple(%v) error = %v", slugs, err)
+	}
+	return run
+}
+
+func taskMultiRunIDBuilder(parentRunID string) func(*model.RuntimeConfig) (string, error) {
+	return func(cfg *model.RuntimeConfig) (string, error) {
+		if cfg == nil {
+			return "", errors.New("runtime config is required")
+		}
+		if runID := strings.TrimSpace(cfg.RunID); runID != "" {
+			return runID, nil
+		}
+		if strings.TrimSpace(cfg.ParentRunID) == parentRunID {
+			return "child-" + strings.TrimSpace(cfg.Name), nil
+		}
+		return "generated-" + strings.TrimSpace(cfg.Name), nil
+	}
+}
+
+func assertNoTaskMultiStart(t *testing.T, ch <-chan string, label string) {
+	t.Helper()
+	select {
+	case got := <-ch:
+		t.Fatalf("unexpected child start while checking %s: %s", label, got)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func requireTaskMultiChildRow(
+	t *testing.T,
+	env *runManagerTestEnv,
+	runID string,
+	parentRunID string,
+	status string,
+) globaldb.Run {
+	t.Helper()
+	row := waitForRun(t, env.globalDB, runID, func(row globaldb.Run) bool {
+		return row.Status == status
+	})
+	if row.ParentRunID != parentRunID {
+		t.Fatalf("%s ParentRunID = %q, want %q", runID, row.ParentRunID, parentRunID)
+	}
+	return row
+}
+
+func hasRunMode(runs []apicore.Run, mode string) bool {
+	return slices.ContainsFunc(runs, func(run apicore.Run) bool {
+		return run.Mode == mode
+	})
+}
+
+func assertTaskMultiItems(t *testing.T, got []apicore.TaskRunMultipleItem, want []apicore.TaskRunMultipleItem) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("items = %#v, want %#v", got, want)
+	}
+	for idx := range want {
+		if got[idx].Slug != want[idx].Slug ||
+			got[idx].Status != want[idx].Status ||
+			got[idx].RunID != want[idx].RunID ||
+			!strings.Contains(got[idx].ErrorText, want[idx].ErrorText) {
+			t.Fatalf("item[%d] = %#v, want %#v", idx, got[idx], want[idx])
+		}
+	}
+}

--- a/internal/daemon/task_multi_test.go
+++ b/internal/daemon/task_multi_test.go
@@ -140,9 +140,11 @@ func TestRunManagerTaskRunMultipleStopsOnFirstChildFailure(t *testing.T) {
 	}
 	wantItems := []apicore.TaskRunMultipleItem{
 		{Slug: "alpha", Status: taskMultiItemStatusFailed, RunID: "child-alpha", ErrorText: "alpha failed"},
-		{Slug: "beta", Status: taskMultiItemStatusQueued},
+		{Slug: "beta", Status: taskMultiItemStatusCanceled, ErrorText: "alpha failed"},
 	}
 	assertTaskMultiItems(t, snapshot.Items, wantItems)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemCanceled)
+	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCanceled)
 }
 
 func TestRunManagerTaskRunMultipleCancellationCancelsActiveAndQueuedChildren(t *testing.T) {
@@ -273,6 +275,121 @@ func TestRunManagerTaskRunMultiplePreflightRejectsInvalidInputBeforeParentRun(t 
 			t.Fatalf("GetRun(task-multi-completed) error = %v, want ErrRunNotFound", err)
 		}
 	})
+}
+
+func TestRunManagerTaskRunMultipleIncludeCompletedStartsCompletedWorkflow(t *testing.T) {
+	started := make(chan string, 2)
+	seenIncludeCompleted := make(chan bool, 2)
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		buildRunID: taskMultiRunIDBuilder("task-multi-include-completed"),
+		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+			started <- cfg.Name + ":" + cfg.RunID
+			seenIncludeCompleted <- cfg.IncludeCompleted
+			return nil
+		},
+	})
+	writeTaskMultiWorkflow(t, env, "alpha", "pending")
+	writeTaskMultiWorkflow(t, env, "beta", "completed")
+
+	parent, err := env.manager.StartTaskRunMultiple(
+		context.Background(),
+		env.workspaceRoot,
+		apicore.TaskRunMultipleRequest{
+			Workspace:        env.workspaceRoot,
+			Slugs:            []string{"alpha", "beta"},
+			PresentationMode: defaultPresentationMode,
+			RuntimeOverrides: rawJSON(t, `{"run_id":"task-multi-include-completed","include_completed":true}`),
+		},
+	)
+	if err != nil {
+		t.Fatalf("StartTaskRunMultiple(include completed) error = %v", err)
+	}
+
+	waitForString(t, started, "alpha:child-alpha")
+	waitForString(t, started, "beta:child-beta")
+	for range 2 {
+		if !waitForBool(t, seenIncludeCompleted) {
+			t.Fatal("child run saw IncludeCompleted=false, want true")
+		}
+	}
+	waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+		return row.Status == runStatusCompleted
+	})
+	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+	if err != nil {
+		t.Fatalf("RunMultipleSnapshot() error = %v", err)
+	}
+	wantItems := []apicore.TaskRunMultipleItem{
+		{Slug: "alpha", Status: taskMultiItemStatusCompleted, RunID: "child-alpha"},
+		{Slug: "beta", Status: taskMultiItemStatusCompleted, RunID: "child-beta"},
+	}
+	assertTaskMultiItems(t, snapshot.Items, wantItems)
+}
+
+func TestRunManagerTaskRunMultipleChildPollReturnsRunLookupErrors(t *testing.T) {
+	env := newRunManagerTestEnv(t, runManagerTestDeps{})
+	if err := env.globalDB.Close(); err != nil {
+		t.Fatalf("Close global DB: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	_, err := env.manager.waitForTaskMultiChild(ctx, "child-alpha")
+	if err == nil {
+		t.Fatal("waitForTaskMultiChild() error = nil, want run lookup error")
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		t.Fatalf("waitForTaskMultiChild() error = %v, want lookup error before context cancellation", err)
+	}
+	if !strings.Contains(err.Error(), "load child run child-alpha") {
+		t.Fatalf("waitForTaskMultiChild() error = %v, want child lookup context", err)
+	}
+}
+
+func TestRunManagerTaskRunMultiplePollLookupErrorCancelsActiveChild(t *testing.T) {
+	childStarted := make(chan struct{})
+	childCanceled := make(chan error, 1)
+	var startedOnce sync.Once
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		buildRunID: taskMultiRunIDBuilder("task-multi-poll-cancel"),
+		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+			if cfg.Name != "alpha" {
+				return nil
+			}
+			startedOnce.Do(func() { close(childStarted) })
+			<-ctx.Done()
+			childCanceled <- ctx.Err()
+			return ctx.Err()
+		},
+	})
+	writeTaskMultiWorkflow(t, env, "alpha", "pending")
+	parent := startTaskMultiRun(t, env, "task-multi-poll-cancel", []string{"alpha"})
+	waitForClosed(t, childStarted, "alpha child start")
+	parentActive := requireActiveRun(t, env.manager, parent.RunID)
+	childActive := requireActiveRun(t, env.manager, "child-alpha")
+	defer parentActive.cancel()
+	defer childActive.cancel()
+
+	if err := env.globalDB.Close(); err != nil {
+		t.Fatalf("Close global DB: %v", err)
+	}
+
+	select {
+	case err := <-childCanceled:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("child context error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("child was not canceled after parent %s hit child lookup error", parent.RunID)
+	}
+	waitForClosed(t, childActive.done, "alpha child cleanup")
+	waitForClosed(t, parentActive.done, "parent multi-run cleanup")
 }
 
 func TestRunManagerTaskRunMultipleSnapshotRejectsNonParentRun(t *testing.T) {

--- a/internal/daemon/task_multi_test.go
+++ b/internal/daemon/task_multi_test.go
@@ -19,184 +19,203 @@ import (
 )
 
 func TestRunManagerTaskRunMultipleRunsChildrenSequentially(t *testing.T) {
-	started := make(chan string, 2)
-	releaseAlpha := make(chan struct{})
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		buildRunID: taskMultiRunIDBuilder("task-multi-sequential"),
-		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
-			return &model.SolvePreparation{}, nil
-		},
-		execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
-			started <- cfg.Name + ":" + cfg.RunID
-			if cfg.Name != "alpha" {
-				return nil
-			}
-			select {
-			case <-releaseAlpha:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		},
+	t.Parallel()
+
+	t.Run("Should run children sequentially", func(t *testing.T) {
+		started := make(chan string, 2)
+		releaseAlpha := make(chan struct{})
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID: taskMultiRunIDBuilder("task-multi-sequential"),
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+				started <- cfg.Name + ":" + cfg.RunID
+				if cfg.Name != "alpha" {
+					return nil
+				}
+				select {
+				case <-releaseAlpha:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+		})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+		writeTaskMultiWorkflow(t, env, "beta", "pending")
+
+		parent := startTaskMultiRun(t, env, "task-multi-sequential", []string{"alpha", "beta"})
+		if parent.Mode != runModeTaskMulti {
+			t.Fatalf("parent mode = %q, want %q", parent.Mode, runModeTaskMulti)
+		}
+		waitForString(t, started, "alpha:child-alpha")
+		waitForCondition(t, 5*time.Second, "task_multi active-run accounting", func() bool {
+			counts := env.manager.ActiveRunCountsByMode()
+			return env.manager.ActiveRunCount() == 2 && counts[runModeTaskMulti] == 1 && counts[runModeTask] == 1
+		})
+		assertNoTaskMultiStart(t, started, "beta before alpha completes")
+
+		close(releaseAlpha)
+		waitForString(t, started, "beta:child-beta")
+		parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCompleted
+		})
+		if parentRow.Mode != runModeTaskMulti {
+			t.Fatalf("parent row mode = %q, want %q", parentRow.Mode, runModeTaskMulti)
+		}
+
+		alpha := requireTaskMultiChildRow(t, env, "child-alpha", parent.RunID, runStatusCompleted)
+		beta := requireTaskMultiChildRow(t, env, "child-beta", parent.RunID, runStatusCompleted)
+		if alpha.Mode != runModeTask || beta.Mode != runModeTask {
+			t.Fatalf("child modes = %q/%q, want %q", alpha.Mode, beta.Mode, runModeTask)
+		}
+
+		runs, err := env.manager.List(
+			context.Background(),
+			apicore.RunListQuery{Workspace: env.workspaceRoot, Limit: 10},
+		)
+		if err != nil {
+			t.Fatalf("List() error = %v", err)
+		}
+		if len(runs) != 3 {
+			t.Fatalf("run count = %d, want parent plus two children", len(runs))
+		}
+		if !hasRunMode(runs, runModeTaskMulti) {
+			t.Fatalf("runs missing %q mode: %#v", runModeTaskMulti, runs)
+		}
+
+		snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+		if err != nil {
+			t.Fatalf("RunMultipleSnapshot() error = %v", err)
+		}
+		wantItems := []apicore.TaskRunMultipleItem{
+			{Slug: "alpha", Status: taskMultiItemStatusCompleted, RunID: "child-alpha"},
+			{Slug: "beta", Status: taskMultiItemStatusCompleted, RunID: "child-beta"},
+		}
+		assertTaskMultiItems(t, snapshot.Items, wantItems)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleStarted)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemQueued)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleChildStarted)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleChildCompleted)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCompleted)
 	})
-	writeTaskMultiWorkflow(t, env, "alpha", "pending")
-	writeTaskMultiWorkflow(t, env, "beta", "pending")
-
-	parent := startTaskMultiRun(t, env, "task-multi-sequential", []string{"alpha", "beta"})
-	if parent.Mode != runModeTaskMulti {
-		t.Fatalf("parent mode = %q, want %q", parent.Mode, runModeTaskMulti)
-	}
-	waitForString(t, started, "alpha:child-alpha")
-	waitForCondition(t, 5*time.Second, "task_multi active-run accounting", func() bool {
-		counts := env.manager.ActiveRunCountsByMode()
-		return env.manager.ActiveRunCount() == 2 && counts[runModeTaskMulti] == 1 && counts[runModeTask] == 1
-	})
-	assertNoTaskMultiStart(t, started, "beta before alpha completes")
-
-	close(releaseAlpha)
-	waitForString(t, started, "beta:child-beta")
-	parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusCompleted
-	})
-	if parentRow.Mode != runModeTaskMulti {
-		t.Fatalf("parent row mode = %q, want %q", parentRow.Mode, runModeTaskMulti)
-	}
-
-	alpha := requireTaskMultiChildRow(t, env, "child-alpha", parent.RunID, runStatusCompleted)
-	beta := requireTaskMultiChildRow(t, env, "child-beta", parent.RunID, runStatusCompleted)
-	if alpha.Mode != runModeTask || beta.Mode != runModeTask {
-		t.Fatalf("child modes = %q/%q, want %q", alpha.Mode, beta.Mode, runModeTask)
-	}
-
-	runs, err := env.manager.List(context.Background(), apicore.RunListQuery{Workspace: env.workspaceRoot, Limit: 10})
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
-	}
-	if len(runs) != 3 {
-		t.Fatalf("run count = %d, want parent plus two children", len(runs))
-	}
-	if !hasRunMode(runs, runModeTaskMulti) {
-		t.Fatalf("runs missing %q mode: %#v", runModeTaskMulti, runs)
-	}
-
-	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
-	if err != nil {
-		t.Fatalf("RunMultipleSnapshot() error = %v", err)
-	}
-	wantItems := []apicore.TaskRunMultipleItem{
-		{Slug: "alpha", Status: taskMultiItemStatusCompleted, RunID: "child-alpha"},
-		{Slug: "beta", Status: taskMultiItemStatusCompleted, RunID: "child-beta"},
-	}
-	assertTaskMultiItems(t, snapshot.Items, wantItems)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleStarted)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemQueued)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleChildStarted)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleChildCompleted)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCompleted)
 }
 
 func TestRunManagerTaskRunMultipleStopsOnFirstChildFailure(t *testing.T) {
-	var betaStarted bool
-	var mu sync.Mutex
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		buildRunID: taskMultiRunIDBuilder("task-multi-failure"),
-		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
-			return &model.SolvePreparation{}, nil
-		},
-		execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
-			if cfg.Name == "beta" {
-				mu.Lock()
-				betaStarted = true
-				mu.Unlock()
-				return nil
-			}
-			return errors.New("alpha failed")
-		},
-	})
-	writeTaskMultiWorkflow(t, env, "alpha", "pending")
-	writeTaskMultiWorkflow(t, env, "beta", "pending")
+	t.Parallel()
 
-	parent := startTaskMultiRun(t, env, "task-multi-failure", []string{"alpha", "beta"})
-	parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusFailed
-	})
-	if !strings.Contains(parentRow.ErrorText, "alpha failed") {
-		t.Fatalf("parent error = %q, want child failure text", parentRow.ErrorText)
-	}
-	requireTaskMultiChildRow(t, env, "child-alpha", parent.RunID, runStatusFailed)
-	if _, err := env.globalDB.GetRun(context.Background(), "child-beta"); !errors.Is(err, globaldb.ErrRunNotFound) {
-		t.Fatalf("GetRun(child-beta) error = %v, want ErrRunNotFound", err)
-	}
-	mu.Lock()
-	started := betaStarted
-	mu.Unlock()
-	if started {
-		t.Fatal("beta child started after first child failed")
-	}
+	t.Run("Should stop on first child failure", func(t *testing.T) {
+		var betaStarted bool
+		var mu sync.Mutex
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID: taskMultiRunIDBuilder("task-multi-failure"),
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+				if cfg.Name == "beta" {
+					mu.Lock()
+					betaStarted = true
+					mu.Unlock()
+					return nil
+				}
+				return errors.New("alpha failed")
+			},
+		})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+		writeTaskMultiWorkflow(t, env, "beta", "pending")
 
-	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
-	if err != nil {
-		t.Fatalf("RunMultipleSnapshot() error = %v", err)
-	}
-	wantItems := []apicore.TaskRunMultipleItem{
-		{Slug: "alpha", Status: taskMultiItemStatusFailed, RunID: "child-alpha", ErrorText: "alpha failed"},
-		{Slug: "beta", Status: taskMultiItemStatusCanceled, ErrorText: "alpha failed"},
-	}
-	assertTaskMultiItems(t, snapshot.Items, wantItems)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemCanceled)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCanceled)
+		parent := startTaskMultiRun(t, env, "task-multi-failure", []string{"alpha", "beta"})
+		parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusFailed
+		})
+		if !strings.Contains(parentRow.ErrorText, "alpha failed") {
+			t.Fatalf("parent error = %q, want child failure text", parentRow.ErrorText)
+		}
+		requireTaskMultiChildRow(t, env, "child-alpha", parent.RunID, runStatusFailed)
+		if _, err := env.globalDB.GetRun(context.Background(), "child-beta"); !errors.Is(err, globaldb.ErrRunNotFound) {
+			t.Fatalf("GetRun(child-beta) error = %v, want ErrRunNotFound", err)
+		}
+		mu.Lock()
+		started := betaStarted
+		mu.Unlock()
+		if started {
+			t.Fatal("beta child started after first child failed")
+		}
+
+		snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+		if err != nil {
+			t.Fatalf("RunMultipleSnapshot() error = %v", err)
+		}
+		wantItems := []apicore.TaskRunMultipleItem{
+			{Slug: "alpha", Status: taskMultiItemStatusFailed, RunID: "child-alpha", ErrorText: "alpha failed"},
+			{Slug: "beta", Status: taskMultiItemStatusCanceled, ErrorText: "alpha failed"},
+		}
+		assertTaskMultiItems(t, snapshot.Items, wantItems)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemCanceled)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCanceled)
+	})
 }
 
 func TestRunManagerTaskRunMultipleCancellationCancelsActiveAndQueuedChildren(t *testing.T) {
-	started := make(chan string, 1)
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		buildRunID: taskMultiRunIDBuilder("task-multi-cancel"),
-		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
-			return &model.SolvePreparation{}, nil
-		},
-		execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
-			started <- cfg.Name + ":" + cfg.RunID
-			<-ctx.Done()
-			return ctx.Err()
-		},
-	})
-	writeTaskMultiWorkflow(t, env, "alpha", "pending")
-	writeTaskMultiWorkflow(t, env, "beta", "pending")
+	t.Parallel()
 
-	parent := startTaskMultiRun(t, env, "task-multi-cancel", []string{"alpha", "beta"})
-	waitForString(t, started, "alpha:child-alpha")
-	if err := env.manager.Cancel(context.Background(), parent.RunID); err != nil {
-		t.Fatalf("Cancel(parent) error = %v", err)
-	}
+	t.Run("Should cancel active and queued children", func(t *testing.T) {
+		started := make(chan string, 1)
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID: taskMultiRunIDBuilder("task-multi-cancel"),
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+				started <- cfg.Name + ":" + cfg.RunID
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+		writeTaskMultiWorkflow(t, env, "beta", "pending")
 
-	waitForRun(t, env.globalDB, "child-alpha", func(row globaldb.Run) bool {
-		return row.Status == runStatusCancelled
-	})
-	parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusCancelled
-	})
-	if parentRow.EndedAt == nil {
-		t.Fatal("parent EndedAt = nil, want terminal timestamp")
-	}
-	if _, err := env.globalDB.GetRun(context.Background(), "child-beta"); !errors.Is(err, globaldb.ErrRunNotFound) {
-		t.Fatalf("GetRun(child-beta) error = %v, want ErrRunNotFound", err)
-	}
+		parent := startTaskMultiRun(t, env, "task-multi-cancel", []string{"alpha", "beta"})
+		waitForString(t, started, "alpha:child-alpha")
+		if err := env.manager.Cancel(context.Background(), parent.RunID); err != nil {
+			t.Fatalf("Cancel(parent) error = %v", err)
+		}
 
-	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
-	if err != nil {
-		t.Fatalf("RunMultipleSnapshot() error = %v", err)
-	}
-	wantItems := []apicore.TaskRunMultipleItem{
-		{Slug: "alpha", Status: taskMultiItemStatusCanceled, RunID: "child-alpha"},
-		{Slug: "beta", Status: taskMultiItemStatusCanceled},
-	}
-	assertTaskMultiItems(t, snapshot.Items, wantItems)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemCanceled)
-	requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCanceled)
+		waitForRun(t, env.globalDB, "child-alpha", func(row globaldb.Run) bool {
+			return row.Status == runStatusCancelled
+		})
+		parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCancelled
+		})
+		if parentRow.EndedAt == nil {
+			t.Fatal("parent EndedAt = nil, want terminal timestamp")
+		}
+		if _, err := env.globalDB.GetRun(context.Background(), "child-beta"); !errors.Is(err, globaldb.ErrRunNotFound) {
+			t.Fatalf("GetRun(child-beta) error = %v, want ErrRunNotFound", err)
+		}
+
+		snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+		if err != nil {
+			t.Fatalf("RunMultipleSnapshot() error = %v", err)
+		}
+		wantItems := []apicore.TaskRunMultipleItem{
+			{Slug: "alpha", Status: taskMultiItemStatusCanceled, RunID: "child-alpha"},
+			{Slug: "beta", Status: taskMultiItemStatusCanceled},
+		}
+		assertTaskMultiItems(t, snapshot.Items, wantItems)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemCanceled)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCanceled)
+	})
 }
 
 func TestRunManagerTaskRunMultiplePreflightRejectsInvalidInputBeforeParentRun(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Should reject unsupported mode", func(t *testing.T) {
+		t.Parallel()
+
 		env := newRunManagerTestEnv(t, runManagerTestDeps{buildRunID: taskMultiRunIDBuilder("task-multi-invalid-mode")})
 		writeTaskMultiWorkflow(t, env, "alpha", "pending")
 
@@ -224,6 +243,8 @@ func TestRunManagerTaskRunMultiplePreflightRejectsInvalidInputBeforeParentRun(t 
 	})
 
 	t.Run("Should reject duplicate slugs", func(t *testing.T) {
+		t.Parallel()
+
 		env := newRunManagerTestEnv(t, runManagerTestDeps{buildRunID: taskMultiRunIDBuilder("task-multi-duplicate")})
 		writeTaskMultiWorkflow(t, env, "alpha", "pending")
 
@@ -250,6 +271,8 @@ func TestRunManagerTaskRunMultiplePreflightRejectsInvalidInputBeforeParentRun(t 
 	})
 
 	t.Run("Should reject completed workflow before creating parent", func(t *testing.T) {
+		t.Parallel()
+
 		env := newRunManagerTestEnv(t, runManagerTestDeps{buildRunID: taskMultiRunIDBuilder("task-multi-completed")})
 		writeTaskMultiWorkflow(t, env, "alpha", "pending")
 		writeTaskMultiWorkflow(t, env, "beta", "completed")
@@ -277,162 +300,222 @@ func TestRunManagerTaskRunMultiplePreflightRejectsInvalidInputBeforeParentRun(t 
 	})
 }
 
+func TestResolveTaskMultiMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "Should default empty mode to enqueued", want: "enqueued"},
+		{name: "Should preserve enqueued mode", raw: " enqueued ", want: "enqueued"},
+		{name: "Should preserve parallel mode", raw: " parallel ", want: "parallel"},
+		{name: "Should reject unsupported mode", raw: "unsupported", wantErr: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveTaskMultiMode(tc.raw)
+			if tc.wantErr {
+				assertProblemStatus(t, err, http.StatusUnprocessableEntity)
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveTaskMultiMode(%q) error = %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveTaskMultiMode(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunManagerTaskRunMultipleIncludeCompletedStartsCompletedWorkflow(t *testing.T) {
-	started := make(chan string, 2)
-	seenIncludeCompleted := make(chan bool, 2)
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		buildRunID: taskMultiRunIDBuilder("task-multi-include-completed"),
-		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
-			return &model.SolvePreparation{}, nil
-		},
-		execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
-			started <- cfg.Name + ":" + cfg.RunID
-			seenIncludeCompleted <- cfg.IncludeCompleted
-			return nil
-		},
-	})
-	writeTaskMultiWorkflow(t, env, "alpha", "pending")
-	writeTaskMultiWorkflow(t, env, "beta", "completed")
+	t.Parallel()
 
-	parent, err := env.manager.StartTaskRunMultiple(
-		context.Background(),
-		env.workspaceRoot,
-		apicore.TaskRunMultipleRequest{
-			Workspace:        env.workspaceRoot,
-			Slugs:            []string{"alpha", "beta"},
-			PresentationMode: defaultPresentationMode,
-			RuntimeOverrides: rawJSON(t, `{"run_id":"task-multi-include-completed","include_completed":true}`),
-		},
-	)
-	if err != nil {
-		t.Fatalf("StartTaskRunMultiple(include completed) error = %v", err)
-	}
+	t.Run("Should start completed workflow when include_completed is true", func(t *testing.T) {
+		started := make(chan string, 2)
+		seenIncludeCompleted := make(chan bool, 2)
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID: taskMultiRunIDBuilder("task-multi-include-completed"),
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+				started <- cfg.Name + ":" + cfg.RunID
+				seenIncludeCompleted <- cfg.IncludeCompleted
+				return nil
+			},
+		})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+		writeTaskMultiWorkflow(t, env, "beta", "completed")
 
-	waitForString(t, started, "alpha:child-alpha")
-	waitForString(t, started, "beta:child-beta")
-	for range 2 {
-		if !waitForBool(t, seenIncludeCompleted) {
-			t.Fatal("child run saw IncludeCompleted=false, want true")
+		parent, err := env.manager.StartTaskRunMultiple(
+			context.Background(),
+			env.workspaceRoot,
+			apicore.TaskRunMultipleRequest{
+				Workspace:        env.workspaceRoot,
+				Slugs:            []string{"alpha", "beta"},
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: rawJSON(t, `{"run_id":"task-multi-include-completed","include_completed":true}`),
+			},
+		)
+		if err != nil {
+			t.Fatalf("StartTaskRunMultiple(include completed) error = %v", err)
 		}
-	}
-	waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusCompleted
+
+		waitForString(t, started, "alpha:child-alpha")
+		waitForString(t, started, "beta:child-beta")
+		for range 2 {
+			if !waitForBool(t, seenIncludeCompleted) {
+				t.Fatal("child run saw IncludeCompleted=false, want true")
+			}
+		}
+		waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCompleted
+		})
+		snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+		if err != nil {
+			t.Fatalf("RunMultipleSnapshot() error = %v", err)
+		}
+		wantItems := []apicore.TaskRunMultipleItem{
+			{Slug: "alpha", Status: taskMultiItemStatusCompleted, RunID: "child-alpha"},
+			{Slug: "beta", Status: taskMultiItemStatusCompleted, RunID: "child-beta"},
+		}
+		assertTaskMultiItems(t, snapshot.Items, wantItems)
 	})
-	snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
-	if err != nil {
-		t.Fatalf("RunMultipleSnapshot() error = %v", err)
-	}
-	wantItems := []apicore.TaskRunMultipleItem{
-		{Slug: "alpha", Status: taskMultiItemStatusCompleted, RunID: "child-alpha"},
-		{Slug: "beta", Status: taskMultiItemStatusCompleted, RunID: "child-beta"},
-	}
-	assertTaskMultiItems(t, snapshot.Items, wantItems)
 }
 
 func TestRunManagerTaskRunMultipleChildPollReturnsRunLookupErrors(t *testing.T) {
-	env := newRunManagerTestEnv(t, runManagerTestDeps{})
-	if err := env.globalDB.Close(); err != nil {
-		t.Fatalf("Close global DB: %v", err)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
-	defer cancel()
+	t.Parallel()
 
-	_, err := env.manager.waitForTaskMultiChild(ctx, "child-alpha")
-	if err == nil {
-		t.Fatal("waitForTaskMultiChild() error = nil, want run lookup error")
-	}
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		t.Fatalf("waitForTaskMultiChild() error = %v, want lookup error before context cancellation", err)
-	}
-	if !strings.Contains(err.Error(), "load child run child-alpha") {
-		t.Fatalf("waitForTaskMultiChild() error = %v, want child lookup context", err)
-	}
+	t.Run("Should return child run lookup errors from poll", func(t *testing.T) {
+		env := newRunManagerTestEnv(t, runManagerTestDeps{})
+		if err := env.globalDB.Close(); err != nil {
+			t.Fatalf("Close global DB: %v", err)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		_, err := env.manager.waitForTaskMultiChild(ctx, "child-alpha")
+		if err == nil {
+			t.Fatal("waitForTaskMultiChild() error = nil, want run lookup error")
+		}
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			t.Fatalf("waitForTaskMultiChild() error = %v, want lookup error before context cancellation", err)
+		}
+		if !strings.Contains(err.Error(), "load child run child-alpha") {
+			t.Fatalf("waitForTaskMultiChild() error = %v, want child lookup context", err)
+		}
+	})
 }
 
 func TestRunManagerTaskRunMultiplePollLookupErrorCancelsActiveChild(t *testing.T) {
-	childStarted := make(chan struct{})
-	childCanceled := make(chan error, 1)
-	var startedOnce sync.Once
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		buildRunID: taskMultiRunIDBuilder("task-multi-poll-cancel"),
-		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
-			return &model.SolvePreparation{}, nil
-		},
-		execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
-			if cfg.Name != "alpha" {
-				return nil
-			}
-			startedOnce.Do(func() { close(childStarted) })
-			<-ctx.Done()
-			childCanceled <- ctx.Err()
-			return ctx.Err()
-		},
-	})
-	writeTaskMultiWorkflow(t, env, "alpha", "pending")
-	parent := startTaskMultiRun(t, env, "task-multi-poll-cancel", []string{"alpha"})
-	waitForClosed(t, childStarted, "alpha child start")
-	parentActive := requireActiveRun(t, env.manager, parent.RunID)
-	childActive := requireActiveRun(t, env.manager, "child-alpha")
-	defer parentActive.cancel()
-	defer childActive.cancel()
+	t.Parallel()
 
-	if err := env.globalDB.Close(); err != nil {
-		t.Fatalf("Close global DB: %v", err)
-	}
+	t.Run("Should cancel active child after poll lookup error", func(t *testing.T) {
+		childStarted := make(chan struct{})
+		childCanceled := make(chan error, 1)
+		var startedOnce sync.Once
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID: taskMultiRunIDBuilder("task-multi-poll-cancel"),
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+				if cfg.Name != "alpha" {
+					return nil
+				}
+				startedOnce.Do(func() { close(childStarted) })
+				<-ctx.Done()
+				childCanceled <- ctx.Err()
+				return ctx.Err()
+			},
+		})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+		parent := startTaskMultiRun(t, env, "task-multi-poll-cancel", []string{"alpha"})
+		waitForClosed(t, childStarted, "alpha child start")
+		parentActive := requireActiveRun(t, env.manager, parent.RunID)
+		childActive := requireActiveRun(t, env.manager, "child-alpha")
+		defer parentActive.cancel()
+		defer childActive.cancel()
 
-	select {
-	case err := <-childCanceled:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("child context error = %v, want context.Canceled", err)
+		if err := env.globalDB.Close(); err != nil {
+			t.Fatalf("Close global DB: %v", err)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatalf("child was not canceled after parent %s hit child lookup error", parent.RunID)
-	}
-	waitForClosed(t, childActive.done, "alpha child cleanup")
-	waitForClosed(t, parentActive.done, "parent multi-run cleanup")
+
+		select {
+		case err := <-childCanceled:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("child context error = %v, want context.Canceled", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("child was not canceled after parent %s hit child lookup error", parent.RunID)
+		}
+		waitForClosed(t, childActive.done, "alpha child cleanup")
+		waitForClosed(t, parentActive.done, "parent multi-run cleanup")
+	})
 }
 
 func TestRunManagerTaskRunMultipleSnapshotRejectsNonParentRun(t *testing.T) {
-	env := newRunManagerTestEnv(t, runManagerTestDeps{})
+	t.Parallel()
 
-	run := env.startTaskRun(t, "task-run-not-multi", nil)
-	waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
-		return isTerminalRunStatus(row.Status)
+	t.Run("Should reject snapshot for non-parent run", func(t *testing.T) {
+		env := newRunManagerTestEnv(t, runManagerTestDeps{})
+
+		run := env.startTaskRun(t, "task-run-not-multi", nil)
+		waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+			return isTerminalRunStatus(row.Status)
+		})
+
+		_, err := env.manager.RunMultipleSnapshot(context.Background(), run.RunID)
+		assertProblemStatus(t, err, http.StatusUnprocessableEntity)
 	})
-
-	_, err := env.manager.RunMultipleSnapshot(context.Background(), run.RunID)
-	assertProblemStatus(t, err, http.StatusUnprocessableEntity)
 }
 
 func TestRunManagerTaskRunMultipleParentRuntimeStartFailureDoesNotStartChildren(t *testing.T) {
-	var childStarted atomic.Bool
-	runtimeManager := &stubRuntimeManager{startErr: errors.New("runtime failed to start")}
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		buildRunID:   taskMultiRunIDBuilder("task-multi-parent-start-failure"),
-		openRunScope: newTestOpenRunScope(runtimeManager),
-		prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
-			return &model.SolvePreparation{}, nil
-		},
-		execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
-			childStarted.Store(true)
-			return nil
-		},
-	})
-	writeTaskMultiWorkflow(t, env, "alpha", "pending")
+	t.Parallel()
 
-	parent := startTaskMultiRun(t, env, "task-multi-parent-start-failure", []string{"alpha"})
-	row := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
-		return row.Status == runStatusFailed
+	t.Run("Should not start children when parent runtime start fails", func(t *testing.T) {
+		var childStarted atomic.Bool
+		runtimeManager := &stubRuntimeManager{startErr: errors.New("runtime failed to start")}
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID:   taskMultiRunIDBuilder("task-multi-parent-start-failure"),
+			openRunScope: newTestOpenRunScope(runtimeManager),
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
+				childStarted.Store(true)
+				return nil
+			},
+		})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+
+		parent := startTaskMultiRun(t, env, "task-multi-parent-start-failure", []string{"alpha"})
+		row := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusFailed
+		})
+		if !strings.Contains(row.ErrorText, "runtime failed to start") {
+			t.Fatalf("parent error = %q, want runtime failure", row.ErrorText)
+		}
+		if childStarted.Load() {
+			t.Fatal("child started after parent runtime start failure")
+		}
+		if _, err := env.globalDB.GetRun(
+			context.Background(),
+			"child-alpha",
+		); !errors.Is(
+			err,
+			globaldb.ErrRunNotFound,
+		) {
+			t.Fatalf("GetRun(child-alpha) error = %v, want ErrRunNotFound", err)
+		}
 	})
-	if !strings.Contains(row.ErrorText, "runtime failed to start") {
-		t.Fatalf("parent error = %q, want runtime failure", row.ErrorText)
-	}
-	if childStarted.Load() {
-		t.Fatal("child started after parent runtime start failure")
-	}
-	if _, err := env.globalDB.GetRun(context.Background(), "child-alpha"); !errors.Is(err, globaldb.ErrRunNotFound) {
-		t.Fatalf("GetRun(child-alpha) error = %v, want ErrRunNotFound", err)
-	}
 }
 
 func writeTaskMultiWorkflow(t *testing.T, env *runManagerTestEnv, slug string, status string) {

--- a/internal/daemon/task_multi_test.go
+++ b/internal/daemon/task_multi_test.go
@@ -158,6 +158,62 @@ func TestRunManagerTaskRunMultipleStopsOnFirstChildFailure(t *testing.T) {
 	})
 }
 
+func TestRunManagerTaskRunMultipleStartChildFailureCancelsQueuedItems(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should mark failed child and cancel queued items when child start fails", func(t *testing.T) {
+		t.Parallel()
+
+		parentRunID := "task-multi-start-child-failure"
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			buildRunID: func(cfg *model.RuntimeConfig) (string, error) {
+				if cfg != nil && strings.TrimSpace(cfg.ParentRunID) == parentRunID {
+					return "", errors.New("child id allocation failed")
+				}
+				return taskMultiRunIDBuilder(parentRunID)(cfg)
+			},
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+		})
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+		writeTaskMultiWorkflow(t, env, "beta", "pending")
+
+		parent := startTaskMultiRun(t, env, parentRunID, []string{"alpha", "beta"})
+		parentRow := waitForRun(t, env.globalDB, parent.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusFailed
+		})
+		if !strings.Contains(parentRow.ErrorText, "child id allocation failed") {
+			t.Fatalf("parent error = %q, want child start failure", parentRow.ErrorText)
+		}
+		if _, err := env.globalDB.GetRun(
+			context.Background(),
+			"child-alpha",
+		); !errors.Is(
+			err,
+			globaldb.ErrRunNotFound,
+		) {
+			t.Fatalf("GetRun(child-alpha) error = %v, want ErrRunNotFound", err)
+		}
+		if _, err := env.globalDB.GetRun(context.Background(), "child-beta"); !errors.Is(err, globaldb.ErrRunNotFound) {
+			t.Fatalf("GetRun(child-beta) error = %v, want ErrRunNotFound", err)
+		}
+
+		snapshot, err := env.manager.RunMultipleSnapshot(context.Background(), parent.RunID)
+		if err != nil {
+			t.Fatalf("RunMultipleSnapshot() error = %v", err)
+		}
+		wantItems := []apicore.TaskRunMultipleItem{
+			{Slug: "alpha", Status: taskMultiItemStatusFailed, ErrorText: "child id allocation failed"},
+			{Slug: "beta", Status: taskMultiItemStatusCanceled, ErrorText: "child id allocation failed"},
+		}
+		assertTaskMultiItems(t, snapshot.Items, wantItems)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleChildFailed)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleItemCanceled)
+		requireRunEvent(t, parent.RunID, eventspkg.EventKindTaskRunMultipleQueueCanceled)
+	})
+}
+
 func TestRunManagerTaskRunMultipleCancellationCancelsActiveAndQueuedChildren(t *testing.T) {
 	t.Parallel()
 
@@ -242,6 +298,38 @@ func TestRunManagerTaskRunMultiplePreflightRejectsInvalidInputBeforeParentRun(t 
 		}
 	})
 
+	t.Run("Should reject parallel mode before creating parent", func(t *testing.T) {
+		t.Parallel()
+
+		env := newRunManagerTestEnv(
+			t,
+			runManagerTestDeps{buildRunID: taskMultiRunIDBuilder("task-multi-parallel-mode")},
+		)
+		writeTaskMultiWorkflow(t, env, "alpha", "pending")
+
+		_, err := env.manager.StartTaskRunMultiple(
+			context.Background(),
+			env.workspaceRoot,
+			apicore.TaskRunMultipleRequest{
+				Workspace:        env.workspaceRoot,
+				Slugs:            []string{"alpha"},
+				Mode:             "parallel",
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: rawJSON(t, `{"run_id":"task-multi-parallel-mode"}`),
+			},
+		)
+		assertProblemStatus(t, err, http.StatusUnprocessableEntity)
+		if _, err := env.globalDB.GetRun(
+			context.Background(),
+			"task-multi-parallel-mode",
+		); !errors.Is(
+			err,
+			globaldb.ErrRunNotFound,
+		) {
+			t.Fatalf("GetRun(task-multi-parallel-mode) error = %v, want ErrRunNotFound", err)
+		}
+	})
+
 	t.Run("Should reject duplicate slugs", func(t *testing.T) {
 		t.Parallel()
 
@@ -311,7 +399,7 @@ func TestResolveTaskMultiMode(t *testing.T) {
 	}{
 		{name: "Should default empty mode to enqueued", want: "enqueued"},
 		{name: "Should preserve enqueued mode", raw: " enqueued ", want: "enqueued"},
-		{name: "Should preserve parallel mode", raw: " parallel ", want: "parallel"},
+		{name: "Should reject parallel mode", raw: " parallel ", wantErr: true},
 		{name: "Should reject unsupported mode", raw: "unsupported", wantErr: true},
 	}
 	for _, tc := range cases {
@@ -531,7 +619,7 @@ func startTaskMultiRun(t *testing.T, env *runManagerTestEnv, runID string, slugs
 		apicore.TaskRunMultipleRequest{
 			Workspace:        env.workspaceRoot,
 			Slugs:            slugs,
-			Mode:             "parallel",
+			Mode:             "enqueued",
 			PresentationMode: defaultPresentationMode,
 			RuntimeOverrides: rawJSON(t, fmt.Sprintf(`{"run_id":%q}`, runID)),
 		},

--- a/internal/daemon/task_transport_service.go
+++ b/internal/daemon/task_transport_service.go
@@ -242,6 +242,21 @@ func (s *transportTaskService) StartRun(
 	return s.runManager.StartTaskRun(ctx, workspaceRef, workflowSlug, req)
 }
 
+func (s *transportTaskService) StartRunMultiple(
+	context.Context,
+	string,
+	apicore.TaskRunMultipleRequest,
+) (apicore.Run, error) {
+	return apicore.Run{}, taskTransportUnavailable("multi-run task runs")
+}
+
+func (s *transportTaskService) RunMultipleSnapshot(
+	context.Context,
+	string,
+) (apicore.TaskRunMultipleSnapshot, error) {
+	return apicore.TaskRunMultipleSnapshot{}, taskTransportUnavailable("multi-run task snapshots")
+}
+
 func (s *transportTaskService) Archive(
 	ctx context.Context,
 	workspaceRef string,

--- a/internal/daemon/task_transport_service.go
+++ b/internal/daemon/task_transport_service.go
@@ -243,18 +243,24 @@ func (s *transportTaskService) StartRun(
 }
 
 func (s *transportTaskService) StartRunMultiple(
-	context.Context,
-	string,
-	apicore.TaskRunMultipleRequest,
+	ctx context.Context,
+	workspaceRef string,
+	req apicore.TaskRunMultipleRequest,
 ) (apicore.Run, error) {
-	return apicore.Run{}, taskTransportUnavailable("multi-run task runs")
+	if s == nil || s.runManager == nil {
+		return apicore.Run{}, taskTransportUnavailable("multi-run task runs")
+	}
+	return s.runManager.StartTaskRunMultiple(ctx, workspaceRef, req)
 }
 
 func (s *transportTaskService) RunMultipleSnapshot(
-	context.Context,
-	string,
+	ctx context.Context,
+	runID string,
 ) (apicore.TaskRunMultipleSnapshot, error) {
-	return apicore.TaskRunMultipleSnapshot{}, taskTransportUnavailable("multi-run task snapshots")
+	if s == nil || s.runManager == nil {
+		return apicore.TaskRunMultipleSnapshot{}, taskTransportUnavailable("multi-run task snapshots")
+	}
+	return s.runManager.RunMultipleSnapshot(ctx, runID)
 }
 
 func (s *transportTaskService) Archive(

--- a/openapi/compozy-daemon.json
+++ b/openapi/compozy-daemon.json
@@ -1506,6 +1506,67 @@
                 },
                 "type": "object"
             },
+            "TaskRunMultipleItem": {
+                "properties": {
+                    "error_text": {
+                        "type": "string"
+                    },
+                    "run_id": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "enum": ["queued", "active", "completed", "failed", "canceled"],
+                        "type": "string"
+                    }
+                },
+                "required": ["slug", "status"],
+                "type": "object"
+            },
+            "TaskRunMultipleRequest": {
+                "properties": {
+                    "mode": {
+                        "enum": ["enqueued", "parallel"],
+                        "type": "string"
+                    },
+                    "presentation_mode": {
+                        "type": "string"
+                    },
+                    "runtime_overrides": {
+                        "additionalProperties": true,
+                        "type": "object"
+                    },
+                    "slugs": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "minItems": 1,
+                        "type": "array"
+                    },
+                    "workspace": {
+                        "type": "string"
+                    }
+                },
+                "required": ["slugs"],
+                "type": "object"
+            },
+            "TaskRunMultipleSnapshotResponse": {
+                "properties": {
+                    "items": {
+                        "items": {
+                            "$ref": "#/components/schemas/TaskRunMultipleItem"
+                        },
+                        "type": "array"
+                    },
+                    "run": {
+                        "$ref": "#/components/schemas/Run"
+                    }
+                },
+                "required": ["run"],
+                "type": "object"
+            },
             "TransportError": {
                 "properties": {
                     "code": {
@@ -2622,6 +2683,91 @@
                 },
                 "summary": "Run explicit daemon reconciliation for a workspace or workflow.",
                 "tags": ["workflows"]
+            }
+        },
+        "/api/task-runs/multiple": {
+            "post": {
+                "operationId": "startTaskRunMultiple",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/ActiveWorkspaceHeader"
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TaskRunMultipleRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RunResponse"
+                                }
+                            }
+                        },
+                        "description": "Created"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/InvalidRequest"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    },
+                    "409": {
+                        "$ref": "#/components/responses/Conflict"
+                    },
+                    "412": {
+                        "$ref": "#/components/responses/StaleWorkspace"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalError"
+                    }
+                },
+                "summary": "Start a daemon-owned multi-run parent for ordered task workflows.",
+                "tags": ["runs"]
+            }
+        },
+        "/api/task-runs/multiple/{run_id}/snapshot": {
+            "get": {
+                "operationId": "getTaskRunMultipleSnapshot",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/RunID"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TaskRunMultipleSnapshotResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalError"
+                    }
+                },
+                "summary": "Read one multi-run parent snapshot.",
+                "tags": ["runs"]
             }
         },
         "/api/tasks": {

--- a/pkg/compozy/events/event.go
+++ b/pkg/compozy/events/event.go
@@ -59,10 +59,18 @@ const (
 	EventKindUsageAggregated EventKind = "usage.aggregated"
 
 	// Task mutation events.
-	EventKindTaskFileUpdated       EventKind = "task.file_updated"
-	EventKindTaskFileSkipped       EventKind = "task.file_skipped"
-	EventKindTaskMetadataRefreshed EventKind = "task.metadata_refreshed"
-	EventKindTaskMemoryUpdated     EventKind = "task.memory_updated"
+	EventKindTaskFileUpdated               EventKind = "task.file_updated"
+	EventKindTaskFileSkipped               EventKind = "task.file_skipped"
+	EventKindTaskMetadataRefreshed         EventKind = "task.metadata_refreshed"
+	EventKindTaskMemoryUpdated             EventKind = "task.memory_updated"
+	EventKindTaskRunMultipleStarted        EventKind = "task.multi.started"
+	EventKindTaskRunMultipleItemQueued     EventKind = "task.multi.item_queued"
+	EventKindTaskRunMultipleChildStarted   EventKind = "task.multi.child_started"
+	EventKindTaskRunMultipleChildCompleted EventKind = "task.multi.child_completed"
+	EventKindTaskRunMultipleChildFailed    EventKind = "task.multi.child_failed"
+	EventKindTaskRunMultipleItemCanceled   EventKind = "task.multi.item_canceled"
+	EventKindTaskRunMultipleQueueCanceled  EventKind = "task.multi.queue_canceled"
+	EventKindTaskRunMultipleQueueCompleted EventKind = "task.multi.queue_completed"
 
 	// Artifact and extension events.
 	EventKindArtifactUpdated EventKind = "artifact.updated"

--- a/pkg/compozy/events/kinds/payload_compat_test.go
+++ b/pkg/compozy/events/kinds/payload_compat_test.go
@@ -142,6 +142,38 @@ func TestReviewWatchPayloadJSONCompatibility(t *testing.T) {
 	})
 }
 
+func TestTaskRunMultiplePayloadJSONCompatibility(t *testing.T) {
+	t.Parallel()
+
+	payload := TaskRunMultiplePayload{
+		RunID:      "multi-run-1",
+		Mode:       "enqueued",
+		Slug:       "alpha",
+		Slugs:      []string{"alpha", "beta"},
+		Index:      1,
+		Total:      2,
+		Status:     "completed",
+		ChildRunID: "task-run-alpha",
+		Error:      "boom",
+	}
+
+	got := mustMarshalMap(t, payload)
+	want := map[string]any{
+		"run_id":       "multi-run-1",
+		"mode":         "enqueued",
+		"slug":         "alpha",
+		"slugs":        []any{"alpha", "beta"},
+		"index":        float64(1),
+		"total":        float64(2),
+		"status":       "completed",
+		"child_run_id": "task-run-alpha",
+		"error":        "boom",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("task run multiple payload JSON mismatch: got %#v want %#v", got, want)
+	}
+}
+
 func mustMarshalMap(t *testing.T, payload any) map[string]any {
 	t.Helper()
 

--- a/pkg/compozy/events/kinds/payload_compat_test.go
+++ b/pkg/compozy/events/kinds/payload_compat_test.go
@@ -143,8 +143,6 @@ func TestReviewWatchPayloadJSONCompatibility(t *testing.T) {
 }
 
 func TestTaskRunMultiplePayloadJSONCompatibility(t *testing.T) {
-	t.Parallel()
-
 	payload := TaskRunMultiplePayload{
 		RunID:      "multi-run-1",
 		Mode:       "enqueued",
@@ -157,21 +155,25 @@ func TestTaskRunMultiplePayloadJSONCompatibility(t *testing.T) {
 		Error:      "boom",
 	}
 
-	got := mustMarshalMap(t, payload)
-	want := map[string]any{
-		"run_id":       "multi-run-1",
-		"mode":         "enqueued",
-		"slug":         "alpha",
-		"slugs":        []any{"alpha", "beta"},
-		"index":        float64(1),
-		"total":        float64(2),
-		"status":       "completed",
-		"child_run_id": "task-run-alpha",
-		"error":        "boom",
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("task run multiple payload JSON mismatch: got %#v want %#v", got, want)
-	}
+	t.Run("Should produce compatible JSON", func(t *testing.T) {
+		t.Parallel()
+
+		got := mustMarshalMap(t, payload)
+		want := map[string]any{
+			"run_id":       "multi-run-1",
+			"mode":         "enqueued",
+			"slug":         "alpha",
+			"slugs":        []any{"alpha", "beta"},
+			"index":        float64(1),
+			"total":        float64(2),
+			"status":       "completed",
+			"child_run_id": "task-run-alpha",
+			"error":        "boom",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("task run multiple payload JSON mismatch: got %#v want %#v", got, want)
+		}
+	})
 }
 
 func mustMarshalMap(t *testing.T, payload any) map[string]any {

--- a/pkg/compozy/events/kinds/task.go
+++ b/pkg/compozy/events/kinds/task.go
@@ -41,3 +41,16 @@ type TaskMetadataRefreshedPayload struct {
 	Completed int       `json:"completed,omitempty"`
 	Pending   int       `json:"pending,omitempty"`
 }
+
+// TaskRunMultiplePayload describes daemon-owned multi-task queue lifecycle events.
+type TaskRunMultiplePayload struct {
+	RunID      string   `json:"run_id,omitempty"`
+	Mode       string   `json:"mode,omitempty"`
+	Slug       string   `json:"slug,omitempty"`
+	Slugs      []string `json:"slugs,omitempty"`
+	Index      int      `json:"index,omitempty"`
+	Total      int      `json:"total,omitempty"`
+	Status     string   `json:"status,omitempty"`
+	ChildRunID string   `json:"child_run_id,omitempty"`
+	Error      string   `json:"error,omitempty"`
+}

--- a/skills/compozy/SKILL.md
+++ b/skills/compozy/SKILL.md
@@ -73,7 +73,7 @@ For a detailed step-by-step walkthrough of each phase, read `references/workflow
 | **Workflow Execution** | | |
 | `compozy daemon` | Manage the home-scoped daemon lifecycle | `start`, `status`, `stop` |
 | `compozy workspaces` | Inspect and manage daemon workspace registrations | `list`, `show`, `register`, `unregister`, `resolve` |
-| `compozy tasks run` | Execute PRD task files through the daemon | `--name`, `--recursive` / `-r`, `--attach`, `--ui`, `--stream`, `--detach`, `--task-runtime` |
+| `compozy tasks run` | Execute PRD task files through the daemon | `--name`, `--multiple`, `--recursive` / `-r`, `--attach`, `--ui`, `--stream`, `--detach`, `--task-runtime` |
 | `compozy exec` | Execute an ad hoc prompt | `--agent`, `--format`, `--prompt-file`, `--tui`, `--persist`, `--run-id` |
 | `compozy runs` | Attach, watch, and purge daemon-managed runs | `attach`, `watch`, `purge` |
 | **Review** | | |

--- a/skills/compozy/references/cli-reference.md
+++ b/skills/compozy/references/cli-reference.md
@@ -56,6 +56,7 @@ Execute PRD task files sequentially from a workflow directory through the shared
 | Flag | Type | Default | Description |
 | --- | --- | --- | --- |
 | `--name` | string | | Task workflow name (resolves to `.compozy/tasks/<name>`) |
+| `--multiple` | string | | Comma-separated task workflow slugs to run through one daemon-owned parent queue |
 | `--include-completed` | bool | false | Include tasks already marked as completed |
 | `--recursive`, `-r` | bool | false | Discover `task_NNN.md` files in nested subdirectories of the workflow root |
 | `--skip-validation` | bool | false | Skip task metadata preflight check |
@@ -70,6 +71,7 @@ Execute PRD task files sequentially from a workflow directory through the shared
 ```
 compozy tasks run multi-repo --ide claude
 compozy tasks run --name multi-repo --ide codex --auto-commit
+compozy tasks run --multiple alpha,beta --stream
 compozy tasks run multi-repo --stream
 ```
 

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -276,6 +276,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/task-runs/multiple": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Start a daemon-owned multi-run parent for ordered task workflows. */
+        post: operations["startTaskRunMultiple"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/task-runs/multiple/{run_id}/snapshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read one multi-run parent snapshot. */
+        get: operations["getTaskRunMultipleSnapshot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/tasks": {
         parameters: {
             query?: never;
@@ -942,6 +976,27 @@ export interface components {
                 [key: string]: unknown;
             };
             workspace?: string;
+        };
+        TaskRunMultipleItem: {
+            error_text?: string;
+            run_id?: string;
+            slug: string;
+            /** @enum {string} */
+            status: "queued" | "active" | "completed" | "failed" | "canceled";
+        };
+        TaskRunMultipleRequest: {
+            /** @enum {string} */
+            mode?: "enqueued" | "parallel";
+            presentation_mode?: string;
+            runtime_overrides?: {
+                [key: string]: unknown;
+            };
+            slugs: string[];
+            workspace?: string;
+        };
+        TaskRunMultipleSnapshotResponse: {
+            items?: components["schemas"]["TaskRunMultipleItem"][];
+            run: components["schemas"]["Run"];
         };
         TransportError: {
             code: string;
@@ -1676,6 +1731,65 @@ export interface operations {
             404: components["responses"]["NotFound"];
             412: components["responses"]["StaleWorkspace"];
             422: components["responses"]["ValidationError"];
+            500: components["responses"]["InternalError"];
+        };
+    };
+    startTaskRunMultiple: {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Active workspace identifier for browser-scoped daemon requests. */
+                "X-Compozy-Workspace-ID": components["parameters"]["ActiveWorkspaceHeader"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TaskRunMultipleRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RunResponse"];
+                };
+            };
+            400: components["responses"]["InvalidRequest"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            409: components["responses"]["Conflict"];
+            412: components["responses"]["StaleWorkspace"];
+            422: components["responses"]["ValidationError"];
+            500: components["responses"]["InternalError"];
+        };
+    };
+    getTaskRunMultipleSnapshot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Run identifier. */
+                run_id: components["parameters"]["RunID"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TaskRunMultipleSnapshotResponse"];
+                };
+            };
+            404: components["responses"]["NotFound"];
             500: components["responses"]["InternalError"];
         };
     };


### PR DESCRIPTION
## Summary
- add config foundations, daemon contracts, and coordinator support for multi-task runs
- add CLI/API/OpenAPI support for running and observing multiple task slugs
- add tabbed multi-run TUI attach flow with horizontal tab navigation

## Verification
- `env -u GOROOT make verify`

<img width="1470" height="890" alt="Screenshot 2026-05-21 at 00 20 31" src="https://github.com/user-attachments/assets/f364f031-acee-46eb-9194-e3728e282c62" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `--multiple` flag to `tasks run` command for executing multiple workflows sequentially in a single daemon-owned queue using comma-separated task slugs
  * Configurable multi-run execution mode (enqueued by default; optional parallel mode)
  * Enhanced UI with tabbed interface to monitor progress of individual tasks within a multi-run queue

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compozy/compozy/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->