### PR TITLE
feat: add Devin CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Execution runtimes are separate from skill installation. To run `compozy exec`, 
 | Claude Agent       | `claude`       | `claude-agent-acp`               |
 | Codex CLI          | `codex`        | `codex-acp`                      |
 | GitHub Copilot CLI | `copilot`      | `copilot --acp`                  |
+| Devin CLI          | `devin`        | `devin acp`                      |
 | Cursor             | `cursor-agent` | `cursor-agent acp`               |
 | Droid              | `droid`        | `droid exec --output-format acp` |
 | OpenCode           | `opencode`     | `opencode acp`                   |
@@ -500,13 +501,14 @@ The `cy-workflow-memory` skill handles all of this automatically when referenced
 | Claude Code    | `claude`       |
 | Codex          | `codex`        |
 | GitHub Copilot | `copilot`      |
+| Devin CLI      | `devin`        |
 | Cursor         | `cursor-agent` |
 | Droid          | `droid`        |
 | OpenCode       | `opencode`     |
 | Pi             | `pi`           |
 | Gemini         | `gemini`       |
 
-**Skill installation** (`compozy setup`) — 40+ agents and editors, including Claude Code, Codex, Cursor, Droid, OpenCode, Pi, Gemini CLI, GitHub Copilot, Windsurf, Amp, Continue, Goose, Roo Code, Augment, Kiro CLI, Cline, and many more. `compozy setup` installs core workflow skills plus any setup assets shipped by enabled extensions. Run `compozy setup` to see all detected agents on your system.
+**Skill installation** (`compozy setup`) — 40+ agents and editors, including Claude Code, Codex, Cursor, Devin CLI, Droid, OpenCode, Pi, Gemini CLI, GitHub Copilot, Windsurf, Amp, Continue, Goose, Roo Code, Augment, Kiro CLI, Cline, and many more. `compozy setup` installs core workflow skills plus any setup assets shipped by enabled extensions. Run `compozy setup` to see all detected agents on your system.
 
 When installing to multiple agents, Compozy offers two modes:
 

--- a/compozy.go
+++ b/compozy.go
@@ -49,6 +49,8 @@ const (
 	IDEGemini = core.IDEGemini
 	// IDECopilot runs GitHub Copilot CLI jobs.
 	IDECopilot = core.IDECopilot
+	// IDEDevin runs Devin CLI jobs.
+	IDEDevin = core.IDEDevin
 )
 
 // Config configures compozy preparation and execution.

--- a/internal/core/agent/registry_specs.go
+++ b/internal/core/agent/registry_specs.go
@@ -83,6 +83,7 @@ var supportedRegistryIDEOrder = []string{
 	model.IDEGemini,
 	model.IDECopilot,
 	model.IDEKiro,
+	model.IDEDevin,
 }
 
 var (
@@ -269,6 +270,20 @@ var (
 					args = append(args, "-a")
 				}
 				return args
+			},
+		},
+		model.IDEDevin: {
+			ID:             model.IDEDevin,
+			DisplayName:    "Devin CLI",
+			SetupAgentName: "devin",
+			DefaultModel:   model.DefaultDevinModel,
+			Command:        "devin",
+			FixedArgs:      []string{"acp"},
+			ProbeArgs:      []string{"acp", "--help"},
+			DocsURL:        "https://devin.ai/cli",
+			InstallHint:    "Install Devin CLI and expose `devin` on PATH so `devin acp` works.",
+			BootstrapArgs: func(_ string, _ string, _ []string, _ string) []string {
+				return nil
 			},
 		},
 	}

--- a/internal/core/agent/registry_specs.go
+++ b/internal/core/agent/registry_specs.go
@@ -282,6 +282,7 @@ var (
 			ProbeArgs:      []string{"acp", "--help"},
 			DocsURL:        "https://devin.ai/cli",
 			InstallHint:    "Install Devin CLI and expose `devin` on PATH so `devin acp` works.",
+			// devin acp resolves its own defaults; do not pass model, reasoning, or access flags.
 			BootstrapArgs: func(_ string, _ string, _ []string, _ string) []string {
 				return nil
 			},

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -27,7 +27,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 		wantProbe           []string
 	}{
 		{
-			name:                "claude",
+			name:                "Should expose Claude ACP commands",
 			ide:                 model.IDEClaude,
 			reasoning:           "medium",
 			addDirs:             []string{"../shared", "../docs"},
@@ -37,7 +37,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe:           []string{"claude-agent-acp", "--help"},
 		},
 		{
-			name:                "codex",
+			name:                "Should expose Codex ACP commands",
 			ide:                 model.IDECodex,
 			reasoning:           "medium",
 			addDirs:             []string{"../shared", "../docs"},
@@ -63,7 +63,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe: []string{"codex-acp", "--help"},
 		},
 		{
-			name:                "droid",
+			name:                "Should expose Droid ACP commands",
 			ide:                 model.IDEDroid,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -82,7 +82,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe: []string{"droid", "exec", "--help"},
 		},
 		{
-			name:                "cursor",
+			name:                "Should expose Cursor ACP commands",
 			ide:                 model.IDECursor,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -91,7 +91,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe:           []string{"cursor-agent", "acp", "--help"},
 		},
 		{
-			name:                "opencode",
+			name:                "Should expose OpenCode ACP commands",
 			ide:                 model.IDEOpenCode,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -100,7 +100,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe:           []string{"opencode", "acp", "--help"},
 		},
 		{
-			name:                "pi",
+			name:                "Should expose Pi ACP commands",
 			ide:                 model.IDEPi,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -109,7 +109,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe:           []string{"pi-acp", "--help"},
 		},
 		{
-			name:                "gemini",
+			name:                "Should expose Gemini ACP commands",
 			ide:                 model.IDEGemini,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -118,7 +118,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe:           []string{"gemini", "--acp", "--help"},
 		},
 		{
-			name:                "copilot",
+			name:                "Should expose Copilot ACP commands",
 			ide:                 model.IDECopilot,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -127,7 +127,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe:           []string{"copilot", "--acp", "--help"},
 		},
 		{
-			name:                "kiro",
+			name:                "Should expose Kiro ACP commands",
 			ide:                 model.IDEKiro,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -136,7 +136,7 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantProbe:           []string{"kiro-cli", "acp", "--help"},
 		},
 		{
-			name:                "devin",
+			name:                "Should expose Devin ACP commands",
 			ide:                 model.IDEDevin,
 			reasoning:           "medium",
 			accessMode:          model.AccessModeFull,
@@ -745,7 +745,7 @@ func TestValidateRuntimeConfigAcceptsSupportedIDEs(t *testing.T) {
 
 	for _, ide := range validIDEs {
 		ide := ide
-		t.Run(ide, func(t *testing.T) {
+		t.Run("Should accept "+ide+" runtime config", func(t *testing.T) {
 			t.Parallel()
 
 			cfg := &model.RuntimeConfig{

--- a/internal/core/agent/registry_test.go
+++ b/internal/core/agent/registry_test.go
@@ -117,6 +117,33 @@ func TestAgentRegistryEntries(t *testing.T) {
 			wantLaunch:          []string{"gemini", "--acp"},
 			wantProbe:           []string{"gemini", "--acp", "--help"},
 		},
+		{
+			name:                "copilot",
+			ide:                 model.IDECopilot,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
+			wantLaunch:          []string{"copilot", "--acp"},
+			wantProbe:           []string{"copilot", "--acp", "--help"},
+		},
+		{
+			name:                "kiro",
+			ide:                 model.IDEKiro,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
+			wantLaunch:          []string{"kiro-cli", "acp", "--model", model.DefaultKiroModel, "-a"},
+			wantProbe:           []string{"kiro-cli", "acp", "--help"},
+		},
+		{
+			name:                "devin",
+			ide:                 model.IDEDevin,
+			reasoning:           "medium",
+			accessMode:          model.AccessModeFull,
+			wantSupportsAddDirs: false,
+			wantLaunch:          []string{"devin", "acp"},
+			wantProbe:           []string{"devin", "acp", "--help"},
+		},
 	}
 
 	for _, tc := range cases {
@@ -711,6 +738,9 @@ func TestValidateRuntimeConfigAcceptsSupportedIDEs(t *testing.T) {
 		model.IDEOpenCode,
 		model.IDEPi,
 		model.IDEGemini,
+		model.IDECopilot,
+		model.IDEKiro,
+		model.IDEDevin,
 	}
 
 	for _, ide := range validIDEs {
@@ -1272,6 +1302,27 @@ func TestDriverCatalogExposesCanonicalCommandsAndFallbacks(t *testing.T) {
 			wantCommand:         []string{"gemini", "--acp"},
 			wantProbe:           []string{"gemini", "--acp", "--help"},
 			wantFallbackCount:   1,
+			wantSupportsAddDirs: false,
+		},
+		{
+			ide:                 model.IDECopilot,
+			wantCommand:         []string{"copilot", "--acp"},
+			wantProbe:           []string{"copilot", "--acp", "--help"},
+			wantFallbackCount:   1,
+			wantSupportsAddDirs: false,
+		},
+		{
+			ide:                 model.IDEKiro,
+			wantCommand:         []string{"kiro-cli", "acp"},
+			wantProbe:           []string{"kiro-cli", "acp", "--help"},
+			wantFallbackCount:   0,
+			wantSupportsAddDirs: false,
+		},
+		{
+			ide:                 model.IDEDevin,
+			wantCommand:         []string{"devin", "acp"},
+			wantProbe:           []string{"devin", "acp", "--help"},
+			wantFallbackCount:   0,
 			wantSupportsAddDirs: false,
 		},
 	}

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -66,6 +66,8 @@ const (
 	IDEGemini IDE = model.IDEGemini
 	// IDECopilot runs GitHub Copilot CLI jobs.
 	IDECopilot IDE = model.IDECopilot
+	// IDEDevin runs Devin CLI jobs.
+	IDEDevin IDE = model.IDEDevin
 )
 
 const (

--- a/internal/core/model/constants.go
+++ b/internal/core/model/constants.go
@@ -13,6 +13,7 @@ const (
 	IDEGemini                = "gemini"
 	IDECopilot               = "copilot"
 	IDEKiro                  = "kiro"
+	IDEDevin                 = "devin"
 	DefaultCodexModel        = "gpt-5.5"
 	DefaultClaudeModel       = "opus"
 	DefaultCursorModel       = "composer-1"
@@ -21,6 +22,7 @@ const (
 	DefaultGeminiModel       = "gemini-2.5-pro"
 	DefaultCopilotModel      = "claude-sonnet-4.6"
 	DefaultKiroModel         = "anthropic/claude-opus-4-6"
+	DefaultDevinModel        = "anthropic/claude-opus-4-6"
 	DefaultActivityTimeout   = 10 * time.Minute
 	WorkflowRootDirName      = ".compozy"
 	WorkflowConfigFileName   = "config.toml"

--- a/internal/setup/agents.go
+++ b/internal/setup/agents.go
@@ -294,6 +294,7 @@ var agentSpecs = []agentSpec{
 	specificAgent("crush", "Crush", ".crush/skills", xdgPath("crush/skills"), xdgPath("crush")),
 	universalAgent("cursor", "Cursor", homePath(".cursor/skills"), homePath(".cursor")),
 	universalAgent("deepagents", "Deep Agents", homePath(".deepagents/agent/skills"), homePath(".deepagents")),
+	specificAgent("devin", "Devin CLI", ".devin/skills", xdgPath("devin/skills"), xdgPath("devin")),
 	specificAgent("droid", "Droid", ".factory/skills", homePath(".factory/skills"), homePath(".factory")),
 	universalAgent("firebender", "Firebender", homePath(".firebender/skills"), homePath(".firebender")),
 	universalAgent("gemini-cli", "Gemini CLI", homePath(".gemini/skills"), homePath(".gemini")),

--- a/internal/setup/agents_test.go
+++ b/internal/setup/agents_test.go
@@ -67,6 +67,9 @@ func TestSupportedAgentsUseDeclarativePaths(t *testing.T) {
 	if err := ensureDir(claudeConfigDir); err != nil {
 		t.Fatalf("create claude dir: %v", err)
 	}
+	if err := ensureDir(filepath.Join(xdgConfigHome, "devin")); err != nil {
+		t.Fatalf("create devin dir: %v", err)
+	}
 	if err := ensureDir(filepath.Join(homeDir, ".trae-cn")); err != nil {
 		t.Fatalf("create trae-cn dir: %v", err)
 	}
@@ -106,6 +109,14 @@ func TestSupportedAgentsUseDeclarativePaths(t *testing.T) {
 		DisplayName:    "OpenClaw",
 		ProjectRootDir: "skills",
 		GlobalRootDir:  filepath.Join(homeDir, ".clawdbot", "skills"),
+		Detected:       true,
+	})
+
+	assertAgent(t, byName["devin"], Agent{
+		Name:           "devin",
+		DisplayName:    "Devin CLI",
+		ProjectRootDir: ".devin/skills",
+		GlobalRootDir:  filepath.Join(xdgConfigHome, "devin", "skills"),
 		Detected:       true,
 	})
 

--- a/internal/setup/runtime_agents.go
+++ b/internal/setup/runtime_agents.go
@@ -8,6 +8,7 @@ import (
 var runtimeIDEAgentNames = map[string]string{
 	"claude":       "claude-code",
 	"codex":        "codex",
+	"copilot":      "github-copilot",
 	"cursor-agent": "cursor",
 	"droid":        "droid",
 	"gemini":       "gemini-cli",

--- a/internal/setup/runtime_agents.go
+++ b/internal/setup/runtime_agents.go
@@ -14,6 +14,7 @@ var runtimeIDEAgentNames = map[string]string{
 	"opencode":     "opencode",
 	"pi":           "pi",
 	"kiro":         "kiro-cli",
+	"devin":        "devin",
 }
 
 // AgentNameForIDE maps a compozy runtime IDE name to the setup agent name.

--- a/internal/setup/verify_test.go
+++ b/internal/setup/verify_test.go
@@ -18,6 +18,8 @@ func TestAgentNameForIDE(t *testing.T) {
 		"gemini":       "gemini-cli",
 		"opencode":     "opencode",
 		"pi":           "pi",
+		"kiro":         "kiro-cli",
+		"devin":        "devin",
 	}
 
 	for ide, want := range tests {

--- a/internal/setup/verify_test.go
+++ b/internal/setup/verify_test.go
@@ -13,6 +13,7 @@ func TestAgentNameForIDE(t *testing.T) {
 	tests := map[string]string{
 		"claude":       "claude-code",
 		"codex":        "codex",
+		"copilot":      "github-copilot",
 		"cursor-agent": "cursor",
 		"droid":        "droid",
 		"gemini":       "gemini-cli",


### PR DESCRIPTION
Adds Devin CLI as an ACP-compatible agent.

Devin exposes an ACP server over stdio via:

devin acp

This PR registers Devin as an agent runtime using:
- command: devin
- args: acp
- probe: devin acp --help

It intentionally does not use --agent-type summarizer by default because that mode has no tools.

Validation:
- make verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Devin CLI as a selectable IDE option, including runtime command/probe support and a default model configuration.
  * Introduced a dedicated Devin skills agent with project and global resolution paths.

* **Tests**
  * Extended IDE registry, driver catalog, and runtime configuration test coverage to include Devin (plus related IDE naming/acceptance cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->