### PR TITLE
fix: pin claude model via ANTHROPIC_MODEL instead of unsupported session/set_model

### DIFF
--- a/internal/core/agent/client.go
+++ b/internal/core/agent/client.go
@@ -315,7 +315,10 @@ func (c *clientImpl) CreateSession(ctx context.Context, req SessionRequest) (Ses
 			ModelId:   acp.ModelId(requestedModel),
 		}); err != nil {
 			c.removeSession(session.id)
-			return nil, wrapSessionSetupError(SessionSetupStageSetModel, wrapACPError(err))
+			return nil, wrapSessionSetupError(
+				SessionSetupStageSetModel,
+				modelSwitchUnsupportedHint(c.spec, requestedModel, wrapACPError(err)),
+			)
 		}
 	}
 	if modeID := c.spec.sessionModeForAccess(c.cfg.AccessMode); modeID != "" {
@@ -609,7 +612,7 @@ func (c *clientImpl) ensureStarted(ctx context.Context, req SessionRequest) erro
 
 	process, err := subprocess.Launch(detachedContext(ctx), subprocess.LaunchConfig{
 		Command:         command,
-		Env:             subprocess.MergeEnvironment(c.spec.EnvVars, req.ExtraEnv),
+		Env:             c.launchEnvironment(req),
 		WorkingDir:      req.WorkingDir,
 		WaitDelay:       c.shutdownTimeout,
 		WaitErrorPrefix: "wait for ACP agent process",
@@ -675,6 +678,24 @@ func detachedContext(ctx context.Context) context.Context {
 		return context.Background()
 	}
 	return context.WithoutCancel(ctx)
+}
+
+// launchEnvironment merges the spec environment, the launch-time model pin,
+// and the per-session extra environment for the agent subprocess.
+func (c *clientImpl) launchEnvironment(req SessionRequest) []string {
+	modelEnv := launchModelEnv(c.spec, firstNonEmpty(req.Model, c.cfg.Model))
+	if len(modelEnv) == 0 {
+		return subprocess.MergeEnvironment(c.spec.EnvVars, req.ExtraEnv)
+	}
+
+	base := make(map[string]string, len(c.spec.EnvVars)+len(modelEnv))
+	for key, value := range c.spec.EnvVars {
+		base[key] = value
+	}
+	for key, value := range modelEnv {
+		base[key] = value
+	}
+	return subprocess.MergeEnvironment(base, req.ExtraEnv)
 }
 
 func (c *clientImpl) resolveStartCommand(ctx context.Context, req SessionRequest) (string, []string, error) {
@@ -1068,6 +1089,28 @@ func pathWithinRoots(path string, roots []string) bool {
 		}
 	}
 	return false
+}
+
+// jsonRPCMethodNotFound is the JSON-RPC 2.0 error code agents return for
+// methods they do not implement.
+const jsonRPCMethodNotFound = -32601
+
+// modelSwitchUnsupportedHint augments session/set_model "Method not found"
+// failures with an actionable explanation, since the raw JSON-RPC error does
+// not tell users that the runtime cannot switch models after launch.
+func modelSwitchUnsupportedHint(spec Spec, modelName string, err error) error {
+	var sessionErr *SessionError
+	if !errors.As(err, &sessionErr) || sessionErr.Code != jsonRPCMethodNotFound {
+		return err
+	}
+	return fmt.Errorf(
+		"%w. The %s runtime does not support switching models over ACP (session/set_model), "+
+			"so the requested model %q cannot be applied; omit --model or use --model auto "+
+			"to run with the runtime default",
+		err,
+		firstNonEmpty(spec.DisplayName, spec.ID),
+		modelName,
+	)
 }
 
 func wrapACPError(err error) error {

--- a/internal/core/agent/client_test.go
+++ b/internal/core/agent/client_test.go
@@ -491,6 +491,148 @@ func TestClientCreateSessionSetsExplicitModelForNonBootstrapACP(t *testing.T) {
 	}
 }
 
+func TestClientCreateSessionPassesExplicitModelThroughLaunchEnv(t *testing.T) {
+	t.Parallel()
+
+	scenario := helperScenario{
+		ExpectedCWD:        t.TempDir(),
+		ExpectedPrompt:     "use launch env model",
+		RejectSessionModel: true,
+		ExpectedEnvVars:    map[string]string{"COMPOZY_TEST_ACP_MODEL": "sonnet"},
+		StopReason:         string(acp.StopReasonEndTurn),
+	}
+	client := newTestClientWithSpecConfig(
+		t,
+		scenario,
+		func(spec *Spec) {
+			spec.ModelEnvVar = "COMPOZY_TEST_ACP_MODEL"
+		},
+		func(cfg *ClientConfig) {
+			cfg.Model = "sonnet"
+		},
+	)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close client: %v", err)
+		}
+	})
+
+	session, err := client.CreateSession(context.Background(), SessionRequest{
+		WorkingDir: scenario.ExpectedCWD,
+		Prompt:     []byte(scenario.ExpectedPrompt),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	updates := collectSessionUpdates(t, session)
+	if len(updates) != 1 {
+		t.Fatalf("unexpected updates length: %d", len(updates))
+	}
+	if updates[0].Status != model.StatusCompleted {
+		t.Fatalf("unexpected final status: %q", updates[0].Status)
+	}
+	if session.Err() != nil {
+		t.Fatalf("unexpected session error: %v", session.Err())
+	}
+}
+
+func TestClientCreateSessionOmitsLaunchEnvModelForAutoModel(t *testing.T) {
+	t.Parallel()
+
+	scenario := helperScenario{
+		ExpectedCWD:        t.TempDir(),
+		ExpectedPrompt:     "use runtime default model",
+		RejectSessionModel: true,
+		ExpectedEnvVars:    map[string]string{"COMPOZY_TEST_ACP_MODEL": ""},
+		StopReason:         string(acp.StopReasonEndTurn),
+	}
+	client := newTestClientWithSpecConfig(
+		t,
+		scenario,
+		func(spec *Spec) {
+			spec.ModelEnvVar = "COMPOZY_TEST_ACP_MODEL"
+		},
+		func(cfg *ClientConfig) {
+			cfg.Model = " AUTO "
+		},
+	)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close client: %v", err)
+		}
+	})
+
+	session, err := client.CreateSession(context.Background(), SessionRequest{
+		WorkingDir: scenario.ExpectedCWD,
+		Prompt:     []byte(scenario.ExpectedPrompt),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	updates := collectSessionUpdates(t, session)
+	if len(updates) != 1 {
+		t.Fatalf("unexpected updates length: %d", len(updates))
+	}
+	if updates[0].Status != model.StatusCompleted {
+		t.Fatalf("unexpected final status: %q", updates[0].Status)
+	}
+	if session.Err() != nil {
+		t.Fatalf("unexpected session error: %v", session.Err())
+	}
+}
+
+func TestClientCreateSessionExplainsModelSwitchUnsupportedOnMethodNotFound(t *testing.T) {
+	t.Parallel()
+
+	scenario := helperScenario{
+		ExpectedCWD: t.TempDir(),
+		SessionModelError: &helperRequestError{
+			Code:    -32601,
+			Message: "Method not found",
+		},
+	}
+	client := newTestClientWithSpecConfig(
+		t,
+		scenario,
+		func(spec *Spec) {
+			spec.DefaultModel = "runtime-default"
+			spec.UsesBootstrapModel = false
+		},
+		func(cfg *ClientConfig) {
+			cfg.Model = "sonnet"
+		},
+	)
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close client: %v", err)
+		}
+	})
+
+	_, err := client.CreateSession(context.Background(), SessionRequest{
+		WorkingDir: scenario.ExpectedCWD,
+		Prompt:     []byte("switch model"),
+	})
+	if err == nil {
+		t.Fatal("expected create session error")
+	}
+
+	var setupErr *SessionSetupError
+	if !errors.As(err, &setupErr) || setupErr.Stage != SessionSetupStageSetModel {
+		t.Fatalf("expected set_model setup error, got %v", err)
+	}
+	for _, want := range []string{
+		"does not support switching models over ACP",
+		`"sonnet"`,
+		"--model auto",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+}
+
 func TestClientCreateSessionForwardsMCPServersIntoNewSessionRequest(t *testing.T) {
 	t.Parallel()
 
@@ -1728,6 +1870,12 @@ func TestACPHelperProcess(_ *testing.T) {
 			os.Exit(2)
 		}
 	}
+	for key, want := range scenario.ExpectedEnvVars {
+		if got := os.Getenv(key); got != want {
+			fmt.Fprintf(os.Stderr, "unexpected helper env %s=%q, want %q\n", key, got, want)
+			os.Exit(2)
+		}
+	}
 
 	agent := &helperAgent{
 		scenario:  scenario,
@@ -1781,22 +1929,26 @@ type helperScenario struct {
 	ExpectedSessionModeID         string              `json:"expected_session_mode_id,omitempty"`
 	ExpectedSessionModelID        string              `json:"expected_session_model_id,omitempty"`
 	RejectSessionModel            bool                `json:"reject_session_model,omitempty"`
-	UpdateIntervalMillis          int                 `json:"update_interval_millis,omitempty"`
-	SupportsLoadSession           bool                `json:"supports_load_session,omitempty"`
-	SessionMeta                   map[string]any      `json:"session_meta,omitempty"`
-	NewSessionUpdates             []acp.SessionUpdate `json:"new_session_updates,omitempty"`
-	ReplayUpdatesOnLoad           []acp.SessionUpdate `json:"replay_updates_on_load,omitempty"`
-	Updates                       []acp.SessionUpdate `json:"updates,omitempty"`
-	StopReason                    string              `json:"stop_reason,omitempty"`
-	BlockUntilCancel              bool                `json:"block_until_cancel,omitempty"`
-	NewSessionError               *helperRequestError `json:"new_session_error,omitempty"`
-	PromptError                   *helperRequestError `json:"prompt_error,omitempty"`
-	PromptErrorAfterUpdates       bool                `json:"prompt_error_after_updates,omitempty"`
-	TerminalCommand               string              `json:"terminal_command,omitempty"`
-	TerminalArgs                  []string            `json:"terminal_args,omitempty"`
-	TerminalEnv                   []acp.EnvVariable   `json:"terminal_env,omitempty"`
-	TerminalWantOutput            string              `json:"terminal_want_output,omitempty"`
-	TerminalWantExitCode          *int                `json:"terminal_want_exit_code,omitempty"`
+	SessionModelError             *helperRequestError `json:"session_model_error,omitempty"`
+	// ExpectedEnvVars asserts process environment values at helper startup.
+	// An empty value means the variable must be unset or empty.
+	ExpectedEnvVars         map[string]string   `json:"expected_env_vars,omitempty"`
+	UpdateIntervalMillis    int                 `json:"update_interval_millis,omitempty"`
+	SupportsLoadSession     bool                `json:"supports_load_session,omitempty"`
+	SessionMeta             map[string]any      `json:"session_meta,omitempty"`
+	NewSessionUpdates       []acp.SessionUpdate `json:"new_session_updates,omitempty"`
+	ReplayUpdatesOnLoad     []acp.SessionUpdate `json:"replay_updates_on_load,omitempty"`
+	Updates                 []acp.SessionUpdate `json:"updates,omitempty"`
+	StopReason              string              `json:"stop_reason,omitempty"`
+	BlockUntilCancel        bool                `json:"block_until_cancel,omitempty"`
+	NewSessionError         *helperRequestError `json:"new_session_error,omitempty"`
+	PromptError             *helperRequestError `json:"prompt_error,omitempty"`
+	PromptErrorAfterUpdates bool                `json:"prompt_error_after_updates,omitempty"`
+	TerminalCommand         string              `json:"terminal_command,omitempty"`
+	TerminalArgs            []string            `json:"terminal_args,omitempty"`
+	TerminalEnv             []acp.EnvVariable   `json:"terminal_env,omitempty"`
+	TerminalWantOutput      string              `json:"terminal_want_output,omitempty"`
+	TerminalWantExitCode    *int                `json:"terminal_want_exit_code,omitempty"`
 }
 
 type helperRequestError struct {
@@ -2026,6 +2178,9 @@ func (a *helperAgent) SetSessionModel(
 	_ context.Context,
 	req acp.SetSessionModelRequest,
 ) (acp.SetSessionModelResponse, error) {
+	if a.scenario.SessionModelError != nil {
+		return acp.SetSessionModelResponse{}, a.scenario.SessionModelError.toACPError()
+	}
 	if a.scenario.RejectSessionModel {
 		return acp.SetSessionModelResponse{}, &acp.RequestError{
 			Code:    4005,

--- a/internal/core/agent/registry_launch.go
+++ b/internal/core/agent/registry_launch.go
@@ -124,8 +124,9 @@ func BuildShellCommandString(
 	}
 	args := spec.launchCommandForPreview(launchModel, reasoningEffort, resolvedDirs, accessMode)
 
-	parts := make([]string, 0, len(spec.EnvVars)+1)
+	parts := make([]string, 0, len(spec.EnvVars)+2)
 	parts = append(parts, sortedEnvAssignments(spec.EnvVars)...)
+	parts = append(parts, sortedEnvAssignments(launchModelEnv(spec, modelName))...)
 	parts = append(parts, formatShellCommand(args))
 	return strings.Join(parts, " ")
 }
@@ -168,6 +169,19 @@ func resolveModel(spec Spec, modelName string) string {
 		selected = spec.DefaultModel
 	}
 	return normalizeRuntimeModel(spec, modelprovider.ResolveAlias(selected))
+}
+
+// launchModelEnv returns the launch-time environment entry that pins an
+// explicitly requested model for runtimes that read it from the environment.
+// It returns nil when the runtime has no model env var or when the user left
+// model selection to the runtime ("auto" or empty), so runtime-side defaults
+// keep applying.
+func launchModelEnv(spec Spec, modelName string) map[string]string {
+	envVar := strings.TrimSpace(spec.ModelEnvVar)
+	if envVar == "" || normalizeRequestedModel(modelName) == "" {
+		return nil
+	}
+	return map[string]string{envVar: resolveModel(spec, modelName)}
 }
 
 func normalizeRequestedModel(modelName string) string {

--- a/internal/core/agent/registry_specs.go
+++ b/internal/core/agent/registry_specs.go
@@ -23,11 +23,15 @@ type Spec struct {
 	Fallbacks          []Launcher
 	SupportsAddDirs    bool
 	UsesBootstrapModel bool
-	EnvVars            map[string]string
-	DocsURL            string
-	InstallHint        string
-	FullAccessModeID   string
-	BootstrapArgs      func(modelName, reasoningEffort string, addDirs []string, accessMode string) []string
+	// ModelEnvVar names the environment variable that carries an explicitly
+	// requested model to the agent process at launch, for runtimes that read
+	// their model from the environment instead of supporting session/set_model.
+	ModelEnvVar      string
+	EnvVars          map[string]string
+	DocsURL          string
+	InstallHint      string
+	FullAccessModeID string
+	BootstrapArgs    func(modelName, reasoningEffort string, addDirs []string, accessMode string) []string
 }
 
 // Launcher defines one ACP-compatible command shape for a runtime.
@@ -91,6 +95,11 @@ var (
 			DefaultModel:    model.DefaultClaudeModel,
 			Command:         "claude-agent-acp",
 			SupportsAddDirs: true,
+			// claude-agent-acp does not implement session/set_model; it resolves
+			// the model at launch with ANTHROPIC_MODEL as the highest priority,
+			// so explicit models must be pinned through the launch environment.
+			UsesBootstrapModel: true,
+			ModelEnvVar:        "ANTHROPIC_MODEL",
 			Fallbacks: []Launcher{
 				{
 					Command:   "npx",

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -188,6 +188,102 @@ func TestValidateRuntimeConfigAcceptsAddDirsForSupportedIDE(t *testing.T) {
 	}
 }
 
+func TestClaudeSpecSelectsModelAtLaunchViaEnv(t *testing.T) {
+	t.Parallel()
+
+	spec, err := lookupAgentSpec(model.IDEClaude)
+	if err != nil {
+		t.Fatalf("lookup claude spec: %v", err)
+	}
+	if !spec.UsesBootstrapModel {
+		t.Fatal("claude spec must use a bootstrap model so sessions never call session/set_model")
+	}
+	if spec.ModelEnvVar != "ANTHROPIC_MODEL" {
+		t.Fatalf("claude spec ModelEnvVar = %q, want %q", spec.ModelEnvVar, "ANTHROPIC_MODEL")
+	}
+}
+
+func TestLaunchModelEnv(t *testing.T) {
+	t.Parallel()
+
+	spec := Spec{
+		ID:           "test-launch-env",
+		DefaultModel: "default-model",
+		ModelEnvVar:  "TEST_MODEL_ENV",
+	}
+
+	cases := []struct {
+		name  string
+		spec  Spec
+		input string
+		want  map[string]string
+	}{
+		{
+			name:  "explicit model is pinned",
+			spec:  spec,
+			input: " sonnet ",
+			want:  map[string]string{"TEST_MODEL_ENV": "sonnet"},
+		},
+		{
+			name:  "auto leaves model selection to the runtime",
+			spec:  spec,
+			input: " AUTO ",
+			want:  nil,
+		},
+		{
+			name:  "empty leaves model selection to the runtime",
+			spec:  spec,
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "spec without model env var",
+			spec:  Spec{ID: "no-env", DefaultModel: "default-model"},
+			input: "sonnet",
+			want:  nil,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := launchModelEnv(tc.spec, tc.input)
+			if len(got) != len(tc.want) {
+				t.Fatalf("launchModelEnv() = %#v, want %#v", got, tc.want)
+			}
+			for key, want := range tc.want {
+				if got[key] != want {
+					t.Fatalf("launchModelEnv()[%q] = %q, want %q", key, got[key], want)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildShellCommandStringIncludesClaudeModelEnv(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should pin explicit model through ANTHROPIC_MODEL", func(t *testing.T) {
+		t.Parallel()
+
+		got := BuildShellCommandString(model.IDEClaude, "sonnet", nil, "", "")
+		if !strings.Contains(got, "ANTHROPIC_MODEL=sonnet") {
+			t.Fatalf("shell command %q does not contain ANTHROPIC_MODEL=sonnet", got)
+		}
+	})
+
+	t.Run("Should omit ANTHROPIC_MODEL for auto model", func(t *testing.T) {
+		t.Parallel()
+
+		got := BuildShellCommandString(model.IDEClaude, "auto", nil, "", "")
+		if strings.Contains(got, "ANTHROPIC_MODEL") {
+			t.Fatalf("shell command %q must not contain ANTHROPIC_MODEL", got)
+		}
+	})
+}
+
 func TestResolveRuntimeModelNormalizesCodexProviderPrefix(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -191,16 +191,20 @@ func TestValidateRuntimeConfigAcceptsAddDirsForSupportedIDE(t *testing.T) {
 func TestClaudeSpecSelectsModelAtLaunchViaEnv(t *testing.T) {
 	t.Parallel()
 
-	spec, err := lookupAgentSpec(model.IDEClaude)
-	if err != nil {
-		t.Fatalf("lookup claude spec: %v", err)
-	}
-	if !spec.UsesBootstrapModel {
-		t.Fatal("claude spec must use a bootstrap model so sessions never call session/set_model")
-	}
-	if spec.ModelEnvVar != "ANTHROPIC_MODEL" {
-		t.Fatalf("claude spec ModelEnvVar = %q, want %q", spec.ModelEnvVar, "ANTHROPIC_MODEL")
-	}
+	t.Run("Should pin the claude model at launch through ANTHROPIC_MODEL", func(t *testing.T) {
+		t.Parallel()
+
+		spec, err := lookupAgentSpec(model.IDEClaude)
+		if err != nil {
+			t.Fatalf("lookup claude spec: %v", err)
+		}
+		if !spec.UsesBootstrapModel {
+			t.Fatal("claude spec must use a bootstrap model so sessions never call session/set_model")
+		}
+		if spec.ModelEnvVar != "ANTHROPIC_MODEL" {
+			t.Fatalf("claude spec ModelEnvVar = %q, want %q", spec.ModelEnvVar, "ANTHROPIC_MODEL")
+		}
+	})
 }
 
 func TestLaunchModelEnv(t *testing.T) {
@@ -219,25 +223,25 @@ func TestLaunchModelEnv(t *testing.T) {
 		want  map[string]string
 	}{
 		{
-			name:  "explicit model is pinned",
+			name:  "Should pin an explicitly requested model",
 			spec:  spec,
 			input: " sonnet ",
 			want:  map[string]string{"TEST_MODEL_ENV": "sonnet"},
 		},
 		{
-			name:  "auto leaves model selection to the runtime",
+			name:  "Should leave model selection to the runtime for auto",
 			spec:  spec,
 			input: " AUTO ",
 			want:  nil,
 		},
 		{
-			name:  "empty leaves model selection to the runtime",
+			name:  "Should leave model selection to the runtime for empty input",
 			spec:  spec,
 			input: "",
 			want:  nil,
 		},
 		{
-			name:  "spec without model env var",
+			name:  "Should return nil for specs without a model env var",
 			spec:  Spec{ID: "no-env", DefaultModel: "default-model"},
 			input: "sonnet",
 			want:  nil,


### PR DESCRIPTION
## Summary

Fixes #184 — `compozy tasks run --ide claude --model sonnet` (or any non-default model) failed 100% of jobs with:

```
create ACP session: set_model: ACP error -32601: "Method not found": session/set_model
```

## Root cause

`CreateSession` calls the ACP method `session/set_model` whenever the requested model differs from the launch model. For the `claude` runtime the launch model was always the spec default (`opus`), so any other `--model` value triggered the call — but the `claude-agent-acp` adapter **does not implement `setSessionModel`** (verified against the adapter source, v0.44.0): model switching there only exists through the newer config-options extension, and `session/new` does not advertise `models` support.

The adapter selects its model **at launch**, with this documented priority: `ANTHROPIC_MODEL` env var (highest) → `settings.json` `model` → SDK default, including fuzzy alias resolution (`sonnet`, `opus`, full IDs, `[1m]` suffixes). It has no `--model` CLI flag, so the launch environment is the canonical selection mechanism.

## Fix

Treat claude as a launch-time-model runtime (same category as Codex/Droid, via env instead of args):

- New `Spec.ModelEnvVar` field; the claude spec now sets `UsesBootstrapModel: true` + `ModelEnvVar: "ANTHROPIC_MODEL"`. The start model now equals the requested model, so `session/set_model` is never called for claude.
- New `launchModelEnv()` pins only **explicitly** requested models into the launch environment. `--model auto` / omitted returns nil, preserving current behavior exactly (the adapter keeps resolving from user settings — nobody gets force-pinned to a model their plan may not have).
- `ensureStarted` injects the pin into the subprocess environment (`os/exec` last-wins dedup guarantees it overrides shell-exported `ANTHROPIC_MODEL`).
- `BuildShellCommandString` now includes the env assignment so the printed `$ …` preview matches what actually runs.
- Any runtime that still hits `-32601` on `session/set_model` now gets an actionable error ("…does not support switching models over ACP… omit `--model` or use `--model auto`") instead of the bare `Method not found`.

Side benefit: resumed claude sessions now honor `--model` too (the resume path never called `set_model`, so the model was silently ignored before).

## Testing

- New tests (TDD, red→green, run with `-race`): launch-env pinning for explicit models, env omission for `auto`, the `-32601` hint (stage + message), claude spec invariants, `launchModelEnv` table cases, and shell-preview assertions.
- `make verify` passes 100%: 3410 tests, zero lint issues, build OK, 5/5 Playwright e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explicit model selection can be passed via environment variables for agent runtimes that support it.
  * Claude agent configured to support model selection via an environment variable.

* **Bug Fixes**
  * Improved error messaging when model switching is unsupported, explaining to use `--model auto` or omit the flag.

* **Tests**
  * Added tests covering model-selection behavior, launch environment handling, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->