### PR TITLE
fix: reviews watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage.out
 coverage.html
 .codex/CONTINUITY*
 .codex/plans
+.peer-reviews/
 .resources/
 .factory/skills
 skills/*/autoresearch-*/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -19,6 +19,7 @@
         "**/coverage/**",
         "**/*.min.js",
         ".resources/**",
+        ".peer-reviews/**",
         ".claude/skills/**",
         ".agents/skills/**",
         ".compozy/tasks/**",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -113,6 +113,7 @@
     "globals": {},
     "ignorePatterns": [
         ".resources/**",
+        ".peer-reviews/**",
         ".claude/skills/**",
         ".agents/skills/**",
         ".compozy/tasks/**",

--- a/internal/api/client/reviews_exec.go
+++ b/internal/api/client/reviews_exec.go
@@ -167,6 +167,7 @@ func (c *Client) StartReviewWatch(
 	path := "/api/reviews/" + url.PathEscape(trimmedSlug) + "/watch"
 	if _, err := c.doJSON(ctx, http.MethodPost, path, contract.ReviewWatchRequest{
 		Workspace:        strings.TrimSpace(workspace),
+		PresentationMode: strings.TrimSpace(req.PresentationMode),
 		Provider:         strings.TrimSpace(req.Provider),
 		PRRef:            strings.TrimSpace(req.PRRef),
 		UntilClean:       req.UntilClean,

--- a/internal/api/client/reviews_exec_test.go
+++ b/internal/api/client/reviews_exec_test.go
@@ -201,6 +201,7 @@ func TestClientReviewRequestsEncodeDaemonPathsAndBodies(t *testing.T) {
 						t.Fatalf("unexpected batching payload: %#v", payload)
 					}
 					if payload["workspace"] != "/tmp/workspace" ||
+						payload["presentation_mode"] != "ui" ||
 						payload["provider"] != "coderabbit" ||
 						payload["pr_ref"] != "85" ||
 						payload["until_clean"] != true ||
@@ -226,6 +227,7 @@ func TestClientReviewRequestsEncodeDaemonPathsAndBodies(t *testing.T) {
 			" /tmp/workspace ",
 			" tools-registry ",
 			apicore.ReviewWatchRequest{
+				PresentationMode: " ui ",
 				Provider:         " coderabbit ",
 				PRRef:            " 85 ",
 				UntilClean:       true,

--- a/internal/api/contract/types.go
+++ b/internal/api/contract/types.go
@@ -78,6 +78,7 @@ type ReviewRunRequest struct {
 
 type ReviewWatchRequest struct {
 	Workspace        string          `json:"workspace"`
+	PresentationMode string          `json:"presentation_mode,omitempty"`
 	Provider         string          `json:"provider,omitempty"`
 	PRRef            string          `json:"pr_ref"`
 	UntilClean       bool            `json:"until_clean,omitempty"`

--- a/internal/api/core/handlers.go
+++ b/internal/api/core/handlers.go
@@ -1129,6 +1129,7 @@ func (h *Handlers) StartReviewWatch(c *gin.Context) {
 
 	run, err := h.Reviews.StartWatch(c.Request.Context(), workspace, c.Param("slug"), ReviewWatchRequest{
 		Workspace:        workspace,
+		PresentationMode: strings.TrimSpace(body.PresentationMode),
 		Provider:         strings.TrimSpace(body.Provider),
 		PRRef:            strings.TrimSpace(body.PRRef),
 		UntilClean:       body.UntilClean,

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -349,7 +349,60 @@ func daemonBuildVersionsCompatible(daemonVersion string, cliVersion string) bool
 	if daemonVersion == cliVersion {
 		return true
 	}
-	return isDevBuildVersion(daemonVersion) || isDevBuildVersion(cliVersion)
+	if isDevBuildVersion(daemonVersion) || isDevBuildVersion(cliVersion) {
+		return true
+	}
+	daemonIdentity, daemonOK := parseDaemonBuildIdentity(daemonVersion)
+	cliIdentity, cliOK := parseDaemonBuildIdentity(cliVersion)
+	return daemonOK && cliOK && daemonIdentity == cliIdentity
+}
+
+type daemonBuildIdentity struct {
+	version string
+	commit  string
+}
+
+func parseDaemonBuildIdentity(value string) (daemonBuildIdentity, bool) {
+	versionPart, metadata, ok := strings.Cut(strings.TrimSpace(value), " (")
+	if !ok {
+		return daemonBuildIdentity{}, false
+	}
+	versionPart = strings.TrimSpace(versionPart)
+	if versionPart == "" || isDevBuildVersion(versionPart) {
+		return daemonBuildIdentity{}, false
+	}
+	metadata = strings.TrimSpace(metadata)
+	if !strings.HasSuffix(metadata, ")") {
+		return daemonBuildIdentity{}, false
+	}
+	metadata = strings.TrimSuffix(metadata, ")")
+
+	var commit string
+	var date string
+	for _, field := range strings.Fields(metadata) {
+		key, val, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "commit":
+			commit = strings.TrimSpace(val)
+		case "date":
+			date = strings.TrimSpace(val)
+		}
+	}
+	if !isStableDaemonBuildCommit(commit) || strings.TrimSpace(date) == "" {
+		return daemonBuildIdentity{}, false
+	}
+	return daemonBuildIdentity{
+		version: versionPart,
+		commit:  commit,
+	}, true
+}
+
+func isStableDaemonBuildCommit(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	return normalized != "" && normalized != "none"
 }
 
 func isDevBuildVersion(value string) bool {

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -1056,6 +1056,7 @@ func (s *commandState) resolveTaskPresentationMode(cmd *cobra.Command) (string, 
 		{name: "ui", value: attachModeUI},
 		{name: "stream", value: attachModeStream},
 		{name: "detach", value: attachModeDetach},
+		{name: "background", value: attachModeDetach},
 	} {
 		if !commandFlagChanged(cmd, item.name) {
 			continue
@@ -1064,7 +1065,11 @@ func (s *commandState) resolveTaskPresentationMode(cmd *cobra.Command) (string, 
 		explicitModes++
 	}
 	if explicitModes > 1 {
-		return "", errors.New("choose only one of --attach, --ui, --stream, or --detach")
+		message := "choose only one of --attach, --ui, --stream, or --detach"
+		if cmd != nil && cmd.Flags() != nil && cmd.Flags().Lookup("background") != nil {
+			message = "choose only one of --attach, --ui, --stream, --detach, or --background"
+		}
+		return "", errors.New(message)
 	}
 
 	isInteractive := s.isInteractive

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -1774,6 +1774,8 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 	t.Parallel()
 
 	currentVersion := "v2.0.0 (commit=current date=2026-06-11)"
+	currentVersionRebuilt := "v2.0.0 (commit=current date=2026-06-11T21:45:40Z)"
+	currentVersionDifferentCommit := "v2.0.0 (commit=different date=2026-06-11)"
 	oldVersion := "v1.9.0 (commit=old date=2026-06-10)"
 	devVersion := "dev (commit=none date=unknown)"
 	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
@@ -1800,6 +1802,32 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 				Version: currentVersion,
 			},
 			wantClient: "initial",
+		},
+		{
+			name:           "Should reuse busy daemon when release version and commit match but dates differ",
+			cliVersion:     currentVersionRebuilt,
+			initialVersion: currentVersion,
+			initialStatus: apicore.DaemonStatus{
+				Version:        currentVersion,
+				ActiveRunCount: 2,
+			},
+			wantClient: "initial",
+		},
+		{
+			name:           "Should fail without stopping busy daemon when commit differs",
+			cliVersion:     currentVersionDifferentCommit,
+			initialVersion: currentVersion,
+			initialStatus: apicore.DaemonStatus{
+				Version:        currentVersion,
+				ActiveRunCount: 2,
+			},
+			wantErr: []string{
+				currentVersion,
+				currentVersionDifferentCommit,
+				"2 active runs",
+				"retry after",
+				"compozy daemon stop --force",
+			},
 		},
 		{
 			name:           "Should restart and reconnect idle daemon when release versions differ",
@@ -1997,6 +2025,77 @@ func TestCLIDaemonBootstrapEnsureChecksDaemonVersion(t *testing.T) {
 			}
 			if len(notices) != 1 || !containsAll(notices[0], tt.wantNotice...) {
 				t.Fatalf("notices = %#v, want one notice with %#v", notices, tt.wantNotice)
+			}
+		})
+	}
+}
+
+func TestDaemonBuildVersionsCompatible(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		daemon string
+		cli    string
+		want   bool
+	}{
+		{
+			name:   "Should match exact build strings",
+			daemon: "v2.0.0 (commit=abc123 date=2026-06-11T17:15:44Z)",
+			cli:    "v2.0.0 (commit=abc123 date=2026-06-11T17:15:44Z)",
+			want:   true,
+		},
+		{
+			name:   "Should ignore build date when release version and commit match",
+			daemon: "v2.0.0 (commit=abc123 date=2026-06-11T17:15:44Z)",
+			cli:    "v2.0.0 (commit=abc123 date=2026-06-11T21:45:40Z)",
+			want:   true,
+		},
+		{
+			name:   "Should reject same version with different commits",
+			daemon: "v2.0.0 (commit=abc123 date=2026-06-11T17:15:44Z)",
+			cli:    "v2.0.0 (commit=def456 date=2026-06-11T21:45:40Z)",
+			want:   false,
+		},
+		{
+			name:   "Should reject different versions with same commit",
+			daemon: "v2.0.0 (commit=abc123 date=2026-06-11T17:15:44Z)",
+			cli:    "v2.1.0 (commit=abc123 date=2026-06-11T21:45:40Z)",
+			want:   false,
+		},
+		{
+			name:   "Should preserve dev compatibility",
+			daemon: "dev (commit=none date=unknown)",
+			cli:    "v2.0.0 (commit=abc123 date=2026-06-11T21:45:40Z)",
+			want:   true,
+		},
+		{
+			name:   "Should reject malformed release strings unless exact",
+			daemon: "v2.0.0 commit=abc123 date=2026-06-11T17:15:44Z",
+			cli:    "v2.0.0 commit=abc123 date=2026-06-11T21:45:40Z",
+			want:   false,
+		},
+		{
+			name:   "Should keep exact-match fallback for release strings missing date metadata",
+			daemon: "v2.0.0 (commit=abc123)",
+			cli:    "v2.0.0 (commit=abc123)",
+			want:   true,
+		},
+		{
+			name:   "Should not treat different missing-date release strings as compatible",
+			daemon: "v2.0.0 (commit=abc123)",
+			cli:    "v2.0.0 (commit=abc123 extra=true)",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := daemonBuildVersionsCompatible(tt.daemon, tt.cli); got != tt.want {
+				t.Fatalf("daemonBuildVersionsCompatible(%q, %q) = %t, want %t", tt.daemon, tt.cli, got, tt.want)
 			}
 		})
 	}

--- a/internal/cli/reviews_exec_daemon.go
+++ b/internal/cli/reviews_exec_daemon.go
@@ -157,8 +157,8 @@ func newReviewsWatchCommandWithDefaults(defaults commandStateDefaults) *cobra.Co
 		Args:         cobra.MaximumNArgs(1),
 		Long: `Start a daemon-owned review watch run that waits for provider feedback,
 imports actionable review rounds, starts child review-fix runs, and optionally pushes committed fixes.
-Text mode starts the watch in the background by default. Use --stream to follow events
-without opening the interactive cockpit UI.`,
+Interactive terminals open the review watch cockpit by default. Use --stream to follow
+events as text, or --background/--detach to start the watch without attaching a client.`,
 		Example: `  compozy reviews watch tools-registry --provider coderabbit --pr 85 --auto-push \
     --until-clean --max-rounds 6
   compozy reviews watch --name tools-registry --provider coderabbit --pr 85 --stream
@@ -188,6 +188,7 @@ without opening the interactive cockpit UI.`,
 	cmd.Flags().Bool("ui", false, "Force interactive UI attach mode")
 	cmd.Flags().Bool("stream", false, "Force textual stream attach mode")
 	cmd.Flags().Bool("detach", false, "Start the run without attaching a client")
+	cmd.Flags().Bool("background", false, "Alias for --detach")
 	return cmd
 }
 
@@ -447,6 +448,7 @@ func (s *commandState) runReviewWatchDaemon(cmd *cobra.Command, args []string) e
 
 	run, err := client.StartReviewWatch(ctx, s.workspaceRoot, s.name, apicore.ReviewWatchRequest{
 		Workspace:        s.workspaceRoot,
+		PresentationMode: presentationMode,
 		Provider:         s.provider,
 		PRRef:            s.pr,
 		UntilClean:       s.untilClean,
@@ -463,7 +465,6 @@ func (s *commandState) runReviewWatchDaemon(cmd *cobra.Command, args []string) e
 	if err != nil {
 		return mapDaemonCommandError(err)
 	}
-	run.PresentationMode = presentationMode
 
 	return s.observeStartedReviewWatchRun(ctx, cmd, client, run)
 }
@@ -573,62 +574,14 @@ func (s *commandState) resolveExecPresentationMode(cmd *cobra.Command) (string, 
 }
 
 func (s *commandState) resolveReviewWatchPresentationMode(cmd *cobra.Command) (string, error) {
-	mode := strings.TrimSpace(s.attachMode)
-	if mode == "" {
-		mode = attachModeAuto
-	}
-
-	explicitModes := 0
-	if commandFlagChanged(cmd, "attach") {
-		explicitModes++
-	}
-	for _, item := range []struct {
-		name  string
-		value string
-	}{
-		{name: "ui", value: attachModeUI},
-		{name: "stream", value: attachModeStream},
-		{name: "detach", value: attachModeDetach},
-	} {
-		if !commandFlagChanged(cmd, item.name) {
-			continue
-		}
-		mode = item.value
-		explicitModes++
-	}
-	if explicitModes > 1 {
-		return "", errors.New("choose only one of --attach, --ui, --stream, or --detach")
-	}
-	switch mode {
-	case attachModeAuto, attachModeUI, attachModeStream, attachModeDetach:
-	default:
-		return "", fmt.Errorf("attach mode must be one of auto, ui, stream, or detach (got %q)", mode)
-	}
-	if mode == attachModeUI || (commandFlagChanged(cmd, "tui") && s.tui) {
-		return "", reviewWatchUIUnsupportedError(cmd)
-	}
 	if isJSONOutputFormat(s.outputFormat) {
+		if commandFlagChanged(cmd, "ui") ||
+			(commandFlagChanged(cmd, "attach") && strings.TrimSpace(s.attachMode) == attachModeUI) {
+			return "", fmt.Errorf("%s cannot combine json output with ui attach mode", cmd.CommandPath())
+		}
 		return attachModeStream, nil
 	}
-	switch mode {
-	case attachModeAuto, attachModeDetach:
-		return attachModeDetach, nil
-	case attachModeStream:
-		return attachModeStream, nil
-	default:
-		return "", fmt.Errorf("attach mode must be one of auto, ui, stream, or detach (got %q)", mode)
-	}
-}
-
-func reviewWatchUIUnsupportedError(cmd *cobra.Command) error {
-	commandLabel := "reviews watch"
-	if cmd != nil {
-		commandLabel = strings.TrimSpace(cmd.CommandPath())
-	}
-	return fmt.Errorf(
-		"%s does not support UI attach; use --stream to follow events or --detach to run in background",
-		commandLabel,
-	)
+	return s.resolveTaskPresentationMode(cmd)
 }
 
 func handleStartedReviewWatchRun(
@@ -637,6 +590,18 @@ func handleStartedReviewWatchRun(
 	client daemonCommandClient,
 	run apicore.Run,
 ) error {
+	if run.PresentationMode == attachModeUI {
+		if err := attachStartedCLIRunUI(ctx, client, run.RunID); err != nil {
+			if errors.Is(err, errRunSettledBeforeUIAttach) {
+				if err := watchCLIRun(ctx, cmd.OutOrStdout(), client, run.RunID); err != nil {
+					return mapDaemonCommandError(err)
+				}
+				return nil
+			}
+			return mapDaemonCommandError(err)
+		}
+		return nil
+	}
 	if err := writeStartedReviewWatchRun(cmd, run); err != nil {
 		return err
 	}
@@ -653,7 +618,9 @@ func writeStartedReviewWatchRun(cmd *cobra.Command, run apicore.Run) error {
 	message := fmt.Sprintf("review watch started: %s (mode=%s)\n", run.RunID, run.PresentationMode)
 	if run.PresentationMode == attachModeDetach {
 		message = fmt.Sprintf(
-			"review watch started: %s (running in background; follow with: compozy runs watch %s)\n",
+			"review watch started: %s (running in background; attach with: compozy runs attach %s; "+
+				"follow text with: compozy runs watch %s)\n",
+			run.RunID,
 			run.RunID,
 			run.RunID,
 		)
@@ -1305,6 +1272,9 @@ func (s *commandState) resolveWorkflowNameArg(cmd *cobra.Command, args []string)
 	if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
 		s.name = strings.TrimSpace(args[0])
 	}
+	if strings.TrimSpace(s.name) == "" && reviewCommandSupportsPRSlugFallback(cmd, s.kind) {
+		s.name = reviewWorkflowSlugFromPR(s.pr)
+	}
 	if strings.TrimSpace(s.name) == "" {
 		commandLabel := "reviews"
 		if cmd != nil {
@@ -1318,6 +1288,31 @@ func (s *commandState) resolveWorkflowNameArg(cmd *cobra.Command, args []string)
 		}
 	}
 	return nil
+}
+
+func reviewCommandSupportsPRSlugFallback(cmd *cobra.Command, kind commandKind) bool {
+	commandName := ""
+	if cmd != nil {
+		commandName = cmd.Name()
+	}
+	switch kind {
+	case commandKindFetchReviews:
+		return commandName == "" || commandName == "fetch"
+	case commandKindFixReviews:
+		return commandName == "" || commandName == "fix"
+	case commandKindWatchReviews:
+		return commandName == "" || commandName == "watch"
+	default:
+		return false
+	}
+}
+
+func reviewWorkflowSlugFromPR(pr string) string {
+	trimmed := strings.TrimSpace(pr)
+	if trimmed == "" {
+		return ""
+	}
+	return "pr-" + trimmed
 }
 
 func (s *commandState) resolveWorkflowNameAndRoundArgs(cmd *cobra.Command, args []string) error {

--- a/internal/cli/reviews_exec_daemon_additional_test.go
+++ b/internal/cli/reviews_exec_daemon_additional_test.go
@@ -122,7 +122,11 @@ func (c *reviewExecCaptureClient) StartReviewWatch(
 	c.startWatchWorkspace = workspace
 	c.startWatchSlug = slug
 	c.startWatchReq = req
-	return c.stubDaemonCommandClient.StartReviewWatch(ctx, workspace, slug, req)
+	run, err := c.stubDaemonCommandClient.StartReviewWatch(ctx, workspace, slug, req)
+	if strings.TrimSpace(run.PresentationMode) == "" {
+		run.PresentationMode = strings.TrimSpace(req.PresentationMode)
+	}
+	return run, err
 }
 
 func (c *reviewExecCaptureClient) StartExecRun(ctx context.Context, req apicore.ExecRequest) (apicore.Run, error) {
@@ -542,7 +546,7 @@ func TestReviewsWatchCommandBuildsDaemonRequest(t *testing.T) {
 			"--batch-size",
 			"2",
 			"--include-resolved",
-			"--detach",
+			"--background",
 		)
 		if err != nil {
 			t.Fatalf("execute reviews watch: %v\noutput:\n%s", err, output)
@@ -551,6 +555,7 @@ func TestReviewsWatchCommandBuildsDaemonRequest(t *testing.T) {
 			output,
 			"review watch started: review-watch-001",
 			"running in background",
+			"compozy runs attach review-watch-001",
 			"compozy runs watch review-watch-001",
 		) {
 			t.Fatalf("unexpected reviews watch output:\n%s", output)
@@ -562,6 +567,9 @@ func TestReviewsWatchCommandBuildsDaemonRequest(t *testing.T) {
 			t.Fatalf("watch slug = %q, want tools-registry", client.startWatchSlug)
 		}
 		req := client.startWatchReq
+		if req.PresentationMode != attachModeDetach {
+			t.Fatalf("watch presentation mode = %q, want detach", req.PresentationMode)
+		}
 		if req.Provider != "coderabbit" || req.PRRef != "85" || !req.AutoPush || !req.UntilClean ||
 			req.MaxRounds != 6 || req.PollInterval != "15s" || req.ReviewTimeout != "10m" ||
 			req.QuietPeriod != "5s" || req.PushRemote != "origin" || req.PushBranch != "feature" {
@@ -590,7 +598,7 @@ func TestReviewsWatchCommandBuildsDaemonRequest(t *testing.T) {
 	})
 }
 
-func TestReviewsWatchCommandNoFlagsUsesInteractiveFormAndRunsInBackground(t *testing.T) {
+func TestReviewsWatchCommandNoFlagsUsesInteractiveFormAndOpensUI(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
 		t.Fatalf("mkdir workflow dir: %v", err)
@@ -607,10 +615,12 @@ func TestReviewsWatchCommandNoFlagsUsesInteractiveFormAndRunsInBackground(t *tes
 		},
 	}
 	installTestCLIReadyDaemonBootstrap(t, client)
+	var attachedRunID string
 	installTestCLIRunObservers(
 		t,
-		func(context.Context, daemonCommandClient, string) error {
-			return errors.New("reviews watch must not attach the UI after form collection")
+		func(_ context.Context, _ daemonCommandClient, runID string) error {
+			attachedRunID = runID
+			return nil
 		},
 		nil,
 	)
@@ -643,17 +653,18 @@ func TestReviewsWatchCommandNoFlagsUsesInteractiveFormAndRunsInBackground(t *tes
 	if client.startWatchReq.Provider != "coderabbit" || client.startWatchReq.PRRef != "85" {
 		t.Fatalf("unexpected watch request from form: %#v", client.startWatchReq)
 	}
-	if !containsAll(
-		output,
-		"review watch started: review-watch-form",
-		"running in background",
-		"compozy runs watch review-watch-form",
-	) {
-		t.Fatalf("unexpected reviews watch background output:\n%s", output)
+	if client.startWatchReq.PresentationMode != attachModeUI {
+		t.Fatalf("watch presentation mode = %q, want ui", client.startWatchReq.PresentationMode)
+	}
+	if attachedRunID != "review-watch-form" {
+		t.Fatalf("attached run id = %q, want review-watch-form", attachedRunID)
+	}
+	if strings.TrimSpace(output) != "" {
+		t.Fatalf("unexpected reviews watch UI output:\n%s", output)
 	}
 }
 
-func TestReviewsWatchCommandInteractiveTextDefaultsToBackground(t *testing.T) {
+func TestReviewsWatchCommandInteractiveTextDefaultsToUI(t *testing.T) {
 	workspaceRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
 		t.Fatalf("mkdir workflow dir: %v", err)
@@ -670,10 +681,12 @@ func TestReviewsWatchCommandInteractiveTextDefaultsToBackground(t *testing.T) {
 		},
 	}
 	installTestCLIReadyDaemonBootstrap(t, client)
+	var attachedRunID string
 	installTestCLIRunObservers(
 		t,
-		func(context.Context, daemonCommandClient, string) error {
-			return errors.New("reviews watch must not attach the UI by default")
+		func(_ context.Context, _ daemonCommandClient, runID string) error {
+			attachedRunID = runID
+			return nil
 		},
 		nil,
 	)
@@ -692,15 +705,16 @@ func TestReviewsWatchCommandInteractiveTextDefaultsToBackground(t *testing.T) {
 		"85",
 	)
 	if err != nil {
-		t.Fatalf("execute reviews watch default background: %v\noutput:\n%s", err, output)
+		t.Fatalf("execute reviews watch default UI: %v\noutput:\n%s", err, output)
 	}
-	if !containsAll(
-		output,
-		"review watch started: review-watch-background",
-		"running in background",
-		"compozy runs watch review-watch-background",
-	) {
-		t.Fatalf("unexpected reviews watch background output:\n%s", output)
+	if client.startWatchReq.PresentationMode != attachModeUI {
+		t.Fatalf("watch presentation mode = %q, want ui", client.startWatchReq.PresentationMode)
+	}
+	if attachedRunID != "review-watch-background" {
+		t.Fatalf("attached run id = %q, want review-watch-background", attachedRunID)
+	}
+	if strings.TrimSpace(output) != "" {
+		t.Fatalf("unexpected reviews watch UI output:\n%s", output)
 	}
 }
 
@@ -954,34 +968,70 @@ func TestReviewsWatchCommandObservationModes(t *testing.T) {
 		}
 	})
 
-	t.Run("Should reject UI attach modes before daemon bootstrap", func(t *testing.T) {
+	t.Run("Should accept explicit UI attach mode in interactive terminals", func(t *testing.T) {
+		workspaceRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
+			t.Fatalf("mkdir workflow dir: %v", err)
+		}
+		withWorkingDir(t, workspaceRoot)
+
+		client := &reviewExecCaptureClient{
+			stubDaemonCommandClient: &stubDaemonCommandClient{
+				health: apicore.DaemonHealth{Ready: true},
+				reviewWatchRun: apicore.Run{
+					RunID: "review-watch-ui",
+					Mode:  "review_watch",
+				},
+			},
+		}
+		installTestCLIReadyDaemonBootstrap(t, client)
+
+		var attachedRunID string
+		installTestCLIRunObservers(
+			t,
+			func(_ context.Context, _ daemonCommandClient, runID string) error {
+				attachedRunID = runID
+				return nil
+			},
+			nil,
+		)
+
+		defaults := testReviewExecCommandDefaults()
+		defaults.isInteractive = func() bool { return true }
+		output, err := executeCommandCombinedOutput(
+			newReviewsCommandWithDefaults(defaults),
+			nil,
+			"watch",
+			"demo",
+			"--provider",
+			"coderabbit",
+			"--pr",
+			"85",
+			"--ui",
+		)
+		if err != nil {
+			t.Fatalf("execute reviews watch ui: %v\noutput:\n%s", err, output)
+		}
+		if client.startWatchReq.PresentationMode != attachModeUI {
+			t.Fatalf("watch presentation mode = %q, want ui", client.startWatchReq.PresentationMode)
+		}
+		if attachedRunID != "review-watch-ui" {
+			t.Fatalf("attached run id = %q, want review-watch-ui", attachedRunID)
+		}
+	})
+
+	t.Run("Should reject UI attach mode in noninteractive terminals", func(t *testing.T) {
 		for _, tc := range []struct {
 			name string
 			args []string
 		}{
 			{
 				name: "ui shorthand",
-				args: []string{
-					"watch", "demo", "--provider", "coderabbit", "--pr", "85", "--ui",
-				},
+				args: []string{"watch", "demo", "--provider", "coderabbit", "--pr", "85", "--ui"},
 			},
 			{
 				name: "attach ui",
-				args: []string{
-					"watch", "demo", "--provider", "coderabbit", "--pr", "85", "--attach", "ui",
-				},
-			},
-			{
-				name: "explicit tui true",
-				args: []string{
-					"watch", "demo", "--provider", "coderabbit", "--pr", "85", "--tui=true",
-				},
-			},
-			{
-				name: "json ui",
-				args: []string{
-					"watch", "demo", "--provider", "coderabbit", "--pr", "85", "--format", "json", "--ui",
-				},
+				args: []string{"watch", "demo", "--provider", "coderabbit", "--pr", "85", "--attach", "ui"},
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
@@ -999,21 +1049,64 @@ func TestReviewsWatchCommandObservationModes(t *testing.T) {
 					},
 				})
 
+				defaults := testReviewExecCommandDefaults()
+				defaults.isInteractive = func() bool { return false }
 				output, err := executeCommandCombinedOutput(
-					newReviewsCommandWithDefaults(testReviewExecCommandDefaults()),
+					newReviewsCommandWithDefaults(defaults),
 					nil,
 					tc.args...,
 				)
 				if err == nil {
-					t.Fatalf("execute reviews watch error = nil, want UI unsupported error\noutput:\n%s", output)
+					t.Fatalf("execute reviews watch error = nil, want noninteractive UI error\noutput:\n%s", output)
 				}
 				if bootstrapCalled {
-					t.Fatal("daemon bootstrap was called before rejecting incompatible output mode")
+					t.Fatal("daemon bootstrap was called before rejecting noninteractive UI mode")
 				}
-				if !containsAll(err.Error(), "does not support UI attach", "--stream", "--detach") {
-					t.Fatalf("error = %v, want UI unsupported guidance", err)
+				if !strings.Contains(err.Error(), "requires an interactive terminal for ui mode") {
+					t.Fatalf("error = %v, want noninteractive UI guidance", err)
 				}
 			})
+		}
+	})
+
+	t.Run("Should reject JSON output with UI attach before daemon bootstrap", func(t *testing.T) {
+		workspaceRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
+			t.Fatalf("mkdir workflow dir: %v", err)
+		}
+		withWorkingDir(t, workspaceRoot)
+
+		bootstrapCalled := false
+		installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
+			resolveHomePaths: func() (compozyconfig.HomePaths, error) {
+				bootstrapCalled = true
+				return compozyconfig.HomePaths{}, errors.New("daemon bootstrap should not run")
+			},
+		})
+
+		defaults := testReviewExecCommandDefaults()
+		defaults.isInteractive = func() bool { return true }
+		output, err := executeCommandCombinedOutput(
+			newReviewsCommandWithDefaults(defaults),
+			nil,
+			"watch",
+			"demo",
+			"--provider",
+			"coderabbit",
+			"--pr",
+			"85",
+			"--format",
+			"json",
+			"--ui",
+		)
+		if err == nil {
+			t.Fatalf("execute reviews watch error = nil, want json/ui conflict\noutput:\n%s", output)
+		}
+		if bootstrapCalled {
+			t.Fatal("daemon bootstrap was called before rejecting json UI mode")
+		}
+		if !strings.Contains(err.Error(), "cannot combine json output with ui attach mode") {
+			t.Fatalf("error = %v, want json UI conflict", err)
 		}
 	})
 
@@ -1050,17 +1143,20 @@ func TestReviewsWatchCommandObservationModes(t *testing.T) {
 		}
 	})
 
-	t.Run("Should reject missing workflow name before daemon bootstrap", func(t *testing.T) {
+	t.Run("Should derive workflow name from PR when name is omitted", func(t *testing.T) {
 		workspaceRoot := t.TempDir()
 		withWorkingDir(t, workspaceRoot)
 
-		bootstrapCalled := false
-		installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
-			resolveHomePaths: func() (compozyconfig.HomePaths, error) {
-				bootstrapCalled = true
-				return compozyconfig.HomePaths{}, errors.New("daemon bootstrap should not run")
+		client := &reviewExecCaptureClient{
+			stubDaemonCommandClient: &stubDaemonCommandClient{
+				health: apicore.DaemonHealth{Ready: true},
+				reviewWatchRun: apicore.Run{
+					RunID: "review-watch-pr",
+					Mode:  "review_watch",
+				},
 			},
-		})
+		}
+		installTestCLIReadyDaemonBootstrap(t, client)
 
 		output, err := executeCommandCombinedOutput(
 			newReviewsCommandWithDefaults(testReviewExecCommandDefaults()),
@@ -1070,15 +1166,16 @@ func TestReviewsWatchCommandObservationModes(t *testing.T) {
 			"coderabbit",
 			"--pr",
 			"85",
+			"--detach",
 		)
-		if err == nil {
-			t.Fatalf("execute reviews watch error = nil, want missing workflow name\noutput:\n%s", output)
+		if err != nil {
+			t.Fatalf("execute reviews watch with PR-derived slug: %v\noutput:\n%s", err, output)
 		}
-		if bootstrapCalled {
-			t.Fatal("daemon bootstrap was called before rejecting missing workflow name")
+		if client.startWatchSlug != "pr-85" {
+			t.Fatalf("watch slug = %q, want pr-85", client.startWatchSlug)
 		}
-		if !strings.Contains(err.Error(), "requires a workflow slug via [slug] or --name") {
-			t.Fatalf("error = %v, want missing workflow name", err)
+		if client.startWatchReq.PresentationMode != attachModeDetach {
+			t.Fatalf("watch presentation mode = %q, want detach", client.startWatchReq.PresentationMode)
 		}
 	})
 }
@@ -1097,7 +1194,7 @@ func TestReviewsExecDaemonHelperFunctions(t *testing.T) {
 
 	t.Run("resolve workflow name and round args validates positionals", func(t *testing.T) {
 		state := newCommandState(commandKindFetchReviews, core.ModePRReview)
-		cmd := &cobra.Command{Use: "reviews fetch"}
+		cmd := &cobra.Command{Use: "fetch [slug]"}
 		if err := state.resolveWorkflowNameAndRoundArgs(cmd, []string{"demo", "3"}); err != nil {
 			t.Fatalf("resolveWorkflowNameAndRoundArgs() error = %v", err)
 		}
@@ -1484,7 +1581,24 @@ func TestReviewsExecDaemonHelperFunctions(t *testing.T) {
 
 	t.Run("workflow argument parsing reports invalid combinations", func(t *testing.T) {
 		state := newCommandState(commandKindFetchReviews, core.ModePRReview)
-		cmd := &cobra.Command{Use: "reviews fetch"}
+		cmd := &cobra.Command{Use: "fetch [slug]"}
+		state.pr = "51"
+		if err := state.resolveWorkflowNameArg(cmd, nil); err != nil {
+			t.Fatalf("resolveWorkflowNameArg(fetch with PR) error = %v", err)
+		}
+		if state.name != "pr-51" {
+			t.Fatalf("resolved name = %q, want pr-51", state.name)
+		}
+
+		state = newCommandState(commandKindFetchReviews, core.ModePRReview)
+		cmd = &cobra.Command{Use: "list"}
+		state.pr = "51"
+		if err := state.resolveWorkflowNameArg(cmd, nil); err == nil ||
+			!strings.Contains(err.Error(), "requires --name") {
+			t.Fatalf("resolveWorkflowNameArg(list with PR) error = %v, want requires --name", err)
+		}
+
+		state = newCommandState(commandKindFetchReviews, core.ModePRReview)
 		if err := state.resolveWorkflowNameArg(
 			cmd,
 			nil,

--- a/internal/cli/reviews_exec_daemon_additional_test.go
+++ b/internal/cli/reviews_exec_daemon_additional_test.go
@@ -599,123 +599,127 @@ func TestReviewsWatchCommandBuildsDaemonRequest(t *testing.T) {
 }
 
 func TestReviewsWatchCommandNoFlagsUsesInteractiveFormAndOpensUI(t *testing.T) {
-	workspaceRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
-		t.Fatalf("mkdir workflow dir: %v", err)
-	}
-	withWorkingDir(t, workspaceRoot)
+	t.Run("Should use interactive form and open UI", func(t *testing.T) {
+		workspaceRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
+			t.Fatalf("mkdir workflow dir: %v", err)
+		}
+		withWorkingDir(t, workspaceRoot)
 
-	client := &reviewExecCaptureClient{
-		stubDaemonCommandClient: &stubDaemonCommandClient{
-			health: apicore.DaemonHealth{Ready: true},
-			reviewWatchRun: apicore.Run{
-				RunID: "review-watch-form",
-				Mode:  "review_watch",
+		client := &reviewExecCaptureClient{
+			stubDaemonCommandClient: &stubDaemonCommandClient{
+				health: apicore.DaemonHealth{Ready: true},
+				reviewWatchRun: apicore.Run{
+					RunID: "review-watch-form",
+					Mode:  "review_watch",
+				},
 			},
-		},
-	}
-	installTestCLIReadyDaemonBootstrap(t, client)
-	var attachedRunID string
-	installTestCLIRunObservers(
-		t,
-		func(_ context.Context, _ daemonCommandClient, runID string) error {
-			attachedRunID = runID
+		}
+		installTestCLIReadyDaemonBootstrap(t, client)
+		var attachedRunID string
+		installTestCLIRunObservers(
+			t,
+			func(_ context.Context, _ daemonCommandClient, runID string) error {
+				attachedRunID = runID
+				return nil
+			},
+			nil,
+		)
+
+		defaults := testReviewExecCommandDefaults()
+		defaults.isInteractive = func() bool { return true }
+		var collectFormCalls int
+		defaults.collectForm = func(_ *cobra.Command, state *commandState) error {
+			collectFormCalls++
+			state.name = "demo"
+			state.provider = "coderabbit"
+			state.pr = "85"
 			return nil
-		},
-		nil,
-	)
+		}
 
-	defaults := testReviewExecCommandDefaults()
-	defaults.isInteractive = func() bool { return true }
-	var collectFormCalls int
-	defaults.collectForm = func(_ *cobra.Command, state *commandState) error {
-		collectFormCalls++
-		state.name = "demo"
-		state.provider = "coderabbit"
-		state.pr = "85"
-		return nil
-	}
-
-	output, err := executeCommandCombinedOutput(
-		newReviewsCommandWithDefaults(defaults),
-		nil,
-		"watch",
-	)
-	if err != nil {
-		t.Fatalf("execute reviews watch form flow: %v\noutput:\n%s", err, output)
-	}
-	if collectFormCalls != 1 {
-		t.Fatalf("expected one interactive form call, got %d", collectFormCalls)
-	}
-	if client.startWatchSlug != "demo" {
-		t.Fatalf("watch slug = %q, want demo", client.startWatchSlug)
-	}
-	if client.startWatchReq.Provider != "coderabbit" || client.startWatchReq.PRRef != "85" {
-		t.Fatalf("unexpected watch request from form: %#v", client.startWatchReq)
-	}
-	if client.startWatchReq.PresentationMode != attachModeUI {
-		t.Fatalf("watch presentation mode = %q, want ui", client.startWatchReq.PresentationMode)
-	}
-	if attachedRunID != "review-watch-form" {
-		t.Fatalf("attached run id = %q, want review-watch-form", attachedRunID)
-	}
-	if strings.TrimSpace(output) != "" {
-		t.Fatalf("unexpected reviews watch UI output:\n%s", output)
-	}
+		output, err := executeCommandCombinedOutput(
+			newReviewsCommandWithDefaults(defaults),
+			nil,
+			"watch",
+		)
+		if err != nil {
+			t.Fatalf("execute reviews watch form flow: %v\noutput:\n%s", err, output)
+		}
+		if collectFormCalls != 1 {
+			t.Fatalf("expected one interactive form call, got %d", collectFormCalls)
+		}
+		if client.startWatchSlug != "demo" {
+			t.Fatalf("watch slug = %q, want demo", client.startWatchSlug)
+		}
+		if client.startWatchReq.Provider != "coderabbit" || client.startWatchReq.PRRef != "85" {
+			t.Fatalf("unexpected watch request from form: %#v", client.startWatchReq)
+		}
+		if client.startWatchReq.PresentationMode != attachModeUI {
+			t.Fatalf("watch presentation mode = %q, want ui", client.startWatchReq.PresentationMode)
+		}
+		if attachedRunID != "review-watch-form" {
+			t.Fatalf("attached run id = %q, want review-watch-form", attachedRunID)
+		}
+		if strings.TrimSpace(output) != "" {
+			t.Fatalf("unexpected reviews watch UI output:\n%s", output)
+		}
+	})
 }
 
 func TestReviewsWatchCommandInteractiveTextDefaultsToUI(t *testing.T) {
-	workspaceRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
-		t.Fatalf("mkdir workflow dir: %v", err)
-	}
-	withWorkingDir(t, workspaceRoot)
+	t.Run("Should default interactive text watch to UI", func(t *testing.T) {
+		workspaceRoot := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(workspaceRoot, ".compozy", "tasks", "demo"), 0o755); err != nil {
+			t.Fatalf("mkdir workflow dir: %v", err)
+		}
+		withWorkingDir(t, workspaceRoot)
 
-	client := &reviewExecCaptureClient{
-		stubDaemonCommandClient: &stubDaemonCommandClient{
-			health: apicore.DaemonHealth{Ready: true},
-			reviewWatchRun: apicore.Run{
-				RunID: "review-watch-background",
-				Mode:  "review_watch",
+		client := &reviewExecCaptureClient{
+			stubDaemonCommandClient: &stubDaemonCommandClient{
+				health: apicore.DaemonHealth{Ready: true},
+				reviewWatchRun: apicore.Run{
+					RunID: "review-watch-background",
+					Mode:  "review_watch",
+				},
 			},
-		},
-	}
-	installTestCLIReadyDaemonBootstrap(t, client)
-	var attachedRunID string
-	installTestCLIRunObservers(
-		t,
-		func(_ context.Context, _ daemonCommandClient, runID string) error {
-			attachedRunID = runID
-			return nil
-		},
-		nil,
-	)
+		}
+		installTestCLIReadyDaemonBootstrap(t, client)
+		var attachedRunID string
+		installTestCLIRunObservers(
+			t,
+			func(_ context.Context, _ daemonCommandClient, runID string) error {
+				attachedRunID = runID
+				return nil
+			},
+			nil,
+		)
 
-	defaults := testReviewExecCommandDefaults()
-	defaults.isInteractive = func() bool { return true }
+		defaults := testReviewExecCommandDefaults()
+		defaults.isInteractive = func() bool { return true }
 
-	output, err := executeCommandCombinedOutput(
-		newReviewsCommandWithDefaults(defaults),
-		nil,
-		"watch",
-		"demo",
-		"--provider",
-		"coderabbit",
-		"--pr",
-		"85",
-	)
-	if err != nil {
-		t.Fatalf("execute reviews watch default UI: %v\noutput:\n%s", err, output)
-	}
-	if client.startWatchReq.PresentationMode != attachModeUI {
-		t.Fatalf("watch presentation mode = %q, want ui", client.startWatchReq.PresentationMode)
-	}
-	if attachedRunID != "review-watch-background" {
-		t.Fatalf("attached run id = %q, want review-watch-background", attachedRunID)
-	}
-	if strings.TrimSpace(output) != "" {
-		t.Fatalf("unexpected reviews watch UI output:\n%s", output)
-	}
+		output, err := executeCommandCombinedOutput(
+			newReviewsCommandWithDefaults(defaults),
+			nil,
+			"watch",
+			"demo",
+			"--provider",
+			"coderabbit",
+			"--pr",
+			"85",
+		)
+		if err != nil {
+			t.Fatalf("execute reviews watch default UI: %v\noutput:\n%s", err, output)
+		}
+		if client.startWatchReq.PresentationMode != attachModeUI {
+			t.Fatalf("watch presentation mode = %q, want ui", client.startWatchReq.PresentationMode)
+		}
+		if attachedRunID != "review-watch-background" {
+			t.Fatalf("attached run id = %q, want review-watch-background", attachedRunID)
+		}
+		if strings.TrimSpace(output) != "" {
+			t.Fatalf("unexpected reviews watch UI output:\n%s", output)
+		}
+	})
 }
 
 func TestReviewsWatchCommandAppliesWatchConfigAndRejectsAutoCommitContradiction(t *testing.T) {
@@ -1599,6 +1603,7 @@ func TestReviewsExecDaemonHelperFunctions(t *testing.T) {
 		}
 
 		state = newCommandState(commandKindFetchReviews, core.ModePRReview)
+		cmd = &cobra.Command{Use: "fetch [slug]"}
 		if err := state.resolveWorkflowNameArg(
 			cmd,
 			nil,

--- a/internal/cli/run_observe.go
+++ b/internal/cli/run_observe.go
@@ -24,6 +24,7 @@ var (
 	watchCLIRun                    = defaultWatchCLIRun
 	openCLIRemoteUISession         = uipkg.AttachRemote
 	openCLIRemoteMultiRunUISession = uipkg.AttachRemoteMultiple
+	openCLIRemoteReviewWatchUI     = uipkg.AttachRemoteReviewWatch
 )
 
 var errRunSettledBeforeUIAttach = errors.New("run settled before ui attach")
@@ -33,6 +34,7 @@ const (
 	defaultUIAttachSnapshotPollInterval = 10 * time.Millisecond
 	defaultOwnedRunCancelTimeout        = 5 * time.Second
 	daemonRunModeTaskMulti              = "task_multi"
+	daemonRunModeReviewWatch            = "review_watch"
 )
 
 type cliRunObserveConfig struct {
@@ -134,6 +136,9 @@ func attachRemoteCLIRunUI(
 	if isTaskMultiRunSnapshot(snapshot) {
 		return attachRemoteCLIMultiRunUI(ctx, client, trimmedRunID, cancelOwnedRunOnExit, cfg)
 	}
+	if isReviewWatchRunSnapshot(snapshot) {
+		return attachRemoteCLIReviewWatchUI(ctx, client, trimmedRunID, snapshot, cancelOwnedRunOnExit, cfg)
+	}
 	if runSnapshotSettledBeforeUIAttach(snapshot) {
 		return errRunSettledBeforeUIAttach
 	}
@@ -169,6 +174,10 @@ func isTaskMultiRunSnapshot(snapshot apicore.RunSnapshot) bool {
 	return snapshot.Run.Mode == daemonRunModeTaskMulti
 }
 
+func isReviewWatchRunSnapshot(snapshot apicore.RunSnapshot) bool {
+	return snapshot.Run.Mode == daemonRunModeReviewWatch
+}
+
 func attachRemoteCLIMultiRunUI(
 	ctx context.Context,
 	client daemonCommandClient,
@@ -191,6 +200,40 @@ func attachRemoteCLIMultiRunUI(
 		OwnerSession: cancelOwnedRunOnExit,
 		LoadSnapshot: func(loadCtx context.Context) (apicore.TaskRunMultipleSnapshot, error) {
 			return client.GetTaskRunMultipleSnapshot(loadCtx, runID)
+		},
+		LoadChildSnapshot: func(loadCtx context.Context, childRunID string) (apicore.RunSnapshot, error) {
+			return client.GetRunSnapshot(loadCtx, childRunID)
+		},
+		OpenParentStream: func(streamCtx context.Context, after apicore.StreamCursor) (apiclient.RunStream, error) {
+			return client.OpenRunStream(streamCtx, runID, after)
+		},
+		OpenChildStream: func(
+			streamCtx context.Context,
+			childRunID string,
+			after apicore.StreamCursor,
+		) (apiclient.RunStream, error) {
+			return client.OpenRunStream(streamCtx, childRunID, after)
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return waitRemoteCLIRunUI(ctx, client, runID, session, cancelOwnedRunOnExit, cfg.ownedRunCancelTimeout)
+}
+
+func attachRemoteCLIReviewWatchUI(
+	ctx context.Context,
+	client daemonCommandClient,
+	runID string,
+	snapshot apicore.RunSnapshot,
+	cancelOwnedRunOnExit bool,
+	cfg cliRunObserveConfig,
+) error {
+	session, err := openCLIRemoteReviewWatchUI(ctx, uipkg.RemoteReviewWatchAttachOptions{
+		Snapshot:     snapshot,
+		OwnerSession: cancelOwnedRunOnExit,
+		LoadSnapshot: func(loadCtx context.Context) (apicore.RunSnapshot, error) {
+			return client.GetRunSnapshot(loadCtx, runID)
 		},
 		LoadChildSnapshot: func(loadCtx context.Context, childRunID string) (apicore.RunSnapshot, error) {
 			return client.GetRunSnapshot(loadCtx, childRunID)

--- a/internal/core/archive.go
+++ b/internal/core/archive.go
@@ -390,12 +390,22 @@ func refreshArchiveEligibility(
 		WorkspaceRoot: workspace.RootDir,
 		TasksDir:      tasksDir,
 	}); err != nil {
-		return globaldb.WorkflowArchiveEligibility{}, err
+		return globaldb.WorkflowArchiveEligibility{}, fmt.Errorf(
+			"refresh archive eligibility sync for workspace %s slug %q: %w",
+			workspace.ID,
+			slug,
+			err,
+		)
 	}
 
 	updatedEligibility, err := db.GetWorkflowArchiveEligibility(ctx, workspace.ID, slug)
 	if err != nil {
-		return globaldb.WorkflowArchiveEligibility{}, err
+		return globaldb.WorkflowArchiveEligibility{}, fmt.Errorf(
+			"refresh archive eligibility lookup for workspace %s slug %q: %w",
+			workspace.ID,
+			slug,
+			err,
+		)
 	}
 	return updatedEligibility, nil
 }

--- a/internal/core/archive.go
+++ b/internal/core/archive.go
@@ -332,6 +332,15 @@ func prepareArchiveWorkflow(
 	conflictOnSkip bool,
 	eligibility globaldb.WorkflowArchiveEligibility,
 ) (globaldb.WorkflowArchiveEligibility, bool, error) {
+	if conflictOnSkip && archiveEligibilityNeedsFilesystemRefresh(eligibility) {
+		// Never-synced workflows still follow workflowStateNotSyncedReason; this
+		// refresh is only for visible DB rows whose zero-artifact counts are stale.
+		updatedEligibility, err := refreshArchiveEligibility(ctx, db, workspace, tasksDir, eligibility.Workflow.Slug)
+		if err != nil {
+			return globaldb.WorkflowArchiveEligibility{}, false, err
+		}
+		eligibility = updatedEligibility
+	}
 	if eligibility.SkipReason() == "" {
 		return eligibility, false, nil
 	}
@@ -360,6 +369,35 @@ func prepareArchiveWorkflow(
 		result.ResolvedReviewIssues += resolvedReviewIssues
 	}
 	return resolveArchiveConflict(result, tasksDir, conflictOnSkip, updatedEligibility)
+}
+
+func archiveEligibilityNeedsFilesystemRefresh(eligibility globaldb.WorkflowArchiveEligibility) bool {
+	// Keep this aligned with WorkflowArchiveEligibility.SkipReason's empty
+	// catalog branch: no active runs, no task files, and no review issues.
+	return eligibility.ActiveRuns == 0 &&
+		eligibility.TaskTotal == 0 &&
+		eligibility.ReviewIssueTotal == 0
+}
+
+func refreshArchiveEligibility(
+	ctx context.Context,
+	db *globaldb.GlobalDB,
+	workspace globaldb.Workspace,
+	tasksDir string,
+	slug string,
+) (globaldb.WorkflowArchiveEligibility, error) {
+	if _, err := SyncWithDB(ctx, db, workspace, SyncConfig{
+		WorkspaceRoot: workspace.RootDir,
+		TasksDir:      tasksDir,
+	}); err != nil {
+		return globaldb.WorkflowArchiveEligibility{}, err
+	}
+
+	updatedEligibility, err := db.GetWorkflowArchiveEligibility(ctx, workspace.ID, slug)
+	if err != nil {
+		return globaldb.WorkflowArchiveEligibility{}, err
+	}
+	return updatedEligibility, nil
 }
 
 func handleForceRequiredConflict(

--- a/internal/core/archive_test.go
+++ b/internal/core/archive_test.go
@@ -332,6 +332,101 @@ func TestArchiveTaskWorkflowHandlesReviewOnlyWorkflows(t *testing.T) {
 	}
 }
 
+func TestArchiveTaskWorkflowRefreshesStaleEmptyCatalogForReviewOnlyWorkflows(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		reviewStatus         string
+		wantErr              error
+		wantArchived         int
+		wantForceReviewTotal int
+		wantForceUnresolved  int
+	}{
+		{
+			name:         "Should archive resolved review-only workflow after stale empty sync",
+			reviewStatus: "resolved",
+			wantArchived: 1,
+		},
+		{
+			name:                 "Should require force for unresolved review-only workflow after stale empty sync",
+			reviewStatus:         "pending",
+			wantErr:              ErrWorkflowForceRequired,
+			wantForceReviewTotal: 1,
+			wantForceUnresolved:  1,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := archiveTestRoot(t)
+			workflowDir := filepath.Join(rootDir, "action-gaps")
+			if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+				t.Fatalf("mkdir workflow dir: %v", err)
+			}
+			mustSyncArchiveWorkflow(t, workflowDir)
+
+			writeArchiveReviewRound(t, workflowDir, 1, []string{tc.reviewStatus}, false)
+
+			result, err := Archive(context.Background(), ArchiveConfig{TasksDir: workflowDir})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Archive(stale review-only) error = %v, want %v", err, tc.wantErr)
+			}
+			if result == nil || result.WorkflowsScanned != 1 || result.Archived != tc.wantArchived {
+				t.Fatalf("unexpected archive result: %#v", result)
+			}
+
+			if tc.wantErr == nil {
+				if len(result.ArchivedPaths) != 1 {
+					t.Fatalf("ArchivedPaths = %#v, want one path", result.ArchivedPaths)
+				}
+				if _, statErr := os.Stat(workflowDir); !os.IsNotExist(statErr) {
+					t.Fatalf("expected review-only workflow to leave active root, got err=%v", statErr)
+				}
+				return
+			}
+
+			var forceRequired WorkflowArchiveForceRequiredError
+			if !errors.As(err, &forceRequired) {
+				t.Fatalf("Archive() error = %T, want WorkflowArchiveForceRequiredError", err)
+			}
+			if forceRequired.ReviewTotal != tc.wantForceReviewTotal ||
+				forceRequired.ReviewUnresolved != tc.wantForceUnresolved {
+				t.Fatalf("unexpected force-required details: %#v", forceRequired)
+			}
+			if errors.Is(err, globaldb.ErrWorkflowNotArchivable) {
+				t.Fatalf("Archive() error = %v, should not report stale no-task eligibility", err)
+			}
+			if _, statErr := os.Stat(workflowDir); statErr != nil {
+				t.Fatalf("expected unresolved review-only workflow dir to remain: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestArchiveTaskWorkflowKeepsTrulyEmptyWorkflowNotArchivableAfterRefresh(t *testing.T) {
+	rootDir := archiveTestRoot(t)
+	workflowDir := filepath.Join(rootDir, "action-gaps")
+	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+	mustSyncArchiveWorkflow(t, workflowDir)
+
+	result, err := Archive(context.Background(), ArchiveConfig{TasksDir: workflowDir})
+	if !errors.Is(err, globaldb.ErrWorkflowNotArchivable) {
+		t.Fatalf("Archive(empty workflow) error = %v, want ErrWorkflowNotArchivable", err)
+	}
+	var notArchivable globaldb.WorkflowNotArchivableError
+	if !errors.As(err, &notArchivable) {
+		t.Fatalf("Archive(empty workflow) error = %T, want WorkflowNotArchivableError", err)
+	}
+	if result == nil || result.WorkflowsScanned != 1 || result.Archived != 0 {
+		t.Fatalf("unexpected archive result for empty workflow: %#v", result)
+	}
+	if _, statErr := os.Stat(workflowDir); statErr != nil {
+		t.Fatalf("expected empty workflow dir to remain: %v", statErr)
+	}
+}
+
 func TestArchiveTaskWorkflowForceCompletesTasksAndResolvesReviewsBeforeArchiving(t *testing.T) {
 	rootDir := archiveTestRoot(t)
 	workflowDir := filepath.Join(rootDir, "daemon")

--- a/internal/core/archive_test.go
+++ b/internal/core/archive_test.go
@@ -404,27 +404,29 @@ func TestArchiveTaskWorkflowRefreshesStaleEmptyCatalogForReviewOnlyWorkflows(t *
 }
 
 func TestArchiveTaskWorkflowKeepsTrulyEmptyWorkflowNotArchivableAfterRefresh(t *testing.T) {
-	rootDir := archiveTestRoot(t)
-	workflowDir := filepath.Join(rootDir, "action-gaps")
-	if err := os.MkdirAll(workflowDir, 0o755); err != nil {
-		t.Fatalf("mkdir workflow dir: %v", err)
-	}
-	mustSyncArchiveWorkflow(t, workflowDir)
+	t.Run("Should keep truly empty workflow not archivable after refresh", func(t *testing.T) {
+		rootDir := archiveTestRoot(t)
+		workflowDir := filepath.Join(rootDir, "action-gaps")
+		if err := os.MkdirAll(workflowDir, 0o755); err != nil {
+			t.Fatalf("mkdir workflow dir: %v", err)
+		}
+		mustSyncArchiveWorkflow(t, workflowDir)
 
-	result, err := Archive(context.Background(), ArchiveConfig{TasksDir: workflowDir})
-	if !errors.Is(err, globaldb.ErrWorkflowNotArchivable) {
-		t.Fatalf("Archive(empty workflow) error = %v, want ErrWorkflowNotArchivable", err)
-	}
-	var notArchivable globaldb.WorkflowNotArchivableError
-	if !errors.As(err, &notArchivable) {
-		t.Fatalf("Archive(empty workflow) error = %T, want WorkflowNotArchivableError", err)
-	}
-	if result == nil || result.WorkflowsScanned != 1 || result.Archived != 0 {
-		t.Fatalf("unexpected archive result for empty workflow: %#v", result)
-	}
-	if _, statErr := os.Stat(workflowDir); statErr != nil {
-		t.Fatalf("expected empty workflow dir to remain: %v", statErr)
-	}
+		result, err := Archive(context.Background(), ArchiveConfig{TasksDir: workflowDir})
+		if !errors.Is(err, globaldb.ErrWorkflowNotArchivable) {
+			t.Fatalf("Archive(empty workflow) error = %v, want ErrWorkflowNotArchivable", err)
+		}
+		var notArchivable globaldb.WorkflowNotArchivableError
+		if !errors.As(err, &notArchivable) {
+			t.Fatalf("Archive(empty workflow) error = %T, want WorkflowNotArchivableError", err)
+		}
+		if result == nil || result.WorkflowsScanned != 1 || result.Archived != 0 {
+			t.Fatalf("unexpected archive result for empty workflow: %#v", result)
+		}
+		if _, statErr := os.Stat(workflowDir); statErr != nil {
+			t.Fatalf("expected empty workflow dir to remain: %v", statErr)
+		}
+	})
 }
 
 func TestArchiveTaskWorkflowForceCompletesTasksAndResolvesReviewsBeforeArchiving(t *testing.T) {

--- a/internal/core/fetch.go
+++ b/internal/core/fetch.go
@@ -194,7 +194,7 @@ func resolveFetchPRDDirectory(cfg *model.RuntimeConfig) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve prd dir: %w", err)
 	}
-	if err := ensureFetchPRDDirectory(resolvedPRDDir); err != nil {
+	if err := ensureFetchPRDDirectory(resolvedPRDDir, cfg.Name, cfg.PR); err != nil {
 		return "", err
 	}
 	return resolvedPRDDir, nil
@@ -219,11 +219,17 @@ func validateFetchConfig(cfg *model.RuntimeConfig) error {
 	return nil
 }
 
-func ensureFetchPRDDirectory(dir string) error {
+func ensureFetchPRDDirectory(dir string, name string, prRef string) error {
 	info, err := os.Stat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("prd directory not found: %s", dir)
+			if !reviews.IsPRDerivedTaskName(name, prRef) {
+				return fmt.Errorf("prd directory not found: %s", dir)
+			}
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("create review workflow directory: %w", err)
+			}
+			return nil
 		}
 		return fmt.Errorf("stat prd directory: %w", err)
 	}

--- a/internal/core/fetch_test.go
+++ b/internal/core/fetch_test.go
@@ -103,6 +103,71 @@ func TestFetchReviewsWritesRoundFiles(t *testing.T) {
 	}
 }
 
+func TestFetchReviewsCreatesReviewOnlyWorkflowDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	restore := defaultProviderRegistry
+	defaultProviderRegistry = func(_ string) *provider.Registry {
+		registry := provider.NewRegistry()
+		registry.Register(stubReviewProvider{
+			name: "stub",
+			items: []provider.ReviewItem{
+				{
+					Title:       "Add nil check",
+					File:        "internal/app/service.go",
+					Line:        42,
+					Author:      "review-bot",
+					ProviderRef: "thread:PRT_1,comment:RC_1",
+					Body:        "Please add a nil check here.",
+				},
+			},
+		})
+		return registry
+	}
+	t.Cleanup(func() { defaultProviderRegistry = restore })
+
+	workflowDir := filepath.Join(tmpDir, ".compozy", "tasks", "pr-51")
+	if _, err := os.Stat(workflowDir); !os.IsNotExist(err) {
+		t.Fatalf("workflow dir stat before fetch = %v, want not exist", err)
+	}
+
+	result, err := fetchReviews(context.Background(), &model.RuntimeConfig{
+		Name:     "pr-51",
+		Provider: "stub",
+		PR:       "51",
+	})
+	if err != nil {
+		t.Fatalf("fetch reviews: %v", err)
+	}
+	if result.Round != 1 {
+		t.Fatalf("expected round 1, got %d", result.Round)
+	}
+	if _, err := os.Stat(filepath.Join(workflowDir, "reviews-001", "issue_001.md")); err != nil {
+		t.Fatalf("expected review issue in review-only workflow dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workflowDir, "_techspec.md")); !os.IsNotExist(err) {
+		t.Fatalf("expected review-only workflow to avoid _techspec.md, got err=%v", err)
+	}
+}
+
+func TestFetchReviewsRequiresExistingDirectoryForExplicitWorkflowName(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	_, err := fetchReviews(context.Background(), &model.RuntimeConfig{
+		Name:     "my-featuer",
+		Provider: "stub",
+		PR:       "51",
+	})
+	if err == nil || !strings.Contains(err.Error(), "prd directory not found") {
+		t.Fatalf("fetch reviews error = %v, want missing prd directory", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmpDir, ".compozy", "tasks", "my-featuer")); !os.IsNotExist(statErr) {
+		t.Fatalf("workflow dir stat after failed fetch = %v, want not exist", statErr)
+	}
+}
+
 func TestFetchReviewsAutoIncrementsRound(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Chdir(tmpDir)

--- a/internal/core/provider/coderabbit/coderabbit.go
+++ b/internal/core/provider/coderabbit/coderabbit.go
@@ -563,7 +563,9 @@ func parseGitHubRemoteURL(raw string) (string, string, bool) {
 
 func parseGitHubRemotePath(path string) (string, string, bool) {
 	trimmed := strings.Trim(strings.TrimSpace(path), "/")
-	trimmed = strings.TrimSuffix(trimmed, ".git")
+	if strings.HasSuffix(strings.ToLower(trimmed), ".git") {
+		trimmed = trimmed[:len(trimmed)-len(".git")]
+	}
 	parts := strings.Split(trimmed, "/")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", false

--- a/internal/core/provider/coderabbit/coderabbit.go
+++ b/internal/core/provider/coderabbit/coderabbit.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"sort"
 	"strconv"
@@ -26,6 +27,8 @@ type Option func(*Provider)
 type Provider struct {
 	botLogin   string
 	run        CommandRunner
+	runGit     CommandRunner
+	runGitSet  bool
 	workingDir string
 }
 
@@ -37,6 +40,7 @@ func New(opts ...Option) *Provider {
 		botLogin: defaultBotLogin,
 	}
 	p.run = p.runGH
+	p.runGit = p.runGitCommand
 	for _, opt := range opts {
 		if opt != nil {
 			opt(p)
@@ -49,6 +53,15 @@ func WithCommandRunner(run CommandRunner) Option {
 	return func(p *Provider) {
 		if run != nil {
 			p.run = run
+		}
+	}
+}
+
+func WithGitCommandRunner(run CommandRunner) Option {
+	return func(p *Provider) {
+		if run != nil {
+			p.runGit = run
+			p.runGitSet = true
 		}
 	}
 }
@@ -477,9 +490,40 @@ func (p *Provider) ResolveIssues(ctx context.Context, _ string, issues []provide
 }
 
 func (p *Provider) getRepo(ctx context.Context) (string, string, error) {
+	gitOwner, gitRepo, gitErr := p.getRepoFromGitRemote(ctx)
+	if gitErr == nil {
+		return gitOwner, gitRepo, nil
+	}
+
+	ghOwner, ghRepo, ghErr := p.getRepoFromGH(ctx)
+	if ghErr == nil {
+		return ghOwner, ghRepo, nil
+	}
+	return "", "", fmt.Errorf("resolve repository metadata: git remote: %w; gh repo view: %w", gitErr, ghErr)
+}
+
+func (p *Provider) getRepoFromGitRemote(ctx context.Context) (string, string, error) {
+	if p == nil || p.runGit == nil {
+		return "", "", errors.New("git command runner is not configured")
+	}
+	if !p.runGitSet && strings.TrimSpace(p.workingDir) == "" {
+		return "", "", errors.New("git working directory is not configured")
+	}
+	output, err := p.runGit(ctx, "remote", "get-url", "origin")
+	if err != nil {
+		return "", "", err
+	}
+	owner, repo, ok := parseGitHubRemoteURL(string(output))
+	if !ok {
+		return "", "", fmt.Errorf("origin remote is not a GitHub repository: %q", strings.TrimSpace(string(output)))
+	}
+	return owner, repo, nil
+}
+
+func (p *Provider) getRepoFromGH(ctx context.Context) (string, string, error) {
 	output, err := p.run(ctx, "repo", "view", "--json", "owner,name")
 	if err != nil {
-		return "", "", fmt.Errorf("resolve repository metadata: %w", err)
+		return "", "", err
 	}
 
 	var payload struct {
@@ -495,6 +539,36 @@ func (p *Provider) getRepo(ctx context.Context) (string, string, error) {
 		return "", "", errors.New("repository metadata response is incomplete")
 	}
 	return payload.Owner.Login, payload.Name, nil
+}
+
+func parseGitHubRemoteURL(raw string) (string, string, bool) {
+	remote := strings.TrimSpace(raw)
+	if remote == "" {
+		return "", "", false
+	}
+	if strings.HasPrefix(remote, "git@github.com:") {
+		return parseGitHubRemotePath(strings.TrimPrefix(remote, "git@github.com:"))
+	}
+
+	parsed, err := url.Parse(remote)
+	if err != nil || parsed.Host == "" {
+		return "", "", false
+	}
+	host := strings.TrimPrefix(strings.ToLower(parsed.Hostname()), "www.")
+	if host != "github.com" {
+		return "", "", false
+	}
+	return parseGitHubRemotePath(parsed.Path)
+}
+
+func parseGitHubRemotePath(path string) (string, string, bool) {
+	trimmed := strings.Trim(strings.TrimSpace(path), "/")
+	trimmed = strings.TrimSuffix(trimmed, ".git")
+	parts := strings.Split(trimmed, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
 }
 
 func (p *Provider) fetchReviewComments(
@@ -669,6 +743,27 @@ func (p *Provider) runGH(ctx context.Context, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("gh %s: %w", strings.Join(args, " "), err)
 	}
 	return nil, fmt.Errorf("gh %s: %s", strings.Join(args, " "), trimmed)
+}
+
+func (p *Provider) runGitCommand(ctx context.Context, args ...string) ([]byte, error) {
+	cmdArgs := make([]string, 0, len(args)+2)
+	if p != nil {
+		if workingDir := strings.TrimSpace(p.workingDir); workingDir != "" {
+			cmdArgs = append(cmdArgs, "-C", workingDir)
+		}
+	}
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return output, nil
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil, fmt.Errorf("git %s: %w", strings.Join(cmdArgs, " "), err)
+	}
+	return nil, fmt.Errorf("git %s: %s", strings.Join(cmdArgs, " "), trimmed)
 }
 
 type pullRequestComment struct {

--- a/internal/core/provider/coderabbit/coderabbit_test.go
+++ b/internal/core/provider/coderabbit/coderabbit_test.go
@@ -10,6 +10,91 @@ import (
 	"github.com/compozy/compozy/internal/core/provider"
 )
 
+func TestGetRepoPrefersLocalGitRemote(t *testing.T) {
+	t.Parallel()
+
+	ghCalled := false
+	runGH := func(context.Context, ...string) ([]byte, error) {
+		ghCalled = true
+		return nil, errors.New("gh should not be called when origin is usable")
+	}
+	runGit := func(_ context.Context, args ...string) ([]byte, error) {
+		if strings.Join(args, " ") != "remote get-url origin" {
+			return nil, errors.New("unexpected git invocation: " + strings.Join(args, " "))
+		}
+		return []byte("git@github.com:acme/compozy.git\n"), nil
+	}
+
+	owner, repo, err := New(WithCommandRunner(runGH), WithGitCommandRunner(runGit)).getRepo(context.Background())
+	if err != nil {
+		t.Fatalf("getRepo() error = %v", err)
+	}
+	if owner != "acme" || repo != "compozy" {
+		t.Fatalf("getRepo() = %s/%s, want acme/compozy", owner, repo)
+	}
+	if ghCalled {
+		t.Fatal("gh repo view was called despite a usable local origin remote")
+	}
+}
+
+func TestGetRepoFallsBackToGHWhenGitRemoteIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	runGit := func(context.Context, ...string) ([]byte, error) {
+		return nil, errors.New("origin not configured")
+	}
+	runGH := func(_ context.Context, args ...string) ([]byte, error) {
+		if strings.Join(args, " ") != "repo view --json owner,name" {
+			return nil, errors.New("unexpected gh invocation: " + strings.Join(args, " "))
+		}
+		return []byte("{\"owner\":{\"login\":\"acme\"},\"name\":\"compozy\"}"), nil
+	}
+
+	owner, repo, err := New(WithCommandRunner(runGH), WithGitCommandRunner(runGit)).getRepo(context.Background())
+	if err != nil {
+		t.Fatalf("getRepo() error = %v", err)
+	}
+	if owner != "acme" || repo != "compozy" {
+		t.Fatalf("getRepo() = %s/%s, want acme/compozy", owner, repo)
+	}
+}
+
+func TestParseGitHubRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		remote string
+		owner  string
+		repo   string
+		ok     bool
+	}{
+		{remote: "git@github.com:acme/compozy.git", owner: "acme", repo: "compozy", ok: true},
+		{remote: "https://github.com/acme/compozy.git", owner: "acme", repo: "compozy", ok: true},
+		{remote: "ssh://git@github.com:22/acme/compozy.git", owner: "acme", repo: "compozy", ok: true},
+		{remote: "https://gitlab.com/acme/compozy.git", ok: false},
+		{remote: "not-a-remote", ok: false},
+	} {
+		tc := tc
+		t.Run(tc.remote, func(t *testing.T) {
+			t.Parallel()
+
+			owner, repo, ok := parseGitHubRemoteURL(tc.remote)
+			if ok != tc.ok || owner != tc.owner || repo != tc.repo {
+				t.Fatalf(
+					"parseGitHubRemoteURL(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.remote,
+					owner,
+					repo,
+					ok,
+					tc.owner,
+					tc.repo,
+					tc.ok,
+				)
+			}
+		})
+	}
+}
+
 func TestFetchReviewsFiltersResolvedThreadsAndNonBotComments(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/provider/coderabbit/coderabbit_test.go
+++ b/internal/core/provider/coderabbit/coderabbit_test.go
@@ -13,69 +13,103 @@ import (
 func TestGetRepoPrefersLocalGitRemote(t *testing.T) {
 	t.Parallel()
 
-	ghCalled := false
-	runGH := func(context.Context, ...string) ([]byte, error) {
-		ghCalled = true
-		return nil, errors.New("gh should not be called when origin is usable")
-	}
-	runGit := func(_ context.Context, args ...string) ([]byte, error) {
-		if strings.Join(args, " ") != "remote get-url origin" {
-			return nil, errors.New("unexpected git invocation: " + strings.Join(args, " "))
-		}
-		return []byte("git@github.com:acme/compozy.git\n"), nil
-	}
+	t.Run("Should prefer local git remote", func(t *testing.T) {
+		t.Parallel()
 
-	owner, repo, err := New(WithCommandRunner(runGH), WithGitCommandRunner(runGit)).getRepo(context.Background())
-	if err != nil {
-		t.Fatalf("getRepo() error = %v", err)
-	}
-	if owner != "acme" || repo != "compozy" {
-		t.Fatalf("getRepo() = %s/%s, want acme/compozy", owner, repo)
-	}
-	if ghCalled {
-		t.Fatal("gh repo view was called despite a usable local origin remote")
-	}
+		ghCalled := false
+		runGH := func(context.Context, ...string) ([]byte, error) {
+			ghCalled = true
+			return nil, errors.New("gh should not be called when origin is usable")
+		}
+		runGit := func(_ context.Context, args ...string) ([]byte, error) {
+			if strings.Join(args, " ") != "remote get-url origin" {
+				return nil, errors.New("unexpected git invocation: " + strings.Join(args, " "))
+			}
+			return []byte("git@github.com:acme/compozy.git\n"), nil
+		}
+
+		owner, repo, err := New(WithCommandRunner(runGH), WithGitCommandRunner(runGit)).getRepo(context.Background())
+		if err != nil {
+			t.Fatalf("getRepo() error = %v", err)
+		}
+		if owner != "acme" || repo != "compozy" {
+			t.Fatalf("getRepo() = %s/%s, want acme/compozy", owner, repo)
+		}
+		if ghCalled {
+			t.Fatal("gh repo view was called despite a usable local origin remote")
+		}
+	})
 }
 
 func TestGetRepoFallsBackToGHWhenGitRemoteIsUnavailable(t *testing.T) {
 	t.Parallel()
 
-	runGit := func(context.Context, ...string) ([]byte, error) {
-		return nil, errors.New("origin not configured")
-	}
-	runGH := func(_ context.Context, args ...string) ([]byte, error) {
-		if strings.Join(args, " ") != "repo view --json owner,name" {
-			return nil, errors.New("unexpected gh invocation: " + strings.Join(args, " "))
-		}
-		return []byte("{\"owner\":{\"login\":\"acme\"},\"name\":\"compozy\"}"), nil
-	}
+	t.Run("Should fall back to gh when git remote is unavailable", func(t *testing.T) {
+		t.Parallel()
 
-	owner, repo, err := New(WithCommandRunner(runGH), WithGitCommandRunner(runGit)).getRepo(context.Background())
-	if err != nil {
-		t.Fatalf("getRepo() error = %v", err)
-	}
-	if owner != "acme" || repo != "compozy" {
-		t.Fatalf("getRepo() = %s/%s, want acme/compozy", owner, repo)
-	}
+		runGit := func(context.Context, ...string) ([]byte, error) {
+			return nil, errors.New("origin not configured")
+		}
+		runGH := func(_ context.Context, args ...string) ([]byte, error) {
+			if strings.Join(args, " ") != "repo view --json owner,name" {
+				return nil, errors.New("unexpected gh invocation: " + strings.Join(args, " "))
+			}
+			return []byte("{\"owner\":{\"login\":\"acme\"},\"name\":\"compozy\"}"), nil
+		}
+
+		owner, repo, err := New(WithCommandRunner(runGH), WithGitCommandRunner(runGit)).getRepo(context.Background())
+		if err != nil {
+			t.Fatalf("getRepo() error = %v", err)
+		}
+		if owner != "acme" || repo != "compozy" {
+			t.Fatalf("getRepo() = %s/%s, want acme/compozy", owner, repo)
+		}
+	})
 }
 
 func TestParseGitHubRemoteURL(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
+		name   string
 		remote string
 		owner  string
 		repo   string
 		ok     bool
 	}{
-		{remote: "git@github.com:acme/compozy.git", owner: "acme", repo: "compozy", ok: true},
-		{remote: "https://github.com/acme/compozy.git", owner: "acme", repo: "compozy", ok: true},
-		{remote: "ssh://git@github.com:22/acme/compozy.git", owner: "acme", repo: "compozy", ok: true},
-		{remote: "https://gitlab.com/acme/compozy.git", ok: false},
-		{remote: "not-a-remote", ok: false},
+		{
+			name:   "Should parse scp-style GitHub remotes",
+			remote: "git@github.com:acme/compozy.git",
+			owner:  "acme",
+			repo:   "compozy",
+			ok:     true,
+		},
+		{
+			name:   "Should parse HTTPS GitHub remotes",
+			remote: "https://github.com/acme/compozy.git",
+			owner:  "acme",
+			repo:   "compozy",
+			ok:     true,
+		},
+		{
+			name:   "Should parse SSH GitHub remotes",
+			remote: "ssh://git@github.com:22/acme/compozy.git",
+			owner:  "acme",
+			repo:   "compozy",
+			ok:     true,
+		},
+		{
+			name:   "Should strip mixed-case git suffixes without changing repo casing",
+			remote: "https://github.com/Acme/Compozy.GIT",
+			owner:  "Acme",
+			repo:   "Compozy",
+			ok:     true,
+		},
+		{name: "Should reject non-GitHub hosts", remote: "https://gitlab.com/acme/compozy.git", ok: false},
+		{name: "Should reject malformed remotes", remote: "not-a-remote", ok: false},
 	} {
 		tc := tc
-		t.Run(tc.remote, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			owner, repo, ok := parseGitHubRemoteURL(tc.remote)
@@ -192,7 +226,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 		wantCommit string
 	}{
 		{
-			name:    "pending when latest provider review has not been submitted",
+			name:    "Should stay pending when latest provider review has not been submitted",
 			headSHA: "head-new",
 			reviews: []pullRequestReview{
 				testPullRequestReview(4100, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
@@ -202,7 +236,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 			wantCommit: "old-head",
 		},
 		{
-			name:    "stale when latest submitted provider review is for an older head",
+			name:    "Should report stale when latest submitted provider review is for an older head",
 			headSHA: "head-new",
 			reviews: []pullRequestReview{
 				testPullRequestReview(4101, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
@@ -211,7 +245,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 			wantCommit: "old-head",
 		},
 		{
-			name:    "current reviewed when latest submitted provider review matches head and status completed",
+			name:    "Should report current reviewed when latest submitted provider review matches head",
 			headSHA: "head-current",
 			reviews: []pullRequestReview{
 				testPullRequestReview(4101, "old-head", "COMMENTED", "2026-04-10T13:33:25Z", defaultBotLogin, ""),
@@ -222,7 +256,7 @@ func TestWatchStatusClassifiesCodeRabbitReviewState(t *testing.T) {
 			wantCommit: "head-current",
 		},
 		{
-			name:    "pending when no provider review exists",
+			name:    "Should stay pending when no provider review exists",
 			headSHA: "head-without-review",
 			reviews: []pullRequestReview{
 				testPullRequestReview(4103, "head-without-review", "COMMENTED", "2026-04-10T14:33:25Z", "pedro", ""),

--- a/internal/core/provider/coderabbit/nitpicks.go
+++ b/internal/core/provider/coderabbit/nitpicks.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	reviewBodyCommentSeverityNitpick = "nitpick"
-	reviewBodyCommentSeverityMinor   = "minor"
-	reviewBodyCommentSeverityMajor   = "major"
-	reviewBodyCommentHashLength      = 12
+	reviewBodyCommentSeverityNitpick  = "nitpick"
+	reviewBodyCommentSeverityMinor    = "minor"
+	reviewBodyCommentSeverityMajor    = "major"
+	reviewBodyCommentSeverityCritical = "critical"
+	reviewBodyCommentHashLength       = 12
 )
 
 var (
@@ -108,7 +109,8 @@ func parseReviewBodyCommentItems(reviews []pullRequestReview, botLogin string) [
 }
 
 func parseReviewBodyComments(review pullRequestReview) []provider.ReviewItem {
-	topLevelBlocks := extractTopLevelDetailsBlocks(review.Body)
+	body := stripMarkdownQuotePrefixes(review.Body)
+	topLevelBlocks := extractTopLevelDetailsBlocks(body)
 	if len(topLevelBlocks) == 0 {
 		return nil
 	}
@@ -116,7 +118,7 @@ func parseReviewBodyComments(review pullRequestReview) []provider.ReviewItem {
 	items := make([]provider.ReviewItem, 0, len(topLevelBlocks))
 	for _, block := range topLevelBlocks {
 		severity, ok := reviewBodyCommentSeverity(block.summary)
-		if !ok {
+		if !ok && !reviewBodyCommentOutsideDiffRange(block.summary) {
 			continue
 		}
 
@@ -147,9 +149,17 @@ func reviewBodyCommentSeverity(summary string) (string, bool) {
 		return reviewBodyCommentSeverityMinor, true
 	case strings.Contains(normalized, "major comments"), strings.Contains(normalized, "major comment"):
 		return reviewBodyCommentSeverityMajor, true
+	case strings.Contains(normalized, "critical comments"), strings.Contains(normalized, "critical comment"):
+		return reviewBodyCommentSeverityCritical, true
 	default:
 		return "", false
 	}
+}
+
+func reviewBodyCommentOutsideDiffRange(summary string) bool {
+	normalized := strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(summary)), " "))
+	return strings.Contains(normalized, "outside diff range comments") ||
+		strings.Contains(normalized, "outside diff comments")
 }
 
 func parseReviewBodyCommentsForFile(
@@ -174,7 +184,12 @@ func parseReviewBodyCommentsForFile(
 			bodyEnd = matches[idx+1][0]
 		}
 
-		title, commentBody := parseReviewBodyCommentSection(trimmed[sectionStart:bodyEnd])
+		section := trimmed[sectionStart:bodyEnd]
+		sectionSeverity := severity
+		if parsedSeverity, ok := reviewBodyCommentSectionSeverity(section); ok {
+			sectionSeverity = parsedSeverity
+		}
+		title, commentBody := parseReviewBodyCommentSection(section)
 		if title == "" {
 			continue
 		}
@@ -185,7 +200,7 @@ func parseReviewBodyCommentsForFile(
 			Title:                   title,
 			File:                    normalizedFilePath,
 			Line:                    parseReviewBodyCommentLine(lineRange),
-			Severity:                severity,
+			Severity:                sectionSeverity,
 			Author:                  review.User.Login,
 			Body:                    commentBody,
 			ProviderRef:             buildReviewBodyCommentProviderRef(reviewID, reviewHash),
@@ -196,6 +211,56 @@ func parseReviewBodyCommentsForFile(
 	}
 
 	return items
+}
+
+func reviewBodyCommentSectionSeverity(section string) (string, bool) {
+	lines := strings.Split(strings.TrimSpace(section), "\n")
+	if len(lines) == 0 {
+		return "", false
+	}
+
+	if severity, ok := reviewBodyCommentMetadataSeverity(lines[0]); ok {
+		return severity, true
+	}
+	if parseInlineReviewBodyCommentTitle(lines[0]) != "" {
+		return "", false
+	}
+	for idx := 1; idx < len(lines); idx++ {
+		line := strings.TrimSpace(lines[idx])
+		if line == "" {
+			continue
+		}
+		if parseInlineReviewBodyCommentTitle(line) != "" || parseStandaloneReviewBodyCommentTitle(line) != "" {
+			return "", false
+		}
+		return reviewBodyCommentMetadataSeverity(line)
+	}
+	return "", false
+}
+
+func reviewBodyCommentMetadataSeverity(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.Contains(trimmed, "**") {
+		return "", false
+	}
+
+	normalized := strings.ToLower(strings.Join(strings.Fields(strings.NewReplacer(
+		"`", " ",
+		"_", " ",
+		"|", " ",
+	).Replace(trimmed)), " "))
+	switch {
+	case strings.Contains(normalized, "nitpick"):
+		return reviewBodyCommentSeverityNitpick, true
+	case strings.Contains(normalized, "minor"):
+		return reviewBodyCommentSeverityMinor, true
+	case strings.Contains(normalized, "major"):
+		return reviewBodyCommentSeverityMajor, true
+	case strings.Contains(normalized, "critical"):
+		return reviewBodyCommentSeverityCritical, true
+	default:
+		return "", false
+	}
 }
 
 func parseReviewBodyCommentSection(section string) (string, string) {
@@ -359,6 +424,23 @@ func stripTopLevelDetailsBlocks(text string) string {
 		builder.WriteString(text[cursor:])
 	}
 	return strings.TrimSpace(builder.String())
+}
+
+func stripMarkdownQuotePrefixes(text string) string {
+	lines := strings.Split(text, "\n")
+	for idx, line := range lines {
+		lines[idx] = stripMarkdownQuotePrefix(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func stripMarkdownQuotePrefix(line string) string {
+	trimmed := strings.TrimLeft(line, " \t")
+	for strings.HasPrefix(trimmed, ">") {
+		trimmed = strings.TrimPrefix(trimmed, ">")
+		trimmed = strings.TrimPrefix(trimmed, " ")
+	}
+	return trimmed
 }
 
 func trimEnclosingTag(text string, tag string) string {

--- a/internal/core/provider/coderabbit/nitpicks_test.go
+++ b/internal/core/provider/coderabbit/nitpicks_test.go
@@ -250,13 +250,24 @@ func TestParseReviewBodyCommentItemsParsesRealCodeRabbitMinorAndMajorMarkup(t *t
 	}
 
 	items := parseReviewBodyCommentItems(reviews, defaultBotLogin)
-	if len(items) != 2 {
-		t.Fatalf("expected 2 parsed review body comment items, got %d (%#v)", len(items), items)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 parsed review body comment items, got %d (%#v)", len(items), items)
 	}
 
 	itemByTitle := make(map[string]provider.ReviewItem, len(items))
 	for _, item := range items {
 		itemByTitle[item.Title] = item
+	}
+
+	outsideItem, ok := itemByTitle["Wrap all post-mutation assertions in waitFor() to prevent flaky tests."]
+	if !ok {
+		t.Fatalf("expected outside-diff item, got %#v", itemByTitle)
+	}
+	if outsideItem.File != "web/src/routes/_app/-automation.integration.test.tsx" {
+		t.Fatalf("unexpected outside-diff file path: %#v", outsideItem)
+	}
+	if outsideItem.Line != 314 || outsideItem.Severity != reviewBodyCommentSeverityMinor {
+		t.Fatalf("unexpected outside-diff metadata: %#v", outsideItem)
 	}
 
 	minorItem, ok := itemByTitle["Use path alias import for MessageMarkdown."]
@@ -285,6 +296,62 @@ func TestParseReviewBodyCommentItemsParsesRealCodeRabbitMinorAndMajorMarkup(t *t
 	}
 	if strings.Contains(majorItem.Body, "Potential issue") || strings.Contains(majorItem.Body, "Suggested change") {
 		t.Fatalf("expected major body to exclude metadata and nested details, got %q", majorItem.Body)
+	}
+}
+
+func TestParseReviewBodyCommentItemsParsesQuotedOutsideDiffRangeComments(t *testing.T) {
+	t.Parallel()
+
+	reviewBody := strings.Join([]string{
+		"> <details>",
+		"> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>",
+		">",
+		"> <details>",
+		"> <summary>web/src/routes/_app/-automation.integration.test.tsx (1)</summary><blockquote>",
+		">",
+		"> `314-342`: _⚠️ Potential issue_ | _🟡 Minor_",
+		">",
+		"> **Wrap all post-mutation assertions in `waitFor()` to prevent flaky tests.**",
+		">",
+		"> Both `handleSubmitJob` and `handleTriggerNow` properly await `mutateAsync()` before calling side effects.",
+		">",
+		"> <details>",
+		"> <summary>🤖 Prompt for AI Agents</summary>",
+		"> ignored prompt details",
+		"> </details>",
+		">",
+		"> </blockquote></details>",
+		">",
+		"> </blockquote></details>",
+	}, "\n")
+	reviews := []pullRequestReview{
+		testPullRequestReview(
+			4473236147,
+			"1cfc78b23d61",
+			"CHANGES_REQUESTED",
+			"2026-06-11T02:35:19Z",
+			defaultBotLogin,
+			reviewBody,
+		),
+	}
+
+	items := parseReviewBodyCommentItems(reviews, defaultBotLogin)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 outside-diff review body comment item, got %d (%#v)", len(items), items)
+	}
+
+	item := items[0]
+	if item.Title != "Wrap all post-mutation assertions in waitFor() to prevent flaky tests." {
+		t.Fatalf("unexpected outside-diff title: %#v", item)
+	}
+	if item.File != "web/src/routes/_app/-automation.integration.test.tsx" {
+		t.Fatalf("unexpected outside-diff file path: %#v", item)
+	}
+	if item.Line != 314 || item.Severity != reviewBodyCommentSeverityMinor {
+		t.Fatalf("unexpected outside-diff metadata: %#v", item)
+	}
+	if strings.Contains(item.Body, "Potential issue") || strings.Contains(item.Body, "Prompt for AI Agents") {
+		t.Fatalf("expected outside-diff body to exclude metadata and nested details, got %q", item.Body)
 	}
 }
 

--- a/internal/core/provider/coderabbit/nitpicks_test.go
+++ b/internal/core/provider/coderabbit/nitpicks_test.go
@@ -241,6 +241,17 @@ func TestParseReviewBodyCommentItemsParsesRealCodeRabbitMinorAndMajorMarkup(t *t
 						"A non-nil `PeerCard.DisplayName` containing only whitespace now produces an empty `DisplayName` instead of falling back to `peer.PeerID`.",
 					),
 				),
+				"",
+				testReviewBodyCommentBlockWithRawSections(
+					"Critical comments",
+					testReviewBodyCommentFileSectionWithMetadata(
+						"internal/core/scheduler.go-44-46",
+						"44-46",
+						"_⚠️ Potential issue_ | _🔴 Critical_",
+						"Stop launching duplicate workers.",
+						"Starting a new worker for an existing job can process the same task twice.",
+					),
+				),
 			}, "\n"),
 			SubmittedAt: "2026-04-10T14:24:56Z",
 			User: struct {
@@ -250,8 +261,8 @@ func TestParseReviewBodyCommentItemsParsesRealCodeRabbitMinorAndMajorMarkup(t *t
 	}
 
 	items := parseReviewBodyCommentItems(reviews, defaultBotLogin)
-	if len(items) != 3 {
-		t.Fatalf("expected 3 parsed review body comment items, got %d (%#v)", len(items), items)
+	if len(items) != 4 {
+		t.Fatalf("expected 4 parsed review body comment items, got %d (%#v)", len(items), items)
 	}
 
 	itemByTitle := make(map[string]provider.ReviewItem, len(items))
@@ -297,62 +308,77 @@ func TestParseReviewBodyCommentItemsParsesRealCodeRabbitMinorAndMajorMarkup(t *t
 	if strings.Contains(majorItem.Body, "Potential issue") || strings.Contains(majorItem.Body, "Suggested change") {
 		t.Fatalf("expected major body to exclude metadata and nested details, got %q", majorItem.Body)
 	}
+
+	criticalItem, ok := itemByTitle["Stop launching duplicate workers."]
+	if !ok {
+		t.Fatalf("expected critical item, got %#v", itemByTitle)
+	}
+	if criticalItem.File != "internal/core/scheduler.go" {
+		t.Fatalf("unexpected critical file path: %#v", criticalItem)
+	}
+	if criticalItem.Line != 44 || criticalItem.Severity != reviewBodyCommentSeverityCritical {
+		t.Fatalf("unexpected critical metadata: %#v", criticalItem)
+	}
 }
 
 func TestParseReviewBodyCommentItemsParsesQuotedOutsideDiffRangeComments(t *testing.T) {
 	t.Parallel()
 
-	reviewBody := strings.Join([]string{
-		"> <details>",
-		"> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>",
-		">",
-		"> <details>",
-		"> <summary>web/src/routes/_app/-automation.integration.test.tsx (1)</summary><blockquote>",
-		">",
-		"> `314-342`: _⚠️ Potential issue_ | _🟡 Minor_",
-		">",
-		"> **Wrap all post-mutation assertions in `waitFor()` to prevent flaky tests.**",
-		">",
-		"> Both `handleSubmitJob` and `handleTriggerNow` properly await `mutateAsync()` before calling side effects.",
-		">",
-		"> <details>",
-		"> <summary>🤖 Prompt for AI Agents</summary>",
-		"> ignored prompt details",
-		"> </details>",
-		">",
-		"> </blockquote></details>",
-		">",
-		"> </blockquote></details>",
-	}, "\n")
-	reviews := []pullRequestReview{
-		testPullRequestReview(
-			4473236147,
-			"1cfc78b23d61",
-			"CHANGES_REQUESTED",
-			"2026-06-11T02:35:19Z",
-			defaultBotLogin,
-			reviewBody,
-		),
-	}
+	t.Run("Should parse quoted outside-diff-range comments", func(t *testing.T) {
+		t.Parallel()
 
-	items := parseReviewBodyCommentItems(reviews, defaultBotLogin)
-	if len(items) != 1 {
-		t.Fatalf("expected 1 outside-diff review body comment item, got %d (%#v)", len(items), items)
-	}
+		reviewBody := strings.Join([]string{
+			"> <details>",
+			"> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>",
+			">",
+			"> <details>",
+			"> <summary>web/src/routes/_app/-automation.integration.test.tsx (1)</summary><blockquote>",
+			">",
+			"> `314-342`: _⚠️ Potential issue_ | _🟡 Minor_",
+			">",
+			"> **Wrap all post-mutation assertions in `waitFor()` to prevent flaky tests.**",
+			">",
+			"> Both `handleSubmitJob` and `handleTriggerNow` properly await `mutateAsync()` before calling side effects.",
+			">",
+			"> <details>",
+			"> <summary>🤖 Prompt for AI Agents</summary>",
+			"> ignored prompt details",
+			"> </details>",
+			">",
+			"> </blockquote></details>",
+			">",
+			"> </blockquote></details>",
+		}, "\n")
+		reviews := []pullRequestReview{
+			testPullRequestReview(
+				4473236147,
+				"1cfc78b23d61",
+				"CHANGES_REQUESTED",
+				"2026-06-11T02:35:19Z",
+				defaultBotLogin,
+				reviewBody,
+			),
+		}
 
-	item := items[0]
-	if item.Title != "Wrap all post-mutation assertions in waitFor() to prevent flaky tests." {
-		t.Fatalf("unexpected outside-diff title: %#v", item)
-	}
-	if item.File != "web/src/routes/_app/-automation.integration.test.tsx" {
-		t.Fatalf("unexpected outside-diff file path: %#v", item)
-	}
-	if item.Line != 314 || item.Severity != reviewBodyCommentSeverityMinor {
-		t.Fatalf("unexpected outside-diff metadata: %#v", item)
-	}
-	if strings.Contains(item.Body, "Potential issue") || strings.Contains(item.Body, "Prompt for AI Agents") {
-		t.Fatalf("expected outside-diff body to exclude metadata and nested details, got %q", item.Body)
-	}
+		items := parseReviewBodyCommentItems(reviews, defaultBotLogin)
+		if len(items) != 1 {
+			t.Fatalf("expected 1 outside-diff review body comment item, got %d (%#v)", len(items), items)
+		}
+
+		item := items[0]
+		if item.Title != "Wrap all post-mutation assertions in waitFor() to prevent flaky tests." {
+			t.Fatalf("unexpected outside-diff title: %#v", item)
+		}
+		if item.File != "web/src/routes/_app/-automation.integration.test.tsx" {
+			t.Fatalf("unexpected outside-diff file path: %#v", item)
+		}
+		if item.Line != 314 || item.Severity != reviewBodyCommentSeverityMinor {
+			t.Fatalf("unexpected outside-diff metadata: %#v", item)
+		}
+		if strings.Contains(item.Body, "Potential issue") || strings.Contains(item.Body, "Prompt for AI Agents") {
+			t.Fatalf("expected outside-diff body to exclude metadata and nested details, got %q", item.Body)
+		}
+	})
 }
 
 func TestFetchReviewsSkipsPullRequestReviewsWhenReviewBodyCommentsAreDisabled(t *testing.T) {

--- a/internal/core/reviews/store.go
+++ b/internal/core/reviews/store.go
@@ -33,6 +33,19 @@ func TaskDirectoryForWorkspace(workspaceRoot, name string) string {
 	return model.TaskDirectoryForWorkspace(workspaceRoot, name)
 }
 
+func IsPRDerivedTaskName(name, prRef string) bool {
+	name = strings.TrimSpace(name)
+	prRef = strings.TrimSpace(prRef)
+	if name == "" || prRef == "" || !strings.HasPrefix(name, "pr-") {
+		return false
+	}
+	if strings.TrimPrefix(name, "pr-") != prRef {
+		return false
+	}
+	_, err := strconv.Atoi(prRef)
+	return err == nil
+}
+
 func RoundDirName(round int) string {
 	return fmt.Sprintf("%s%03d", reviewsPrefix, round)
 }

--- a/internal/core/reviews/store.go
+++ b/internal/core/reviews/store.go
@@ -23,7 +23,10 @@ const (
 
 var ErrNoReviewRounds = errors.New("no review rounds found")
 
-var errReviewRoundMetadataUnavailable = errors.New("review round metadata unavailable from issue front matter")
+var (
+	errReviewRoundMetadataUnavailable = errors.New("review round metadata unavailable from issue front matter")
+	prRefRe                           = regexp.MustCompile(`^[1-9][0-9]*$`)
+)
 
 func TaskDirectory(name string) string {
 	return TaskDirectoryForWorkspace("", name)
@@ -42,8 +45,7 @@ func IsPRDerivedTaskName(name, prRef string) bool {
 	if strings.TrimPrefix(name, "pr-") != prRef {
 		return false
 	}
-	_, err := strconv.Atoi(prRef)
-	return err == nil
+	return prRefRe.MatchString(prRef)
 }
 
 func RoundDirName(round int) string {

--- a/internal/core/reviews/store_test.go
+++ b/internal/core/reviews/store_test.go
@@ -18,21 +18,25 @@ func TestIsPRDerivedTaskName(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		name string
-		pr   string
-		want bool
+		caseName string
+		name     string
+		pr       string
+		want     bool
 	}{
-		{name: "pr-51", pr: "51", want: true},
-		{name: " pr-51 ", pr: " 51 ", want: true},
-		{name: "pr-051", pr: "051", want: true},
-		{name: "pr-51", pr: "52", want: false},
-		{name: "demo", pr: "51", want: false},
-		{name: "pr-main", pr: "main", want: false},
-		{name: "pr-", pr: "", want: false},
+		{caseName: "Should accept canonical PR-derived task names", name: "pr-51", pr: "51", want: true},
+		{caseName: "Should trim surrounding whitespace", name: " pr-51 ", pr: " 51 ", want: true},
+		{caseName: "Should reject PR refs with leading zeroes", name: "pr-051", pr: "051", want: false},
+		{caseName: "Should reject mismatched PR refs", name: "pr-51", pr: "52", want: false},
+		{caseName: "Should reject names without PR prefix", name: "demo", pr: "51", want: false},
+		{caseName: "Should reject non-numeric PR refs", name: "pr-main", pr: "main", want: false},
+		{caseName: "Should reject empty PR refs", name: "pr-", pr: "", want: false},
+		{caseName: "Should reject signed positive PR refs", name: "pr-+1", pr: "+1", want: false},
+		{caseName: "Should reject signed negative PR refs", name: "pr--1", pr: "-1", want: false},
+		{caseName: "Should reject zero PR refs", name: "pr-0", pr: "0", want: false},
 	}
 	for _, tc := range cases {
 		tc := tc
-		t.Run(tc.name+"/"+tc.pr, func(t *testing.T) {
+		t.Run(tc.caseName, func(t *testing.T) {
 			t.Parallel()
 
 			if got := IsPRDerivedTaskName(tc.name, tc.pr); got != tc.want {

--- a/internal/core/reviews/store_test.go
+++ b/internal/core/reviews/store_test.go
@@ -14,6 +14,34 @@ import (
 	"github.com/compozy/compozy/internal/core/provider"
 )
 
+func TestIsPRDerivedTaskName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		pr   string
+		want bool
+	}{
+		{name: "pr-51", pr: "51", want: true},
+		{name: " pr-51 ", pr: " 51 ", want: true},
+		{name: "pr-051", pr: "051", want: true},
+		{name: "pr-51", pr: "52", want: false},
+		{name: "demo", pr: "51", want: false},
+		{name: "pr-main", pr: "main", want: false},
+		{name: "pr-", pr: "", want: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name+"/"+tc.pr, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IsPRDerivedTaskName(tc.name, tc.pr); got != tc.want {
+				t.Fatalf("IsPRDerivedTaskName(%q, %q) = %t, want %t", tc.name, tc.pr, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReadLegacyRoundMetaAllowsOptionalPR(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/run/ui/review_watch_remote.go
+++ b/internal/core/run/ui/review_watch_remote.go
@@ -1,0 +1,1229 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image/color"
+	"strings"
+	"sync"
+	"time"
+
+	apiclient "github.com/compozy/compozy/internal/api/client"
+	apicore "github.com/compozy/compozy/internal/api/core"
+	"github.com/compozy/compozy/pkg/compozy/events"
+	"github.com/compozy/compozy/pkg/compozy/events/kinds"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+const (
+	reviewWatchTabsHeight = 2
+	reviewWatchMaxLines   = 200
+
+	reviewWatchStatusWatching = "watching"
+	reviewWatchStatusWaiting  = "waiting"
+	reviewWatchStatusFixing   = "fixing"
+	reviewWatchStatusPushing  = "pushing"
+	reviewWatchStatusClean    = "clean"
+	reviewWatchStatusDone     = "done"
+	reviewWatchStatusFailed   = "failed"
+	reviewWatchStatusCanceled = "canceled"
+)
+
+var (
+	setupRemoteReviewWatchUISession = newReviewWatchController
+	newReviewWatchTeaProgram        = defaultNewReviewWatchTeaProgram
+)
+
+// RemoteReviewWatchAttachOptions configures a daemon-backed review-watch UI attach session.
+type RemoteReviewWatchAttachOptions struct {
+	Snapshot          apicore.RunSnapshot
+	Config            *config
+	OwnerSession      bool
+	LoadSnapshot      func(context.Context) (apicore.RunSnapshot, error)
+	LoadChildSnapshot func(context.Context, string) (apicore.RunSnapshot, error)
+	OpenParentStream  func(context.Context, apicore.StreamCursor) (apiclient.RunStream, error)
+	OpenChildStream   func(context.Context, string, apicore.StreamCursor) (apiclient.RunStream, error)
+}
+
+type reviewWatchOverview struct {
+	provider        string
+	pr              string
+	workflow        string
+	round           int
+	headSHA         string
+	reviewID        string
+	reviewState     string
+	status          string
+	remote          string
+	branch          string
+	total           int
+	resolved        int
+	unresolved      int
+	dirty           bool
+	unpushedCommits int
+	phase           string
+	lastError       string
+	lines           []string
+}
+
+type reviewWatchModel struct {
+	parentRun  apicore.Run
+	overview   reviewWatchOverview
+	children   []multiRunTab
+	activeTab  int
+	width      int
+	height     int
+	cfg        *config
+	quitDialog quitDialogState
+	shutdown   shutdownState
+	onQuit     func(uiQuitRequest)
+	now        time.Time
+}
+
+type reviewWatchController struct {
+	model         *reviewWatchModel
+	prog          *tea.Program
+	done          chan error
+	quitHandler   func(uiQuitRequest)
+	quitHandlerMu sync.RWMutex
+	ctx           context.Context
+	cancel        context.CancelFunc
+	workers       sync.WaitGroup
+	shutdownOnce  sync.Once
+}
+
+// AttachRemoteReviewWatch boots the tabbed review-watch cockpit from a daemon-owned parent snapshot.
+func AttachRemoteReviewWatch(ctx context.Context, opts RemoteReviewWatchAttachOptions) (Session, error) {
+	mdl := newRemoteReviewWatchModel(opts)
+	session := setupRemoteReviewWatchUISession(ctx, mdl)
+	if session == nil {
+		return nil, errors.New("remote review-watch ui session is required")
+	}
+
+	observedChildren := make(map[string]struct{})
+	var observedMu sync.Mutex
+	observeChild := func(runID string, cursor apicore.StreamCursor, bootstrap bool) {
+		trimmedRunID := strings.TrimSpace(runID)
+		if trimmedRunID == "" {
+			return
+		}
+		observedMu.Lock()
+		if _, ok := observedChildren[trimmedRunID]; ok {
+			observedMu.Unlock()
+			return
+		}
+		observedChildren[trimmedRunID] = struct{}{}
+		observedMu.Unlock()
+
+		startRemoteWorker(session, func(workerCtx context.Context) {
+			followRemoteReviewWatchChild(workerCtx, session, opts, trimmedRunID, cursor, bootstrap)
+		})
+	}
+
+	if opts.OpenParentStream != nil {
+		stream, err := opts.OpenParentStream(ctx, apicore.StreamCursor{})
+		if err != nil {
+			session.Shutdown()
+			return nil, fmt.Errorf("open remote review-watch parent stream: %w", err)
+		}
+		startRemoteWorker(session, func(workerCtx context.Context) {
+			followRemoteReviewWatchParent(workerCtx, session, opts, stream, observeChild)
+		})
+	}
+	return session, nil
+}
+
+func newRemoteReviewWatchModel(opts RemoteReviewWatchAttachOptions) *reviewWatchModel {
+	cfg := opts.Config
+	if cfg == nil {
+		cfg = &config{}
+	}
+	localCfg := *cfg
+	localCfg.DetachOnly = !opts.OwnerSession
+	localCfg.DaemonOwned = true
+
+	workflow := strings.TrimSpace(opts.Snapshot.Run.WorkflowSlug)
+	mdl := &reviewWatchModel{
+		parentRun: opts.Snapshot.Run,
+		overview: reviewWatchOverview{
+			workflow: workflow,
+			phase:    reviewWatchStatusWatching,
+			status:   strings.TrimSpace(opts.Snapshot.Run.Status),
+		},
+		width:      120,
+		height:     40,
+		cfg:        &localCfg,
+		quitDialog: newQuitDialogState(),
+		now:        time.Now(),
+	}
+	return mdl
+}
+
+func newReviewWatchController(ctx context.Context, mdl *reviewWatchModel) remoteWorkerSession {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	sessionCtx, cancel := context.WithCancel(ctx)
+	if mdl == nil {
+		mdl = newRemoteReviewWatchModel(RemoteReviewWatchAttachOptions{})
+	}
+	ctrl := &reviewWatchController{
+		model:  mdl,
+		done:   make(chan error, 1),
+		ctx:    sessionCtx,
+		cancel: cancel,
+	}
+	mdl.onQuit = ctrl.requestQuit
+	ctrl.prog = newReviewWatchTeaProgram(mdl)
+	go func() {
+		_, runErr := ctrl.prog.Run()
+		if runErr != nil {
+			ctrl.done <- runErr
+		}
+		close(ctrl.done)
+	}()
+	return ctrl
+}
+
+func defaultNewReviewWatchTeaProgram(mdl tea.Model) *tea.Program {
+	return tea.NewProgram(mdl, tea.WithoutSignalHandler())
+}
+
+func (c *reviewWatchController) Enqueue(msg any) {
+	if c == nil || c.prog == nil {
+		return
+	}
+	c.prog.Send(msg)
+}
+
+func (c *reviewWatchController) SetQuitHandler(fn func(uiQuitRequest)) {
+	if c == nil {
+		return
+	}
+	c.quitHandlerMu.Lock()
+	defer c.quitHandlerMu.Unlock()
+	c.quitHandler = fn
+}
+
+func (c *reviewWatchController) requestQuit(req uiQuitRequest) {
+	c.quitHandlerMu.RLock()
+	fn := c.quitHandler
+	c.quitHandlerMu.RUnlock()
+	if fn != nil {
+		fn(req)
+	}
+}
+
+func (c *reviewWatchController) CloseEvents() {}
+
+func (c *reviewWatchController) Shutdown() {
+	if c == nil {
+		return
+	}
+	c.shutdownOnce.Do(func() {
+		if c.cancel != nil {
+			c.cancel()
+		}
+		if c.prog != nil {
+			c.prog.Quit()
+		}
+	})
+}
+
+func (c *reviewWatchController) Wait() error {
+	if c == nil {
+		return nil
+	}
+	err, ok := <-c.done
+	if c.cancel != nil {
+		c.cancel()
+	}
+	c.workers.Wait()
+	if !ok {
+		return nil
+	}
+	return err
+}
+
+func (c *reviewWatchController) StartRemoteWorker(fn func(context.Context)) {
+	if c == nil || fn == nil {
+		return
+	}
+	c.workers.Add(1)
+	go func() {
+		defer c.workers.Done()
+		fn(c.ctx)
+	}()
+}
+
+func followRemoteReviewWatchParent(
+	ctx context.Context,
+	session Session,
+	opts RemoteReviewWatchAttachOptions,
+	stream apiclient.RunStream,
+	observeChild func(string, apicore.StreamCursor, bool),
+) {
+	parentSession := reviewWatchParentSession{
+		Session:      session,
+		observeChild: observeChild,
+	}
+	followOpts := RemoteAttachOptions{
+		LoadSnapshot: func(loadCtx context.Context) (apicore.RunSnapshot, error) {
+			if opts.LoadSnapshot == nil {
+				return opts.Snapshot, nil
+			}
+			return opts.LoadSnapshot(loadCtx)
+		},
+		OpenStream: opts.OpenParentStream,
+	}
+	followRemoteRun(ctx, parentSession, followOpts, stream, apicore.StreamCursor{})
+}
+
+type reviewWatchParentSession struct {
+	Session
+	observeChild func(string, apicore.StreamCursor, bool)
+}
+
+func (s reviewWatchParentSession) Enqueue(msg any) {
+	s.Session.Enqueue(msg)
+	if ev, ok := msg.(events.Event); ok {
+		if childRunID := childRunIDFromReviewWatchEvent(ev); childRunID != "" && s.observeChild != nil {
+			s.observeChild(childRunID, apicore.StreamCursor{}, true)
+		}
+	}
+}
+
+func followRemoteReviewWatchChild(
+	ctx context.Context,
+	session Session,
+	opts RemoteReviewWatchAttachOptions,
+	runID string,
+	cursor apicore.StreamCursor,
+	bootstrap bool,
+) {
+	if bootstrap && opts.LoadChildSnapshot != nil {
+		snapshot, err := opts.LoadChildSnapshot(ctx, runID)
+		if err == nil {
+			session.Enqueue(multiRunChildBootstrapMsg{RunID: runID, Snapshot: snapshot})
+			cursor = streamCursorOrZero(snapshot.NextCursor)
+			if isTerminalRunStatus(snapshot.Run.Status) {
+				return
+			}
+		}
+	}
+	if opts.OpenChildStream == nil {
+		return
+	}
+	stream, err := opts.OpenChildStream(ctx, runID, cursor)
+	if err != nil {
+		return
+	}
+	followRemoteRun(ctx, multiRunChildSession{Session: session, runID: runID}, RemoteAttachOptions{
+		LoadSnapshot: func(loadCtx context.Context) (apicore.RunSnapshot, error) {
+			if opts.LoadChildSnapshot == nil {
+				return apicore.RunSnapshot{}, nil
+			}
+			return opts.LoadChildSnapshot(loadCtx, runID)
+		},
+		OpenStream: func(streamCtx context.Context, after apicore.StreamCursor) (apiclient.RunStream, error) {
+			return opts.OpenChildStream(streamCtx, runID, after)
+		},
+	}, stream, cursor)
+}
+
+func childRunIDFromReviewWatchEvent(ev events.Event) string {
+	switch ev.Kind {
+	case events.EventKindReviewWatchFixStarted, events.EventKindReviewWatchFixCompleted:
+		payload, ok := decodeReviewWatchPayload(ev)
+		if !ok {
+			return ""
+		}
+		return strings.TrimSpace(payload.ChildRunID)
+	default:
+		return ""
+	}
+}
+
+func (m *reviewWatchModel) Init() tea.Cmd {
+	return m.clockTick()
+}
+
+func (m *reviewWatchModel) clockTick() tea.Cmd {
+	return tea.Every(uiClockTickInterval, func(at time.Time) tea.Msg {
+		return clockTickMsg{at: at}
+	})
+}
+
+func (m *reviewWatchModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch value := msg.(type) {
+	case tea.KeyPressMsg:
+		return m, m.handleKey(value)
+	case tea.WindowSizeMsg:
+		m.handleWindowSize(value)
+		return m, nil
+	case clockTickMsg:
+		return m, m.handleClockTick(value)
+	case spinnerTickMsg:
+		return m, m.handleSpinnerTick(value)
+	case events.Event:
+		m.handleParentEvent(value)
+		return m, nil
+	case multiRunChildBootstrapMsg:
+		m.handleChildBootstrap(value)
+		return m, nil
+	case multiRunChildEventMsg:
+		return m, m.handleChildEvent(value)
+	default:
+		if child := m.activeChild(); child != nil {
+			_, cmd := child.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+}
+
+func (m *reviewWatchModel) handleKey(v tea.KeyPressMsg) tea.Cmd {
+	if m.quitDialog.Active {
+		return m.handleQuitDialogKey(v)
+	}
+	switch strings.ToLower(v.String()) {
+	case keyCtrlC, "q":
+		return m.handleQuitKey()
+	case keyLeft, "h":
+		m.moveActiveTab(-1)
+		return nil
+	case keyRight, "l":
+		m.moveActiveTab(1)
+		return nil
+	default:
+		if child := m.activeChild(); child != nil {
+			_, cmd := child.Update(v)
+			return cmd
+		}
+		return nil
+	}
+}
+
+func (m *reviewWatchModel) handleQuitKey() tea.Cmd {
+	if m.cfg != nil && m.cfg.DetachOnly {
+		return tea.Quit
+	}
+	if isTerminalRunStatus(m.parentRun.Status) {
+		return tea.Quit
+	}
+	if !m.shutdown.Active() {
+		m.quitDialog.Open()
+		return nil
+	}
+	return m.requestStopFromQuit()
+}
+
+func (m *reviewWatchModel) handleQuitDialogKey(v tea.KeyPressMsg) tea.Cmd {
+	switch strings.ToLower(v.String()) {
+	case keyLeft, "h", keyShiftTab:
+		m.quitDialog.Move(-1)
+		return nil
+	case keyRight, "l", keyTab:
+		m.quitDialog.Move(1)
+		return nil
+	case keyEnter, "q", keyCtrlC:
+		return m.confirmQuitDialog()
+	case keyEscape:
+		m.quitDialog.Close()
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (m *reviewWatchModel) confirmQuitDialog() tea.Cmd {
+	selected := m.quitDialog.Selected
+	m.quitDialog.Close()
+	switch selected {
+	case quitDialogActionClose:
+		return tea.Quit
+	case quitDialogActionStop:
+		return m.requestStopFromQuit()
+	default:
+		return nil
+	}
+}
+
+func (m *reviewWatchModel) requestStopFromQuit() tea.Cmd {
+	req, ok := m.nextQuitRequest()
+	if !ok {
+		return nil
+	}
+	m.markActiveChildrenCanceled("stop requested")
+	if m.onQuit == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		m.onQuit(req)
+		return drainMsg{}
+	}
+}
+
+func (m *reviewWatchModel) nextQuitRequest() (uiQuitRequest, bool) {
+	now := time.Now()
+	m.now = now
+	switch m.shutdown.Phase {
+	case shutdownPhaseIdle:
+		m.shutdown = shutdownState{
+			Phase:       shutdownPhaseDraining,
+			Source:      shutdownSourceUI,
+			RequestedAt: now,
+			DeadlineAt:  now.Add(gracefulShutdownTimeout),
+		}
+		return uiQuitRequestDrain, true
+	case shutdownPhaseDraining:
+		m.shutdown = shutdownState{
+			Phase:       shutdownPhaseForcing,
+			Source:      shutdownSourceUI,
+			RequestedAt: now,
+		}
+		return uiQuitRequestForce, true
+	default:
+		return uiQuitRequestDrain, false
+	}
+}
+
+func (m *reviewWatchModel) markActiveChildrenCanceled(message string) {
+	for idx := range m.children {
+		if !isTerminalTaskMultiStatus(m.children[idx].status) {
+			m.children[idx].status = taskMultiStatusCanceled
+			m.children[idx].terminal = true
+			if strings.TrimSpace(m.children[idx].errorText) == "" {
+				m.children[idx].errorText = message
+			}
+		}
+	}
+}
+
+func (m *reviewWatchModel) handleWindowSize(v tea.WindowSizeMsg) {
+	m.width = v.Width
+	m.height = v.Height
+	for idx := range m.children {
+		m.resizeChild(m.children[idx].child)
+	}
+}
+
+func (m *reviewWatchModel) handleClockTick(v clockTickMsg) tea.Cmd {
+	if !v.at.IsZero() {
+		m.now = v.at
+	}
+	if child := m.activeChild(); child != nil {
+		child.handleClockTick(v)
+	}
+	return m.clockTick()
+}
+
+func (m *reviewWatchModel) handleSpinnerTick(v spinnerTickMsg) tea.Cmd {
+	if child := m.activeChild(); child != nil {
+		return child.handleSpinnerTick(v)
+	}
+	return nil
+}
+
+func (m *reviewWatchModel) handleParentEvent(ev events.Event) {
+	switch ev.Kind {
+	case events.EventKindReviewWatchStarted,
+		events.EventKindReviewWatchWaiting,
+		events.EventKindReviewWatchRoundFetched,
+		events.EventKindReviewWatchFixStarted,
+		events.EventKindReviewWatchFixCompleted,
+		events.EventKindReviewWatchPushStarted,
+		events.EventKindReviewWatchPushCompleted,
+		events.EventKindReviewWatchPushFailed,
+		events.EventKindReviewWatchClean,
+		events.EventKindReviewWatchMaxRounds:
+		payload, ok := decodeReviewWatchPayload(ev)
+		if !ok {
+			return
+		}
+		m.applyReviewWatchPayload(ev.Kind, payload)
+	case events.EventKindRunCompleted:
+		m.parentRun.Status = remoteRunStatusCompleted
+		m.overview.phase = reviewWatchStatusDone
+		m.quitDialog.Close()
+		m.shutdown = shutdownState{}
+	case events.EventKindRunFailed:
+		m.parentRun.Status = remoteRunStatusFailed
+		m.overview.phase = reviewWatchStatusFailed
+		m.quitDialog.Close()
+	case events.EventKindRunCancelled:
+		m.parentRun.Status = remoteRunStatusCanceled
+		m.overview.phase = reviewWatchStatusCanceled
+		m.quitDialog.Close()
+	default:
+		return
+	}
+}
+
+func (m *reviewWatchModel) applyReviewWatchPayload(kind events.EventKind, payload kinds.ReviewWatchPayload) {
+	m.mergeOverview(payload)
+	line := m.reviewWatchTimelineLine(kind, payload)
+	if line != "" {
+		m.appendTimeline(line)
+	}
+	switch kind {
+	case events.EventKindReviewWatchStarted:
+		m.overview.phase = reviewWatchStatusWatching
+	case events.EventKindReviewWatchWaiting:
+		m.overview.phase = reviewWatchStatusWaiting
+	case events.EventKindReviewWatchRoundFetched:
+		m.overview.phase = reviewWatchStatusWatching
+	case events.EventKindReviewWatchFixStarted:
+		m.overview.phase = reviewWatchStatusFixing
+		idx := m.ensureChildTab(payload)
+		if idx >= 0 && m.activeTab == 0 {
+			m.activeTab = idx + 1
+		}
+	case events.EventKindReviewWatchFixCompleted:
+		m.applyFixCompleted(payload)
+	case events.EventKindReviewWatchPushStarted:
+		m.overview.phase = reviewWatchStatusPushing
+	case events.EventKindReviewWatchPushCompleted:
+		m.overview.phase = reviewWatchStatusWatching
+	case events.EventKindReviewWatchPushFailed:
+		m.overview.phase = reviewWatchStatusFailed
+		m.overview.lastError = strings.TrimSpace(payload.Error)
+	case events.EventKindReviewWatchClean:
+		m.parentRun.Status = remoteRunStatusCompleted
+		m.overview.phase = reviewWatchStatusClean
+		m.quitDialog.Close()
+	case events.EventKindReviewWatchMaxRounds:
+		m.parentRun.Status = remoteRunStatusCompleted
+		m.overview.phase = reviewWatchStatusDone
+		m.quitDialog.Close()
+	}
+}
+
+func (m *reviewWatchModel) mergeOverview(payload kinds.ReviewWatchPayload) {
+	m.mergeOverviewIdentity(payload)
+	m.mergeOverviewReview(payload)
+	m.mergeOverviewCounts(payload)
+	m.mergeOverviewPush(payload)
+}
+
+func (m *reviewWatchModel) mergeOverviewIdentity(payload kinds.ReviewWatchPayload) {
+	if payload.Provider != "" {
+		m.overview.provider = payload.Provider
+	}
+	if payload.PR != "" {
+		m.overview.pr = payload.PR
+	}
+	if payload.Workflow != "" {
+		m.overview.workflow = payload.Workflow
+	}
+	if payload.Round > 0 {
+		m.overview.round = payload.Round
+	}
+	if payload.HeadSHA != "" {
+		m.overview.headSHA = payload.HeadSHA
+	}
+}
+
+func (m *reviewWatchModel) mergeOverviewReview(payload kinds.ReviewWatchPayload) {
+	if payload.ReviewID != "" {
+		m.overview.reviewID = payload.ReviewID
+	}
+	if payload.ReviewState != "" {
+		m.overview.reviewState = payload.ReviewState
+	}
+	if payload.Status != "" {
+		m.overview.status = payload.Status
+	}
+	if payload.Error != "" {
+		m.overview.lastError = payload.Error
+	}
+}
+
+func (m *reviewWatchModel) mergeOverviewPush(payload kinds.ReviewWatchPayload) {
+	if payload.Remote != "" {
+		m.overview.remote = payload.Remote
+	}
+	if payload.Branch != "" {
+		m.overview.branch = payload.Branch
+	}
+	m.overview.dirty = payload.Dirty
+	if payload.UnpushedCommits > 0 {
+		m.overview.unpushedCommits = payload.UnpushedCommits
+	}
+}
+
+func (m *reviewWatchModel) mergeOverviewCounts(payload kinds.ReviewWatchPayload) {
+	if payload.Total > 0 {
+		m.overview.total = payload.Total
+	}
+	if payload.Resolved > 0 {
+		m.overview.resolved = payload.Resolved
+	}
+	if payload.Unresolved > 0 {
+		m.overview.unresolved = payload.Unresolved
+	}
+}
+
+func (m *reviewWatchModel) reviewWatchTimelineLine(
+	kind events.EventKind,
+	payload kinds.ReviewWatchPayload,
+) string {
+	round := ""
+	if payload.Round > 0 {
+		round = fmt.Sprintf(" round=%03d", payload.Round)
+	}
+	switch kind {
+	case events.EventKindReviewWatchStarted:
+		return fmt.Sprintf(
+			"watch started provider=%s pr=%s head=%s",
+			payload.Provider,
+			payload.PR,
+			shortSHA(payload.HeadSHA),
+		)
+	case events.EventKindReviewWatchWaiting:
+		return fmt.Sprintf(
+			"waiting status=%s review=%s head=%s",
+			payload.Status,
+			payload.ReviewState,
+			shortSHA(payload.HeadSHA),
+		)
+	case events.EventKindReviewWatchRoundFetched:
+		return fmt.Sprintf("fetched%s unresolved=%d resolved=%d", round, payload.Unresolved, payload.Resolved)
+	case events.EventKindReviewWatchFixStarted:
+		return fmt.Sprintf("fix started%s child=%s", round, payload.ChildRunID)
+	case events.EventKindReviewWatchFixCompleted:
+		line := fmt.Sprintf("fix completed%s child=%s status=%s", round, payload.ChildRunID, payload.Status)
+		if payload.Error != "" {
+			line += " error=" + payload.Error
+		}
+		return line
+	case events.EventKindReviewWatchPushStarted:
+		return fmt.Sprintf("push started%s remote=%s branch=%s", round, payload.Remote, payload.Branch)
+	case events.EventKindReviewWatchPushCompleted:
+		return fmt.Sprintf("push completed%s remote=%s branch=%s", round, payload.Remote, payload.Branch)
+	case events.EventKindReviewWatchPushFailed:
+		return fmt.Sprintf("push failed%s error=%s", round, payload.Error)
+	case events.EventKindReviewWatchClean:
+		return fmt.Sprintf("clean status=%s head=%s", payload.Status, shortSHA(payload.HeadSHA))
+	case events.EventKindReviewWatchMaxRounds:
+		return fmt.Sprintf("max rounds reached%s head=%s", round, shortSHA(payload.HeadSHA))
+	default:
+		return ""
+	}
+}
+
+func (m *reviewWatchModel) appendTimeline(line string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return
+	}
+	m.overview.lines = append(m.overview.lines, line)
+	if len(m.overview.lines) > reviewWatchMaxLines {
+		m.overview.lines = append([]string(nil), m.overview.lines[len(m.overview.lines)-reviewWatchMaxLines:]...)
+	}
+}
+
+func (m *reviewWatchModel) ensureChildTab(payload kinds.ReviewWatchPayload) int {
+	childRunID := strings.TrimSpace(payload.ChildRunID)
+	if childRunID == "" {
+		return -1
+	}
+	if idx := m.findChildByRunID(childRunID); idx >= 0 {
+		m.children[idx].status = taskMultiStatusRunning
+		return idx
+	}
+	label := reviewWatchChildLabel(payload)
+	m.children = append(m.children, multiRunTab{
+		slug:       label,
+		status:     taskMultiStatusRunning,
+		runID:      childRunID,
+		translator: newUIEventTranslator(),
+	})
+	return len(m.children) - 1
+}
+
+func (m *reviewWatchModel) applyFixCompleted(payload kinds.ReviewWatchPayload) {
+	m.overview.phase = reviewWatchStatusWatching
+	idx := m.ensureChildTab(payload)
+	if idx < 0 {
+		return
+	}
+	status := taskMultiStatusFromRunStatus(payload.Status)
+	if status == "" {
+		status = strings.TrimSpace(payload.Status)
+	}
+	if status == "" {
+		status = taskMultiStatusCompleted
+	}
+	m.children[idx].status = status
+	m.children[idx].terminal = isTerminalTaskMultiStatus(status)
+	m.children[idx].errorText = strings.TrimSpace(payload.Error)
+}
+
+func reviewWatchChildLabel(payload kinds.ReviewWatchPayload) string {
+	if payload.Round > 0 {
+		return fmt.Sprintf("round %03d", payload.Round)
+	}
+	return firstNonEmpty(strings.TrimSpace(payload.ChildRunID), "fix run")
+}
+
+func (m *reviewWatchModel) handleChildBootstrap(msg multiRunChildBootstrapMsg) {
+	idx := m.findChildByRunID(msg.RunID)
+	if idx < 0 {
+		return
+	}
+	m.children[idx].applyChildSnapshot(msg.Snapshot, m.cfg, m.childWidth(), m.childHeight())
+	if status := taskMultiStatusFromRunStatus(msg.Snapshot.Run.Status); status != "" {
+		m.children[idx].status = status
+		m.children[idx].terminal = isTerminalTaskMultiStatus(status)
+	}
+}
+
+func (m *reviewWatchModel) handleChildEvent(msg multiRunChildEventMsg) tea.Cmd {
+	idx := m.findChildByRunID(msg.RunID)
+	if idx < 0 {
+		return nil
+	}
+	tab := &m.children[idx]
+	if tab.child == nil {
+		tab.child = newPlaceholderChildModel(tab.slug, m.cfg, m.childWidth(), m.childHeight())
+	}
+	if tab.translator == nil {
+		tab.translator = newUIEventTranslator()
+	}
+	var cmd tea.Cmd
+	for _, uiMsg := range tab.translator.translateMessages(msg.Event) {
+		if nextCmd := applyChildUIMsg(tab, uiMsg); nextCmd != nil && idx+1 == m.activeTab {
+			cmd = nextCmd
+		}
+	}
+	if status := taskMultiStatusFromChildRunEvent(msg.Event.Kind); status != "" {
+		tab.status = status
+		tab.terminal = isTerminalTaskMultiStatus(status)
+	}
+	return cmd
+}
+
+func (m *reviewWatchModel) View() tea.View {
+	if m.quitDialog.Active {
+		return m.renderQuitDialogView()
+	}
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		m.renderTabs(),
+		m.renderActiveTabContent(),
+	)
+	return m.renderRoot(content)
+}
+
+func (m *reviewWatchModel) renderRoot(content string) tea.View {
+	v := tea.NewView(rootScreenStyle(m.width, m.height).Render(content))
+	v.AltScreen = true
+	v.MouseMode = tea.MouseModeCellMotion
+	return v
+}
+
+func (m *reviewWatchModel) renderTabs() string {
+	bg := colorBgBase
+	chunks := make([]string, 0, len(m.children)+1)
+	watchLabel := fmt.Sprintf("1 Watch %s", strings.ToUpper(firstNonEmpty(m.overview.phase, reviewWatchStatusWatching)))
+	watchStyle := lipgloss.NewStyle().
+		Padding(0, 1).
+		Background(colorBgSurface).
+		Foreground(reviewWatchStatusColor(m.overview.phase))
+	if m.activeTab == 0 {
+		watchStyle = watchStyle.Bold(true).Background(colorAccent).Foreground(colorBgBase)
+	}
+	chunks = append(chunks, watchStyle.Render(truncateString(watchLabel, 32)))
+	for idx := range m.children {
+		tab := m.children[idx]
+		label := fmt.Sprintf(
+			"%d %s %s",
+			idx+2,
+			firstNonEmpty(tab.slug, tab.runID, "fix"),
+			strings.ToUpper(tabStatus(&tab)),
+		)
+		style := lipgloss.NewStyle().
+			Padding(0, 1).
+			Background(colorBgSurface).
+			Foreground(multiRunStatusColor(tabStatus(&tab)))
+		if idx+1 == m.activeTab {
+			style = style.Bold(true).Background(colorAccent).Foreground(colorBgBase)
+		}
+		chunks = append(chunks, style.Render(truncateString(label, 32)))
+	}
+	left := renderGap(bg, 1) + strings.Join(chunks, renderGap(bg, 1))
+	hint := renderKeycap("left/right", bg) + renderGap(bg, 1) + renderStyledOnBackground(styleMutedText, bg, "TABS")
+	gap := max(m.width-lipgloss.Width(left)-lipgloss.Width(hint)-1, 1)
+	line := renderOwnedLineKnownOwned(m.width, bg, left+renderGap(bg, gap)+hint)
+	separator := renderOwnedLineKnownOwned(
+		m.width,
+		bg,
+		renderStyledOnBackground(styleSeparator, bg, strings.Repeat("─", m.width)),
+	)
+	return line + "\n" + separator
+}
+
+func (m *reviewWatchModel) renderActiveTabContent() string {
+	if m.activeTab == 0 {
+		return m.renderWatchTabContent()
+	}
+	idx := m.activeTab - 1
+	if idx < 0 || idx >= len(m.children) {
+		return m.renderWatchTabContent()
+	}
+	tab := &m.children[idx]
+	if tab.child == nil {
+		return m.renderQueuedChildContent(tab)
+	}
+	m.resizeChild(tab.child)
+	return tab.child.View().Content
+}
+
+func (m *reviewWatchModel) renderWatchTabContent() string {
+	width := max(m.width, 1)
+	height := max(m.childHeight(), 1)
+	panelWidth := max(width-4, 20)
+	innerStyle := techPanelStyle(panelWidth, reviewWatchStatusColor(m.overview.phase)).Padding(1, 2)
+	innerWidth := max(panelWidth-innerStyle.GetHorizontalFrameSize(), 1)
+	bg := colorBgSurface
+	lines := []string{
+		renderOwnedLineKnownOwned(innerWidth, bg, renderTechLabel("review.watch", bg)),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedLineKnownOwned(innerWidth, bg, renderStyledOnBackground(
+			styleBodyText,
+			bg,
+			truncateString(m.watchTitle(innerWidth), innerWidth),
+		)),
+		renderOwnedLineKnownOwned(innerWidth, bg, renderStyledOnBackground(
+			styleMutedText,
+			bg,
+			truncateString(m.watchMetaLine(), innerWidth),
+		)),
+		renderOwnedLineKnownOwned(innerWidth, bg, renderStyledOnBackground(
+			styleMutedText,
+			bg,
+			truncateString(m.watchReviewLine(), innerWidth),
+		)),
+	}
+	if pushLine := m.watchPushLine(); pushLine != "" {
+		lines = append(lines, renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(styleMutedText, bg, truncateString(pushLine, innerWidth)),
+		))
+	}
+	if errText := strings.TrimSpace(m.overview.lastError); errText != "" {
+		lines = append(lines, renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(styleMutedText.Foreground(colorError), bg, truncateString(errText, innerWidth)),
+		))
+	}
+	lines = append(lines, renderOwnedLineKnownOwned(innerWidth, bg, ""))
+	lines = append(lines, m.renderTimelineLines(innerWidth, max(height-len(lines)-3, 1))...)
+	panel := innerStyle.Render(strings.Join(lines, "\n"))
+	return lipgloss.Place(
+		width,
+		height,
+		lipgloss.Center,
+		lipgloss.Center,
+		panel,
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(colorBgBase)),
+	)
+}
+
+func (m *reviewWatchModel) watchTitle(width int) string {
+	workflow := firstNonEmpty(m.overview.workflow, m.parentRun.WorkflowSlug, "review workflow")
+	return truncateString(fmt.Sprintf("%s / PR %s", workflow, firstNonEmpty(m.overview.pr, "unknown")), width)
+}
+
+func (m *reviewWatchModel) watchMetaLine() string {
+	parts := []string{
+		"phase=" + firstNonEmpty(m.overview.phase, reviewWatchStatusWatching),
+		"status=" + firstNonEmpty(m.overview.status, m.parentRun.Status, "pending"),
+	}
+	if m.overview.provider != "" {
+		parts = append(parts, "provider="+m.overview.provider)
+	}
+	if m.overview.headSHA != "" {
+		parts = append(parts, "head="+shortSHA(m.overview.headSHA))
+	}
+	if m.overview.round > 0 {
+		parts = append(parts, fmt.Sprintf("round=%03d", m.overview.round))
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (m *reviewWatchModel) watchReviewLine() string {
+	parts := []string{
+		fmt.Sprintf(
+			"issues total=%d unresolved=%d resolved=%d",
+			m.overview.total,
+			m.overview.unresolved,
+			m.overview.resolved,
+		),
+	}
+	if m.overview.reviewState != "" {
+		parts = append(parts, "review="+m.overview.reviewState)
+	}
+	if m.overview.reviewID != "" {
+		parts = append(parts, "review_id="+m.overview.reviewID)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (m *reviewWatchModel) watchPushLine() string {
+	parts := make([]string, 0, 4)
+	if m.overview.remote != "" {
+		parts = append(parts, "remote="+m.overview.remote)
+	}
+	if m.overview.branch != "" {
+		parts = append(parts, "branch="+m.overview.branch)
+	}
+	if m.overview.unpushedCommits > 0 {
+		parts = append(parts, fmt.Sprintf("unpushed=%d", m.overview.unpushedCommits))
+	}
+	if m.overview.dirty {
+		parts = append(parts, "dirty=true")
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (m *reviewWatchModel) renderTimelineLines(width int, maxLines int) []string {
+	bg := colorBgSurface
+	if len(m.overview.lines) == 0 {
+		return []string{
+			renderOwnedLineKnownOwned(width, bg, renderStyledOnBackground(
+				styleMutedText,
+				bg,
+				truncateString("Waiting for review-watch events...", width),
+			)),
+		}
+	}
+	start := max(len(m.overview.lines)-maxLines, 0)
+	lines := make([]string, 0, len(m.overview.lines)-start)
+	for _, line := range m.overview.lines[start:] {
+		lines = append(lines, renderOwnedLineKnownOwned(
+			width,
+			bg,
+			renderStyledOnBackground(styleMutedText, bg, truncateString(line, width)),
+		))
+	}
+	return lines
+}
+
+func (m *reviewWatchModel) renderQueuedChildContent(tab *multiRunTab) string {
+	width := max(m.width, 1)
+	height := max(m.childHeight(), 1)
+	panelWidth := max(width-4, 20)
+	innerStyle := techPanelStyle(panelWidth, multiRunStatusColor(tabStatus(tab))).Padding(1, 2)
+	innerWidth := max(panelWidth-innerStyle.GetHorizontalFrameSize(), 1)
+	name := "fix run"
+	status := taskMultiStatusQueued
+	if tab != nil {
+		name = firstNonEmpty(tab.slug, tab.runID, name)
+		status = tabStatus(tab)
+	}
+	bg := colorBgSurface
+	lines := []string{
+		renderOwnedLineKnownOwned(innerWidth, bg, renderTechLabel("review.fix."+status, bg)),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedLineKnownOwned(innerWidth, bg, renderStyledOnBackground(
+			styleBodyText,
+			bg,
+			truncateString(name, innerWidth),
+		)),
+		renderOwnedLineKnownOwned(innerWidth, bg, renderStyledOnBackground(
+			styleMutedText,
+			bg,
+			truncateString("Fix run has not emitted a snapshot yet.", innerWidth),
+		)),
+	}
+	panel := innerStyle.Render(strings.Join(lines, "\n"))
+	return lipgloss.Place(
+		width,
+		height,
+		lipgloss.Center,
+		lipgloss.Center,
+		panel,
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(colorBgBase)),
+	)
+}
+
+func (m *reviewWatchModel) renderQuitDialogView() tea.View {
+	panel := m.renderQuitDialogPanel()
+	content := lipgloss.Place(
+		max(m.width, 1),
+		max(m.height, 1),
+		lipgloss.Center,
+		lipgloss.Center,
+		panel,
+		lipgloss.WithWhitespaceStyle(lipgloss.NewStyle().Background(colorBgBase)),
+	)
+	return m.renderRoot(content)
+}
+
+func (m *reviewWatchModel) renderQuitDialogPanel() string {
+	availableWidth := max(m.width-4, 1)
+	panelWidth := min(availableWidth, quitDialogMaxWidth)
+	panelStyle := techPanelStyle(panelWidth, colorBorderFocus).Padding(1, 2)
+	innerWidth := max(panelWidth-panelStyle.GetHorizontalFrameSize(), 1)
+	bg := colorBgSurface
+	lines := []string{
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				lipgloss.NewStyle().Bold(true).Foreground(colorAccentDeep),
+				bg,
+				truncateString("Leave Active Watch?", innerWidth),
+			),
+		),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				styleBodyText,
+				bg,
+				truncateString("This review watch is still active.", innerWidth),
+			),
+		),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				styleMutedText,
+				bg,
+				truncateString("Close the TUI and keep watching in the daemon.", innerWidth),
+			),
+		),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				styleMutedText,
+				bg,
+				truncateString("Choose Stop Run to cancel this watch and its active fix run.", innerWidth),
+			),
+		),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedBlock(innerWidth, bg, m.renderQuitDialogActions(innerWidth, bg)),
+		renderOwnedLineKnownOwned(innerWidth, bg, ""),
+		renderOwnedLineKnownOwned(
+			innerWidth,
+			bg,
+			renderStyledOnBackground(
+				styleDimText,
+				bg,
+				truncateString("[enter/q] confirm  [tab/left/right] choice  [esc] back", innerWidth),
+			),
+		),
+	}
+	return panelStyle.Render(strings.Join(lines, "\n"))
+}
+
+func (m *reviewWatchModel) renderQuitDialogActions(width int, bg color.Color) string {
+	actions := []string{
+		m.renderQuitDialogAction("Close TUI", quitDialogActionClose),
+		m.renderQuitDialogAction("Stop Run", quitDialogActionStop),
+		m.renderQuitDialogAction("Cancel", quitDialogActionCancel),
+	}
+	if width < 44 {
+		return strings.Join(actions, "\n")
+	}
+	return strings.Join(actions, renderGap(bg, 1))
+}
+
+func (m *reviewWatchModel) renderQuitDialogAction(label string, action quitDialogAction) string {
+	baseStyle := lipgloss.NewStyle().Bold(true).Padding(0, 1)
+	if m.quitDialog.Selected == action {
+		return baseStyle.Foreground(colorBgSurface).Background(colorAccent).Render(label)
+	}
+	return baseStyle.Foreground(colorFgBright).Background(colorBgBase).Render(label)
+}
+
+func (m *reviewWatchModel) activeChild() *uiModel {
+	idx := m.activeTab - 1
+	if idx < 0 || idx >= len(m.children) {
+		return nil
+	}
+	return m.children[idx].child
+}
+
+func (m *reviewWatchModel) moveActiveTab(delta int) {
+	totalTabs := len(m.children) + 1
+	if totalTabs <= 0 {
+		return
+	}
+	if child := m.activeChild(); child != nil {
+		child.persistSelectedViewportState()
+	}
+	m.activeTab = (m.activeTab + delta + totalTabs) % totalTabs
+	if child := m.activeChild(); child != nil {
+		m.resizeChild(child)
+		child.refreshViewportContent()
+	}
+}
+
+func (m *reviewWatchModel) findChildByRunID(runID string) int {
+	trimmed := strings.TrimSpace(runID)
+	if trimmed == "" {
+		return -1
+	}
+	for idx := range m.children {
+		if strings.TrimSpace(m.children[idx].runID) == trimmed {
+			return idx
+		}
+	}
+	return -1
+}
+
+func (m *reviewWatchModel) resizeChild(child *uiModel) {
+	if child == nil {
+		return
+	}
+	child.handleWindowSize(tea.WindowSizeMsg{
+		Width:  m.childWidth(),
+		Height: m.childHeight(),
+	})
+}
+
+func (m *reviewWatchModel) childWidth() int {
+	return max(m.width, 1)
+}
+
+func (m *reviewWatchModel) childHeight() int {
+	return max(m.height-reviewWatchTabsHeight, 1)
+}
+
+func reviewWatchStatusColor(status string) color.Color {
+	switch strings.TrimSpace(status) {
+	case reviewWatchStatusFixing, reviewWatchStatusPushing:
+		return colorAccentAlt
+	case reviewWatchStatusClean, reviewWatchStatusDone:
+		return colorSuccess
+	case reviewWatchStatusFailed:
+		return colorError
+	case reviewWatchStatusCanceled:
+		return colorWarning
+	default:
+		return colorMuted
+	}
+}
+
+func shortSHA(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if len(trimmed) <= 12 {
+		return trimmed
+	}
+	return trimmed[:12]
+}
+
+func decodeReviewWatchPayload(ev events.Event) (kinds.ReviewWatchPayload, bool) {
+	return decodeUIEventPayload[kinds.ReviewWatchPayload](ev)
+}

--- a/internal/core/run/ui/review_watch_remote_test.go
+++ b/internal/core/run/ui/review_watch_remote_test.go
@@ -1,0 +1,218 @@
+package ui
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	apicore "github.com/compozy/compozy/internal/api/core"
+	"github.com/compozy/compozy/pkg/compozy/events"
+	"github.com/compozy/compozy/pkg/compozy/events/kinds"
+)
+
+func TestReviewWatchModelAddsChildTabFromFixStartedEvent(t *testing.T) {
+	t.Parallel()
+
+	mdl := newRemoteReviewWatchModel(RemoteReviewWatchAttachOptions{
+		Snapshot: apicore.RunSnapshot{
+			Run: apicore.Run{
+				RunID:        "review-watch-1",
+				Mode:         "review_watch",
+				WorkflowSlug: "pr-51",
+				Status:       remoteRunStatusRunning,
+			},
+		},
+	})
+
+	mdl.handleParentEvent(reviewWatchEvent(t, events.EventKindReviewWatchFixStarted, kinds.ReviewWatchPayload{
+		Provider:   "coderabbit",
+		PR:         "51",
+		Workflow:   "pr-51",
+		Round:      2,
+		HeadSHA:    "1234567890abcdef",
+		ChildRunID: "review-fix-2",
+	}))
+
+	if mdl.overview.phase != reviewWatchStatusFixing {
+		t.Fatalf("overview phase = %q, want fixing", mdl.overview.phase)
+	}
+	if mdl.overview.workflow != "pr-51" || mdl.overview.pr != "51" {
+		t.Fatalf("overview = %#v, want workflow/pr metadata", mdl.overview)
+	}
+	if len(mdl.children) != 1 {
+		t.Fatalf("child tabs = %d, want 1", len(mdl.children))
+	}
+	if child := mdl.children[0]; child.runID != "review-fix-2" || child.slug != "round 002" {
+		t.Fatalf("child tab = %#v, want review-fix-2 round 002", child)
+	}
+	if mdl.activeTab != 1 {
+		t.Fatalf("active tab = %d, want child tab 1", mdl.activeTab)
+	}
+	if len(mdl.overview.lines) != 1 || mdl.overview.lines[0] == "" {
+		t.Fatalf("overview timeline = %#v, want fix-started line", mdl.overview.lines)
+	}
+}
+
+func TestReviewWatchModelUpdatesChildStatusFromFixCompletedEvent(t *testing.T) {
+	t.Parallel()
+
+	mdl := newRemoteReviewWatchModel(RemoteReviewWatchAttachOptions{})
+	mdl.handleParentEvent(reviewWatchEvent(t, events.EventKindReviewWatchFixStarted, kinds.ReviewWatchPayload{
+		Round:      1,
+		ChildRunID: "review-fix-1",
+	}))
+	mdl.handleParentEvent(reviewWatchEvent(t, events.EventKindReviewWatchFixCompleted, kinds.ReviewWatchPayload{
+		Round:      1,
+		ChildRunID: "review-fix-1",
+		Status:     remoteRunStatusCompleted,
+	}))
+
+	if len(mdl.children) != 1 {
+		t.Fatalf("child tabs = %d, want 1", len(mdl.children))
+	}
+	if mdl.children[0].status != taskMultiStatusCompleted || !mdl.children[0].terminal {
+		t.Fatalf("child tab = %#v, want completed terminal", mdl.children[0])
+	}
+	if childRunID := childRunIDFromReviewWatchEvent(reviewWatchEvent(
+		t,
+		events.EventKindReviewWatchFixCompleted,
+		kinds.ReviewWatchPayload{ChildRunID: "review-fix-1"},
+	)); childRunID != "review-fix-1" {
+		t.Fatalf("childRunIDFromReviewWatchEvent() = %q, want review-fix-1", childRunID)
+	}
+}
+
+func TestReviewWatchModelSuppressesDuplicateChildTabs(t *testing.T) {
+	t.Parallel()
+
+	mdl := newRemoteReviewWatchModel(RemoteReviewWatchAttachOptions{})
+	started := reviewWatchEvent(t, events.EventKindReviewWatchFixStarted, kinds.ReviewWatchPayload{
+		Round:      1,
+		ChildRunID: "review-fix-1",
+	})
+	mdl.handleParentEvent(started)
+	mdl.handleParentEvent(started)
+
+	if len(mdl.children) != 1 {
+		t.Fatalf("child tabs = %d, want 1", len(mdl.children))
+	}
+	if mdl.children[0].runID != "review-fix-1" {
+		t.Fatalf("child run id = %q, want review-fix-1", mdl.children[0].runID)
+	}
+}
+
+func TestReviewWatchModelStopQuitRequestsDrainAndCancelsChildren(t *testing.T) {
+	t.Parallel()
+
+	mdl := newRemoteReviewWatchModel(RemoteReviewWatchAttachOptions{
+		OwnerSession: true,
+		Snapshot: apicore.RunSnapshot{
+			Run: apicore.Run{
+				RunID:  "review-watch-1",
+				Mode:   "review_watch",
+				Status: remoteRunStatusRunning,
+			},
+		},
+	})
+	mdl.handleParentEvent(reviewWatchEvent(t, events.EventKindReviewWatchFixStarted, kinds.ReviewWatchPayload{
+		Round:      1,
+		ChildRunID: "review-fix-1",
+	}))
+	var requests []uiQuitRequest
+	mdl.onQuit = func(req uiQuitRequest) {
+		requests = append(requests, req)
+	}
+
+	if cmd := mdl.handleQuitKey(); cmd != nil {
+		t.Fatalf("handleQuitKey() returned cmd before dialog confirmation")
+	}
+	if !mdl.quitDialog.Active {
+		t.Fatal("quit dialog is closed, want open")
+	}
+	mdl.quitDialog.Selected = quitDialogActionStop
+	cmd := mdl.confirmQuitDialog()
+	if cmd == nil {
+		t.Fatal("confirmQuitDialog(stop) returned nil cmd")
+	}
+	_ = cmd()
+
+	if len(requests) != 1 || requests[0] != uiQuitRequestDrain {
+		t.Fatalf("quit requests = %#v, want one drain request", requests)
+	}
+	if mdl.shutdown.Phase != shutdownPhaseDraining {
+		t.Fatalf("shutdown phase = %q, want draining", mdl.shutdown.Phase)
+	}
+	if len(mdl.children) != 1 || mdl.children[0].status != taskMultiStatusCanceled || !mdl.children[0].terminal {
+		t.Fatalf("child tabs after stop = %#v, want canceled terminal child", mdl.children)
+	}
+	if mdl.children[0].errorText != "stop requested" {
+		t.Fatalf("child error text = %q, want stop requested", mdl.children[0].errorText)
+	}
+}
+
+func TestReviewWatchModelParentTerminalEventsCloseQuitDialog(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		kind       events.EventKind
+		wantStatus string
+		wantPhase  string
+	}{
+		{
+			name:       "completed",
+			kind:       events.EventKindRunCompleted,
+			wantStatus: remoteRunStatusCompleted,
+			wantPhase:  reviewWatchStatusDone,
+		},
+		{
+			name:       "failed",
+			kind:       events.EventKindRunFailed,
+			wantStatus: remoteRunStatusFailed,
+			wantPhase:  reviewWatchStatusFailed,
+		},
+		{
+			name:       "canceled",
+			kind:       events.EventKindRunCancelled,
+			wantStatus: remoteRunStatusCanceled,
+			wantPhase:  reviewWatchStatusCanceled,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mdl := newRemoteReviewWatchModel(RemoteReviewWatchAttachOptions{})
+			mdl.quitDialog.Open()
+			mdl.handleParentEvent(reviewWatchEvent(t, tc.kind, kinds.ReviewWatchPayload{}))
+
+			if mdl.parentRun.Status != tc.wantStatus {
+				t.Fatalf("parent status = %q, want %q", mdl.parentRun.Status, tc.wantStatus)
+			}
+			if mdl.overview.phase != tc.wantPhase {
+				t.Fatalf("overview phase = %q, want %q", mdl.overview.phase, tc.wantPhase)
+			}
+			if mdl.quitDialog.Active {
+				t.Fatal("quit dialog is open, want closed")
+			}
+		})
+	}
+}
+
+func reviewWatchEvent(t *testing.T, kind events.EventKind, payload kinds.ReviewWatchPayload) events.Event {
+	t.Helper()
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return events.Event{
+		SchemaVersion: events.SchemaVersion,
+		RunID:         "review-watch-1",
+		Seq:           1,
+		Kind:          kind,
+		Timestamp:     time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC),
+		Payload:       raw,
+	}
+}

--- a/internal/daemon/review_watch.go
+++ b/internal/daemon/review_watch.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -109,7 +110,12 @@ func (m *RunManager) StartReviewWatch(
 	workflowSlug string,
 	req apicore.ReviewWatchRequest,
 ) (apicore.Run, error) {
-	prepared, runtimeCfg, err := m.prepareReviewWatchStart(detachContext(ctx), workspaceRef, workflowSlug, req)
+	prepared, runtimeCfg, presentationMode, err := m.prepareReviewWatchStart(
+		detachContext(ctx),
+		workspaceRef,
+		workflowSlug,
+		req,
+	)
 	if err != nil {
 		return apicore.Run{}, err
 	}
@@ -134,7 +140,7 @@ func (m *RunManager) StartReviewWatch(
 		workflowSlug:     prepared.workflowSlug,
 		workflowRoot:     prepared.workflowRoot,
 		mode:             runModeReviewWatch,
-		presentationMode: defaultPresentationMode,
+		presentationMode: presentationMode,
 		runtimeCfg:       runtimeCfg,
 		reviewWatch:      prepared,
 		reviewWatchKey:   &key,
@@ -151,21 +157,25 @@ func (m *RunManager) prepareReviewWatchStart(
 	workspaceRef string,
 	workflowSlug string,
 	req apicore.ReviewWatchRequest,
-) (*preparedReviewWatch, *model.RuntimeConfig, error) {
+) (*preparedReviewWatch, *model.RuntimeConfig, string, error) {
 	workspaceRow, workflowID, projectCfg, err := m.resolveWorkflowContext(ctx, workspaceRef, workflowSlug)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	options, err := resolveReviewWatchOptions(projectCfg, req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
+	}
+	presentationMode, err := normalizePresentationMode(req.PresentationMode)
+	if err != nil {
+		return nil, nil, "", err
 	}
 	overrides, err := parseRuntimeOverrides(req.RuntimeOverrides)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	if options.AutoPush && overrides.AutoCommit != nil && !*overrides.AutoCommit {
-		return nil, nil, apicore.NewProblem(
+		return nil, nil, "", apicore.NewProblem(
 			http.StatusUnprocessableEntity,
 			"invalid_watch_request",
 			"auto_push requires auto_commit to be true",
@@ -175,17 +185,17 @@ func (m *RunManager) prepareReviewWatchStart(
 	}
 	childRuntimeOverrides, err := reviewWatchChildRuntimeOverrides(req.RuntimeOverrides, options.AutoPush)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	options.RuntimeOverrides = childRuntimeOverrides
 	if _, err := parseReviewBatching(req.Batching); err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	options.Batching = cloneJSON(req.Batching)
 
 	workflowRoot := model.TaskDirectoryForWorkspace(workspaceRow.RootDir, workflowSlug)
-	if err := requireDirectory(workflowRoot); err != nil {
-		return nil, nil, err
+	if err := ensureReviewWatchWorkflowDirectory(workflowRoot, workflowSlug, options.PR); err != nil {
+		return nil, nil, "", err
 	}
 
 	runtimeCfg := &model.RuntimeConfig{
@@ -212,7 +222,27 @@ func (m *RunManager) prepareReviewWatchStart(
 		workflowSlug: strings.TrimSpace(workflowSlug),
 		workflowRoot: workflowRoot,
 		options:      options,
-	}, runtimeCfg, nil
+	}, runtimeCfg, presentationMode, nil
+}
+
+func ensureReviewWatchWorkflowDirectory(dir string, workflowSlug string, prRef string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if !reviews.IsPRDerivedTaskName(workflowSlug, prRef) {
+				return fmt.Errorf("review watch workflow directory not found: %s", dir)
+			}
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("create review watch workflow directory: %w", err)
+			}
+			return nil
+		}
+		return fmt.Errorf("stat review watch workflow directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("review watch workflow path is not a directory: %s", dir)
+	}
+	return nil
 }
 
 func resolveReviewWatchOptions(

--- a/internal/daemon/review_watch_test.go
+++ b/internal/daemon/review_watch_test.go
@@ -40,12 +40,17 @@ func TestRunManagerReviewWatchCompletesCleanWithoutEmptyRound(t *testing.T) {
 		}
 		env := newReviewWatchTestEnv(t, reviewProvider, git, runManagerTestDeps{})
 
-		run := startReviewWatch(t, env, reviewWatchRequest(`{"run_id":"review-watch-clean"}`))
+		req := reviewWatchRequest("{\"run_id\":\"review-watch-clean\"}")
+		req.PresentationMode = "ui"
+		run := startReviewWatch(t, env, req)
 		row := waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
 			return row.Status == runStatusCompleted
 		})
 		if row.Mode != runModeReviewWatch {
 			t.Fatalf("row.Mode = %q, want %q", row.Mode, runModeReviewWatch)
+		}
+		if row.PresentationMode != "ui" {
+			t.Fatalf("row.PresentationMode = %q, want ui", row.PresentationMode)
 		}
 		if _, err := os.Stat(env.workflowDir(env.workflowSlug) + "/reviews-001"); !os.IsNotExist(err) {
 			t.Fatalf("reviews-001 stat error = %v, want not exist", err)
@@ -56,6 +61,74 @@ func TestRunManagerReviewWatchCompletesCleanWithoutEmptyRound(t *testing.T) {
 			t.Fatalf("watch_started payload = %#v, want dirty/unpushed/head metadata", started)
 		}
 		requireRunEvent(t, run.RunID, eventspkg.EventKindReviewWatchClean)
+	})
+}
+
+func TestRunManagerReviewWatchCreatesReviewOnlyWorkflowDirectory(t *testing.T) {
+	t.Run("Should create missing review-only workflow directory", func(t *testing.T) {
+		reviewProvider := &fakeReviewWatchProvider{
+			statuses: []provider.WatchStatus{currentWatchStatus("head-1")},
+			fetches:  [][]provider.ReviewItem{{}},
+		}
+		git := &fakeReviewWatchGit{
+			states: []ReviewWatchGitState{{HeadSHA: "head-1"}},
+		}
+		env := newReviewWatchTestEnv(t, reviewProvider, git, runManagerTestDeps{})
+		slug := "pr-51"
+		workflowDir := env.workflowDir(slug)
+		if _, err := os.Stat(workflowDir); !os.IsNotExist(err) {
+			t.Fatalf("workflow dir stat before start = %v, want not exist", err)
+		}
+
+		req := reviewWatchRequest("{\"run_id\":\"review-watch-pr-51\"}")
+		req.PRRef = "51"
+		run, err := env.manager.StartReviewWatch(
+			context.Background(),
+			env.workspaceRoot,
+			slug,
+			req,
+		)
+		if err != nil {
+			t.Fatalf("StartReviewWatch() error = %v", err)
+		}
+		waitForRun(t, env.globalDB, run.RunID, func(row globaldb.Run) bool {
+			return row.Status == runStatusCompleted
+		})
+		info, err := os.Stat(workflowDir)
+		if err != nil {
+			t.Fatalf("workflow dir stat after start: %v", err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("workflow path is not a directory: %s", workflowDir)
+		}
+	})
+}
+
+func TestRunManagerReviewWatchRequiresExistingDirectoryForExplicitWorkflowName(t *testing.T) {
+	t.Run("Should not create arbitrary missing workflow directory", func(t *testing.T) {
+		reviewProvider := &fakeReviewWatchProvider{
+			statuses: []provider.WatchStatus{currentWatchStatus("head-1")},
+			fetches:  [][]provider.ReviewItem{{}},
+		}
+		git := &fakeReviewWatchGit{
+			states: []ReviewWatchGitState{{HeadSHA: "head-1"}},
+		}
+		env := newReviewWatchTestEnv(t, reviewProvider, git, runManagerTestDeps{})
+		slug := "my-featuer"
+		workflowDir := env.workflowDir(slug)
+
+		_, err := env.manager.StartReviewWatch(
+			context.Background(),
+			env.workspaceRoot,
+			slug,
+			reviewWatchRequest("{\"run_id\":\"review-watch-explicit-missing\"}"),
+		)
+		if err == nil || !strings.Contains(err.Error(), "review watch workflow directory not found") {
+			t.Fatalf("StartReviewWatch() error = %v, want missing workflow directory", err)
+		}
+		if _, statErr := os.Stat(workflowDir); !os.IsNotExist(statErr) {
+			t.Fatalf("workflow dir stat after failed start = %v, want not exist", statErr)
+		}
 	})
 }
 

--- a/internal/daemon/transport_service_test.go
+++ b/internal/daemon/transport_service_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -290,6 +291,78 @@ func TestTaskTransportService_ShouldHandleWorkflowReadsAndUnavailableBranches(t 
 		}
 		if detail.Task.Title != "Transport task" || detail.Document.Title != "Transport task" {
 			t.Fatalf("unexpected archived task detail: %#v", detail)
+		}
+	})
+
+	t.Run("Should refresh stale empty workflow state before archiving review-only workflows", func(t *testing.T) {
+		testCases := []struct {
+			name         string
+			slug         string
+			reviewStatus string
+			wantArchived bool
+			wantProblem  bool
+		}{
+			{
+				name:         "Should archive resolved review-only workflow",
+				slug:         "review-only-resolved-stale",
+				reviewStatus: "resolved",
+				wantArchived: true,
+			},
+			{
+				name:         "Should require force for unresolved review-only workflow",
+				slug:         "review-only-pending-stale",
+				reviewStatus: "pending",
+				wantProblem:  true,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				env := newRunManagerTestEnv(t, runManagerTestDeps{})
+				if err := os.MkdirAll(env.workflowDir(tc.slug), 0o755); err != nil {
+					t.Fatalf("mkdir workflow dir: %v", err)
+				}
+				syncNamedWorkflowForDaemonTest(t, env, tc.slug)
+				env.writeWorkflowFile(
+					t,
+					tc.slug,
+					filepath.Join("reviews-001", "issue_001.md"),
+					daemonReviewIssueBody(tc.reviewStatus, "medium"),
+				)
+
+				service := newTransportTaskService(env.globalDB, env.manager)
+				result, err := service.Archive(
+					context.Background(),
+					env.workspaceRoot,
+					tc.slug,
+					apicore.ArchiveRequest{},
+				)
+				if tc.wantProblem {
+					var problem *apicore.Problem
+					if !errors.As(err, &problem) {
+						t.Fatalf("Archive() error = %v, want transport problem", err)
+					}
+					if problem.Code != string(contract.CodeWorkflowForceRequired) {
+						t.Fatalf(
+							"Archive() problem code = %q, want %q",
+							problem.Code,
+							contract.CodeWorkflowForceRequired,
+						)
+					}
+					if got := problem.Details["review_unresolved"]; got != 1 {
+						t.Fatalf("review_unresolved = %#v, want 1", got)
+					}
+					return
+				}
+
+				if err != nil {
+					t.Fatalf("Archive() error = %v", err)
+				}
+				if result.Archived != tc.wantArchived {
+					t.Fatalf("Archive().Archived = %v, want %v", result.Archived, tc.wantArchived)
+				}
+			})
 		}
 	})
 

--- a/openapi/compozy-daemon.json
+++ b/openapi/compozy-daemon.json
@@ -2016,6 +2016,9 @@
                         "additionalProperties": true,
                         "type": "object"
                     },
+                    "presentation_mode": {
+                        "type": "string"
+                    },
                     "max_rounds": {
                         "type": "integer"
                     },

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -1141,6 +1141,7 @@ export interface components {
             batching?: {
                 [key: string]: unknown;
             };
+            presentation_mode?: string;
             max_rounds?: number;
             poll_interval?: string;
             pr_ref: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review watch accepts explicit presentation mode (UI/text) and includes a new remote TUI with tabbed child-run views
  * Added --background alias for detach; workflow slug can be derived from PR when --name is omitted

* **Improvements**
  * Archive eligibility refresh for stale review-only workflows
  * Fetch validates PR-derived workflow directories before creating them
  * Prefer local git remote for CodeRabbit repo resolution before falling back to GitHub CLI
  * Better parsing of quoted/out-of-range review comments and clearer CLI attach/error messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->