### PR TITLE
fix: surface ACP session setup errors in job logs and fail runs fast

### DIFF
--- a/internal/core/agent/client.go
+++ b/internal/core/agent/client.go
@@ -159,6 +159,36 @@ type SessionError struct {
 	Data    json.RawMessage
 }
 
+// AuthenticationRequiredError marks ACP protocol authentication failures.
+type AuthenticationRequiredError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e *AuthenticationRequiredError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Err == nil {
+		return "authentication required"
+	}
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying ACP session error.
+func (e *AuthenticationRequiredError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// IsAuthenticationRequired reports whether err is an ACP authentication failure.
+func IsAuthenticationRequired(err error) bool {
+	var authErr *AuthenticationRequiredError
+	return errors.As(err, &authErr)
+}
+
 // SessionSetupStage identifies which ACP bootstrap or session-configuration step failed.
 type SessionSetupStage string
 
@@ -1091,9 +1121,16 @@ func pathWithinRoots(path string, roots []string) bool {
 	return false
 }
 
-// jsonRPCMethodNotFound is the JSON-RPC 2.0 error code agents return for
-// methods they do not implement.
-const jsonRPCMethodNotFound = -32601
+const (
+	// jsonRPCServerError is the JSON-RPC 2.0 server error code currently used by
+	// ACP runtimes for protocol-level authentication failures.
+	jsonRPCServerError = -32000
+	// jsonRPCMethodNotFound is the JSON-RPC 2.0 error code agents return for
+	// methods they do not implement.
+	jsonRPCMethodNotFound = -32601
+)
+
+const acpAuthenticationRequiredMessage = "Authentication required"
 
 // modelSwitchUnsupportedHint augments session/set_model "Method not found"
 // failures with an actionable explanation, since the raw JSON-RPC error does
@@ -1129,9 +1166,35 @@ func wrapACPError(err error) error {
 			return errors.Join(sessionErr, fmt.Errorf("marshal ACP request error data: %w", marshalErr))
 		}
 		sessionErr.Data = data
+		if isAuthenticationRequiredSessionError(sessionErr) {
+			return &AuthenticationRequiredError{Err: sessionErr}
+		}
 		return sessionErr
 	}
 	return err
+}
+
+func isAuthenticationRequiredSessionError(err *SessionError) bool {
+	if err == nil || err.Code != jsonRPCServerError {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(err.Message), acpAuthenticationRequiredMessage) {
+		return true
+	}
+	return strings.EqualFold(sessionErrorDataMessage(err.Data), acpAuthenticationRequiredMessage)
+}
+
+func sessionErrorDataMessage(data json.RawMessage) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var payload struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(payload.Message)
 }
 
 func wrapACPLaunchError(spec Spec, command []string, stderr, stage string, err error) error {

--- a/internal/core/agent/client_test.go
+++ b/internal/core/agent/client_test.go
@@ -1723,6 +1723,23 @@ func TestClientUtilityHelpers(t *testing.T) {
 		t.Fatalf("unexpected session error string: %q", sessionErr.Error())
 	}
 
+	authWrapped := wrapACPError(&acp.RequestError{
+		Code:    -32000,
+		Message: "Authentication required",
+		Data:    map[string]any{"message": "Authentication required"},
+	})
+	var authErr *AuthenticationRequiredError
+	if !errors.As(authWrapped, &authErr) {
+		t.Fatalf("expected AuthenticationRequiredError, got %T", authWrapped)
+	}
+	var authSessionErr *SessionError
+	if !errors.As(authWrapped, &authSessionErr) || authSessionErr.Code != -32000 {
+		t.Fatalf("expected wrapped SessionError, got %#v", authWrapped)
+	}
+	if !IsAuthenticationRequired(authWrapped) {
+		t.Fatal("expected IsAuthenticationRequired to match typed auth error")
+	}
+
 	noDataErr := (&SessionError{Code: 7, Message: "plain"}).Error()
 	if !strings.Contains(noDataErr, "plain") {
 		t.Fatalf("unexpected no-data session error string: %q", noDataErr)

--- a/internal/core/agent/registry_specs.go
+++ b/internal/core/agent/registry_specs.go
@@ -334,6 +334,15 @@ func DisplayName(ide string) string {
 	return spec.DisplayName
 }
 
+// RuntimeCommandName returns the primary executable name for an agent runtime.
+func RuntimeCommandName(ide string) string {
+	spec, err := lookupAgentSpec(ide)
+	if err != nil {
+		return strings.TrimSpace(ide)
+	}
+	return firstNonEmpty(spec.Command, spec.ID)
+}
+
 // SetupAgentName returns the setup/install agent identifier for one ACP runtime.
 func SetupAgentName(ide string) (string, error) {
 	spec, err := lookupAgentSpec(ide)

--- a/internal/core/run/exec/exec.go
+++ b/internal/core/run/exec/exec.go
@@ -1425,6 +1425,9 @@ func isExecRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
+	if agent.IsAuthenticationRequired(err) {
+		return false
+	}
 	if isActivityTimeout(err) {
 		return true
 	}

--- a/internal/core/run/exec/exec_test.go
+++ b/internal/core/run/exec/exec_test.go
@@ -443,6 +443,14 @@ func TestExecRetryHelpersCoverRetryableAndBoundedTimeouts(t *testing.T) {
 	}) {
 		t.Fatal("expected session setup errors to be retryable")
 	}
+	if isExecRetryableError(&agent.SessionSetupError{
+		Stage: agent.SessionSetupStageNewSession,
+		Err: &agent.AuthenticationRequiredError{
+			Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
+		},
+	}) {
+		t.Fatal("expected authentication setup errors not to be retryable")
+	}
 	if isExecRetryableError(errors.New("plain")) {
 		t.Fatal("expected plain errors not to be retryable")
 	}

--- a/internal/core/run/executor/execution.go
+++ b/internal/core/run/executor/execution.go
@@ -427,6 +427,7 @@ type jobExecutionContext struct {
 	wg             sync.WaitGroup
 	clientsMu      sync.Mutex
 	activeClients  map[agent.Client]struct{}
+	cancelJobs     context.CancelCauseFunc
 }
 
 func newJobExecutionContext(
@@ -590,6 +591,13 @@ func (j *jobExecutionContext) launchOrderedWorkers(jobCtx context.Context) {
 			j.executeSequentialJob(jobCtx, idx, &j.jobs[idx])
 		}
 	}()
+}
+
+func (j *jobExecutionContext) stopJobsAfterAuthenticationFailure(err error) {
+	if j == nil || err == nil || !agent.IsAuthenticationRequired(err) || j.cancelJobs == nil {
+		return
+	}
+	j.cancelJobs(err)
 }
 
 func (j *jobExecutionContext) executeSequentialJob(jobCtx context.Context, index int, jb *job) {

--- a/internal/core/run/executor/execution_acp_test.go
+++ b/internal/core/run/executor/execution_acp_test.go
@@ -418,89 +418,91 @@ func TestJobRunnerDoesNotRetryNonRetryableACPSetupFailure(t *testing.T) {
 }
 
 func TestJobExecutionContextLaunchWorkersStopsAfterAuthenticationSetupFailure(t *testing.T) {
-	tmpDir := t.TempDir()
-	authErr := &agent.SessionSetupError{
-		Stage: agent.SessionSetupStageNewSession,
-		Err: &agent.AuthenticationRequiredError{
-			Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
-		},
-	}
-	firstClient := newFakeACPClient(func(context.Context, agent.SessionRequest) (agent.Session, error) {
-		return nil, authErr
-	})
-	secondClient := newFakeACPClient(func(_ context.Context, _ agent.SessionRequest) (agent.Session, error) {
-		session := newFakeACPSession("sess-should-not-run")
-		go session.finish(nil)
-		return session, nil
-	})
-	installFakeACPClients(t, firstClient, secondClient)
-
-	jobs := []job{
-		newTestACPJob(tmpDir),
-		newTestACPJob(tmpDir),
-	}
-	jobs[1].SafeName = "task_02"
-	jobs[1].CodeFiles = []string{"task_02"}
-	jobs[1].OutLog = filepath.Join(tmpDir, "task_02.out.log")
-	jobs[1].ErrLog = filepath.Join(tmpDir, "task_02.err.log")
-	execCtx := &jobExecutionContext{
-		ctx: context.Background(),
-		cfg: &config{
-			IDE:                    model.IDECursor,
-			Model:                  "test-model",
-			ReasoningEffort:        "medium",
-			Concurrent:             1,
-			MaxRetries:             3,
-			RetryBackoffMultiplier: 2,
-			Timeout:                time.Second,
-		},
-		jobs:  jobs,
-		total: len(jobs),
-		cwd:   tmpDir,
-		sem:   make(chan struct{}, 1),
-	}
-	jobCtx, cancel := context.WithCancelCause(context.Background())
-	defer cancel(nil)
-	execCtx.cancelJobs = cancel
-
-	execCtx.launchWorkers(jobCtx)
-	select {
-	case <-execCtx.waitChannel():
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for auth fail-fast execution")
-	}
-
-	if got := firstClient.createCalls.Load(); got != 1 {
-		t.Fatalf("expected authentication setup attempt once, got %d", got)
-	}
-	if got := secondClient.createCalls.Load(); got != 0 {
-		t.Fatalf("expected later job not to create an ACP session after auth failure, got %d", got)
-	}
-	if got := jobs[0].Status; got != runStatusFailed {
-		t.Fatalf("expected first job failed status, got %q", got)
-	}
-	if got := jobs[1].Status; got != runStatusCanceled {
-		t.Fatalf("expected second job canceled status after fail-fast, got %q", got)
-	}
-	for _, want := range []string{
-		"cursor-agent is not authenticated",
-		"Run 'cursor-agent login' and retry",
-		"Authentication required",
-	} {
-		if !strings.Contains(jobs[0].Failure, want) {
-			t.Fatalf("first job failure %q does not contain %q", jobs[0].Failure, want)
+	t.Run("Should stop remaining jobs after authentication setup failure", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		authErr := &agent.SessionSetupError{
+			Stage: agent.SessionSetupStageNewSession,
+			Err: &agent.AuthenticationRequiredError{
+				Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
+			},
 		}
-	}
-	if !agent.IsAuthenticationRequired(context.Cause(jobCtx)) {
-		t.Fatalf("expected auth failure cancel cause, got %v", context.Cause(jobCtx))
-	}
-	errLog, err := os.ReadFile(jobs[0].ErrLog)
-	if err != nil {
-		t.Fatalf("read first job err log: %v", err)
-	}
-	if !strings.Contains(string(errLog), "cursor-agent is not authenticated") {
-		t.Fatalf("expected actionable auth message in err log, got %q", string(errLog))
-	}
+		firstClient := newFakeACPClient(func(context.Context, agent.SessionRequest) (agent.Session, error) {
+			return nil, authErr
+		})
+		secondClient := newFakeACPClient(func(_ context.Context, _ agent.SessionRequest) (agent.Session, error) {
+			session := newFakeACPSession("sess-should-not-run")
+			go session.finish(nil)
+			return session, nil
+		})
+		installFakeACPClients(t, firstClient, secondClient)
+
+		jobs := []job{
+			newTestACPJob(tmpDir),
+			newTestACPJob(tmpDir),
+		}
+		jobs[1].SafeName = "task_02"
+		jobs[1].CodeFiles = []string{"task_02"}
+		jobs[1].OutLog = filepath.Join(tmpDir, "task_02.out.log")
+		jobs[1].ErrLog = filepath.Join(tmpDir, "task_02.err.log")
+		execCtx := &jobExecutionContext{
+			ctx: context.Background(),
+			cfg: &config{
+				IDE:                    model.IDECursor,
+				Model:                  "test-model",
+				ReasoningEffort:        "medium",
+				Concurrent:             1,
+				MaxRetries:             3,
+				RetryBackoffMultiplier: 2,
+				Timeout:                time.Second,
+			},
+			jobs:  jobs,
+			total: len(jobs),
+			cwd:   tmpDir,
+			sem:   make(chan struct{}, 1),
+		}
+		jobCtx, cancel := context.WithCancelCause(context.Background())
+		defer cancel(nil)
+		execCtx.cancelJobs = cancel
+
+		execCtx.launchWorkers(jobCtx)
+		select {
+		case <-execCtx.waitChannel():
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for auth fail-fast execution")
+		}
+
+		if got := firstClient.createCalls.Load(); got != 1 {
+			t.Fatalf("expected authentication setup attempt once, got %d", got)
+		}
+		if got := secondClient.createCalls.Load(); got != 0 {
+			t.Fatalf("expected later job not to create an ACP session after auth failure, got %d", got)
+		}
+		if got := jobs[0].Status; got != runStatusFailed {
+			t.Fatalf("expected first job failed status, got %q", got)
+		}
+		if got := jobs[1].Status; got != runStatusCanceled {
+			t.Fatalf("expected second job canceled status after fail-fast, got %q", got)
+		}
+		for _, want := range []string{
+			"cursor-agent is not authenticated",
+			"Run 'cursor-agent login' and retry",
+			"Authentication required",
+		} {
+			if !strings.Contains(jobs[0].Failure, want) {
+				t.Fatalf("first job failure %q does not contain %q", jobs[0].Failure, want)
+			}
+		}
+		if !agent.IsAuthenticationRequired(context.Cause(jobCtx)) {
+			t.Fatalf("expected auth failure cancel cause, got %v", context.Cause(jobCtx))
+		}
+		errLog, err := os.ReadFile(jobs[0].ErrLog)
+		if err != nil {
+			t.Fatalf("read first job err log: %v", err)
+		}
+		if !strings.Contains(string(errLog), "cursor-agent is not authenticated") {
+			t.Fatalf("expected actionable auth message in err log, got %q", string(errLog))
+		}
+	})
 }
 
 func TestJobRunnerSuccessRunsTaskPostSuccessHook(t *testing.T) {

--- a/internal/core/run/executor/execution_acp_test.go
+++ b/internal/core/run/executor/execution_acp_test.go
@@ -417,6 +417,92 @@ func TestJobRunnerDoesNotRetryNonRetryableACPSetupFailure(t *testing.T) {
 	}
 }
 
+func TestJobExecutionContextLaunchWorkersStopsAfterAuthenticationSetupFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	authErr := &agent.SessionSetupError{
+		Stage: agent.SessionSetupStageNewSession,
+		Err: &agent.AuthenticationRequiredError{
+			Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
+		},
+	}
+	firstClient := newFakeACPClient(func(context.Context, agent.SessionRequest) (agent.Session, error) {
+		return nil, authErr
+	})
+	secondClient := newFakeACPClient(func(_ context.Context, _ agent.SessionRequest) (agent.Session, error) {
+		session := newFakeACPSession("sess-should-not-run")
+		go session.finish(nil)
+		return session, nil
+	})
+	installFakeACPClients(t, firstClient, secondClient)
+
+	jobs := []job{
+		newTestACPJob(tmpDir),
+		newTestACPJob(tmpDir),
+	}
+	jobs[1].SafeName = "task_02"
+	jobs[1].CodeFiles = []string{"task_02"}
+	jobs[1].OutLog = filepath.Join(tmpDir, "task_02.out.log")
+	jobs[1].ErrLog = filepath.Join(tmpDir, "task_02.err.log")
+	execCtx := &jobExecutionContext{
+		ctx: context.Background(),
+		cfg: &config{
+			IDE:                    model.IDECursor,
+			Model:                  "test-model",
+			ReasoningEffort:        "medium",
+			Concurrent:             1,
+			MaxRetries:             3,
+			RetryBackoffMultiplier: 2,
+			Timeout:                time.Second,
+		},
+		jobs:  jobs,
+		total: len(jobs),
+		cwd:   tmpDir,
+		sem:   make(chan struct{}, 1),
+	}
+	jobCtx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+	execCtx.cancelJobs = cancel
+
+	execCtx.launchWorkers(jobCtx)
+	select {
+	case <-execCtx.waitChannel():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for auth fail-fast execution")
+	}
+
+	if got := firstClient.createCalls.Load(); got != 1 {
+		t.Fatalf("expected authentication setup attempt once, got %d", got)
+	}
+	if got := secondClient.createCalls.Load(); got != 0 {
+		t.Fatalf("expected later job not to create an ACP session after auth failure, got %d", got)
+	}
+	if got := jobs[0].Status; got != runStatusFailed {
+		t.Fatalf("expected first job failed status, got %q", got)
+	}
+	if got := jobs[1].Status; got != runStatusCanceled {
+		t.Fatalf("expected second job canceled status after fail-fast, got %q", got)
+	}
+	for _, want := range []string{
+		"cursor-agent is not authenticated",
+		"Run 'cursor-agent login' and retry",
+		"Authentication required",
+	} {
+		if !strings.Contains(jobs[0].Failure, want) {
+			t.Fatalf("first job failure %q does not contain %q", jobs[0].Failure, want)
+		}
+	}
+	if !agent.IsAuthenticationRequired(context.Cause(jobCtx)) {
+		t.Fatalf("expected auth failure cancel cause, got %v", context.Cause(jobCtx))
+	}
+	errLog, err := os.ReadFile(jobs[0].ErrLog)
+	if err != nil {
+		t.Fatalf("read first job err log: %v", err)
+	}
+	if !strings.Contains(string(errLog), "cursor-agent is not authenticated") {
+		t.Fatalf("expected actionable auth message in err log, got %q", string(errLog))
+	}
+}
+
 func TestJobRunnerSuccessRunsTaskPostSuccessHook(t *testing.T) {
 	tmpDir := t.TempDir()
 	tasksDir := filepath.Join(tmpDir, ".compozy", "tasks", "demo")
@@ -983,6 +1069,11 @@ func TestJobLifecycleEmitsFailedEvent(t *testing.T) {
 	if got := events[1].Kind; got != eventspkg.EventKindJobFailed {
 		t.Fatalf("expected job.failed event, got %s", got)
 	}
+	var payload kinds.JobFailedPayload
+	decodeRuntimeEventPayload(t, events[1], &payload)
+	if payload.Error != "boom" {
+		t.Fatalf("expected job.failed payload error to carry failure reason, got %#v", payload)
+	}
 }
 
 func TestHandleNilExecutionReturnsSetupFailure(t *testing.T) {
@@ -1023,6 +1114,16 @@ func TestRetryableSetupFailureMatchesExpectedStages(t *testing.T) {
 			name: "retryable new session",
 			err:  &agent.SessionSetupError{Stage: agent.SessionSetupStageNewSession, Err: errors.New("boom")},
 			want: true,
+		},
+		{
+			name: "non retryable authentication required",
+			err: &agent.SessionSetupError{
+				Stage: agent.SessionSetupStageNewSession,
+				Err: &agent.AuthenticationRequiredError{
+					Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
+				},
+			},
+			want: false,
 		},
 		{
 			name: "non retryable set model",

--- a/internal/core/run/executor/result.go
+++ b/internal/core/run/executor/result.go
@@ -89,10 +89,17 @@ func buildExecutionResult(cfg *config, jobs []job, failures []failInfo, shutdown
 }
 
 func deriveRunStatus(jobs []job, failures []failInfo) string {
+	hasCanceled := false
 	for idx := range jobs {
-		if jobs[idx].Status == runStatusCanceled {
-			return runStatusCanceled
+		switch jobs[idx].Status {
+		case runStatusFailed:
+			return runStatusFailed
+		case runStatusCanceled:
+			hasCanceled = true
 		}
+	}
+	if hasCanceled {
+		return runStatusCanceled
 	}
 	if len(failures) > 0 {
 		return runStatusFailed

--- a/internal/core/run/executor/result_test.go
+++ b/internal/core/run/executor/result_test.go
@@ -199,6 +199,53 @@ func TestBuildExecutionResultKeepsCanceledStatusWhenFailuresArePresent(t *testin
 	}
 }
 
+func TestBuildExecutionResultPrefersFailedStatusOverFailFastCanceledJobs(t *testing.T) {
+	t.Parallel()
+
+	runArtifacts := model.NewRunArtifacts(t.TempDir(), "exec-test-run")
+	cfg := &config{
+		Mode:         model.ExecutionModeExec,
+		IDE:          model.IDECursor,
+		Model:        "gpt-5.5",
+		OutputFormat: model.OutputFormatJSON,
+		RunArtifacts: runArtifacts,
+	}
+	jobs := []job{
+		{
+			SafeName:      "first",
+			CodeFiles:     []string{"first"},
+			Status:        runStatusFailed,
+			ExitCode:      -1,
+			OutPromptPath: filepath.Join(runArtifacts.JobsDir, "first.Prompt.md"),
+			OutLog:        filepath.Join(runArtifacts.JobsDir, "first.out.log"),
+			ErrLog:        filepath.Join(runArtifacts.JobsDir, "first.err.log"),
+		},
+		{
+			SafeName:      "second",
+			CodeFiles:     []string{"second"},
+			Status:        runStatusCanceled,
+			ExitCode:      -1,
+			OutPromptPath: filepath.Join(runArtifacts.JobsDir, "second.Prompt.md"),
+			OutLog:        filepath.Join(runArtifacts.JobsDir, "second.out.log"),
+			ErrLog:        filepath.Join(runArtifacts.JobsDir, "second.err.log"),
+		},
+	}
+
+	result := buildExecutionResult(
+		cfg,
+		jobs,
+		[]failInfo{{Err: errors.New("cursor-agent is not authenticated")}},
+		nil,
+	)
+
+	if result.Status != runStatusFailed {
+		t.Fatalf("unexpected result Status: %q", result.Status)
+	}
+	if result.Error != "cursor-agent is not authenticated" {
+		t.Fatalf("unexpected primary result error: %q", result.Error)
+	}
+}
+
 func TestEmitExecutionResultWritesArtifactForTextModeWithoutStdout(t *testing.T) {
 	runArtifacts := model.NewRunArtifacts(t.TempDir(), "workflow-run")
 	if err := os.MkdirAll(runArtifacts.RunDir, 0o755); err != nil {

--- a/internal/core/run/executor/runner.go
+++ b/internal/core/run/executor/runner.go
@@ -128,7 +128,9 @@ func (r *jobRunner) handleResult(
 		return timeout, 0, false
 	}
 	if !result.NeedsRetry() || attempt == attempts {
-		r.lifecycle.markGiveUp(r.ensureFailure(result, "job failed"))
+		failure := r.ensureFailure(result, "job failed")
+		r.lifecycle.markGiveUp(failure)
+		r.execCtx.stopJobsAfterAuthenticationFailure(failure.Err)
 		return timeout, 0, false
 	}
 	retryDecision, err := r.dispatchPreRetryHook(ctx, attempt, result)

--- a/internal/core/run/executor/shutdown.go
+++ b/internal/core/run/executor/shutdown.go
@@ -64,6 +64,7 @@ func executeJobsWithGracefulShutdown(
 		shutdownRequests: make(chan shutdownRequest, 4),
 		onNormalDone:     onNormalDone,
 	}
+	execCtx.cancelJobs = cancelJobs
 	if execCtx.ui != nil {
 		execCtx.ui.SetQuitHandler(controller.requestShutdown)
 	}

--- a/internal/core/run/internal/acpshared/command_io.go
+++ b/internal/core/run/internal/acpshared/command_io.go
@@ -175,8 +175,9 @@ func SetupSessionExecution(req SessionSetupRequest) (*SessionExecution, error) {
 		req.Index,
 		session.Identity(),
 	); err != nil {
+		writeErr := writeSetupFailureToErrLog(execution.ErrFile, err)
 		execution.Close()
-		return nil, err
+		return nil, joinSetupFailure(err, writeErr)
 	}
 
 	return execution, nil

--- a/internal/core/run/internal/acpshared/command_io.go
+++ b/internal/core/run/internal/acpshared/command_io.go
@@ -2,6 +2,7 @@ package acpshared
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -122,20 +123,20 @@ func SetupSessionExecution(req SessionSetupRequest) (*SessionExecution, error) {
 	}
 	logger := resolveSessionLogger(req.Logger)
 
-	client, err := createACPClient(req.Context, req.Config, req.Job, logger)
+	outFile, errFile, err := createSessionLogFiles(req.Job)
 	if err != nil {
 		return nil, err
+	}
+	client, err := createACPClient(req.Context, req.Config, req.Job, logger)
+	if err != nil {
+		setupErr := setupFailureForUser(req.Config, req.Job, err)
+		writeErr := writeSetupFailureToErrLog(errFile, setupErr)
+		closeSetupLogFiles(outFile, errFile)
+		return nil, joinSetupFailure(setupErr, writeErr)
 	}
 	releaseClient := func() {}
 	if req.TrackClient != nil {
 		releaseClient = req.TrackClient(client)
-	}
-
-	outFile, errFile, err := createSessionLogFiles(req.Job)
-	if err != nil {
-		_ = client.Close()
-		releaseClient()
-		return nil, err
 	}
 	if err := emitReusableAgentSetupLifecycle(
 		req.Context,
@@ -148,11 +149,12 @@ func SetupSessionExecution(req SessionSetupRequest) (*SessionExecution, error) {
 
 	session, err := createACPSession(req.Context, client, req.Config, req.Job, req.CWD)
 	if err != nil {
-		_ = outFile.Close()
-		_ = errFile.Close()
+		setupErr := setupFailureForUser(req.Config, req.Job, fmt.Errorf("create ACP session: %w", err))
+		writeErr := writeSetupFailureToErrLog(errFile, setupErr)
+		closeSetupLogFiles(outFile, errFile)
 		_ = client.Close()
 		releaseClient()
-		return nil, fmt.Errorf("create ACP session: %w", err)
+		return nil, joinSetupFailure(setupErr, writeErr)
 	}
 
 	execution := buildSessionExecution(
@@ -298,6 +300,41 @@ func createACPClient(ctx context.Context, cfg *config, job *job, logger *slog.Lo
 	return client, nil
 }
 
+func setupFailureForUser(cfg *config, job *job, err error) error {
+	if err == nil || !agent.IsAuthenticationRequired(err) {
+		return err
+	}
+	runtimeID := strings.TrimSpace(jobIDE(cfg, job))
+	command := firstNonEmpty(agent.RuntimeCommandName(runtimeID), runtimeID, "ACP runtime")
+	return fmt.Errorf("%s is not authenticated. Run '%s login' and retry: %w", command, command, err)
+}
+
+func writeSetupFailureToErrLog(errFile *os.File, err error) error {
+	if errFile == nil || err == nil {
+		return nil
+	}
+	if _, writeErr := fmt.Fprintf(errFile, "ACP session setup error: %s\n", err.Error()); writeErr != nil {
+		return fmt.Errorf("write ACP session setup error: %w", writeErr)
+	}
+	return nil
+}
+
+func closeSetupLogFiles(outFile *os.File, errFile *os.File) {
+	if outFile != nil {
+		_ = outFile.Close()
+	}
+	if errFile != nil {
+		_ = errFile.Close()
+	}
+}
+
+func joinSetupFailure(setupErr error, writeErr error) error {
+	if writeErr == nil {
+		return setupErr
+	}
+	return errors.Join(setupErr, writeErr)
+}
+
 func createACPSession(
 	ctx context.Context,
 	client agent.Client,
@@ -368,7 +405,9 @@ func createSessionLogFiles(job *job) (*os.File, *os.File, error) {
 	}
 	errFile, err := CreateLogFile(job.ErrLog)
 	if err != nil {
-		_ = outFile.Close()
+		if outFile != nil {
+			_ = outFile.Close()
+		}
 		return nil, nil, fmt.Errorf("create err log: %w", err)
 	}
 	return outFile, errFile, nil

--- a/internal/core/run/internal/acpshared/command_io_test.go
+++ b/internal/core/run/internal/acpshared/command_io_test.go
@@ -411,132 +411,136 @@ func TestSetupSessionExecutionWarnsButContinuesWhenReusableAgentSetupLifecycleSu
 }
 
 func TestSetupSessionExecutionWritesSessionCreateFailureToErrLog(t *testing.T) {
-	authErr := &agent.SessionSetupError{
-		Stage: agent.SessionSetupStageNewSession,
-		Err: &agent.AuthenticationRequiredError{
-			Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
-		},
-	}
-	restore := SwapNewAgentClientForTest(
-		func(context.Context, agent.ClientConfig) (agent.Client, error) {
-			return &failingCommandIOClient{createErr: authErr}, nil
-		},
-	)
-	defer restore()
+	t.Run("Should write authentication error to err.log when session creation fails", func(t *testing.T) {
+		authErr := &agent.SessionSetupError{
+			Stage: agent.SessionSetupStageNewSession,
+			Err: &agent.AuthenticationRequiredError{
+				Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
+			},
+		}
+		restore := SwapNewAgentClientForTest(
+			func(context.Context, agent.ClientConfig) (agent.Client, error) {
+				return &failingCommandIOClient{createErr: authErr}, nil
+			},
+		)
+		defer restore()
 
-	tmpDir := t.TempDir()
-	_, err := SetupSessionExecution(SessionSetupRequest{
-		Context: context.Background(),
-		Config: &config{
-			IDE:          model.IDECursor,
-			RunArtifacts: model.RunArtifacts{RunID: "run-auth"},
-		},
-		Job: &job{
-			SafeName: "exec",
-			Prompt:   []byte("finish the task"),
-			OutLog:   filepath.Join(tmpDir, "exec.out.log"),
-			ErrLog:   filepath.Join(tmpDir, "exec.err.log"),
-		},
-		CWD:    tmpDir,
-		Logger: silentLogger(),
+		tmpDir := t.TempDir()
+		_, err := SetupSessionExecution(SessionSetupRequest{
+			Context: context.Background(),
+			Config: &config{
+				IDE:          model.IDECursor,
+				RunArtifacts: model.RunArtifacts{RunID: "run-auth"},
+			},
+			Job: &job{
+				SafeName: "exec",
+				Prompt:   []byte("finish the task"),
+				OutLog:   filepath.Join(tmpDir, "exec.out.log"),
+				ErrLog:   filepath.Join(tmpDir, "exec.err.log"),
+			},
+			CWD:    tmpDir,
+			Logger: silentLogger(),
+		})
+		if err == nil {
+			t.Fatal("expected setup error")
+		}
+		for _, want := range []string{
+			"cursor-agent is not authenticated",
+			"Run 'cursor-agent login' and retry",
+			"create ACP session",
+			"Authentication required",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("setup error %q does not contain %q", err, want)
+			}
+		}
+
+		errLog, readErr := os.ReadFile(filepath.Join(tmpDir, "exec.err.log"))
+		if readErr != nil {
+			t.Fatalf("read err log: %v", readErr)
+		}
+		for _, want := range []string{
+			"ACP session setup error:",
+			"cursor-agent is not authenticated",
+			"Run 'cursor-agent login' and retry",
+			"Authentication required",
+		} {
+			if !strings.Contains(string(errLog), want) {
+				t.Fatalf("err log %q does not contain %q", string(errLog), want)
+			}
+		}
 	})
-	if err == nil {
-		t.Fatal("expected setup error")
-	}
-	for _, want := range []string{
-		"cursor-agent is not authenticated",
-		"Run 'cursor-agent login' and retry",
-		"create ACP session",
-		"Authentication required",
-	} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("setup error %q does not contain %q", err, want)
-		}
-	}
-
-	errLog, readErr := os.ReadFile(filepath.Join(tmpDir, "exec.err.log"))
-	if readErr != nil {
-		t.Fatalf("read err log: %v", readErr)
-	}
-	for _, want := range []string{
-		"ACP session setup error:",
-		"cursor-agent is not authenticated",
-		"Run 'cursor-agent login' and retry",
-		"Authentication required",
-	} {
-		if !strings.Contains(string(errLog), want) {
-			t.Fatalf("err log %q does not contain %q", string(errLog), want)
-		}
-	}
 }
 
 func TestSetupSessionExecutionWritesSessionStartedEventFailureToErrLog(t *testing.T) {
-	restore := SwapNewAgentClientForTest(
-		func(context.Context, agent.ClientConfig) (agent.Client, error) {
-			return &lifecycleCommandIOClient{
-				session: fakeSessionExecutionSession{
-					id: "sess-event-failure",
-					identity: agent.SessionIdentity{
-						ACPSessionID: "sess-event-failure",
+	t.Run("Should write session started event failure to err.log", func(t *testing.T) {
+		restore := SwapNewAgentClientForTest(
+			func(context.Context, agent.ClientConfig) (agent.Client, error) {
+				return &lifecycleCommandIOClient{
+					session: fakeSessionExecutionSession{
+						id: "sess-event-failure",
+						identity: agent.SessionIdentity{
+							ACPSessionID: "sess-event-failure",
+						},
+						updates: make(chan model.SessionUpdate),
+						done:    make(chan struct{}),
 					},
-					updates: make(chan model.SessionUpdate),
-					done:    make(chan struct{}),
-				},
-			}, nil
-		},
-	)
-	defer restore()
+				}, nil
+			},
+		)
+		defer restore()
 
-	submitter := &stubRuntimeEventSubmitter{
-		submitFn: func(ev eventspkg.Event) error {
-			if ev.Kind == eventspkg.EventKindSessionStarted {
-				return errors.New("journal unavailable")
+		submitter := &stubRuntimeEventSubmitter{
+			submitFn: func(ev eventspkg.Event) error {
+				if ev.Kind == eventspkg.EventKindSessionStarted {
+					return errors.New("journal unavailable")
+				}
+				return nil
+			},
+		}
+		tmpDir := t.TempDir()
+		_, err := SetupSessionExecution(SessionSetupRequest{
+			Context: context.Background(),
+			Config: &config{
+				IDE:          model.IDECodex,
+				RunArtifacts: model.RunArtifacts{RunID: "run-event-failure"},
+			},
+			Job: &job{
+				SafeName: "exec",
+				Prompt:   []byte("finish the task"),
+				OutLog:   filepath.Join(tmpDir, "exec.out.log"),
+				ErrLog:   filepath.Join(tmpDir, "exec.err.log"),
+			},
+			CWD:        tmpDir,
+			RunJournal: submitter,
+			Logger:     silentLogger(),
+		})
+		if err == nil {
+			t.Fatal("expected setup error")
+		}
+		for _, want := range []string{
+			"submit session started event",
+			"journal unavailable",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("setup error %q does not contain %q", err, want)
 			}
-			return nil
-		},
-	}
-	tmpDir := t.TempDir()
-	_, err := SetupSessionExecution(SessionSetupRequest{
-		Context: context.Background(),
-		Config: &config{
-			IDE:          model.IDECodex,
-			RunArtifacts: model.RunArtifacts{RunID: "run-event-failure"},
-		},
-		Job: &job{
-			SafeName: "exec",
-			Prompt:   []byte("finish the task"),
-			OutLog:   filepath.Join(tmpDir, "exec.out.log"),
-			ErrLog:   filepath.Join(tmpDir, "exec.err.log"),
-		},
-		CWD:        tmpDir,
-		RunJournal: submitter,
-		Logger:     silentLogger(),
-	})
-	if err == nil {
-		t.Fatal("expected setup error")
-	}
-	for _, want := range []string{
-		"submit session started event",
-		"journal unavailable",
-	} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("setup error %q does not contain %q", err, want)
 		}
-	}
 
-	errLog, readErr := os.ReadFile(filepath.Join(tmpDir, "exec.err.log"))
-	if readErr != nil {
-		t.Fatalf("read err log: %v", readErr)
-	}
-	for _, want := range []string{
-		"ACP session setup error:",
-		"submit session started event",
-		"journal unavailable",
-	} {
-		if !strings.Contains(string(errLog), want) {
-			t.Fatalf("err log %q does not contain %q", string(errLog), want)
+		errLog, readErr := os.ReadFile(filepath.Join(tmpDir, "exec.err.log"))
+		if readErr != nil {
+			t.Fatalf("read err log: %v", readErr)
 		}
-	}
+		for _, want := range []string{
+			"ACP session setup error:",
+			"submit session started event",
+			"journal unavailable",
+		} {
+			if !strings.Contains(string(errLog), want) {
+				t.Fatalf("err log %q does not contain %q", string(errLog), want)
+			}
+		}
+	})
 }
 
 type fakeSessionExecutionSession struct {

--- a/internal/core/run/internal/acpshared/command_io_test.go
+++ b/internal/core/run/internal/acpshared/command_io_test.go
@@ -410,6 +410,66 @@ func TestSetupSessionExecutionWarnsButContinuesWhenReusableAgentSetupLifecycleSu
 	}
 }
 
+func TestSetupSessionExecutionWritesSessionCreateFailureToErrLog(t *testing.T) {
+	authErr := &agent.SessionSetupError{
+		Stage: agent.SessionSetupStageNewSession,
+		Err: &agent.AuthenticationRequiredError{
+			Err: &agent.SessionError{Code: -32000, Message: "Authentication required"},
+		},
+	}
+	restore := SwapNewAgentClientForTest(
+		func(context.Context, agent.ClientConfig) (agent.Client, error) {
+			return &failingCommandIOClient{createErr: authErr}, nil
+		},
+	)
+	defer restore()
+
+	tmpDir := t.TempDir()
+	_, err := SetupSessionExecution(SessionSetupRequest{
+		Context: context.Background(),
+		Config: &config{
+			IDE:          model.IDECursor,
+			RunArtifacts: model.RunArtifacts{RunID: "run-auth"},
+		},
+		Job: &job{
+			SafeName: "exec",
+			Prompt:   []byte("finish the task"),
+			OutLog:   filepath.Join(tmpDir, "exec.out.log"),
+			ErrLog:   filepath.Join(tmpDir, "exec.err.log"),
+		},
+		CWD:    tmpDir,
+		Logger: silentLogger(),
+	})
+	if err == nil {
+		t.Fatal("expected setup error")
+	}
+	for _, want := range []string{
+		"cursor-agent is not authenticated",
+		"Run 'cursor-agent login' and retry",
+		"create ACP session",
+		"Authentication required",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("setup error %q does not contain %q", err, want)
+		}
+	}
+
+	errLog, readErr := os.ReadFile(filepath.Join(tmpDir, "exec.err.log"))
+	if readErr != nil {
+		t.Fatalf("read err log: %v", readErr)
+	}
+	for _, want := range []string{
+		"ACP session setup error:",
+		"cursor-agent is not authenticated",
+		"Run 'cursor-agent login' and retry",
+		"Authentication required",
+	} {
+		if !strings.Contains(string(errLog), want) {
+			t.Fatalf("err log %q does not contain %q", string(errLog), want)
+		}
+	}
+}
+
 type fakeSessionExecutionSession struct {
 	id       string
 	identity agent.SessionIdentity
@@ -452,6 +512,10 @@ type capturingCommandIOClient struct {
 
 type lifecycleCommandIOClient struct {
 	session agent.Session
+}
+
+type failingCommandIOClient struct {
+	createErr error
 }
 
 type stubRuntimeEventSubmitter struct {
@@ -529,3 +593,21 @@ func (c *lifecycleCommandIOClient) ResumeSession(
 func (*lifecycleCommandIOClient) SupportsLoadSession() bool { return true }
 func (*lifecycleCommandIOClient) Close() error              { return nil }
 func (*lifecycleCommandIOClient) Kill() error               { return nil }
+
+func (c *failingCommandIOClient) CreateSession(
+	context.Context,
+	agent.SessionRequest,
+) (agent.Session, error) {
+	return nil, c.createErr
+}
+
+func (c *failingCommandIOClient) ResumeSession(
+	context.Context,
+	agent.ResumeSessionRequest,
+) (agent.Session, error) {
+	return nil, c.createErr
+}
+
+func (*failingCommandIOClient) SupportsLoadSession() bool { return true }
+func (*failingCommandIOClient) Close() error              { return nil }
+func (*failingCommandIOClient) Kill() error               { return nil }

--- a/internal/core/run/internal/acpshared/command_io_test.go
+++ b/internal/core/run/internal/acpshared/command_io_test.go
@@ -470,6 +470,75 @@ func TestSetupSessionExecutionWritesSessionCreateFailureToErrLog(t *testing.T) {
 	}
 }
 
+func TestSetupSessionExecutionWritesSessionStartedEventFailureToErrLog(t *testing.T) {
+	restore := SwapNewAgentClientForTest(
+		func(context.Context, agent.ClientConfig) (agent.Client, error) {
+			return &lifecycleCommandIOClient{
+				session: fakeSessionExecutionSession{
+					id: "sess-event-failure",
+					identity: agent.SessionIdentity{
+						ACPSessionID: "sess-event-failure",
+					},
+					updates: make(chan model.SessionUpdate),
+					done:    make(chan struct{}),
+				},
+			}, nil
+		},
+	)
+	defer restore()
+
+	submitter := &stubRuntimeEventSubmitter{
+		submitFn: func(ev eventspkg.Event) error {
+			if ev.Kind == eventspkg.EventKindSessionStarted {
+				return errors.New("journal unavailable")
+			}
+			return nil
+		},
+	}
+	tmpDir := t.TempDir()
+	_, err := SetupSessionExecution(SessionSetupRequest{
+		Context: context.Background(),
+		Config: &config{
+			IDE:          model.IDECodex,
+			RunArtifacts: model.RunArtifacts{RunID: "run-event-failure"},
+		},
+		Job: &job{
+			SafeName: "exec",
+			Prompt:   []byte("finish the task"),
+			OutLog:   filepath.Join(tmpDir, "exec.out.log"),
+			ErrLog:   filepath.Join(tmpDir, "exec.err.log"),
+		},
+		CWD:        tmpDir,
+		RunJournal: submitter,
+		Logger:     silentLogger(),
+	})
+	if err == nil {
+		t.Fatal("expected setup error")
+	}
+	for _, want := range []string{
+		"submit session started event",
+		"journal unavailable",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("setup error %q does not contain %q", err, want)
+		}
+	}
+
+	errLog, readErr := os.ReadFile(filepath.Join(tmpDir, "exec.err.log"))
+	if readErr != nil {
+		t.Fatalf("read err log: %v", readErr)
+	}
+	for _, want := range []string{
+		"ACP session setup error:",
+		"submit session started event",
+		"journal unavailable",
+	} {
+		if !strings.Contains(string(errLog), want) {
+			t.Fatalf("err log %q does not contain %q", string(errLog), want)
+		}
+	}
+}
+
 type fakeSessionExecutionSession struct {
 	id       string
 	identity agent.SessionIdentity

--- a/internal/core/run/internal/acpshared/session_exec.go
+++ b/internal/core/run/internal/acpshared/session_exec.go
@@ -370,6 +370,9 @@ func BuildFailureResult(err error, exitCode int, j *job, index int, emitHuman bo
 }
 
 func RetryableSetupFailure(err error) bool {
+	if agent.IsAuthenticationRequired(err) {
+		return false
+	}
 	var setupErr *agent.SessionSetupError
 	if !errors.As(err, &setupErr) {
 		return false


### PR DESCRIPTION
## Summary

Fixes #186: unauthenticated ACP runtimes (e.g. cursor-agent reporting `Not logged in`) made runs fail with 0-byte job logs, `exit_code: -1` on every job, and the real cause buried in `result.json`.

**Root cause:** in `acpshared.SetupSessionExecution`, the per-job `*.out.log`/`*.err.log` files were created *after* the ACP client and session bootstrap — so any session-stage failure (auth, spawn, handshake) happened before the log files captured anything, and the failure path never wrote the error to them or to the stream events.

**Changes:**
- Job log files are created **before** the ACP client; any session setup failure is written to the job's `err.log` (`ACP session setup error: ...`) and carried in the failure event, so stream/console output shows the cause.
- New typed `agent.AuthenticationRequiredError` (+ `agent.IsAuthenticationRequired`) classifies ACP `-32000 Authentication required` protocol errors at the boundary where they arise — matched with `errors.As`, not string compares downstream.
- Auth failures produce an actionable, runtime-named message built from the runtime catalog: `cursor-agent is not authenticated. Run 'cursor-agent login' and retry.` This works for all ACP runtimes, no cursor-agent special case.
- **Fail fast:** auth errors are never retried, and the first auth-class job failure cancels the remaining queued jobs instead of letting every job fail identically. Run status computation now reports `failed` (with the cause) rather than `canceled` when cancellation was triggered by a failing job.

**Design note:** a separate pre-enqueue session probe was considered; failing the whole run on the first auth-class error was chosen instead because it adds no extra session round-trip on the happy path and fits the existing executor lifecycle (give-up → cancel cause propagation).

**Tests:** extended the canonical suites — `acpshared/command_io_test.go` (session-create failure lands in err.log with the actionable message), `executor/execution_acp_test.go` (auth failure cancels remaining jobs, failure event carries the reason), `executor/result_test.go` (failed beats canceled), `agent/client_test.go` (auth error classification), `exec/exec_test.go` (auth errors are non-retryable).

**Verification:** `make verify` (fmt + lint + test + build + e2e) exits 0 on this branch — run twice independently (implementation pass and orchestrator re-verification).

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime lookup returns a primary executable name for IDE runtimes to improve command resolution.

* **Bug Fixes**
  * Authentication-required failures are detected and cause immediate job shutdown instead of retries.
  * Session setup errors now log clearer, actionable authentication guidance to exec error logs.
  * Overall run results now prefer a failed status when any job failed, even if others were canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->