### PR TITLE
fix: sanitize OpenCode ACP env in Orca shells

### DIFF
--- a/internal/core/agent/client.go
+++ b/internal/core/agent/client.go
@@ -609,7 +609,7 @@ func (c *clientImpl) ensureStarted(ctx context.Context, req SessionRequest) erro
 
 	process, err := subprocess.Launch(detachedContext(ctx), subprocess.LaunchConfig{
 		Command:         command,
-		Env:             subprocess.MergeEnvironment(c.spec.EnvVars, req.ExtraEnv),
+		Env:             buildLaunchEnvironment(c.spec, req.ExtraEnv),
 		WorkingDir:      req.WorkingDir,
 		WaitDelay:       c.shutdownTimeout,
 		WaitErrorPrefix: "wait for ACP agent process",

--- a/internal/core/agent/client_test.go
+++ b/internal/core/agent/client_test.go
@@ -1636,6 +1636,10 @@ func TestACPHelperProcess(_ *testing.T) {
 			os.Exit(2)
 		}
 	}
+	if err := validateHelperEnvironment(scenario.ExpectedProcessEnv, scenario.UnexpectedProcessEnv); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
 
 	agent := &helperAgent{
 		scenario:  scenario,
@@ -1682,6 +1686,8 @@ type helperScenario struct {
 	SessionID                     string              `json:"session_id,omitempty"`
 	ExpectedCWD                   string              `json:"expected_cwd,omitempty"`
 	ExpectedProcessCWD            string              `json:"expected_process_cwd,omitempty"`
+	ExpectedProcessEnv            map[string]string   `json:"expected_process_env,omitempty"`
+	UnexpectedProcessEnv          []string            `json:"unexpected_process_env,omitempty"`
 	ExpectedLoadSessionID         string              `json:"expected_load_session_id,omitempty"`
 	ExpectedNewSessionMCPServers  []acp.McpServer     `json:"expected_new_session_mcp_servers,omitempty"`
 	ExpectedLoadSessionMCPServers []acp.McpServer     `json:"expected_load_session_mcp_servers,omitempty"`

--- a/internal/core/agent/launch_env.go
+++ b/internal/core/agent/launch_env.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/compozy/compozy/internal/core/model"
+)
+
+const (
+	openCodeConfigDirEnv           = "OPENCODE_CONFIG_DIR"
+	orcaOpenCodeConfigDirEnv       = "ORCA_OPENCODE_CONFIG_DIR"
+	orcaOpenCodeSourceConfigDirEnv = "ORCA_OPENCODE_SOURCE_CONFIG_DIR"
+)
+
+func buildLaunchEnvironment(spec Spec, extraEnv map[string]string) []string {
+	env := currentEnvironmentMap()
+	sanitizeInheritedLaunchEnvironment(spec, env)
+	overlayEnvironment(env, spec.EnvVars)
+	overlayEnvironment(env, extraEnv)
+	return environmentAssignments(env)
+}
+
+func currentEnvironmentMap() map[string]string {
+	assignments := os.Environ()
+	env := make(map[string]string, len(assignments))
+	for _, assignment := range assignments {
+		key, value, ok := strings.Cut(assignment, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			continue
+		}
+		env[key] = value
+	}
+	return env
+}
+
+func sanitizeInheritedLaunchEnvironment(spec Spec, env map[string]string) {
+	if env == nil || !isOpenCodeSpec(spec) {
+		return
+	}
+
+	currentConfigDir := strings.TrimSpace(env[openCodeConfigDirEnv])
+	overlayConfigDir := strings.TrimSpace(env[orcaOpenCodeConfigDirEnv])
+	sourceDir := strings.TrimSpace(env[orcaOpenCodeSourceConfigDirEnv])
+	currentLooksOrcaManaged := currentConfigDir == "" || currentConfigDir == overlayConfigDir ||
+		isOrcaOpenCodeConfigDir(currentConfigDir)
+
+	switch {
+	case sourceDir != "" && currentLooksOrcaManaged:
+		env[openCodeConfigDirEnv] = sourceDir
+	case overlayConfigDir != "" && currentLooksOrcaManaged:
+		delete(env, openCodeConfigDirEnv)
+	case overlayConfigDir == "" && sourceDir == "" && isOrcaOpenCodeConfigDir(currentConfigDir):
+		delete(env, openCodeConfigDirEnv)
+	}
+
+	delete(env, orcaOpenCodeConfigDirEnv)
+	delete(env, orcaOpenCodeSourceConfigDirEnv)
+}
+
+func isOpenCodeSpec(spec Spec) bool {
+	if spec.ID == model.IDEOpenCode {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(spec.SetupAgentName), "opencode")
+}
+
+func overlayEnvironment(env map[string]string, overrides map[string]string) {
+	if env == nil || len(overrides) == 0 {
+		return
+	}
+	for key, value := range overrides {
+		if strings.TrimSpace(key) == "" {
+			continue
+		}
+		env[key] = value
+	}
+}
+
+func environmentAssignments(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	assignments := make([]string, 0, len(keys))
+	for _, key := range keys {
+		assignments = append(assignments, fmt.Sprintf("%s=%s", key, env[key]))
+	}
+	return assignments
+}
+
+func isOrcaOpenCodeConfigDir(path string) bool {
+	clean := strings.TrimSpace(path)
+	if clean == "" {
+		return false
+	}
+
+	segments := strings.Split(filepath.ToSlash(filepath.Clean(clean)), "/")
+	for i := 0; i+1 < len(segments); i++ {
+		if segments[i] != "orca" {
+			continue
+		}
+		if segments[i+1] == "opencode-hooks" || segments[i+1] == "opencode-config-overlays" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/core/agent/opencode_env_test.go
+++ b/internal/core/agent/opencode_env_test.go
@@ -1,0 +1,293 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	"github.com/compozy/compozy/internal/core/model"
+)
+
+func TestSanitizeInheritedLaunchEnvironmentForOpenCode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		spec Spec
+		env  map[string]string
+		want map[string]string
+	}{
+		{
+			name: "restore source config dir and drop Orca vars",
+			spec: Spec{SetupAgentName: "opencode"},
+			env: map[string]string{
+				openCodeConfigDirEnv:           "/Users/test/Library/Application Support/orca/opencode-hooks/missing",
+				orcaOpenCodeConfigDirEnv:       "/Users/test/Library/Application Support/orca/opencode-hooks/missing",
+				orcaOpenCodeSourceConfigDirEnv: "/Users/test/.config/opencode",
+				"KEEP":                         "value",
+			},
+			want: map[string]string{
+				openCodeConfigDirEnv: "/Users/test/.config/opencode",
+				"KEEP":               "value",
+			},
+		},
+		{
+			name: "drop Orca overlay config when no source exists",
+			spec: Spec{SetupAgentName: "opencode"},
+			env: map[string]string{
+				openCodeConfigDirEnv:     "/Users/test/Library/Application Support/orca/opencode-hooks/missing",
+				orcaOpenCodeConfigDirEnv: "/Users/test/Library/Application Support/orca/opencode-hooks/missing",
+				"KEEP":                   "value",
+			},
+			want: map[string]string{
+				"KEEP": "value",
+			},
+		},
+		{
+			name: "drop stale Orca config dir even without Orca helper vars",
+			spec: Spec{ID: model.IDEOpenCode},
+			env: map[string]string{
+				openCodeConfigDirEnv: "/Users/test/Library/Application Support/orca/opencode-config-overlays/overlay",
+				"KEEP":               "value",
+			},
+			want: map[string]string{
+				"KEEP": "value",
+			},
+		},
+		{
+			name: "preserve explicit custom config dir when Orca vars are stale",
+			spec: Spec{SetupAgentName: "opencode"},
+			env: map[string]string{
+				openCodeConfigDirEnv:           "/Users/test/.config/opencode-custom",
+				orcaOpenCodeConfigDirEnv:       "/Users/test/Library/Application Support/orca/opencode-hooks/missing",
+				orcaOpenCodeSourceConfigDirEnv: "/Users/test/.config/opencode-source",
+				"KEEP":                         "value",
+			},
+			want: map[string]string{
+				openCodeConfigDirEnv: "/Users/test/.config/opencode-custom",
+				"KEEP":               "value",
+			},
+		},
+		{
+			name: "leave non OpenCode runtimes unchanged",
+			spec: Spec{ID: model.IDECodex, SetupAgentName: "codex"},
+			env: map[string]string{
+				openCodeConfigDirEnv:     "/Users/test/custom-opencode",
+				orcaOpenCodeConfigDirEnv: "/Users/test/Library/Application Support/orca/opencode-hooks/missing",
+			},
+			want: map[string]string{
+				openCodeConfigDirEnv:     "/Users/test/custom-opencode",
+				orcaOpenCodeConfigDirEnv: "/Users/test/Library/Application Support/orca/opencode-hooks/missing",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			env := cloneStringMap(tc.env)
+			sanitizeInheritedLaunchEnvironment(tc.spec, env)
+			if !reflect.DeepEqual(env, tc.want) {
+				t.Fatalf("sanitizeInheritedLaunchEnvironment() = %#v, want %#v", env, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildLaunchEnvironmentAppliesExplicitOverridesAfterSanitizingOpenCode(t *testing.T) {
+	t.Setenv(openCodeConfigDirEnv, "/Users/test/Library/Application Support/orca/opencode-hooks/missing")
+	t.Setenv(orcaOpenCodeConfigDirEnv, "/Users/test/Library/Application Support/orca/opencode-hooks/missing")
+	t.Setenv(orcaOpenCodeSourceConfigDirEnv, "/Users/test/.config/opencode")
+
+	env := parseEnvironmentAssignments(buildLaunchEnvironment(
+		Spec{SetupAgentName: "opencode", EnvVars: map[string]string{"SPEC_ONLY": "1"}},
+		map[string]string{openCodeConfigDirEnv: "/Users/test/custom-opencode"},
+	))
+
+	if got := env[openCodeConfigDirEnv]; got != "/Users/test/custom-opencode" {
+		t.Fatalf("%s = %q, want %q", openCodeConfigDirEnv, got, "/Users/test/custom-opencode")
+	}
+	if got := env["SPEC_ONLY"]; got != "1" {
+		t.Fatalf("SPEC_ONLY = %q, want %q", got, "1")
+	}
+	for _, key := range []string{orcaOpenCodeConfigDirEnv, orcaOpenCodeSourceConfigDirEnv} {
+		if _, ok := env[key]; ok {
+			t.Fatalf("expected %s to be removed from launch env, got %#v", key, env)
+		}
+	}
+}
+
+func TestEnsureAvailableSanitizesOrcaInjectedOpenCodeProbeEnvironment(t *testing.T) {
+	overlayDir := "/Users/test/Library/Application Support/orca/opencode-hooks/missing"
+	t.Setenv(openCodeConfigDirEnv, overlayDir)
+	t.Setenv(orcaOpenCodeConfigDirEnv, overlayDir)
+	t.Setenv(orcaOpenCodeSourceConfigDirEnv, "")
+
+	specID := "test-open-code-probe-" + sanitizeTestName(t.Name())
+	registerTestSpec(t, Spec{
+		ID:             specID,
+		DisplayName:    "Test OpenCode Probe",
+		SetupAgentName: "opencode",
+		DefaultModel:   "test-model",
+		Command:        os.Args[0],
+		ProbeArgs:      []string{"-test.run=TestProbeEnvHelperProcess", "--"},
+		EnvVars: map[string]string{
+			"GO_WANT_PROBE_ENV_HELPER": "1",
+			"GO_EXPECT_ENV_ABSENT": strings.Join([]string{
+				openCodeConfigDirEnv,
+				orcaOpenCodeConfigDirEnv,
+				orcaOpenCodeSourceConfigDirEnv,
+			}, ","),
+		},
+	})
+
+	if err := EnsureAvailable(context.Background(), &model.RuntimeConfig{IDE: specID}); err != nil {
+		t.Fatalf("EnsureAvailable() error = %v", err)
+	}
+}
+
+func TestClientCreateSessionRestoresSourceOpenCodeConfigDir(t *testing.T) {
+	workingDir := t.TempDir()
+	overlayDir := "/Users/test/Library/Application Support/orca/opencode-hooks/missing"
+	sourceDir := "/Users/test/.config/opencode"
+	t.Setenv(openCodeConfigDirEnv, overlayDir)
+	t.Setenv(orcaOpenCodeConfigDirEnv, overlayDir)
+	t.Setenv(orcaOpenCodeSourceConfigDirEnv, sourceDir)
+
+	scenario := helperScenario{
+		ExpectedCWD:        workingDir,
+		ExpectedProcessCWD: workingDir,
+		ExpectedPrompt:     "hello from compozy",
+		ExpectedProcessEnv: map[string]string{
+			openCodeConfigDirEnv: sourceDir,
+		},
+		UnexpectedProcessEnv: []string{
+			orcaOpenCodeConfigDirEnv,
+			orcaOpenCodeSourceConfigDirEnv,
+		},
+		StopReason: string(acp.StopReasonEndTurn),
+	}
+
+	scenarioJSON, err := json.Marshal(scenario)
+	if err != nil {
+		t.Fatalf("marshal helper scenario: %v", err)
+	}
+
+	specID := "test-open-code-session-" + sanitizeTestName(t.Name())
+	registerTestSpec(t, Spec{
+		ID:                 specID,
+		DisplayName:        "Test OpenCode Session",
+		SetupAgentName:     "opencode",
+		DefaultModel:       "test-model",
+		Command:            os.Args[0],
+		UsesBootstrapModel: true,
+		EnvVars: map[string]string{
+			"GO_WANT_ACP_HELPER_PROCESS": "1",
+			"GO_ACP_SCENARIO":            string(scenarioJSON),
+		},
+		BootstrapArgs: func(_, _ string, _ []string, _ string) []string {
+			return []string{"-test.run=TestACPHelperProcess", "--"}
+		},
+	})
+
+	client, err := NewClient(context.Background(), ClientConfig{
+		IDE:             specID,
+		Model:           "test-model",
+		ReasoningEffort: "medium",
+		ShutdownTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+
+	session, err := client.CreateSession(context.Background(), SessionRequest{
+		WorkingDir: workingDir,
+		Prompt:     []byte(scenario.ExpectedPrompt),
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+
+	_ = collectSessionUpdates(t, session)
+	if err := client.Close(); err != nil {
+		t.Fatalf("close client: %v", err)
+	}
+}
+
+func TestProbeEnvHelperProcess(_ *testing.T) {
+	if os.Getenv("GO_WANT_PROBE_ENV_HELPER") != "1" {
+		return
+	}
+	if err := validateHelperEnvironment(nil, splitCSV(os.Getenv("GO_EXPECT_ENV_ABSENT"))); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func validateHelperEnvironment(expected map[string]string, absent []string) error {
+	for key, want := range expected {
+		got, ok := os.LookupEnv(key)
+		if !ok {
+			return fmt.Errorf("missing environment variable %s", key)
+		}
+		if got != want {
+			return fmt.Errorf("unexpected %s value %q, want %q", key, got, want)
+		}
+	}
+	for _, key := range absent {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if got, ok := os.LookupEnv(key); ok {
+			return fmt.Errorf("unexpected environment variable %s=%q", key, got)
+		}
+	}
+	return nil
+}
+
+func parseEnvironmentAssignments(assignments []string) map[string]string {
+	env := make(map[string]string, len(assignments))
+	for _, assignment := range assignments {
+		key, value, ok := strings.Cut(assignment, "=")
+		if !ok {
+			continue
+		}
+		env[key] = value
+	}
+	return env
+}
+
+func splitCSV(value string) []string {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	items := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			items = append(items, trimmed)
+		}
+	}
+	return items
+}
+
+func cloneStringMap(src map[string]string) map[string]string {
+	if len(src) == 0 {
+		return map[string]string{}
+	}
+	dst := make(map[string]string, len(src))
+	for key, value := range src {
+		dst[key] = value
+	}
+	return dst
+}

--- a/internal/core/agent/registry_launch.go
+++ b/internal/core/agent/registry_launch.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/core/modelprovider"
-	"github.com/compozy/compozy/internal/core/subprocess"
 )
 
 // AvailabilityError reports an ACP runtime that is missing or incorrectly installed.
@@ -324,7 +323,7 @@ func verifyLauncher(ctx context.Context, spec Spec, launcher Launcher) error {
 	}
 
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...)
-	cmd.Env = subprocess.MergeEnvironment(spec.EnvVars, nil)
+	cmd.Env = buildLaunchEnvironment(spec, nil)
 	var output bytes.Buffer
 	cmd.Stdout = &output
 	cmd.Stderr = &output


### PR DESCRIPTION
## Summary
- sanitize inherited OpenCode launch env before ACP startup and launcher probes
- strip Orca-managed OpenCode overlay vars while preserving explicit user config dirs
- add regression coverage for probe and session launches in Orca-style environments

## Verification
- unset GOROOT && make verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved environment variable handling for agent process launches with more consistent and predictable behavior.

* **Tests**
  * Enhanced test coverage for environment variable sanitization and validation scenarios.
  * Added validation of process environment constraints in test fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compozy/compozy/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->