### PR TITLE
feat: warn when tasks run starts beside active runs in other workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Task and review issue files use YAML frontmatter for parseable metadata such as 
 - `compozy workspaces list|show|register|unregister|resolve` exposes the daemon workspace registry. Workspaces are also lazily registered when you run daemon-backed commands inside them.
 - `compozy tasks run <slug>` is the canonical single-workflow runner. In interactive terminals it attaches to the TUI by default; in non-interactive environments it falls back to streaming. Use `--ui`, `--stream`, `--detach`, or `--attach` to override that behavior.
 - `compozy tasks run --multiple alpha,beta` starts one daemon-owned queue for several task workflows. Use `tasks run --multiple` when the same flags and runtime defaults should apply to an ordered batch; keep using `tasks run <slug>` for one workflow or scripts that expect one run ID per invocation.
+- Independent `compozy tasks run` invocations from different workspaces run concurrently on the shared home-scoped daemon. When another workspace already has an active run, the CLI prints a warning with the busy workspace and run ID before starting the new run.
 - `compozy runs attach <run-id>` restores the interactive TUI for an existing daemon-managed run, while `compozy runs watch <run-id>` streams textual observation from the same snapshot-plus-stream transport.
 - `compozy reviews fetch|list|show|fix` is the canonical review command family.
 
@@ -644,6 +645,8 @@ run_multiple_mode = "enqueued"
 ```
 
 `"enqueued"` is the default and runs one child workflow at a time in the requested order. `"parallel"` is also accepted in V1, but Compozy prints a fallback message and still runs the queue as `"enqueued"` until V2 adds git worktree-backed isolation for concurrent agents.
+
+Cross-workspace runs are different from `--multiple` scheduling: the home-scoped daemon accepts separate `compozy tasks run` invocations from different workspaces concurrently and does not queue or reject the second run. Before starting a non-dry-run task workflow, the CLI checks daemon status; if active runs belong to another registered workspace, it warns with the busy workspace name/path and run ID, then proceeds. The warning is skipped when the daemon is idle, when the active run belongs to the same workspace, or when `--dry-run` is set.
 
 In the TUI, every requested slug has a tab. Queued tabs appear before their child run exists, the running tab shows the familiar task-run surface, and completed, failed, or canceled tabs remain available for inspection. The quit dialog applies to the parent queue: `Close TUI` detaches and leaves the queue running in the daemon, `Stop Run` cancels the parent queue, cancels the active child, and marks queued workflows canceled, and `Cancel` returns to the TUI without changing execution.
 

--- a/internal/api/client/client_transport_test.go
+++ b/internal/api/client/client_transport_test.go
@@ -553,7 +553,7 @@ func TestClientRunQueriesUseCanonicalContract(t *testing.T) {
 				case http.MethodGet + " /api/runs":
 					query := req.URL.Query()
 					if query.Get("workspace") != "/tmp/workspace" ||
-						query.Get("status") != "running" ||
+						query.Get("status") != "pending,running" ||
 						query.Get("mode") != "exec" ||
 						query.Get("limit") != "25" {
 						t.Fatalf("run list query = %#v, want canonical filters", query)
@@ -584,7 +584,7 @@ func TestClientRunQueriesUseCanonicalContract(t *testing.T) {
 
 	runs, err := client.ListRuns(context.Background(), RunListOptions{
 		Workspace: "/tmp/workspace",
-		Status:    "running",
+		Statuses:  []string{" pending ", "running"},
 		Mode:      "exec",
 		Limit:     25,
 	})

--- a/internal/api/client/runs.go
+++ b/internal/api/client/runs.go
@@ -25,6 +25,7 @@ var streamHeartbeatGapTolerance = contract.HeartbeatGapTolerance
 type RunListOptions struct {
 	Workspace string
 	Status    string
+	Statuses  []string
 	Mode      string
 	Limit     int
 }
@@ -107,8 +108,8 @@ func (c *Client) ListRuns(ctx context.Context, opts RunListOptions) ([]apicore.R
 	if workspace := strings.TrimSpace(opts.Workspace); workspace != "" {
 		values.Set("workspace", workspace)
 	}
-	if status := strings.TrimSpace(opts.Status); status != "" {
-		values.Set("status", status)
+	if statuses := runListStatusFilters(opts.Status, opts.Statuses); len(statuses) > 0 {
+		values.Set("status", strings.Join(statuses, ","))
 	}
 	if mode := strings.TrimSpace(opts.Mode); mode != "" {
 		values.Set("mode", mode)
@@ -126,6 +127,29 @@ func (c *Client) ListRuns(ctx context.Context, opts RunListOptions) ([]apicore.R
 		return nil, err
 	}
 	return response.Runs, nil
+}
+
+func runListStatusFilters(status string, statuses []string) []string {
+	seen := make(map[string]struct{}, len(statuses)+1)
+	filters := make([]string, 0, len(statuses)+1)
+	appendStatus := func(raw string) {
+		for _, candidate := range strings.Split(raw, ",") {
+			trimmed := strings.TrimSpace(candidate)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			filters = append(filters, trimmed)
+		}
+	}
+	appendStatus(status)
+	for _, candidate := range statuses {
+		appendStatus(candidate)
+	}
+	return filters
 }
 
 // GetRun loads the latest daemon-backed run summary for one run.

--- a/internal/api/contract/types.go
+++ b/internal/api/contract/types.go
@@ -493,6 +493,7 @@ type RunSnapshot struct {
 type RunListQuery struct {
 	Workspace string
 	Status    string
+	Statuses  []string
 	Mode      string
 	Limit     int
 }

--- a/internal/api/core/handlers.go
+++ b/internal/api/core/handlers.go
@@ -1176,6 +1176,7 @@ func (h *Handlers) ListRuns(c *gin.Context) {
 	runs, err := h.Runs.List(c.Request.Context(), RunListQuery{
 		Workspace: h.optionalWorkspaceContext(c, c.Query("workspace")),
 		Status:    strings.TrimSpace(c.Query("status")),
+		Statuses:  runListStatusFilters(c.QueryArray("status")),
 		Mode:      strings.TrimSpace(c.Query("mode")),
 		Limit:     limit,
 	})
@@ -1184,6 +1185,25 @@ func (h *Handlers) ListRuns(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, contract.RunListResponse{Runs: runs})
+}
+
+func runListStatusFilters(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	filters := make([]string, 0, len(values))
+	for _, value := range values {
+		for _, candidate := range strings.Split(value, ",") {
+			trimmed := strings.TrimSpace(candidate)
+			if trimmed == "" {
+				continue
+			}
+			if _, ok := seen[trimmed]; ok {
+				continue
+			}
+			seen[trimmed] = struct{}{}
+			filters = append(filters, trimmed)
+		}
+	}
+	return filters
 }
 
 // GetRun returns one run summary.

--- a/internal/api/core/handlers_test.go
+++ b/internal/api/core/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -387,12 +388,54 @@ func TestStreamRunLogsCloseErrors(t *testing.T) {
 	}
 }
 
+func TestListRunsParsesMultiStatusFilters(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+
+	var got core.RunListQuery
+	handlers := core.NewHandlers(&core.HandlerConfig{
+		TransportName: "test",
+		Runs: &fakeRunService{
+			list: func(_ context.Context, query core.RunListQuery) ([]core.Run, error) {
+				got = query
+				return nil, nil
+			},
+		},
+	})
+	engine := gin.New()
+	engine.Use(core.RequestIDMiddleware())
+	engine.Use(core.ErrorMiddleware())
+	core.RegisterRoutes(engine, handlers)
+
+	request := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"/api/runs?status=running,pending&status=retrying&limit=10",
+		http.NoBody,
+	)
+	response := httptest.NewRecorder()
+	engine.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusOK, response.Body.String())
+	}
+	want := []string{"running", "pending", "retrying"}
+	if !slices.Equal(got.Statuses, want) {
+		t.Fatalf("statuses = %#v, want %#v", got.Statuses, want)
+	}
+}
+
 type fakeRunService struct {
 	getErr     error
+	list       func(context.Context, core.RunListQuery) ([]core.Run, error)
 	openStream func(context.Context, string, core.StreamCursor) (core.RunStream, error)
 }
 
-func (f *fakeRunService) List(context.Context, core.RunListQuery) ([]core.Run, error) {
+func (f *fakeRunService) List(ctx context.Context, query core.RunListQuery) ([]core.Run, error) {
+	if f.list != nil {
+		return f.list(ctx, query)
+	}
 	return nil, nil
 }
 

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -33,6 +34,7 @@ const (
 
 	defaultDaemonStartupTimeout = 10 * time.Second
 	defaultDaemonPollInterval   = 100 * time.Millisecond
+	taskRunGuardRunListLimit    = 1000
 )
 
 var (
@@ -55,6 +57,7 @@ type daemonCommandClient interface {
 	GetWorkspace(context.Context, string) (apicore.Workspace, error)
 	DeleteWorkspace(context.Context, string) error
 	ResolveWorkspace(context.Context, string) (apicore.Workspace, error)
+	ListRuns(context.Context, apiclient.RunListOptions) ([]apicore.Run, error)
 	ListTaskWorkflows(context.Context, string) ([]apicore.WorkflowSummary, error)
 	ArchiveTaskWorkflow(context.Context, string, string) (apicore.ArchiveResult, error)
 	SyncWorkflow(context.Context, apicore.SyncRequest) (apicore.SyncResult, error)
@@ -391,6 +394,9 @@ func (s *commandState) runTaskWorkflow(cmd *cobra.Command, args []string) error 
 	if err != nil {
 		return withExitCode(2, err)
 	}
+	if err := s.warnIfOtherWorkspaceTaskRunsActive(ctx, cmd, client); err != nil {
+		return err
+	}
 
 	run, err := client.StartTaskRun(ctx, s.name, apicore.TaskRunRequest{
 		Workspace:        s.workspaceRoot,
@@ -436,6 +442,9 @@ func (s *commandState) runTaskWorkflowsMultiple(cmd *cobra.Command, args []strin
 	client, err := newCLIDaemonBootstrap().ensure(ctx)
 	if err != nil {
 		return withExitCode(2, err)
+	}
+	if err := s.warnIfOtherWorkspaceTaskRunsActive(ctx, cmd, client); err != nil {
+		return err
 	}
 
 	run, err := client.StartTaskRunMultiple(ctx, apicore.TaskRunMultipleRequest{
@@ -514,6 +523,225 @@ func (s *commandState) resolveTaskRunMultipleMode(cmd *cobra.Command) (string, e
 			mode,
 		)
 	}
+}
+
+type taskRunBusyWorkspace struct {
+	workspaceID string
+	rootDir     string
+	name        string
+	runIDs      []string
+}
+
+func (s *commandState) warnIfOtherWorkspaceTaskRunsActive(
+	ctx context.Context,
+	cmd *cobra.Command,
+	client daemonCommandClient,
+) error {
+	if s.dryRun {
+		return nil
+	}
+	status, err := client.DaemonStatus(ctx)
+	if err != nil {
+		return withExitCode(2, fmt.Errorf("query daemon status before task run: %w", err))
+	}
+	if status.ActiveRunCount <= 0 {
+		return nil
+	}
+
+	activeRuns, err := listTaskRunGuardActiveRuns(ctx, client)
+	if err != nil {
+		return withExitCode(2, fmt.Errorf("list active daemon runs before task run: %w", err))
+	}
+	if len(activeRuns) == 0 {
+		return nil
+	}
+	workspaces, err := client.ListWorkspaces(ctx)
+	if err != nil {
+		return withExitCode(2, fmt.Errorf("list daemon workspaces before task run: %w", err))
+	}
+	busy := otherWorkspaceActiveRuns(s.workspaceRoot, activeRuns, workspaces)
+	if len(busy) == 0 {
+		return nil
+	}
+	return writeTaskRunConcurrencyWarning(cmd, busy)
+}
+
+func listTaskRunGuardActiveRuns(ctx context.Context, client daemonCommandClient) ([]apicore.Run, error) {
+	statuses := []string{"starting", "running", "pending", "retrying"}
+	runs := make([]apicore.Run, 0)
+	seen := make(map[string]struct{})
+	for _, status := range statuses {
+		listed, err := client.ListRuns(ctx, apiclient.RunListOptions{
+			Status: status,
+			Limit:  taskRunGuardRunListLimit,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for i := range listed {
+			run := listed[i]
+			runID := strings.TrimSpace(run.RunID)
+			if runID == "" {
+				continue
+			}
+			if _, ok := seen[runID]; ok {
+				continue
+			}
+			seen[runID] = struct{}{}
+			runs = append(runs, run)
+		}
+	}
+	return runs, nil
+}
+
+func otherWorkspaceActiveRuns(
+	currentRoot string,
+	activeRuns []apicore.Run,
+	workspaces []apicore.Workspace,
+) []taskRunBusyWorkspace {
+	workspaceByID, currentWorkspaceID, currentKey := taskRunGuardWorkspaceIndex(currentRoot, workspaces)
+	groupsByWorkspace := make(map[string]*taskRunBusyWorkspace)
+	for i := range activeRuns {
+		run := activeRuns[i]
+		runID := strings.TrimSpace(run.RunID)
+		workspaceID := strings.TrimSpace(run.WorkspaceID)
+		if runID == "" || workspaceID == "" {
+			continue
+		}
+		workspace := workspaceByID[workspaceID]
+		if taskRunGuardIsCurrentWorkspace(workspaceID, currentWorkspaceID, currentKey, workspace) {
+			continue
+		}
+		group := taskRunGuardBusyWorkspaceGroup(groupsByWorkspace, workspaceID, workspace)
+		group.runIDs = append(group.runIDs, runID)
+	}
+	return taskRunGuardSortedBusyWorkspaces(groupsByWorkspace)
+}
+
+func taskRunGuardWorkspaceIndex(
+	currentRoot string,
+	workspaces []apicore.Workspace,
+) (map[string]*apicore.Workspace, string, string) {
+	workspaceByID := make(map[string]*apicore.Workspace, len(workspaces))
+	currentWorkspaceID := ""
+	currentKey := taskRunGuardWorkspaceRootKey(currentRoot)
+	for i := range workspaces {
+		workspace := &workspaces[i]
+		workspaceID := strings.TrimSpace(workspace.ID)
+		if workspaceID != "" {
+			workspaceByID[workspaceID] = workspace
+		}
+		if currentKey != "" && taskRunGuardWorkspaceRootKey(workspace.RootDir) == currentKey {
+			currentWorkspaceID = workspaceID
+		}
+	}
+	return workspaceByID, currentWorkspaceID, currentKey
+}
+
+func taskRunGuardIsCurrentWorkspace(
+	workspaceID string,
+	currentWorkspaceID string,
+	currentKey string,
+	workspace *apicore.Workspace,
+) bool {
+	if currentWorkspaceID != "" {
+		return workspaceID == currentWorkspaceID
+	}
+	return currentKey != "" && workspace != nil && taskRunGuardWorkspaceRootKey(workspace.RootDir) == currentKey
+}
+
+func taskRunGuardBusyWorkspaceGroup(
+	groupsByWorkspace map[string]*taskRunBusyWorkspace,
+	workspaceID string,
+	workspace *apicore.Workspace,
+) *taskRunBusyWorkspace {
+	group, ok := groupsByWorkspace[workspaceID]
+	if ok {
+		return group
+	}
+	group = &taskRunBusyWorkspace{workspaceID: workspaceID}
+	if workspace != nil {
+		group.rootDir = strings.TrimSpace(workspace.RootDir)
+		group.name = strings.TrimSpace(workspace.Name)
+	}
+	groupsByWorkspace[workspaceID] = group
+	return group
+}
+
+func taskRunGuardSortedBusyWorkspaces(
+	groupsByWorkspace map[string]*taskRunBusyWorkspace,
+) []taskRunBusyWorkspace {
+	busy := make([]taskRunBusyWorkspace, 0, len(groupsByWorkspace))
+	for _, group := range groupsByWorkspace {
+		sort.Strings(group.runIDs)
+		busy = append(busy, *group)
+	}
+	sort.Slice(busy, func(i, j int) bool {
+		left := taskRunBusyWorkspaceLabel(busy[i])
+		right := taskRunBusyWorkspaceLabel(busy[j])
+		if left == right {
+			return busy[i].workspaceID < busy[j].workspaceID
+		}
+		return left < right
+	})
+	return busy
+}
+
+func taskRunGuardWorkspaceRootKey(root string) string {
+	trimmed := strings.TrimSpace(root)
+	if trimmed == "" {
+		return ""
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		absolute = trimmed
+	}
+	resolved, err := filepath.EvalSymlinks(absolute)
+	if err == nil {
+		absolute = resolved
+	}
+	return filepath.Clean(absolute)
+}
+
+func writeTaskRunConcurrencyWarning(cmd *cobra.Command, busy []taskRunBusyWorkspace) error {
+	writer := cmd.ErrOrStderr()
+	if _, err := fmt.Fprintln(
+		writer,
+		"Warning: daemon already has active run(s) in another workspace; starting this task run concurrently.",
+	); err != nil {
+		return withExitCode(2, fmt.Errorf("write cross-workspace run warning: %w", err))
+	}
+	if _, err := fmt.Fprintln(writer, "Busy workspace(s):"); err != nil {
+		return withExitCode(2, fmt.Errorf("write cross-workspace run warning: %w", err))
+	}
+	for _, workspace := range busy {
+		if _, err := fmt.Fprintf(
+			writer,
+			"  - %s: %s\n",
+			taskRunBusyWorkspaceLabel(workspace),
+			strings.Join(workspace.runIDs, ", "),
+		); err != nil {
+			return withExitCode(2, fmt.Errorf("write cross-workspace run warning: %w", err))
+		}
+	}
+	return nil
+}
+
+func taskRunBusyWorkspaceLabel(workspace taskRunBusyWorkspace) string {
+	parts := make([]string, 0, 3)
+	if workspace.name != "" {
+		parts = append(parts, workspace.name)
+	}
+	if workspace.rootDir != "" {
+		parts = append(parts, workspace.rootDir)
+	}
+	if workspace.workspaceID != "" {
+		parts = append(parts, "id="+workspace.workspaceID)
+	}
+	if len(parts) == 0 {
+		return "unknown workspace"
+	}
+	return strings.Join(parts, " | ")
 }
 
 func handleStartedTaskRun(

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -394,9 +394,7 @@ func (s *commandState) runTaskWorkflow(cmd *cobra.Command, args []string) error 
 	if err != nil {
 		return withExitCode(2, err)
 	}
-	if err := s.warnIfOtherWorkspaceTaskRunsActive(ctx, cmd, client); err != nil {
-		return err
-	}
+	s.warnIfOtherWorkspaceTaskRunsActive(ctx, cmd, client)
 
 	run, err := client.StartTaskRun(ctx, s.name, apicore.TaskRunRequest{
 		Workspace:        s.workspaceRoot,
@@ -443,9 +441,7 @@ func (s *commandState) runTaskWorkflowsMultiple(cmd *cobra.Command, args []strin
 	if err != nil {
 		return withExitCode(2, err)
 	}
-	if err := s.warnIfOtherWorkspaceTaskRunsActive(ctx, cmd, client); err != nil {
-		return err
-	}
+	s.warnIfOtherWorkspaceTaskRunsActive(ctx, cmd, client)
 
 	run, err := client.StartTaskRunMultiple(ctx, apicore.TaskRunMultipleRequest{
 		Workspace:        s.workspaceRoot,
@@ -532,64 +528,64 @@ type taskRunBusyWorkspace struct {
 	runIDs      []string
 }
 
+var taskRunGuardActiveStatuses = []string{"starting", "running", "pending", "retrying"}
+
 func (s *commandState) warnIfOtherWorkspaceTaskRunsActive(
 	ctx context.Context,
 	cmd *cobra.Command,
 	client daemonCommandClient,
-) error {
+) {
 	if s.dryRun {
-		return nil
+		return
 	}
 	status, err := client.DaemonStatus(ctx)
 	if err != nil {
-		return withExitCode(2, fmt.Errorf("query daemon status before task run: %w", err))
+		// This guard is advisory; inability to inspect daemon state must not block a task run.
+		return
 	}
 	if status.ActiveRunCount <= 0 {
-		return nil
+		return
 	}
 
 	activeRuns, err := listTaskRunGuardActiveRuns(ctx, client)
 	if err != nil {
-		return withExitCode(2, fmt.Errorf("list active daemon runs before task run: %w", err))
+		return
 	}
 	if len(activeRuns) == 0 {
-		return nil
+		return
 	}
 	workspaces, err := client.ListWorkspaces(ctx)
 	if err != nil {
-		return withExitCode(2, fmt.Errorf("list daemon workspaces before task run: %w", err))
+		return
 	}
 	busy := otherWorkspaceActiveRuns(s.workspaceRoot, activeRuns, workspaces)
 	if len(busy) == 0 {
-		return nil
+		return
 	}
-	return writeTaskRunConcurrencyWarning(cmd, busy)
+	writeTaskRunConcurrencyWarning(cmd, busy)
 }
 
 func listTaskRunGuardActiveRuns(ctx context.Context, client daemonCommandClient) ([]apicore.Run, error) {
-	statuses := []string{"starting", "running", "pending", "retrying"}
-	runs := make([]apicore.Run, 0)
+	listed, err := client.ListRuns(ctx, apiclient.RunListOptions{
+		Statuses: taskRunGuardActiveStatuses,
+		Limit:    taskRunGuardRunListLimit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]apicore.Run, 0, len(listed))
 	seen := make(map[string]struct{})
-	for _, status := range statuses {
-		listed, err := client.ListRuns(ctx, apiclient.RunListOptions{
-			Status: status,
-			Limit:  taskRunGuardRunListLimit,
-		})
-		if err != nil {
-			return nil, err
+	for i := range listed {
+		run := listed[i]
+		runID := strings.TrimSpace(run.RunID)
+		if runID == "" {
+			continue
 		}
-		for i := range listed {
-			run := listed[i]
-			runID := strings.TrimSpace(run.RunID)
-			if runID == "" {
-				continue
-			}
-			if _, ok := seen[runID]; ok {
-				continue
-			}
-			seen[runID] = struct{}{}
-			runs = append(runs, run)
+		if _, ok := seen[runID]; ok {
+			continue
 		}
+		seen[runID] = struct{}{}
+		runs = append(runs, run)
 	}
 	return runs, nil
 }
@@ -612,6 +608,7 @@ func otherWorkspaceActiveRuns(
 		if taskRunGuardIsCurrentWorkspace(workspaceID, currentWorkspaceID, currentKey, workspace) {
 			continue
 		}
+		// The registry can miss a workspace referenced by a durable run; keep reporting it by id.
 		group := taskRunGuardBusyWorkspaceGroup(groupsByWorkspace, workspaceID, workspace)
 		group.runIDs = append(group.runIDs, runID)
 	}
@@ -703,16 +700,17 @@ func taskRunGuardWorkspaceRootKey(root string) string {
 	return filepath.Clean(absolute)
 }
 
-func writeTaskRunConcurrencyWarning(cmd *cobra.Command, busy []taskRunBusyWorkspace) error {
+func writeTaskRunConcurrencyWarning(cmd *cobra.Command, busy []taskRunBusyWorkspace) {
 	writer := cmd.ErrOrStderr()
 	if _, err := fmt.Fprintln(
 		writer,
 		"Warning: daemon already has active run(s) in another workspace; starting this task run concurrently.",
 	); err != nil {
-		return withExitCode(2, fmt.Errorf("write cross-workspace run warning: %w", err))
+		// The warning is advisory; a closed stderr must not prevent starting the run.
+		return
 	}
 	if _, err := fmt.Fprintln(writer, "Busy workspace(s):"); err != nil {
-		return withExitCode(2, fmt.Errorf("write cross-workspace run warning: %w", err))
+		return
 	}
 	for _, workspace := range busy {
 		if _, err := fmt.Fprintf(
@@ -721,10 +719,9 @@ func writeTaskRunConcurrencyWarning(cmd *cobra.Command, busy []taskRunBusyWorksp
 			taskRunBusyWorkspaceLabel(workspace),
 			strings.Join(workspace.runIDs, ", "),
 		); err != nil {
-			return withExitCode(2, fmt.Errorf("write cross-workspace run warning: %w", err))
+			return
 		}
 	}
-	return nil
 }
 
 func taskRunBusyWorkspaceLabel(workspace taskRunBusyWorkspace) string {

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -46,6 +46,7 @@ type stubDaemonCommandClient struct {
 	status               apicore.DaemonStatus
 	statusErr            error
 	statusCtx            context.Context
+	statusCalls          int
 	startCalls           int
 	startSlug            string
 	startRequest         apicore.TaskRunRequest
@@ -70,6 +71,9 @@ type stubDaemonCommandClient struct {
 	register             apicore.WorkspaceRegisterResult
 	registerErr          error
 	listErr              error
+	runs                 []apicore.Run
+	runsErr              error
+	runListRequests      []apiclient.RunListOptions
 	deleteRef            string
 	deleteErr            error
 	workflows            []apicore.WorkflowSummary
@@ -129,6 +133,7 @@ func (c *stubDaemonCommandClient) DaemonStatus(ctx context.Context) (apicore.Dae
 		return apicore.DaemonStatus{}, errors.New("stub daemon client is required")
 	}
 	c.statusCtx = ctx
+	c.statusCalls++
 	if c.statusErr != nil {
 		return apicore.DaemonStatus{}, c.statusErr
 	}
@@ -210,6 +215,31 @@ func (c *stubDaemonCommandClient) ResolveWorkspace(context.Context, string) (api
 		return apicore.Workspace{}, c.workspaceErr
 	}
 	return c.workspace, nil
+}
+
+func (c *stubDaemonCommandClient) ListRuns(
+	_ context.Context,
+	opts apiclient.RunListOptions,
+) ([]apicore.Run, error) {
+	if c == nil {
+		return nil, errors.New("stub daemon client is required")
+	}
+	c.runListRequests = append(c.runListRequests, opts)
+	if c.runsErr != nil {
+		return nil, c.runsErr
+	}
+	status := strings.TrimSpace(opts.Status)
+	if status == "" {
+		return append([]apicore.Run(nil), c.runs...), nil
+	}
+	runs := make([]apicore.Run, 0, len(c.runs))
+	for i := range c.runs {
+		run := c.runs[i]
+		if strings.EqualFold(strings.TrimSpace(run.Status), status) {
+			runs = append(runs, run)
+		}
+	}
+	return runs, nil
 }
 
 func (c *stubDaemonCommandClient) ListTaskWorkflows(context.Context, string) ([]apicore.WorkflowSummary, error) {
@@ -2352,6 +2382,145 @@ func TestResolveTaskPresentationModeRejectsConflictsAndInvalidModes(t *testing.T
 	if _, err := state.resolveTaskPresentationMode(cmd); err == nil ||
 		!containsAll(err.Error(), "attach mode must be one of auto, ui, stream, or detach") {
 		t.Fatalf("expected invalid attach mode error, got %v", err)
+	}
+}
+
+func TestWarnIfOtherWorkspaceTaskRunsActive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                string
+		configure           func(t *testing.T) (*commandState, *stubDaemonCommandClient)
+		wantWarningContains []string
+		wantNoWarning       bool
+		wantStatusCalls     int
+		wantRunListCalls    int
+	}{
+		{
+			name: "Should warn for active run in different workspace",
+			configure: func(t *testing.T) (*commandState, *stubDaemonCommandClient) {
+				t.Helper()
+				currentRoot := t.TempDir()
+				busyRoot := t.TempDir()
+				state := newCommandState(commandKindTasksRun, "")
+				state.workspaceRoot = currentRoot
+				client := &stubDaemonCommandClient{
+					status: apicore.DaemonStatus{ActiveRunCount: 1},
+					workspaces: []apicore.Workspace{
+						{ID: "ws-current", RootDir: currentRoot, Name: "current"},
+						{ID: "ws-busy", RootDir: busyRoot, Name: "busy-project"},
+					},
+					runs: []apicore.Run{{
+						RunID:       "run-busy-001",
+						WorkspaceID: "ws-busy",
+						Status:      "running",
+					}},
+				}
+				return state, client
+			},
+			wantWarningContains: []string{
+				"Warning: daemon already has active run(s) in another workspace",
+				"busy-project",
+				"ws-busy",
+				"run-busy-001",
+			},
+			wantStatusCalls:  1,
+			wantRunListCalls: 4,
+		},
+		{
+			name: "Should not warn for active run in same workspace",
+			configure: func(t *testing.T) (*commandState, *stubDaemonCommandClient) {
+				t.Helper()
+				currentRoot := t.TempDir()
+				state := newCommandState(commandKindTasksRun, "")
+				state.workspaceRoot = currentRoot
+				client := &stubDaemonCommandClient{
+					status: apicore.DaemonStatus{ActiveRunCount: 1},
+					workspaces: []apicore.Workspace{{
+						ID:      "ws-current",
+						RootDir: currentRoot,
+						Name:    "current",
+					}},
+					runs: []apicore.Run{{
+						RunID:       "run-current-001",
+						WorkspaceID: "ws-current",
+						Status:      "running",
+					}},
+				}
+				return state, client
+			},
+			wantNoWarning:    true,
+			wantStatusCalls:  1,
+			wantRunListCalls: 4,
+		},
+		{
+			name: "Should not inspect runs when daemon is idle",
+			configure: func(t *testing.T) (*commandState, *stubDaemonCommandClient) {
+				t.Helper()
+				state := newCommandState(commandKindTasksRun, "")
+				state.workspaceRoot = t.TempDir()
+				client := &stubDaemonCommandClient{
+					status: apicore.DaemonStatus{ActiveRunCount: 0},
+				}
+				return state, client
+			},
+			wantNoWarning:    true,
+			wantStatusCalls:  1,
+			wantRunListCalls: 0,
+		},
+		{
+			name: "Should skip guard for dry run",
+			configure: func(t *testing.T) (*commandState, *stubDaemonCommandClient) {
+				t.Helper()
+				state := newCommandState(commandKindTasksRun, "")
+				state.workspaceRoot = t.TempDir()
+				state.dryRun = true
+				client := &stubDaemonCommandClient{
+					status: apicore.DaemonStatus{ActiveRunCount: 1},
+					runs: []apicore.Run{{
+						RunID:       "run-busy-001",
+						WorkspaceID: "ws-busy",
+						Status:      "running",
+					}},
+				}
+				return state, client
+			},
+			wantNoWarning:    true,
+			wantStatusCalls:  0,
+			wantRunListCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state, client := tt.configure(t)
+			cmd := &cobra.Command{Use: "compozy tasks run"}
+			var stderr bytes.Buffer
+			cmd.SetErr(&stderr)
+
+			if err := state.warnIfOtherWorkspaceTaskRunsActive(context.Background(), cmd, client); err != nil {
+				t.Fatalf("warnIfOtherWorkspaceTaskRunsActive() error = %v", err)
+			}
+
+			output := stderr.String()
+			if tt.wantNoWarning && output != "" {
+				t.Fatalf("expected no warning, got %q", output)
+			}
+			for _, want := range tt.wantWarningContains {
+				if !strings.Contains(output, want) {
+					t.Fatalf("expected warning to contain %q, got %q", want, output)
+				}
+			}
+			if client.statusCalls != tt.wantStatusCalls {
+				t.Fatalf("status calls = %d, want %d", client.statusCalls, tt.wantStatusCalls)
+			}
+			if len(client.runListRequests) != tt.wantRunListCalls {
+				t.Fatalf("run list calls = %d, want %d", len(client.runListRequests), tt.wantRunListCalls)
+			}
+		})
 	}
 }
 

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -228,18 +229,44 @@ func (c *stubDaemonCommandClient) ListRuns(
 	if c.runsErr != nil {
 		return nil, c.runsErr
 	}
-	status := strings.TrimSpace(opts.Status)
-	if status == "" {
+	statuses := stubRunListStatuses(opts)
+	if len(statuses) == 0 {
 		return append([]apicore.Run(nil), c.runs...), nil
 	}
 	runs := make([]apicore.Run, 0, len(c.runs))
 	for i := range c.runs {
 		run := c.runs[i]
-		if strings.EqualFold(strings.TrimSpace(run.Status), status) {
+		if slices.ContainsFunc(statuses, func(status string) bool {
+			return strings.EqualFold(strings.TrimSpace(run.Status), status)
+		}) {
 			runs = append(runs, run)
 		}
 	}
 	return runs, nil
+}
+
+func stubRunListStatuses(opts apiclient.RunListOptions) []string {
+	statuses := make([]string, 0, len(opts.Statuses)+1)
+	appendStatus := func(raw string) {
+		for _, candidate := range strings.Split(raw, ",") {
+			trimmed := strings.TrimSpace(candidate)
+			if trimmed == "" || slices.Contains(statuses, trimmed) {
+				continue
+			}
+			statuses = append(statuses, trimmed)
+		}
+	}
+	appendStatus(opts.Status)
+	for _, status := range opts.Statuses {
+		appendStatus(status)
+	}
+	return statuses
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
 }
 
 func (c *stubDaemonCommandClient) ListTaskWorkflows(context.Context, string) ([]apicore.WorkflowSummary, error) {
@@ -2395,6 +2422,7 @@ func TestWarnIfOtherWorkspaceTaskRunsActive(t *testing.T) {
 		wantNoWarning       bool
 		wantStatusCalls     int
 		wantRunListCalls    int
+		wantRunStatuses     []string
 	}{
 		{
 			name: "Should warn for active run in different workspace",
@@ -2425,7 +2453,8 @@ func TestWarnIfOtherWorkspaceTaskRunsActive(t *testing.T) {
 				"run-busy-001",
 			},
 			wantStatusCalls:  1,
-			wantRunListCalls: 4,
+			wantRunListCalls: 1,
+			wantRunStatuses:  taskRunGuardActiveStatuses,
 		},
 		{
 			name: "Should not warn for active run in same workspace",
@@ -2451,7 +2480,62 @@ func TestWarnIfOtherWorkspaceTaskRunsActive(t *testing.T) {
 			},
 			wantNoWarning:    true,
 			wantStatusCalls:  1,
-			wantRunListCalls: 4,
+			wantRunListCalls: 1,
+			wantRunStatuses:  taskRunGuardActiveStatuses,
+		},
+		{
+			name: "Should ignore daemon status errors because guard is best effort",
+			configure: func(t *testing.T) (*commandState, *stubDaemonCommandClient) {
+				t.Helper()
+				state := newCommandState(commandKindTasksRun, "")
+				state.workspaceRoot = t.TempDir()
+				client := &stubDaemonCommandClient{
+					statusErr: errors.New("status unavailable"),
+				}
+				return state, client
+			},
+			wantNoWarning:    true,
+			wantStatusCalls:  1,
+			wantRunListCalls: 0,
+		},
+		{
+			name: "Should ignore run list errors because guard is best effort",
+			configure: func(t *testing.T) (*commandState, *stubDaemonCommandClient) {
+				t.Helper()
+				state := newCommandState(commandKindTasksRun, "")
+				state.workspaceRoot = t.TempDir()
+				client := &stubDaemonCommandClient{
+					status:  apicore.DaemonStatus{ActiveRunCount: 1},
+					runsErr: errors.New("runs unavailable"),
+				}
+				return state, client
+			},
+			wantNoWarning:    true,
+			wantStatusCalls:  1,
+			wantRunListCalls: 1,
+			wantRunStatuses:  taskRunGuardActiveStatuses,
+		},
+		{
+			name: "Should ignore workspace list errors because guard is best effort",
+			configure: func(t *testing.T) (*commandState, *stubDaemonCommandClient) {
+				t.Helper()
+				state := newCommandState(commandKindTasksRun, "")
+				state.workspaceRoot = t.TempDir()
+				client := &stubDaemonCommandClient{
+					status:  apicore.DaemonStatus{ActiveRunCount: 1},
+					listErr: errors.New("workspaces unavailable"),
+					runs: []apicore.Run{{
+						RunID:       "run-busy-001",
+						WorkspaceID: "ws-busy",
+						Status:      "running",
+					}},
+				}
+				return state, client
+			},
+			wantNoWarning:    true,
+			wantStatusCalls:  1,
+			wantRunListCalls: 1,
+			wantRunStatuses:  taskRunGuardActiveStatuses,
 		},
 		{
 			name: "Should not inspect runs when daemon is idle",
@@ -2501,9 +2585,7 @@ func TestWarnIfOtherWorkspaceTaskRunsActive(t *testing.T) {
 			var stderr bytes.Buffer
 			cmd.SetErr(&stderr)
 
-			if err := state.warnIfOtherWorkspaceTaskRunsActive(context.Background(), cmd, client); err != nil {
-				t.Fatalf("warnIfOtherWorkspaceTaskRunsActive() error = %v", err)
-			}
+			state.warnIfOtherWorkspaceTaskRunsActive(context.Background(), cmd, client)
 
 			output := stderr.String()
 			if tt.wantNoWarning && output != "" {
@@ -2520,7 +2602,48 @@ func TestWarnIfOtherWorkspaceTaskRunsActive(t *testing.T) {
 			if len(client.runListRequests) != tt.wantRunListCalls {
 				t.Fatalf("run list calls = %d, want %d", len(client.runListRequests), tt.wantRunListCalls)
 			}
+			if len(tt.wantRunStatuses) > 0 {
+				if len(client.runListRequests) == 0 {
+					t.Fatal("expected one run list request")
+				}
+				if !slices.Equal(client.runListRequests[0].Statuses, tt.wantRunStatuses) {
+					t.Fatalf(
+						"run list statuses = %#v, want %#v",
+						client.runListRequests[0].Statuses,
+						tt.wantRunStatuses,
+					)
+				}
+			}
 		})
+	}
+}
+
+func TestWarnIfOtherWorkspaceTaskRunsActiveIgnoresWarningWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	currentRoot := t.TempDir()
+	busyRoot := t.TempDir()
+	state := newCommandState(commandKindTasksRun, "")
+	state.workspaceRoot = currentRoot
+	client := &stubDaemonCommandClient{
+		status: apicore.DaemonStatus{ActiveRunCount: 1},
+		workspaces: []apicore.Workspace{
+			{ID: "ws-current", RootDir: currentRoot, Name: "current"},
+			{ID: "ws-busy", RootDir: busyRoot, Name: "busy-project"},
+		},
+		runs: []apicore.Run{{
+			RunID:       "run-busy-001",
+			WorkspaceID: "ws-busy",
+			Status:      "running",
+		}},
+	}
+	cmd := &cobra.Command{Use: "compozy tasks run"}
+	cmd.SetErr(failingWriter{})
+
+	state.warnIfOtherWorkspaceTaskRunsActive(context.Background(), cmd, client)
+
+	if len(client.runListRequests) != 1 {
+		t.Fatalf("run list calls = %d, want 1", len(client.runListRequests))
 	}
 }
 

--- a/internal/cli/daemon_exec_test_helpers_test.go
+++ b/internal/cli/daemon_exec_test_helpers_test.go
@@ -148,8 +148,11 @@ func (*inProcessDaemonCommandClient) Health(context.Context) (apicore.DaemonHeal
 	return apicore.DaemonHealth{Ready: true}, nil
 }
 
-func (*inProcessDaemonCommandClient) DaemonStatus(context.Context) (apicore.DaemonStatus, error) {
-	return apicore.DaemonStatus{}, nil
+func (c *inProcessDaemonCommandClient) DaemonStatus(context.Context) (apicore.DaemonStatus, error) {
+	if c == nil || c.manager == nil {
+		return apicore.DaemonStatus{}, errors.New("DaemonStatus requires an in-process run manager")
+	}
+	return apicore.DaemonStatus{ActiveRunCount: c.manager.ActiveRunCount()}, nil
 }
 
 func (*inProcessDaemonCommandClient) StopDaemon(context.Context, bool) error { return nil }
@@ -169,8 +172,34 @@ func (*inProcessDaemonCommandClient) RegisterWorkspace(
 	return apicore.WorkspaceRegisterResult{}, errors.New("RegisterWorkspace not implemented for in-process exec tests")
 }
 
-func (*inProcessDaemonCommandClient) ListWorkspaces(context.Context) ([]apicore.Workspace, error) {
-	return nil, errors.New("ListWorkspaces not implemented for in-process exec tests")
+func (c *inProcessDaemonCommandClient) ListWorkspaces(ctx context.Context) ([]apicore.Workspace, error) {
+	if c == nil || c.globalDB == nil {
+		return nil, errors.New("ListWorkspaces requires an in-process global db")
+	}
+	rows, err := c.globalDB.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	workspaces := make([]apicore.Workspace, 0, len(rows))
+	for i := range rows {
+		row := rows[i]
+		workspaces = append(workspaces, apicore.Workspace{
+			ID:              row.ID,
+			RootDir:         row.RootDir,
+			Name:            row.Name,
+			FilesystemState: row.FilesystemState,
+			ReadOnly:        row.ReadOnly,
+			HasCatalogData:  row.HasCatalogData,
+			WorkflowCount:   row.WorkflowCount,
+			RunCount:        row.RunCount,
+			LastCheckedAt:   row.LastCheckedAt,
+			LastSyncedAt:    row.LastSyncedAt,
+			LastSyncError:   row.LastSyncError,
+			CreatedAt:       row.CreatedAt,
+			UpdatedAt:       row.UpdatedAt,
+		})
+	}
+	return workspaces, nil
 }
 
 func (*inProcessDaemonCommandClient) GetWorkspace(context.Context, string) (apicore.Workspace, error) {
@@ -183,6 +212,21 @@ func (*inProcessDaemonCommandClient) DeleteWorkspace(context.Context, string) er
 
 func (*inProcessDaemonCommandClient) ResolveWorkspace(context.Context, string) (apicore.Workspace, error) {
 	return apicore.Workspace{}, errors.New("ResolveWorkspace not implemented for in-process exec tests")
+}
+
+func (c *inProcessDaemonCommandClient) ListRuns(
+	ctx context.Context,
+	opts apiclient.RunListOptions,
+) ([]apicore.Run, error) {
+	if c == nil || c.manager == nil {
+		return nil, errors.New("ListRuns requires an in-process run manager")
+	}
+	return c.manager.List(ctx, apicore.RunListQuery{
+		Workspace: opts.Workspace,
+		Status:    opts.Status,
+		Mode:      opts.Mode,
+		Limit:     opts.Limit,
+	})
 }
 
 func (*inProcessDaemonCommandClient) ListTaskWorkflows(context.Context, string) ([]apicore.WorkflowSummary, error) {

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -492,9 +492,10 @@ func (m *RunManager) StartExecRun(
 func (m *RunManager) List(ctx context.Context, query apicore.RunListQuery) ([]apicore.Run, error) {
 	listCtx := detachContext(ctx)
 	opts := globaldb.ListRunsOptions{
-		Status: strings.TrimSpace(query.Status),
-		Mode:   strings.TrimSpace(query.Mode),
-		Limit:  query.Limit,
+		Status:   strings.TrimSpace(query.Status),
+		Statuses: query.Statuses,
+		Mode:     strings.TrimSpace(query.Mode),
+		Limit:    query.Limit,
 	}
 	if opts.Limit <= 0 {
 		opts.Limit = defaultRunListLimit

--- a/internal/store/globaldb/registry.go
+++ b/internal/store/globaldb/registry.go
@@ -3,6 +3,7 @@ package globaldb
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -100,6 +101,7 @@ type ListWorkflowsOptions struct {
 type ListRunsOptions struct {
 	WorkspaceID string
 	Status      string
+	Statuses    []string
 	Mode        string
 	Limit       int
 }
@@ -708,10 +710,17 @@ func (g *GlobalDB) ListRuns(ctx context.Context, opts ListRunsOptions) ([]Run, e
 		query += ` AND workspace_id = ?`
 		args = append(args, workspaceID)
 	}
-	if status := strings.TrimSpace(opts.Status); status != "" {
-		status = normalizeRunStatus(status)
+	if statuses := normalizeRunStatusFilters(opts.Status, opts.Statuses); len(statuses) == 1 {
+		status := statuses[0]
 		query += ` AND status = ?`
 		args = append(args, status)
+	} else if len(statuses) > 1 {
+		statusPayload, err := json.Marshal(statuses)
+		if err != nil {
+			return nil, fmt.Errorf("globaldb: encode run status filters: %w", err)
+		}
+		query += ` AND status IN (SELECT value FROM json_each(?))`
+		args = append(args, string(statusPayload))
 	}
 	if mode := strings.TrimSpace(opts.Mode); mode != "" {
 		query += ` AND mode = ?`

--- a/internal/store/globaldb/run_status.go
+++ b/internal/store/globaldb/run_status.go
@@ -18,3 +18,26 @@ func normalizeRunStatus(status string) string {
 	}
 	return normalized
 }
+
+func normalizeRunStatusFilters(status string, statuses []string) []string {
+	seen := make(map[string]struct{}, len(statuses)+1)
+	filters := make([]string, 0, len(statuses)+1)
+	appendStatus := func(raw string) {
+		for _, candidate := range strings.Split(raw, ",") {
+			normalized := normalizeRunStatus(candidate)
+			if normalized == "" {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			filters = append(filters, normalized)
+		}
+	}
+	appendStatus(status)
+	for _, candidate := range statuses {
+		appendStatus(candidate)
+	}
+	return filters
+}

--- a/internal/store/globaldb/runs_test.go
+++ b/internal/store/globaldb/runs_test.go
@@ -238,6 +238,19 @@ func TestPutRunNormalizesStatusAndListRunsUsesWorkspaceStatusIndex(t *testing.T)
 	if !strings.Contains(plan, "idx_runs_workspace_status") {
 		t.Fatalf("query plan = %q, want idx_runs_workspace_status", plan)
 	}
+
+	listed, err := db.ListRuns(context.Background(), ListRunsOptions{
+		WorkspaceID: workspace.ID,
+		Statuses:    []string{" running ", "completed"},
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListRuns(multi-status) error = %v", err)
+	}
+	wantRuns := []string{"run-status-190000.000000002", "run-status-190000.000000000"}
+	if got := runIDs(listed); !reflect.DeepEqual(got, wantRuns) {
+		t.Fatalf("multi-status runs = %v, want %v", got, wantRuns)
+	}
 }
 
 func TestRunParentRunIDRoundTripsThroughDurableQueries(t *testing.T) {

--- a/pkg/compozy/runs/run.go
+++ b/pkg/compozy/runs/run.go
@@ -190,6 +190,7 @@ func (d *defaultDaemonRunReader) ListRuns(
 
 	runs, err := d.daemon.ListRuns(ctx, apiclient.RunListOptions{
 		Workspace: strings.TrimSpace(workspaceRoot),
+		Statuses:  opts.Status,
 		Limit:     limit,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary

Implements the guard + docs requested in #183.

**Behavior answer (investigated):** the home-scoped singleton daemon accepts independent `tasks run` invocations from different workspaces **concurrently** — the second run is neither queued nor rejected. What was missing was any signal that another workspace was already mid-run.

**Changes:**
- `tasks run` (single and `--multiple`) now performs a cheap preflight through the existing daemon client: one `DaemonStatus` query; only when `active_runs > 0` does it list active runs and workspaces.
- When active runs belong to a *different* registered workspace, the CLI prints a warning to stderr naming the busy workspace(s) (name | root | id) and their run id(s), then proceeds (warn-and-proceed — concurrent cross-workspace runs are an accepted daemon behavior, so they are not gated behind a flag).
- The guard is skipped for `--dry-run`, idle daemons, and same-workspace runs (workspace matched by ID or symlink-resolved root path).
- README documents the cross-workspace concurrency model and the new warning.

**Tests:** table-driven cases in the existing canonical suite (`internal/cli/daemon_commands_test.go`) covering: different-workspace warning, same-workspace silence, idle daemon (no run listing), and dry-run skip. The in-process exec test client now implements `DaemonStatus`/`ListRuns`/`ListWorkspaces` against the real run manager and global DB instead of erroring stubs.

**Verification:** `make verify` (fmt + lint + test + build + e2e) exits 0 on this branch — run twice independently (implementation pass and orchestrator re-verification).

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now warns before running tasks if active task runs are detected in other workspaces, listing the busy workspace labels and active run IDs.
  * Run-listing supports multi-status filtering so run queries can match multiple statuses (e.g., pending,running), improving run visibility and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->