### PR TITLE
fix: add Windows daemon support

### DIFF
--- a/internal/cli/daemon_launch_other.go
+++ b/internal/cli/daemon_launch_other.go
@@ -1,4 +1,4 @@
-//go:build !(darwin || dragonfly || freebsd || linux || netbsd || openbsd)
+//go:build !(darwin || dragonfly || freebsd || linux || netbsd || openbsd || windows)
 
 package cli
 

--- a/internal/cli/daemon_launch_windows.go
+++ b/internal/cli/daemon_launch_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package cli
+
+import (
+	"syscall"
+)
+
+func daemonLaunchSysProcAttr() *syscall.SysProcAttr {
+	// CREATE_NEW_PROCESS_GROUP detaches the daemon from the parent console's
+	// process group so that Ctrl+C events are not forwarded to the daemon.
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/internal/daemon/boot_test.go
+++ b/internal/daemon/boot_test.go
@@ -30,7 +30,7 @@ func TestStartRemovesStaleArtifactsAndMarksReady(t *testing.T) {
 	if err := os.WriteFile(paths.SocketPath, []byte("stale"), 0o600); err != nil {
 		t.Fatalf("write stale socket marker: %v", err)
 	}
-	if err := os.WriteFile(paths.LockPath, []byte("999001\n"), 0o600); err != nil {
+	if err := os.WriteFile(lockPIDPath(paths.LockPath), []byte("999001\n"), 0o600); err != nil {
 		t.Fatalf("write stale lock file: %v", err)
 	}
 
@@ -71,7 +71,7 @@ func TestStartRemovesStaleArtifactsAndMarksReady(t *testing.T) {
 	if currentInfo.State != ReadyStateReady {
 		t.Fatalf("current info state = %q, want %q", currentInfo.State, ReadyStateReady)
 	}
-	lockPID, err := readLockPID(paths.LockPath)
+	lockPID, err := readLockPID(lockPIDPath(paths.LockPath))
 	if err != nil {
 		t.Fatalf("readLockPID() error = %v", err)
 	}
@@ -254,7 +254,7 @@ func TestStartCleansUpAfterPrepareFailure(t *testing.T) {
 	if _, statErr := os.Stat(paths.InfoPath); !os.IsNotExist(statErr) {
 		t.Fatalf("expected info file to be removed after prepare failure, stat err = %v", statErr)
 	}
-	pid, readErr := readLockPID(paths.LockPath)
+	pid, readErr := readLockPID(lockPIDPath(paths.LockPath))
 	if readErr != nil {
 		t.Fatalf("readLockPID() error = %v", readErr)
 	}
@@ -336,7 +336,7 @@ func TestStartRebuildsMismatchedRuntimeArtifacts(t *testing.T) {
 	if err := WriteInfo(paths.InfoPath, existingInfo); err != nil {
 		t.Fatalf("WriteInfo(existing) error = %v", err)
 	}
-	if err := os.WriteFile(paths.LockPath, []byte("2222\n"), 0o600); err != nil {
+	if err := os.WriteFile(lockPIDPath(paths.LockPath), []byte("2222\n"), 0o600); err != nil {
 		t.Fatalf("write stale lock file: %v", err)
 	}
 	if err := os.WriteFile(paths.SocketPath, []byte("stale"), 0o600); err != nil {
@@ -369,7 +369,7 @@ func TestStartRebuildsMismatchedRuntimeArtifacts(t *testing.T) {
 		t.Fatalf("current info started_at = %v, want %v", currentInfo.StartedAt, startedAt)
 	}
 
-	lockPID, err := readLockPID(paths.LockPath)
+	lockPID, err := readLockPID(lockPIDPath(paths.LockPath))
 	if err != nil {
 		t.Fatalf("readLockPID() error = %v", err)
 	}

--- a/internal/daemon/info.go
+++ b/internal/daemon/info.go
@@ -134,18 +134,3 @@ func RemoveInfo(path string) error {
 	}
 	return nil
 }
-
-func syncDir(path string) error {
-	dir, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("daemon: open directory %q for sync: %w", path, err)
-	}
-	defer func() {
-		_ = dir.Close()
-	}()
-
-	if err := dir.Sync(); err != nil {
-		return fmt.Errorf("daemon: sync directory %q: %w", path, err)
-	}
-	return nil
-}

--- a/internal/daemon/info_lock_test.go
+++ b/internal/daemon/info_lock_test.go
@@ -146,7 +146,7 @@ func TestAcquireLockLifecycle(t *testing.T) {
 		t.Fatalf("lock.StalePID() = %d, want 0", got)
 	}
 
-	pid, err := readLockPID(path)
+	pid, err := readLockPID(lockPIDPath(path))
 	if err != nil {
 		t.Fatalf("readLockPID() error = %v", err)
 	}
@@ -157,7 +157,7 @@ func TestAcquireLockLifecycle(t *testing.T) {
 	if err := lock.Release(); err != nil {
 		t.Fatalf("lock.Release() error = %v", err)
 	}
-	pid, err = readLockPID(path)
+	pid, err = readLockPID(lockPIDPath(path))
 	if err != nil {
 		t.Fatalf("readLockPID(after release) error = %v", err)
 	}
@@ -173,7 +173,7 @@ func TestAcquireLockDetectsStalePID(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatalf("mkdir lock dir: %v", err)
 	}
-	if err := os.WriteFile(path, []byte("999001\n"), 0o600); err != nil {
+	if err := os.WriteFile(lockPIDPath(path), []byte("999001\n"), 0o600); err != nil {
 		t.Fatalf("write stale pid: %v", err)
 	}
 

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -67,7 +67,7 @@ func acquireLock(path string, pid int, deps lockDeps) (*Lock, error) {
 		return nil, fmt.Errorf("daemon: create lock directory for %q: %w", cleanPath, err)
 	}
 
-	priorPID, err := readLockPID(cleanPath)
+	priorPID, err := readLockPID(lockPIDPath(cleanPath))
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func acquireLock(path string, pid int, deps lockDeps) (*Lock, error) {
 		stalePID = priorPID
 	}
 
-	if err := writeLockPID(cleanPath, pid); err != nil {
+	if err := writeLockPID(lockPIDPath(cleanPath), pid); err != nil {
 		unlockErr := fileLock.Unlock()
 		closeErr := fileLock.Close()
 		return nil, errors.Join(err, unlockErr, closeErr)
@@ -123,7 +123,7 @@ func (l *Lock) Release() error {
 	}
 
 	var errs []error
-	if err := writeLockPID(l.path, 0); err != nil {
+	if err := writeLockPID(lockPIDPath(l.path), 0); err != nil {
 		errs = append(errs, err)
 	}
 	if l.flock != nil {

--- a/internal/daemon/lock_pid_other.go
+++ b/internal/daemon/lock_pid_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package daemon
+
+// lockPIDPath returns the path used to persist the daemon PID.
+// On non-Windows platforms, advisory locks don't block writes from other file
+// descriptors, so the PID can be stored inside the lock file itself.
+func lockPIDPath(lockPath string) string {
+	return lockPath
+}

--- a/internal/daemon/lock_pid_windows.go
+++ b/internal/daemon/lock_pid_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package daemon
+
+// lockPIDPath returns the path used to persist the daemon PID.
+// On Windows, flock's LockFileEx acquires a byte-range lock that prevents
+// other file handles — even within the same process — from writing to the
+// locked file. A separate .pid sidecar avoids that conflict.
+func lockPIDPath(lockPath string) string {
+	return lockPath + ".pid"
+}

--- a/internal/daemon/sync_dir_unix.go
+++ b/internal/daemon/sync_dir_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+)
+
+func syncDir(path string) error {
+	dir, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("daemon: open directory %q for sync: %w", path, err)
+	}
+	defer func() {
+		_ = dir.Close()
+	}()
+
+	if err := dir.Sync(); err != nil {
+		return fmt.Errorf("daemon: sync directory %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/daemon/sync_dir_windows.go
+++ b/internal/daemon/sync_dir_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package daemon
+
+// syncDir is a no-op on Windows: FlushFileBuffers requires write access on
+// directory handles, but os.Open opens them read-only. Directory entry
+// durability after an atomic rename is handled by the NTFS journal.
+func syncDir(_ string) error {
+	return nil
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -91,9 +91,17 @@ func openSQLiteDatabaseOnce(
 }
 
 func sqliteDSN(path string) string {
+	slashPath := filepath.ToSlash(path)
+	// url.URL requires an absolute path starting with "/" to produce the
+	// three-slash form "file:///...". On Windows, filepath.ToSlash yields
+	// "C:/...", which url.URL serialises as "file://C:/..." where the SQLite
+	// URI parser interprets "C:" as the authority rather than a drive letter.
+	if !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
 	u := url.URL{
 		Scheme: "file",
-		Path:   filepath.ToSlash(path),
+		Path:   slashPath,
 	}
 	query := u.Query()
 	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", defaultBusyTimeoutMS))

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -93,10 +93,13 @@ func openSQLiteDatabaseOnce(
 func sqliteDSN(path string) string {
 	slashPath := filepath.ToSlash(path)
 	// url.URL requires an absolute path starting with "/" to produce the
-	// three-slash form "file:///...". On Windows, filepath.ToSlash yields
-	// "C:/...", which url.URL serialises as "file://C:/..." where the SQLite
-	// URI parser interprets "C:" as the authority rather than a drive letter.
-	if !strings.HasPrefix(slashPath, "/") {
+	// three-slash form "file:///...". On Windows, filepath.IsAbs returns true
+	// for drive-letter paths (e.g. "C:\..."), but filepath.ToSlash yields
+	// "C:/..." which url.URL serializes as "file://C:/..." — the SQLite URI
+	// parser then interprets "C:" as the network authority rather than a drive
+	// letter. Prepend "/" only for absolute paths that lack one; relative paths
+	// are left unchanged so callers that pass relative paths are unaffected.
+	if filepath.IsAbs(path) && !strings.HasPrefix(slashPath, "/") {
 		slashPath = "/" + slashPath
 	}
 	u := url.URL{

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -4,9 +4,337 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestSQLiteDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		path        string
+		wantPrefix  string
+		wantNoSlash bool
+	}{
+		{
+			name:       "absolute unix path keeps triple-slash form",
+			path:       "/home/user/.compozy/db.sqlite",
+			wantPrefix: "file:///home/user/.compozy/db.sqlite",
+		},
+		{
+			// Relative paths must not be converted to absolute file:/// URIs;
+			// the leading slash would point to the filesystem root instead.
+			name:        "relative path is not prefixed with slash",
+			path:        "relative.db",
+			wantNoSlash: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := sqliteDSN(tt.path)
+			if tt.wantPrefix != "" && !strings.HasPrefix(dsn, tt.wantPrefix) {
+				t.Errorf("sqliteDSN(%q) = %q, want prefix %q", tt.path, dsn, tt.wantPrefix)
+			}
+			if tt.wantNoSlash && strings.HasPrefix(dsn, "file:///") {
+				t.Errorf("sqliteDSN(%q) = %q, must not produce absolute file:/// URI for relative path", tt.path, dsn)
+			}
+		})
+	}
+}
+
+func TestShouldRecoverSQLite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error returns false", err: nil, want: false},
+		{name: "not a database error triggers recovery", err: errors.New("file is not a database"), want: true},
+		{name: "malformed error triggers recovery", err: errors.New("database disk image is malformed"), want: true},
+		{name: "malformed schema error triggers recovery", err: errors.New("malformed database schema"), want: true},
+		{
+			name: "encrypted file error triggers recovery",
+			err:  errors.New("file is encrypted or is not a database"),
+			want: true,
+		},
+		{name: "unrelated error does not trigger recovery", err: errors.New("connection refused"), want: false},
+		{name: "partial keyword match is case-insensitive", err: errors.New("MALFORMED"), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ShouldRecoverSQLite(tt.err)
+			if got != tt.want {
+				t.Errorf("ShouldRecoverSQLite(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenSQLiteDatabase(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects empty path", func(t *testing.T) {
+		t.Parallel()
+		_, err := OpenSQLiteDatabase(context.Background(), "", nil)
+		if err == nil {
+			t.Fatal("OpenSQLiteDatabase(\"\") error = nil, want error")
+		}
+	})
+
+	t.Run("opens and initializes a fresh database", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "test.db")
+		ctx := context.Background()
+
+		var initCalled bool
+		initialize := func(ctx context.Context, db *sql.DB) error {
+			initCalled = true
+			return EnsureSchema(ctx, db, []string{
+				"CREATE TABLE IF NOT EXISTS items (id TEXT PRIMARY KEY)",
+			})
+		}
+
+		db, err := OpenSQLiteDatabase(ctx, dbPath, initialize)
+		if err != nil {
+			t.Fatalf("OpenSQLiteDatabase() error = %v", err)
+		}
+		if !initCalled {
+			t.Error("initialize callback was not called")
+		}
+
+		if closeErr := CloseSQLiteDatabase(ctx, db); closeErr != nil {
+			t.Errorf("CloseSQLiteDatabase() error = %v", closeErr)
+		}
+	})
+
+	t.Run("opens without initialize callback", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "noninit.db")
+		ctx := context.Background()
+
+		db, err := OpenSQLiteDatabase(ctx, dbPath, nil)
+		if err != nil {
+			t.Fatalf("OpenSQLiteDatabase() with nil initialize error = %v", err)
+		}
+		if closeErr := CloseSQLiteDatabase(ctx, db); closeErr != nil {
+			t.Errorf("CloseSQLiteDatabase() error = %v", closeErr)
+		}
+	})
+
+	t.Run("reopening an existing database succeeds", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "reopen.db")
+		ctx := context.Background()
+
+		db, err := OpenSQLiteDatabase(ctx, dbPath, nil)
+		if err != nil {
+			t.Fatalf("first open error = %v", err)
+		}
+		if closeErr := CloseSQLiteDatabase(ctx, db); closeErr != nil {
+			t.Fatalf("first close error = %v", closeErr)
+		}
+
+		db2, err := OpenSQLiteDatabase(ctx, dbPath, nil)
+		if err != nil {
+			t.Fatalf("second open error = %v", err)
+		}
+		if closeErr := CloseSQLiteDatabase(ctx, db2); closeErr != nil {
+			t.Errorf("second close error = %v", closeErr)
+		}
+	})
+
+	t.Run("recovers from corrupt database file and returns fresh database", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "corrupt.db")
+		ctx := context.Background()
+
+		// Write garbage to trigger "file is not a database" from the SQLite driver.
+		if err := os.WriteFile(dbPath, []byte("this is not a sqlite database file"), 0o644); err != nil {
+			t.Fatalf("write corrupt file: %v", err)
+		}
+
+		db, err := OpenSQLiteDatabase(ctx, dbPath, nil)
+		if err != nil {
+			t.Fatalf("OpenSQLiteDatabase() recovery error = %v", err)
+		}
+		defer closeQuietly(db)
+
+		entries, readErr := os.ReadDir(dir)
+		if readErr != nil {
+			t.Fatalf("ReadDir: %v", readErr)
+		}
+		var foundCorrupt bool
+		for _, e := range entries {
+			if strings.Contains(e.Name(), ".corrupt") {
+				foundCorrupt = true
+				break
+			}
+		}
+		if !foundCorrupt {
+			t.Error("no .corrupt backup file created after recovery")
+		}
+	})
+
+	t.Run("returns error when initialize callback fails", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "init_fail.db")
+		ctx := context.Background()
+
+		initErr := errors.New("initialization failed")
+		_, err := OpenSQLiteDatabase(ctx, dbPath, func(_ context.Context, _ *sql.DB) error {
+			return initErr
+		})
+		if !errors.Is(err, initErr) {
+			t.Errorf("OpenSQLiteDatabase() error = %v, want wrapping %v", err, initErr)
+		}
+	})
+}
+
+func TestCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil db is a no-op", func(t *testing.T) {
+		t.Parallel()
+		if err := Checkpoint(context.Background(), nil); err != nil {
+			t.Errorf("Checkpoint(nil) error = %v, want nil", err)
+		}
+	})
+
+	t.Run("checkpoints a real WAL database", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "wal.db")
+		ctx := context.Background()
+
+		db, err := OpenSQLiteDatabase(ctx, dbPath, nil)
+		if err != nil {
+			t.Fatalf("OpenSQLiteDatabase() error = %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		if err := Checkpoint(ctx, db); err != nil {
+			t.Errorf("Checkpoint() error = %v", err)
+		}
+	})
+}
+
+func TestCloseSQLiteDatabaseNilCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil db returns nil without panicking", func(t *testing.T) {
+		t.Parallel()
+		if err := CloseSQLiteDatabase(context.Background(), nil); err != nil {
+			t.Errorf("CloseSQLiteDatabase(nil db) error = %v, want nil", err)
+		}
+	})
+
+	t.Run("nil context returns error", func(t *testing.T) {
+		t.Parallel()
+		var nilCtx context.Context
+		err := CloseSQLiteDatabase(nilCtx, &sql.DB{})
+		if err == nil {
+			t.Fatal("CloseSQLiteDatabase(nil ctx) error = nil, want error")
+		}
+	})
+}
+
+func TestCloseQuietly(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil db does not panic", func(t *testing.T) {
+		t.Parallel()
+		closeQuietly(nil)
+	})
+
+	t.Run("non-nil db gets closed", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "close_quietly.db")
+		db, err := sql.Open(sqliteDriverName, sqliteDSN(dbPath))
+		if err != nil {
+			t.Fatalf("sql.Open() error = %v", err)
+		}
+		closeQuietly(db)
+	})
+}
+
+func TestRecoverSQLiteDatabase(t *testing.T) {
+	t.Parallel()
+
+	t.Run("renames main file and existing companions", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "db.sqlite")
+
+		for _, suffix := range []string{"", "-wal", "-shm"} {
+			if err := os.WriteFile(dbPath+suffix, []byte("content"), 0o644); err != nil {
+				t.Fatalf("write %s: %v", suffix, err)
+			}
+		}
+
+		corruptPath, err := recoverSQLiteDatabase(dbPath)
+		if err != nil {
+			t.Fatalf("recoverSQLiteDatabase() error = %v", err)
+		}
+		if corruptPath == "" {
+			t.Fatal("recoverSQLiteDatabase() returned empty path")
+		}
+		if _, statErr := os.Stat(dbPath); statErr == nil {
+			t.Error("original file still exists after recovery")
+		}
+	})
+
+	t.Run("succeeds when companion files are absent", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "solo.sqlite")
+
+		if err := os.WriteFile(dbPath, []byte("content"), 0o644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+
+		if _, err := recoverSQLiteDatabase(dbPath); err != nil {
+			t.Fatalf("recoverSQLiteDatabase() without companions error = %v", err)
+		}
+	})
+}
+
+func TestEnsureSchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns error for invalid SQL statement", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "schema_err.db")
+		ctx := context.Background()
+
+		db, err := OpenSQLiteDatabase(ctx, dbPath, nil)
+		if err != nil {
+			t.Fatalf("OpenSQLiteDatabase() error = %v", err)
+		}
+		defer closeQuietly(db)
+
+		if err := EnsureSchema(ctx, db, []string{"NOT VALID SQL;;;"}); err == nil {
+			t.Fatal("EnsureSchema() with invalid SQL error = nil, want error")
+		}
+	})
+}
 
 func TestCloseSQLiteDatabase(t *testing.T) {
 	t.Run("Should checkpoint before closing the SQLite handle", func(t *testing.T) {
@@ -68,6 +396,46 @@ func TestCloseSQLiteDatabase(t *testing.T) {
 		}
 		if !closeCalled {
 			t.Fatal("expected close handler to run even when checkpoint fails")
+		}
+	})
+
+	t.Run("Should return close error when checkpoint succeeds but close fails", func(t *testing.T) {
+		originalCheckpoint := checkpointSQLiteWAL
+		originalClose := closeSQLiteHandle
+		t.Cleanup(func() {
+			checkpointSQLiteWAL = originalCheckpoint
+			closeSQLiteHandle = originalClose
+		})
+
+		closeErr := errors.New("close failed")
+		checkpointSQLiteWAL = func(context.Context, *sql.DB) error { return nil }
+		closeSQLiteHandle = func(*sql.DB) error { return closeErr }
+
+		err := CloseSQLiteDatabase(context.Background(), &sql.DB{})
+		if !errors.Is(err, closeErr) {
+			t.Errorf("CloseSQLiteDatabase() error = %v, want %v", err, closeErr)
+		}
+	})
+
+	t.Run("Should join errors when both checkpoint and close fail", func(t *testing.T) {
+		originalCheckpoint := checkpointSQLiteWAL
+		originalClose := closeSQLiteHandle
+		t.Cleanup(func() {
+			checkpointSQLiteWAL = originalCheckpoint
+			closeSQLiteHandle = originalClose
+		})
+
+		checkpointErr := errors.New("checkpoint failed")
+		closeErr := errors.New("close failed")
+		checkpointSQLiteWAL = func(context.Context, *sql.DB) error { return checkpointErr }
+		closeSQLiteHandle = func(*sql.DB) error { return closeErr }
+
+		err := CloseSQLiteDatabase(context.Background(), &sql.DB{})
+		if !errors.Is(err, checkpointErr) {
+			t.Errorf("CloseSQLiteDatabase() error does not wrap checkpoint error: %v", err)
+		}
+		if !errors.Is(err, closeErr) {
+			t.Errorf("CloseSQLiteDatabase() error does not wrap close error: %v", err)
 		}
 	})
 }

--- a/internal/store/sqlite_windows_test.go
+++ b/internal/store/sqlite_windows_test.go
@@ -9,12 +9,14 @@ import (
 
 func TestSQLiteDSNWindowsDriveLetter(t *testing.T) {
 	t.Parallel()
+	t.Run("Should format Windows drive-letter absolute path as file URI", func(t *testing.T) {
+		t.Parallel()
+		path := `C:\Users\user\.compozy\db.sqlite`
+		dsn := sqliteDSN(path)
 
-	path := `C:\Users\user\.compozy\db.sqlite`
-	dsn := sqliteDSN(path)
-
-	const wantPrefix = "file:///C:/Users/user/.compozy/db.sqlite"
-	if !strings.HasPrefix(dsn, wantPrefix) {
-		t.Errorf("sqliteDSN(%q) = %q, want prefix %q", path, dsn, wantPrefix)
-	}
+		const wantPrefix = "file:///C:/Users/user/.compozy/db.sqlite"
+		if !strings.HasPrefix(dsn, wantPrefix) {
+			t.Errorf("sqliteDSN(%q) = %q, want prefix %q", path, dsn, wantPrefix)
+		}
+	})
 }

--- a/internal/store/sqlite_windows_test.go
+++ b/internal/store/sqlite_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSQLiteDSNWindowsDriveLetter(t *testing.T) {
+	t.Parallel()
+
+	path := `C:\Users\user\.compozy\db.sqlite`
+	dsn := sqliteDSN(path)
+
+	const wantPrefix = "file:///C:/Users/user/.compozy/db.sqlite"
+	if !strings.HasPrefix(dsn, wantPrefix) {
+		t.Errorf("sqliteDSN(%q) = %q, want prefix %q", path, dsn, wantPrefix)
+	}
+}

--- a/internal/store/values_test.go
+++ b/internal/store/values_test.go
@@ -33,7 +33,7 @@ func TestFormatTimestamp(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run("Should "+tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := FormatTimestamp(tt.in)
 			if got != tt.want {
@@ -47,10 +47,11 @@ func TestParseTimestamp(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		in      string
-		want    time.Time
-		wantErr bool
+		name        string
+		in          string
+		want        time.Time
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name: "valid canonical timestamp",
@@ -63,23 +64,28 @@ func TestParseTimestamp(t *testing.T) {
 			want: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
 		},
 		{
-			name:    "invalid format returns error",
-			in:      "not-a-timestamp",
-			wantErr: true,
+			name:        "invalid format returns error",
+			in:          "not-a-timestamp",
+			wantErr:     true,
+			errContains: "store: parse timestamp",
 		},
 		{
-			name:    "empty string returns error",
-			in:      "",
-			wantErr: true,
+			name:        "empty string returns error",
+			in:          "",
+			wantErr:     true,
+			errContains: "store: parse timestamp",
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run("Should "+tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ParseTimestamp(tt.in)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ParseTimestamp(%q) error = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("ParseTimestamp(%q) error = %q, want to contain %q", tt.in, err.Error(), tt.errContains)
 			}
 			if !tt.wantErr && !got.Equal(tt.want) {
 				t.Errorf("ParseTimestamp(%q) = %v, want %v", tt.in, got, tt.want)
@@ -103,7 +109,7 @@ func TestNullableString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run("Should "+tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := NullableString(tt.in)
 			if got != tt.want {
@@ -151,7 +157,7 @@ func TestNullString(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run("Should "+tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := NullString(tt.in)
 			if tt.want == nil {
@@ -173,7 +179,7 @@ func TestNullString(t *testing.T) {
 func TestNewID(t *testing.T) {
 	t.Parallel()
 
-	t.Run("without prefix returns 16-char hex string", func(t *testing.T) {
+	t.Run("Should return 16-char hex string without prefix", func(t *testing.T) {
 		t.Parallel()
 		id := NewID("")
 		if id == "" {
@@ -184,7 +190,7 @@ func TestNewID(t *testing.T) {
 		}
 	})
 
-	t.Run("with prefix returns prefix-hex format", func(t *testing.T) {
+	t.Run("Should return prefix-hex format with prefix", func(t *testing.T) {
 		t.Parallel()
 		id := NewID("run")
 		if !strings.HasPrefix(id, "run-") {
@@ -192,7 +198,7 @@ func TestNewID(t *testing.T) {
 		}
 	})
 
-	t.Run("whitespace-only prefix treated as empty prefix", func(t *testing.T) {
+	t.Run("Should treat whitespace-only prefix as empty", func(t *testing.T) {
 		t.Parallel()
 		id := NewID("   ")
 		if strings.Contains(id, " ") {
@@ -203,7 +209,7 @@ func TestNewID(t *testing.T) {
 		}
 	})
 
-	t.Run("successive calls return unique IDs", func(t *testing.T) {
+	t.Run("Should return unique IDs on successive calls", func(t *testing.T) {
 		t.Parallel()
 		id1 := NewID("test")
 		id2 := NewID("test")

--- a/internal/store/values_test.go
+++ b/internal/store/values_test.go
@@ -1,0 +1,214 @@
+package store
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatTimestamp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{
+			name: "zero time returns empty string",
+			in:   time.Time{},
+			want: "",
+		},
+		{
+			name: "non-zero UTC time formats canonically",
+			in:   time.Date(2024, 1, 15, 10, 30, 0, 123456789, time.UTC),
+			want: "2024-01-15T10:30:00.123456789Z",
+		},
+		{
+			name: "non-UTC time is converted to UTC",
+			in:   time.Date(2024, 1, 15, 12, 0, 0, 0, time.FixedZone("UTC+2", 2*3600)),
+			want: "2024-01-15T10:00:00.000000000Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatTimestamp(tt.in)
+			if got != tt.want {
+				t.Errorf("FormatTimestamp() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTimestamp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name: "valid canonical timestamp",
+			in:   "2024-01-15T10:30:00.123456789Z",
+			want: time.Date(2024, 1, 15, 10, 30, 0, 123456789, time.UTC),
+		},
+		{
+			name: "trims surrounding whitespace",
+			in:   "  2024-01-15T10:30:00.000000000Z  ",
+			want: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{
+			name:    "invalid format returns error",
+			in:      "not-a-timestamp",
+			wantErr: true,
+		},
+		{
+			name:    "empty string returns error",
+			in:      "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseTimestamp(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseTimestamp(%q) error = %v, wantErr %v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && !got.Equal(tt.want) {
+				t.Errorf("ParseTimestamp(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNullableString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want any
+	}{
+		{name: "empty string returns nil", in: "", want: nil},
+		{name: "whitespace-only string returns nil", in: "   \t\n", want: nil},
+		{name: "non-empty string returns trimmed value", in: "  hello  ", want: "hello"},
+		{name: "value without spaces returned unchanged", in: "value", want: "value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NullableString(tt.in)
+			if got != tt.want {
+				t.Errorf("NullableString(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNullString(t *testing.T) {
+	t.Parallel()
+
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name string
+		in   sql.NullString
+		want *string
+	}{
+		{
+			name: "invalid NullString returns nil",
+			in:   sql.NullString{Valid: false},
+			want: nil,
+		},
+		{
+			name: "valid but empty NullString returns nil",
+			in:   sql.NullString{Valid: true, String: ""},
+			want: nil,
+		},
+		{
+			name: "valid whitespace-only NullString returns nil",
+			in:   sql.NullString{Valid: true, String: "   "},
+			want: nil,
+		},
+		{
+			name: "valid non-empty NullString returns trimmed pointer",
+			in:   sql.NullString{Valid: true, String: "  hello  "},
+			want: strPtr("hello"),
+		},
+		{
+			name: "valid string without padding returned as-is",
+			in:   sql.NullString{Valid: true, String: "value"},
+			want: strPtr("value"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := NullString(tt.in)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("NullString() = %q, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("NullString() = nil, want %q", *tt.want)
+			}
+			if *got != *tt.want {
+				t.Errorf("NullString() = %q, want %q", *got, *tt.want)
+			}
+		})
+	}
+}
+
+func TestNewID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without prefix returns 16-char hex string", func(t *testing.T) {
+		t.Parallel()
+		id := NewID("")
+		if id == "" {
+			t.Fatal("NewID(\"\") returned empty string")
+		}
+		if len(id) != 16 {
+			t.Errorf("NewID(\"\") length = %d, want 16", len(id))
+		}
+	})
+
+	t.Run("with prefix returns prefix-hex format", func(t *testing.T) {
+		t.Parallel()
+		id := NewID("run")
+		if !strings.HasPrefix(id, "run-") {
+			t.Errorf("NewID(%q) = %q, want prefix %q", "run", id, "run-")
+		}
+	})
+
+	t.Run("whitespace-only prefix treated as empty prefix", func(t *testing.T) {
+		t.Parallel()
+		id := NewID("   ")
+		if strings.Contains(id, " ") {
+			t.Errorf("NewID(whitespace) = %q, must not contain spaces", id)
+		}
+		if len(id) != 16 {
+			t.Errorf("NewID(whitespace) length = %d, want 16", len(id))
+		}
+	})
+
+	t.Run("successive calls return unique IDs", func(t *testing.T) {
+		t.Parallel()
+		id1 := NewID("test")
+		id2 := NewID("test")
+		if id1 == id2 {
+			t.Errorf("NewID() returned duplicate IDs: %q", id1)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #148
Fixes #157
Fixes #170

## Problem

Three independent failures prevented the daemon from running on Windows — all causing a silent exit with no error shown to the user:

1. **Lock file sharing violation (#148)** — lock uses LockFileEx on Windows, which holds a byte-range lock that blocks *all* file handles, including those in the same process. Writing the PID back to the locked file returned ERROR_SHARING_VIOLATION.
2. **Silent crash on startup (#157)** — syncDir called ile.Sync() on a directory opened read-only. On Windows, FlushFileBuffers requires a writable handle; it returns ERROR_ACCESS_DENIED, causing the daemon to exit before writing daemon.json.
3. **SQLite URI rejected (#157)** — ilepath.ToSlash produces C:/path/to/db on Windows. Passed to url.URL, this serialises as ile://C:/... where the SQLite URI parser interprets C: as a network authority rather than a drive letter, failing to open the database.
4. **Daemon inherited Ctrl+C** — The daemon process inherited the parent console's process group, so any Ctrl+C sent to the CLI also terminated the daemon.

## Changes

| File | Change |
|------|--------|
| internal/daemon/sync_dir_unix.go | Extracted existing syncDir implementation (non-Windows build) |
| internal/daemon/sync_dir_windows.go | No-op syncDir on Windows — NTFS journal guarantees durability after atomic rename |
| internal/daemon/lock_pid_other.go | lockPIDPath identity function for non-Windows (PID stored in lock file) |
| internal/daemon/lock_pid_windows.go | lockPIDPath returns path + .pid sidecar to avoid LockFileEx conflict |
| internal/daemon/lock.go | Use lockPIDPath() helper for all PID read/write calls |
| internal/daemon/info_lock_test.go | Update tests to use lockPIDPath() to reflect platform-correct path |
| internal/daemon/info.go | Remove syncDir (moved to platform-specific files) |
| internal/cli/daemon_launch_windows.go | SysProcAttr with CREATE_NEW_PROCESS_GROUP to detach daemon from parent console |
| internal/cli/daemon_launch_other.go | Add windows to the exclusion build constraint |
| internal/store/sqlite.go | Prepend / to drive-letter paths so url.URL produces valid ile:///C:/... URIs |

## Impact on Unix / Linux / macOS

No behavioral change. All Windows-specific code is behind //go:build windows build tags. The lockPIDPath non-Windows implementation is an identity function (returns the same path). The SQLite fix only triggers when the path does not start with /, which never happens on Unix. The syncDir move is a pure refactor with identical logic.

## Verification

`
make verify
`

- golangci-lint: 0 issues
- Go race suite: all tests pass
- Build: compiles cleanly for Windows target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform daemon launching and process detachment (Windows/unix behaviors)
  * Refined lock/PID file handling for more reliable PID tracking and release
  * Enhanced directory sync/durability handling per platform
  * Normalized database file path handling for consistent connection URIs

* **Tests**
  * Expanded and hardened test coverage for daemon lifecycle, locking, SQLite behavior, and store utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compozy/compozy/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
