### PR TITLE
release: Release v0.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-## 0.2.9 - 2026-06-13
+## 0.2.10 - 2026-06-18
+
+### ♻️  Refactoring
+
+- Tui redesign (#201)
+### 🎉 Features
+
+- Worktree-backed parallel multi-run for tasks run --multiple (#200)- Add Devin CLI agent support (#204)
+### 🐛 Bug Fixes
+
+- Reviews watch bug
+### 📦 Build System
+
+- Skeeper config (#206)- Converge skeeper sidecar lock to main branch
+## 0.2.9 - 2026-06-14
 
 ### 🐛 Bug Fixes
 
@@ -324,6 +338,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
+[0.2.10]: https://github.com///compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com///compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com///compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com///compare/v0.2.6...v0.2.7

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,35 +1,14 @@
-## 0.2.9 - 2026-06-13
+## 0.2.10 - 2026-06-18
 
+### ♻️  Refactoring
+
+- Tui redesign (#201)
+### 🎉 Features
+
+- Worktree-backed parallel multi-run for tasks run --multiple (#200)- Add Devin CLI agent support (#204)
 ### 🐛 Bug Fixes
 
-- Record ACP token usage and adapt to acp-go-sdk v0.13.5 (#198)
+- Reviews watch bug
+### 📦 Build System
 
-### Release Notes
-
-#### Fixes
-
-##### ACP agents now record token usage
-Token usage from ACP-backed agents (Claude Code, Codex, and other ACP runtimes) is now recorded and surfaced. Previously the engine discarded the usage payload returned with each prompt response, so run journals and the Compozy UI always reported zero tokens for ACP agents. Usage is now converted after every prompt response and published as a session update, so it reaches the run journal and the live event stream.
-
-### What gets reported
-
-After each ACP prompt response, Compozy maps the runtime's usage payload into the run's usage totals:
-
-| Reported field       | Source                                                                     |
-| -------------------- | -------------------------------------------------------------------------- |
-| Input tokens         | ACP `inputTokens`                                                          |
-| Output tokens        | ACP `outputTokens` + `thoughtTokens` (reasoning tokens folded into output) |
-| Total tokens         | ACP `totalTokens` (the session-wide sum of all token types)                |
-| Cache reads / writes | ACP `cachedReadTokens` / `cachedWriteTokens`                               |
-
-Reasoning/thought tokens are summed into output tokens for this release; a dedicated reasoning-token field is planned for a later milestone. Totals stay self-consistent because ACP's `totalTokens` already includes reasoning tokens, so `input + output` continues to match `total` after folding.
-
-### Behavior
-
-- **Accumulates across turns.** Each prompt response adds to both the per-job and the aggregate run totals, so long-running sessions report cumulative usage rather than only the last turn.
-- **Zero-usage updates are skipped.** Empty payloads never perturb the totals or emit spurious usage events.
-- **Streamed to the UI and journal.** Every non-empty update emits a usage event and is appended to the durable run journal, so token counts show up live and on replay.
-
-### Under the hood
-
-This change upgrades the ACP SDK (`github.com/coder/acp-go-sdk`) to v0.13.5. The SDK dropped the `session/set_model` RPC, so model selection for ACP agents is resolved at session creation rather than switched at runtime — pass the model up front (Compozy already pins the Claude agent's model via the environment).
+- Skeeper config (#206)- Converge skeeper sidecar lock to main branch

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,18 @@
+## 0.2.10 - 2026-06-18
+
+### ♻️  Refactoring
+
+- Tui redesign (#201)
+### 🎉 Features
+
+- Worktree-backed parallel multi-run for tasks run --multiple (#200)- Add Devin CLI agent support (#204)
+### 🐛 Bug Fixes
+
+- Reviews watch bug
+### 📦 Build System
+
+- Skeeper config (#206)- Converge skeeper sidecar lock to main branch
+
 ## 0.2.9 - 2026-06-13
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:config": "bunx vitest run --config vitest.config.ts test/*.test.ts",
     "typecheck": "turbo run typecheck"
   },
-  "version": "0.2.9",
+  "version": "0.2.10",
   "workspaces": [
     "packages/ui",
     "web",


### PR DESCRIPTION
## Release v0.2.10
This PR prepares the release of version v0.2.10.
### Changelog
## 0.2.10 - 2026-06-18
### ♻️  Refactoring
- Tui redesign (#201)
### 🎉 Features
- Worktree-backed parallel multi-run for tasks run --multiple (#200)- Add Devin CLI agent support (#204)
### 🐛 Bug Fixes
- Reviews watch bug