### PR TITLE
fix: restart stale daemon when CLI and daemon versions mismatch

### DIFF
--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -276,7 +276,12 @@ func (b cliDaemonBootstrap) waitForDaemonInfoRelease(
 		}
 		info, err := b.readInfo(strings.TrimSpace(infoPath))
 		if err != nil {
-			return nil
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			lastErr = fmt.Errorf("read daemon info while waiting for stale daemon release: %w", err)
+			b.sleep(b.pollInterval)
+			continue
 		}
 		if !sameDaemonInfoOwner(info, previous) {
 			return nil
@@ -341,7 +346,7 @@ func daemonBuildVersionsCompatible(daemonVersion string, cliVersion string) bool
 	if daemonVersion == cliVersion {
 		return true
 	}
-	return isDevBuildVersion(daemonVersion) && isDevBuildVersion(cliVersion)
+	return isDevBuildVersion(daemonVersion) || isDevBuildVersion(cliVersion)
 }
 
 func isDevBuildVersion(value string) bool {

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -22,6 +22,7 @@ import (
 	workspacecfg "github.com/compozy/compozy/internal/core/workspace"
 	"github.com/compozy/compozy/internal/daemon"
 	daemonlogger "github.com/compozy/compozy/internal/logger"
+	"github.com/compozy/compozy/internal/version"
 	"github.com/spf13/cobra"
 )
 
@@ -81,6 +82,8 @@ type cliDaemonBootstrap struct {
 	launch           func(compozyconfig.HomePaths) error
 	sleep            func(time.Duration)
 	now              func() time.Time
+	cliVersion       func() string
+	notify           func(string) error
 	startupTimeout   time.Duration
 	pollInterval     time.Duration
 }
@@ -116,9 +119,14 @@ func newDefaultCLIDaemonBootstrap() cliDaemonBootstrap {
 		newClient: func(target apiclient.Target) (daemonCommandClient, error) {
 			return apiclient.New(target)
 		},
-		launch:         launchCLIDaemonProcess,
-		sleep:          sleepForCLIDaemonPoll,
-		now:            nowForCLIDaemonPoll,
+		launch:     launchCLIDaemonProcess,
+		sleep:      sleepForCLIDaemonPoll,
+		now:        nowForCLIDaemonPoll,
+		cliVersion: version.String,
+		notify: func(message string) error {
+			_, err := fmt.Fprintln(os.Stderr, message)
+			return err
+		},
 		startupTimeout: defaultDaemonStartupTimeout,
 		pollInterval:   defaultDaemonPollInterval,
 	}
@@ -134,26 +142,45 @@ func (b cliDaemonBootstrap) ensure(ctx context.Context) (daemonCommandClient, er
 	if err == nil {
 		return client, nil
 	}
+	var versionMismatch *cliDaemonVersionMismatchError
+	if errors.As(err, &versionMismatch) {
+		return b.handleVersionMismatch(ctx, paths, versionMismatch)
+	}
 	lastErr := err
 
 	if err := b.launch(paths); err != nil {
 		return nil, fmt.Errorf("start daemon process: %w", err)
 	}
 
+	return b.waitForDaemonReadiness(ctx, paths.InfoPath, lastErr)
+}
+
+func (b cliDaemonBootstrap) waitForDaemonReadiness(
+	ctx context.Context,
+	infoPath string,
+	lastErr error,
+) (daemonCommandClient, error) {
 	deadline := b.now().Add(b.startupTimeout)
 	for b.now().Before(deadline) || b.now().Equal(deadline) {
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("wait for daemon readiness: %w", err)
 		}
 
-		client, err := b.probe(ctx, paths.InfoPath)
+		client, err := b.probe(ctx, infoPath)
 		if err == nil {
 			return client, nil
+		}
+		var versionMismatch *cliDaemonVersionMismatchError
+		if errors.As(err, &versionMismatch) {
+			return nil, versionMismatch
 		}
 		lastErr = err
 		b.sleep(b.pollInterval)
 	}
 
+	if lastErr == nil {
+		lastErr = errors.New("daemon did not become ready")
+	}
 	return nil, fmt.Errorf("wait for daemon readiness: %w", lastErr)
 }
 
@@ -178,7 +205,163 @@ func (b cliDaemonBootstrap) probe(ctx context.Context, infoPath string) (daemonC
 	if !health.Ready {
 		return nil, fmt.Errorf("probe daemon health via %s: %w", client.Target().String(), cliDaemonHealthError(health))
 	}
+	status, err := client.DaemonStatus(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("probe daemon status via %s: %w", client.Target().String(), err)
+	}
+	daemonVersion := firstNonEmptyDaemonBuildVersion(status.Version, info.Version)
+	cliVersion := b.currentCLIVersion()
+	if !daemonBuildVersionsCompatible(daemonVersion, cliVersion) {
+		return nil, &cliDaemonVersionMismatchError{
+			info:           info,
+			client:         client,
+			daemonVersion:  daemonVersion,
+			cliVersion:     cliVersion,
+			activeRunCount: status.ActiveRunCount,
+		}
+	}
 	return client, nil
+}
+
+func (b cliDaemonBootstrap) handleVersionMismatch(
+	ctx context.Context,
+	paths compozyconfig.HomePaths,
+	mismatch *cliDaemonVersionMismatchError,
+) (daemonCommandClient, error) {
+	if mismatch == nil {
+		return nil, errors.New("daemon version mismatch details are required")
+	}
+	if mismatch.activeRunCount > 0 {
+		return nil, mismatch
+	}
+	if err := b.notifyVersionMismatchRestart(mismatch); err != nil {
+		return nil, err
+	}
+	if err := mismatch.client.StopDaemon(ctx, false); err != nil {
+		return nil, fmt.Errorf("stop stale daemon: %w", err)
+	}
+	if err := b.waitForDaemonInfoRelease(ctx, paths.InfoPath, mismatch.info); err != nil {
+		return nil, err
+	}
+	if err := b.launch(paths); err != nil {
+		return nil, fmt.Errorf("start daemon process: %w", err)
+	}
+	return b.waitForDaemonReadiness(ctx, paths.InfoPath, nil)
+}
+
+func (b cliDaemonBootstrap) notifyVersionMismatchRestart(mismatch *cliDaemonVersionMismatchError) error {
+	if b.notify == nil {
+		return nil
+	}
+	if err := b.notify(fmt.Sprintf(
+		"Restarting stale compozy daemon (daemon %s, CLI %s).",
+		displayDaemonBuildVersion(mismatch.daemonVersion),
+		displayDaemonBuildVersion(mismatch.cliVersion),
+	)); err != nil {
+		return fmt.Errorf("write daemon restart notice: %w", err)
+	}
+	return nil
+}
+
+func (b cliDaemonBootstrap) waitForDaemonInfoRelease(
+	ctx context.Context,
+	infoPath string,
+	previous daemon.Info,
+) error {
+	deadline := b.now().Add(b.startupTimeout)
+	var lastErr error
+	for b.now().Before(deadline) || b.now().Equal(deadline) {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("wait for stale daemon shutdown: %w", err)
+		}
+		info, err := b.readInfo(strings.TrimSpace(infoPath))
+		if err != nil {
+			return nil
+		}
+		if !sameDaemonInfoOwner(info, previous) {
+			return nil
+		}
+		lastErr = fmt.Errorf("stale daemon still owns daemon info (pid=%d)", previous.PID)
+		b.sleep(b.pollInterval)
+	}
+	if lastErr == nil {
+		lastErr = errors.New("stale daemon info was not released")
+	}
+	return fmt.Errorf("wait for stale daemon shutdown: %w", lastErr)
+}
+
+func (b cliDaemonBootstrap) currentCLIVersion() string {
+	if b.cliVersion == nil {
+		return version.String()
+	}
+	return b.cliVersion()
+}
+
+type cliDaemonVersionMismatchError struct {
+	info           daemon.Info
+	client         daemonCommandClient
+	daemonVersion  string
+	cliVersion     string
+	activeRunCount int
+}
+
+func (e *cliDaemonVersionMismatchError) Error() string {
+	if e == nil {
+		return "daemon version mismatch"
+	}
+	if e.activeRunCount > 0 {
+		return fmt.Sprintf(
+			"running compozy daemon version %q does not match CLI version %q and has %d active runs; "+
+				"retry after the active runs finish or, when it is safe to cancel them, run "+
+				"`compozy daemon stop --force` and retry so the CLI starts the current daemon",
+			displayDaemonBuildVersion(e.daemonVersion),
+			displayDaemonBuildVersion(e.cliVersion),
+			e.activeRunCount,
+		)
+	}
+	return fmt.Sprintf(
+		"running compozy daemon version %q does not match CLI version %q",
+		displayDaemonBuildVersion(e.daemonVersion),
+		displayDaemonBuildVersion(e.cliVersion),
+	)
+}
+
+func firstNonEmptyDaemonBuildVersion(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func daemonBuildVersionsCompatible(daemonVersion string, cliVersion string) bool {
+	daemonVersion = strings.TrimSpace(daemonVersion)
+	cliVersion = strings.TrimSpace(cliVersion)
+	if daemonVersion == cliVersion {
+		return true
+	}
+	return isDevBuildVersion(daemonVersion) && isDevBuildVersion(cliVersion)
+}
+
+func isDevBuildVersion(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return normalized == "" ||
+		normalized == "dev" ||
+		strings.HasPrefix(normalized, "dev ") ||
+		strings.HasPrefix(normalized, "dev(")
+}
+
+func displayDaemonBuildVersion(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "unknown build"
+	}
+	return trimmed
+}
+
+func sameDaemonInfoOwner(a daemon.Info, b daemon.Info) bool {
+	return a.PID > 0 && a.PID == b.PID && a.StartedAt.Equal(b.StartedAt)
 }
 
 func defaultLaunchCLIDaemonProcess(paths compozyconfig.HomePaths) error {

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -46,6 +46,7 @@ type stubDaemonCommandClient struct {
 	status               apicore.DaemonStatus
 	statusErr            error
 	statusCtx            context.Context
+	statusCalls          int
 	startCalls           int
 	startSlug            string
 	startRequest         apicore.TaskRunRequest
@@ -129,6 +130,7 @@ func (c *stubDaemonCommandClient) DaemonStatus(ctx context.Context) (apicore.Dae
 		return apicore.DaemonStatus{}, errors.New("stub daemon client is required")
 	}
 	c.statusCtx = ctx
+	c.statusCalls++
 	if c.statusErr != nil {
 		return apicore.DaemonStatus{}, c.statusErr
 	}
@@ -1269,6 +1271,7 @@ func TestDaemonStartCommandDetachedReturnsReadyStatus(t *testing.T) {
 		readInfo: func(string) (daemon.Info, error) {
 			return daemon.Info{
 				PID:        4242,
+				Version:    "test-version",
 				SocketPath: "/tmp/compozy-ready.sock",
 				StartedAt:  time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC),
 				State:      daemon.ReadyStateReady,
@@ -1283,6 +1286,7 @@ func TestDaemonStartCommandDetachedReturnsReadyStatus(t *testing.T) {
 		},
 		sleep:          func(time.Duration) {},
 		now:            func() time.Time { return time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC) },
+		cliVersion:     func() string { return "test-version" },
 		startupTimeout: time.Second,
 		pollInterval:   time.Millisecond,
 	})
@@ -1689,7 +1693,7 @@ func TestNewDefaultCLIDaemonBootstrapProvidesRuntimeDependencies(t *testing.T) {
 
 	bootstrap := newDefaultCLIDaemonBootstrap()
 	if bootstrap.resolveHomePaths == nil || bootstrap.readInfo == nil || bootstrap.newClient == nil ||
-		bootstrap.launch == nil {
+		bootstrap.launch == nil || bootstrap.cliVersion == nil || bootstrap.notify == nil {
 		t.Fatalf("expected daemon bootstrap dependencies to be wired: %#v", bootstrap)
 	}
 	if bootstrap.sleep == nil || bootstrap.now == nil {
@@ -1708,6 +1712,219 @@ func TestNewDefaultCLIDaemonBootstrapProvidesRuntimeDependencies(t *testing.T) {
 	}
 	if client.Target().HTTPPort != 43123 {
 		t.Fatalf("unexpected bootstrap client target: %#v", client.Target())
+	}
+}
+
+func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
+	t.Parallel()
+
+	currentVersion := "v2.0.0 (commit=current date=2026-06-11)"
+	oldVersion := "v1.9.0 (commit=old date=2026-06-10)"
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name              string
+		cliVersion        string
+		initialVersion    string
+		initialStatus     apicore.DaemonStatus
+		restartedVersion  string
+		readInfoErrOnStop bool
+		wantClient        string
+		wantLaunchCalls   int
+		wantStopCalls     int
+		wantStopForce     bool
+		wantNotice        []string
+		wantErr           []string
+	}{
+		{
+			name:           "matching versions reuse daemon",
+			cliVersion:     currentVersion,
+			initialVersion: currentVersion,
+			initialStatus: apicore.DaemonStatus{
+				Version: currentVersion,
+			},
+			wantClient: "initial",
+		},
+		{
+			name:           "idle mismatch restarts and reconnects",
+			cliVersion:     currentVersion,
+			initialVersion: oldVersion,
+			initialStatus: apicore.DaemonStatus{
+				Version:        oldVersion,
+				ActiveRunCount: 0,
+			},
+			restartedVersion:  currentVersion,
+			readInfoErrOnStop: true,
+			wantClient:        "restarted",
+			wantLaunchCalls:   1,
+			wantStopCalls:     1,
+			wantNotice: []string{
+				"Restarting stale compozy daemon",
+				oldVersion,
+				currentVersion,
+			},
+		},
+		{
+			name:           "busy mismatch fails without stopping",
+			cliVersion:     currentVersion,
+			initialVersion: oldVersion,
+			initialStatus: apicore.DaemonStatus{
+				Version:        oldVersion,
+				ActiveRunCount: 2,
+			},
+			wantErr: []string{
+				oldVersion,
+				currentVersion,
+				"2 active runs",
+				"retry after",
+				"compozy daemon stop --force",
+			},
+		},
+		{
+			name:           "dev and empty versions are compatible",
+			cliVersion:     "dev (commit=none date=unknown)",
+			initialVersion: "",
+			initialStatus:  apicore.DaemonStatus{},
+			wantClient:     "initial",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			initialInfo := daemon.Info{
+				PID:        1234,
+				Version:    tt.initialVersion,
+				SocketPath: "/tmp/compozy-version-old.sock",
+				StartedAt:  now,
+				State:      daemon.ReadyStateReady,
+			}
+			restartedInfo := daemon.Info{
+				PID:        4321,
+				Version:    tt.restartedVersion,
+				SocketPath: "/tmp/compozy-version-new.sock",
+				StartedAt:  now.Add(time.Second),
+				State:      daemon.ReadyStateReady,
+			}
+			initialClient := &stubDaemonCommandClient{
+				target: apiclient.Target{SocketPath: initialInfo.SocketPath},
+				health: apicore.DaemonHealth{
+					Ready: true,
+				},
+				status: tt.initialStatus,
+			}
+			restartedClient := &stubDaemonCommandClient{
+				target: apiclient.Target{SocketPath: restartedInfo.SocketPath},
+				health: apicore.DaemonHealth{
+					Ready: true,
+				},
+				status: apicore.DaemonStatus{
+					Version: tt.restartedVersion,
+				},
+			}
+
+			var launchCalls int
+			var notices []string
+			var readInfoCalls int
+			bootstrap := cliDaemonBootstrap{
+				resolveHomePaths: func() (compozyconfig.HomePaths, error) {
+					return compozyconfig.HomePaths{InfoPath: "/tmp/compozy-home/daemon.json"}, nil
+				},
+				readInfo: func(path string) (daemon.Info, error) {
+					if path != "/tmp/compozy-home/daemon.json" {
+						t.Fatalf("unexpected daemon info path: %q", path)
+					}
+					readInfoCalls++
+					if readInfoCalls == 2 && tt.readInfoErrOnStop {
+						return daemon.Info{}, errors.New("daemon info removed")
+					}
+					if launchCalls > 0 {
+						return restartedInfo, nil
+					}
+					return initialInfo, nil
+				},
+				newClient: func(target apiclient.Target) (daemonCommandClient, error) {
+					switch target.SocketPath {
+					case initialInfo.SocketPath:
+						return initialClient, nil
+					case restartedInfo.SocketPath:
+						return restartedClient, nil
+					default:
+						return nil, fmt.Errorf("unexpected daemon target: %#v", target)
+					}
+				},
+				launch: func(compozyconfig.HomePaths) error {
+					launchCalls++
+					return nil
+				},
+				sleep:          func(time.Duration) {},
+				now:            func() time.Time { return now },
+				startupTimeout: time.Second,
+				pollInterval:   time.Millisecond,
+				cliVersion:     func() string { return tt.cliVersion },
+				notify: func(message string) error {
+					notices = append(notices, message)
+					return nil
+				},
+			}
+
+			gotClient, err := bootstrap.ensure(context.Background())
+			if len(tt.wantErr) > 0 {
+				if err == nil {
+					t.Fatal("ensure() error = nil, want version mismatch")
+				}
+				if !containsAll(err.Error(), tt.wantErr...) {
+					t.Fatalf("ensure() error = %q, want fragments %#v", err.Error(), tt.wantErr)
+				}
+				if initialClient.stopCtx != nil {
+					t.Fatal("expected busy version mismatch not to stop daemon")
+				}
+				if launchCalls != 0 {
+					t.Fatalf("expected busy version mismatch not to launch, got %d", launchCalls)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("ensure() error = %v", err)
+			}
+			switch tt.wantClient {
+			case "initial":
+				if gotClient != initialClient {
+					t.Fatalf("ensure() client = %#v, want initial client", gotClient)
+				}
+			case "restarted":
+				if gotClient != restartedClient {
+					t.Fatalf("ensure() client = %#v, want restarted client", gotClient)
+				}
+			default:
+				t.Fatalf("test has unsupported wantClient %q", tt.wantClient)
+			}
+			if launchCalls != tt.wantLaunchCalls {
+				t.Fatalf("launch calls = %d, want %d", launchCalls, tt.wantLaunchCalls)
+			}
+			stopCalls := 0
+			if initialClient.stopCtx != nil {
+				stopCalls = 1
+			}
+			if stopCalls != tt.wantStopCalls {
+				t.Fatalf("stop calls = %d, want %d", stopCalls, tt.wantStopCalls)
+			}
+			if initialClient.stopForce != tt.wantStopForce {
+				t.Fatalf("stop force = %t, want %t", initialClient.stopForce, tt.wantStopForce)
+			}
+			if len(tt.wantNotice) == 0 {
+				if len(notices) != 0 {
+					t.Fatalf("notices = %#v, want none", notices)
+				}
+				return
+			}
+			if len(notices) != 1 || !containsAll(notices[0], tt.wantNotice...) {
+				t.Fatalf("notices = %#v, want one notice with %#v", notices, tt.wantNotice)
+			}
+		})
 	}
 }
 

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -1720,6 +1720,7 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 
 	currentVersion := "v2.0.0 (commit=current date=2026-06-11)"
 	oldVersion := "v1.9.0 (commit=old date=2026-06-10)"
+	devVersion := "dev (commit=none date=unknown)"
 	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
 
 	tests := []struct {
@@ -1737,7 +1738,7 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 		wantErr           []string
 	}{
 		{
-			name:           "matching versions reuse daemon",
+			name:           "Should reuse daemon when versions match",
 			cliVersion:     currentVersion,
 			initialVersion: currentVersion,
 			initialStatus: apicore.DaemonStatus{
@@ -1746,7 +1747,7 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 			wantClient: "initial",
 		},
 		{
-			name:           "idle mismatch restarts and reconnects",
+			name:           "Should restart and reconnect idle daemon when release versions differ",
 			cliVersion:     currentVersion,
 			initialVersion: oldVersion,
 			initialStatus: apicore.DaemonStatus{
@@ -1765,7 +1766,7 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 			},
 		},
 		{
-			name:           "busy mismatch fails without stopping",
+			name:           "Should fail without stopping busy daemon when release versions differ",
 			cliVersion:     currentVersion,
 			initialVersion: oldVersion,
 			initialStatus: apicore.DaemonStatus{
@@ -1781,11 +1782,29 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 			},
 		},
 		{
-			name:           "dev and empty versions are compatible",
-			cliVersion:     "dev (commit=none date=unknown)",
+			name:           "Should reuse daemon when dev and empty versions are compatible",
+			cliVersion:     devVersion,
 			initialVersion: "",
 			initialStatus:  apicore.DaemonStatus{},
 			wantClient:     "initial",
+		},
+		{
+			name:           "Should reuse daemon when daemon build is dev and CLI build is release",
+			cliVersion:     currentVersion,
+			initialVersion: devVersion,
+			initialStatus: apicore.DaemonStatus{
+				Version: devVersion,
+			},
+			wantClient: "initial",
+		},
+		{
+			name:           "Should reuse daemon when CLI build is dev and daemon build is release",
+			cliVersion:     devVersion,
+			initialVersion: currentVersion,
+			initialStatus: apicore.DaemonStatus{
+				Version: currentVersion,
+			},
+			wantClient: "initial",
 		},
 	}
 
@@ -1838,7 +1857,7 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 					}
 					readInfoCalls++
 					if readInfoCalls == 2 && tt.readInfoErrOnStop {
-						return daemon.Info{}, errors.New("daemon info removed")
+						return daemon.Info{}, fmt.Errorf("daemon info removed: %w", os.ErrNotExist)
 					}
 					if launchCalls > 0 {
 						return restartedInfo, nil
@@ -1923,6 +1942,107 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 			}
 			if len(notices) != 1 || !containsAll(notices[0], tt.wantNotice...) {
 				t.Fatalf("notices = %#v, want one notice with %#v", notices, tt.wantNotice)
+			}
+		})
+	}
+}
+
+func TestCLIDaemonBootstrapWaitForDaemonInfoRelease(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 11, 12, 30, 0, 0, time.UTC)
+	previous := daemon.Info{
+		PID:        1234,
+		SocketPath: "/tmp/compozy-version-old.sock",
+		StartedAt:  now,
+		State:      daemon.ReadyStateReady,
+	}
+	permissionErr := errors.New("permission denied")
+
+	tests := []struct {
+		name        string
+		readErrors  []error
+		wantCalls   int
+		wantErrText []string
+	}{
+		{
+			name:       "Should proceed when daemon info is missing",
+			readErrors: []error{fmt.Errorf("daemon info removed: %w", os.ErrNotExist)},
+			wantCalls:  1,
+		},
+		{
+			name: "Should proceed after transient read error when daemon info becomes missing",
+			readErrors: []error{
+				permissionErr,
+				fmt.Errorf("daemon info removed: %w", os.ErrNotExist),
+			},
+			wantCalls: 2,
+		},
+		{
+			name:       "Should time out when daemon info read keeps failing without missing sentinel",
+			readErrors: []error{permissionErr},
+			wantCalls:  4,
+			wantErrText: []string{
+				"wait for stale daemon shutdown",
+				"read daemon info while waiting for stale daemon release",
+				"permission denied",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			currentTime := now
+			readInfoCalls := 0
+			bootstrap := cliDaemonBootstrap{
+				readInfo: func(path string) (daemon.Info, error) {
+					if path != "/tmp/compozy-home/daemon.json" {
+						t.Fatalf("unexpected daemon info path: %q", path)
+					}
+					readInfoCalls++
+					errIndex := readInfoCalls - 1
+					if errIndex >= len(tt.readErrors) {
+						errIndex = len(tt.readErrors) - 1
+					}
+					if err := tt.readErrors[errIndex]; err != nil {
+						return daemon.Info{}, err
+					}
+					return previous, nil
+				},
+				sleep: func(duration time.Duration) {
+					currentTime = currentTime.Add(duration)
+				},
+				now:            func() time.Time { return currentTime },
+				startupTimeout: 3 * time.Millisecond,
+				pollInterval:   time.Millisecond,
+			}
+
+			err := bootstrap.waitForDaemonInfoRelease(
+				context.Background(),
+				" /tmp/compozy-home/daemon.json ",
+				previous,
+			)
+			if len(tt.wantErrText) == 0 {
+				if err != nil {
+					t.Fatalf("waitForDaemonInfoRelease() error = %v, want nil", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("waitForDaemonInfoRelease() error = nil, want timeout")
+				}
+				if !containsAll(err.Error(), tt.wantErrText...) {
+					t.Fatalf(
+						"waitForDaemonInfoRelease() error = %q, want fragments %#v",
+						err.Error(),
+						tt.wantErrText,
+					)
+				}
+			}
+			if readInfoCalls != tt.wantCalls {
+				t.Fatalf("readInfo calls = %d, want %d", readInfoCalls, tt.wantCalls)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes the `runtime_overrides: json: unknown field "recursive"` failure from #185 at its root.

**Root cause (not the obvious one):** the daemon already accepts `recursive` in `runtime_overrides` since #153 (included in v0.2.7). The error occurs because the daemon is a long-lived home-scoped singleton: after a CLI upgrade, the still-running daemon was started by an **older binary**, and its strict `DisallowUnknownFields` decode rejects fields newer CLIs send. `--recursive` was just one instance of a systemic CLI↔daemon version-skew bug — the bootstrap (`cliDaemonBootstrap.probe`) only health-checked the daemon and never compared versions.

**Fix — version handshake in the daemon bootstrap:**
- `probe()` now compares the daemon build version (from daemon status, falling back to the info file) with the CLI version and returns a typed `cliDaemonVersionMismatchError` carrying the active-run count.
- **Idle daemon + mismatch:** one-line notice to stderr, graceful `StopDaemon`, wait for the stale daemon to release its info file (PID + StartedAt ownership check), relaunch the current binary, reconnect.
- **Busy daemon + mismatch:** fail fast with an actionable error naming both versions and instructing to retry after active runs finish (or `compozy daemon stop --force` when safe) — in-flight runs are never killed.
- Dev/empty build versions are treated as mutually compatible so local development keeps working.
- `DisallowUnknownFields` is intentionally kept: it now surfaces skew through a clear, actionable path instead of a cryptic decode error.

**Tests:** table-driven cases in the existing canonical suite (`internal/cli/daemon_commands_test.go`) via the injectable bootstrap hooks: version match reuses the daemon; idle mismatch restarts and reconnects; busy mismatch fails without stopping; dev/empty versions are compatible.

**Verification:** `make verify` (fmt + lint + test + build + e2e) exits 0 on this branch — run twice independently (implementation pass and orchestrator re-verification).

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now checks daemon build-version compatibility before reporting readiness.
  * When compatible, CLI may restart a stale daemon (if no active operations) and notify the user.

* **Bug Fixes**
  * Readiness probing now surfaces version-mismatch errors immediately instead of attempting silent recovery.

* **Tests**
  * Added comprehensive tests covering version compatibility, restart/stop behavior, and info-release waiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->