### PR TITLE
fix: keep multi-run task timers ticking

### DIFF
--- a/internal/core/run/ui/multi_remote.go
+++ b/internal/core/run/ui/multi_remote.go
@@ -433,10 +433,13 @@ func childRunIDFromTaskMultiEvent(ev events.Event) string {
 }
 
 func (m *multiRunModel) Init() tea.Cmd {
-	if child := m.activeChild(); child != nil {
-		return child.Init()
-	}
-	return nil
+	return m.clockTick()
+}
+
+func (m *multiRunModel) clockTick() tea.Cmd {
+	return tea.Every(uiClockTickInterval, func(at time.Time) tea.Msg {
+		return clockTickMsg{at: at}
+	})
 }
 
 func (m *multiRunModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -601,9 +604,9 @@ func (m *multiRunModel) handleClockTick(v clockTickMsg) tea.Cmd {
 		m.now = v.at
 	}
 	if child := m.activeChild(); child != nil {
-		return child.handleClockTick(v)
+		child.handleClockTick(v)
 	}
-	return nil
+	return m.clockTick()
 }
 
 func (m *multiRunModel) handleSpinnerTick(v spinnerTickMsg) tea.Cmd {

--- a/internal/core/run/ui/multi_remote_test.go
+++ b/internal/core/run/ui/multi_remote_test.go
@@ -148,6 +148,45 @@ func TestMultiRunCompletedTabRemainsNavigableAfterActiveAdvances(t *testing.T) {
 	})
 }
 
+func TestMultiRunInitStartsClockWhenActiveTabHasNoChild(t *testing.T) {
+	t.Parallel()
+
+	mdl, _, err := newRemoteMultiRunModel(context.Background(), RemoteMultiRunAttachOptions{
+		Snapshot: apicore.TaskRunMultipleSnapshot{
+			Run:   apicore.Run{RunID: "parent-run", Status: remoteRunStatusRunning},
+			Items: []apicore.TaskRunMultipleItem{{Slug: "alpha", Status: taskMultiStatusQueued}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("newRemoteMultiRunModel() error = %v", err)
+	}
+
+	if cmd := mdl.Init(); cmd == nil {
+		t.Fatal("expected multi-run init to start clock ticks without an active child")
+	}
+}
+
+func TestMultiRunClockTickContinuesAfterAdvancingToQueuedTab(t *testing.T) {
+	t.Parallel()
+
+	mdl := multiRunModelForQuitTest()
+	mdl.handleChildEvent(multiRunChildEventMsg{
+		RunID: "run-alpha",
+		Event: mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindRunCompleted,
+			kinds.RunCompletedPayload{JobsTotal: 1, JobsSucceeded: 1},
+		),
+	})
+	if got := mdl.activeTab; got != 1 {
+		t.Fatalf("expected active tab to advance to queued beta, got %d", got)
+	}
+
+	if _, cmd := mdl.Update(clockTickMsg{at: time.Unix(1, 0)}); cmd == nil {
+		t.Fatal("expected clock loop to continue after the active tab advances to a queued child")
+	}
+}
+
 func TestMultiRunTabNavigationDoesNotCycleChildPaneFocus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- keep the multi-run UI clock loop owned by the parent tabbed model
- continue clock ticks even when the active tab has not started its child run yet
- add regression tests for queued-tab attach and queued-tab advance cases

## Verification
- GOROOT="/opt/homebrew/opt/go/libexec" make verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved clock tick scheduling reliability in multi-run operations.

* **Tests**
  * Added test coverage for clock tick initialization and continuation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compozy/compozy/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->