### PR TITLE
feat: support COMPOZY_HOME env override for home directory

### DIFF
--- a/internal/cli/extension/display_test.go
+++ b/internal/cli/extension/display_test.go
@@ -678,6 +678,7 @@ func TestPathExistsAndRenderHooksHelpers(t *testing.T) {
 func TestDefaultCommandDepsAndHelperFunctions(t *testing.T) {
 	deps := defaultCommandDeps()
 	if deps.resolveHomeDir == nil ||
+		deps.resolveCompozyHome == nil ||
 		deps.resolveWorkspaceRoot == nil ||
 		deps.isInteractive == nil ||
 		deps.confirmInstall == nil ||
@@ -993,6 +994,7 @@ func newTestDeps(t *testing.T) testDeps {
 
 	deps := defaultCommandDeps()
 	deps.resolveHomeDir = func() (string, error) { return homeDir, nil }
+	deps.resolveCompozyHome = func() (string, error) { return filepath.Join(homeDir, ".compozy"), nil }
 	deps.resolveWorkspaceRoot = func(context.Context) (string, error) { return workspaceRoot, nil }
 	deps.isInteractive = func() bool { return false }
 	deps.confirmInstall = func(*cobra.Command, installPrompt) (bool, error) { return true, nil }
@@ -1127,7 +1129,9 @@ func writeTestFile(t *testing.T, path string, content string) {
 func mustEnablementStore(t *testing.T, homeDir string) *extensions.EnablementStore {
 	t.Helper()
 
-	store, err := extensions.NewEnablementStore(context.Background(), homeDir)
+	// homeDir is the OS-home temp; the store roots at the Compozy home, matching
+	// how the CLI resolves it via resolveCompozyHome (config.ResolveHomeDir).
+	store, err := extensions.NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 	if err != nil {
 		t.Fatalf("create enablement store: %v", err)
 	}

--- a/internal/cli/extension/install.go
+++ b/internal/cli/extension/install.go
@@ -127,7 +127,7 @@ func runUninstallCommand(cmd *cobra.Command, deps commandDeps, rawName string) e
 		return err
 	}
 
-	userPath := filepath.Join(userExtensionsRoot(env.homeDir), name)
+	userPath := filepath.Join(userExtensionsRoot(env.compozyHome), name)
 	exists, err := deps.pathExists(userPath)
 	if err != nil {
 		return fmt.Errorf("inspect user extension path %q: %w", userPath, err)
@@ -254,7 +254,7 @@ func prepareInstallRequest(
 		)
 	}
 
-	installPath := filepath.Join(userExtensionsRoot(env.homeDir), manifest.Extension.Name)
+	installPath := filepath.Join(userExtensionsRoot(env.compozyHome), manifest.Extension.Name)
 	if sameInstallPath(resolvedSource.SourcePath, installPath) {
 		return nil, "", installPrompt{}, fmt.Errorf(
 			"extension %q is already installed at %s",
@@ -402,8 +402,8 @@ func ensureInstallTargetAvailable(deps commandDeps, installPath string, name str
 	return nil
 }
 
-func userExtensionsRoot(homeDir string) string {
-	return filepath.Join(homeDir, ".compozy", "extensions")
+func userExtensionsRoot(compozyHome string) string {
+	return filepath.Join(compozyHome, "extensions")
 }
 
 func sameInstallPath(left string, right string) bool {

--- a/internal/cli/extension/root.go
+++ b/internal/cli/extension/root.go
@@ -12,6 +12,7 @@ import (
 
 	huh "charm.land/huh/v2"
 
+	compozyconfig "github.com/compozy/compozy/internal/config"
 	extensions "github.com/compozy/compozy/internal/core/extension"
 	"github.com/compozy/compozy/internal/core/kernel"
 	"github.com/compozy/compozy/internal/core/workspace"
@@ -27,6 +28,7 @@ type discoverRequest struct {
 
 type commandDeps struct {
 	resolveHomeDir       func() (string, error)
+	resolveCompozyHome   func() (string, error)
 	resolveWorkspaceRoot func(context.Context) (string, error)
 	isInteractive        func() bool
 	confirmInstall       func(*cobra.Command, installPrompt) (bool, error)
@@ -42,7 +44,12 @@ type commandDeps struct {
 }
 
 type commandEnv struct {
-	homeDir       string
+	// homeDir is the OS user home, used only for setup.ResolverOptions
+	// (.claude/.codex/.config detection).
+	homeDir string
+	// compozyHome is the Compozy home root (".compozy" or COMPOZY_HOME), used for
+	// extension install, enablement state, and discovery.
+	compozyHome   string
 	workspaceRoot string
 	store         *extensions.EnablementStore
 }
@@ -57,7 +64,8 @@ type installPrompt struct {
 
 func defaultCommandDeps() commandDeps {
 	return commandDeps{
-		resolveHomeDir: os.UserHomeDir,
+		resolveHomeDir:     os.UserHomeDir,
+		resolveCompozyHome: compozyconfig.ResolveHomeDir,
 		resolveWorkspaceRoot: func(ctx context.Context) (string, error) {
 			root, err := workspace.Discover(ctx, "")
 			if err != nil {
@@ -94,18 +102,23 @@ func (d commandDeps) resolveEnv(ctx context.Context) (commandEnv, error) {
 	if err != nil {
 		return commandEnv{}, fmt.Errorf("resolve home directory: %w", err)
 	}
+	compozyHome, err := d.resolveCompozyHome()
+	if err != nil {
+		return commandEnv{}, fmt.Errorf("resolve compozy home directory: %w", err)
+	}
 	workspaceRoot, err := d.resolveWorkspaceRoot(ctx)
 	if err != nil {
 		return commandEnv{}, err
 	}
 
-	store, err := d.newEnablementStore(ctx, homeDir)
+	store, err := d.newEnablementStore(ctx, compozyHome)
 	if err != nil {
 		return commandEnv{}, fmt.Errorf("create enablement store: %w", err)
 	}
 
 	return commandEnv{
 		homeDir:       filepath.Clean(homeDir),
+		compozyHome:   filepath.Clean(compozyHome),
 		workspaceRoot: workspaceRoot,
 		store:         store,
 	}, nil
@@ -113,7 +126,7 @@ func (d commandDeps) resolveEnv(ctx context.Context) (commandEnv, error) {
 
 func (d commandDeps) discoverAll(ctx context.Context, env commandEnv) (extensions.DiscoveryResult, error) {
 	return d.discover(ctx, discoverRequest{
-		HomeDir:         env.homeDir,
+		HomeDir:         env.compozyHome,
 		WorkspaceRoot:   env.workspaceRoot,
 		IncludeDisabled: true,
 		Store:           env.store,

--- a/internal/cli/extensions_bootstrap_test.go
+++ b/internal/cli/extensions_bootstrap_test.go
@@ -357,7 +357,9 @@ func assertBootstrapFileExists(t *testing.T, path string) {
 func enableBootstrapWorkspaceExtension(t *testing.T, homeDir string, workspaceRoot string, name string) {
 	t.Helper()
 
-	store, err := extensions.NewEnablementStore(context.Background(), homeDir)
+	// homeDir is the OS-home temp; the store roots at the Compozy home so it
+	// matches how the runtime resolves it via config.ResolveHomeDir.
+	store, err := extensions.NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 	if err != nil {
 		t.Fatalf("create enablement store: %v", err)
 	}

--- a/internal/cli/root_command_execution_test.go
+++ b/internal/cli/root_command_execution_test.go
@@ -4060,7 +4060,9 @@ capabilities = ["tasks.read"]
 		t.Fatalf("write extension manifest: %v", err)
 	}
 
-	store, err := extensions.NewEnablementStore(context.Background(), homeDir)
+	// homeDir is the OS-home temp; the store roots at the Compozy home so it
+	// matches how the runtime resolves it via config.ResolveHomeDir.
+	store, err := extensions.NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 	if err != nil {
 		t.Fatalf("create enablement store: %v", err)
 	}

--- a/internal/cli/setup_assets.go
+++ b/internal/cli/setup_assets.go
@@ -14,14 +14,15 @@ func loadEffectiveSetupCatalog(
 	ctx context.Context,
 	resolver setup.ResolverOptions,
 ) (setup.EffectiveCatalog, error) {
-	workspaceRoot, homeDir, err := resolveSetupAssetRoots(resolver)
+	workspaceRoot, err := resolveSetupWorkspaceRoot(resolver)
 	if err != nil {
 		return setup.EffectiveCatalog{}, err
 	}
 
+	// Discovery resolves the Compozy home root internally (honoring COMPOZY_HOME),
+	// so setup asset discovery tracks the same root as the rest of the runtime.
 	discovery, err := extensions.Discovery{
 		WorkspaceRoot: workspaceRoot,
-		HomeDir:       homeDir,
 	}.Discover(ctx)
 	if err != nil {
 		return setup.EffectiveCatalog{}, fmt.Errorf("discover setup extension assets: %w", err)
@@ -66,24 +67,15 @@ func effectiveExtensionSkillSources(discovery extensions.DiscoveryResult) ([]set
 	return setup.ExtensionSkillPackSources(catalog.Skills), nil
 }
 
-func resolveSetupAssetRoots(options setup.ResolverOptions) (string, string, error) {
+func resolveSetupWorkspaceRoot(options setup.ResolverOptions) (string, error) {
 	workspaceRoot := strings.TrimSpace(options.CWD)
 	if workspaceRoot == "" {
 		cwd, err := os.Getwd()
 		if err != nil {
-			return "", "", fmt.Errorf("resolve setup workspace root: %w", err)
+			return "", fmt.Errorf("resolve setup workspace root: %w", err)
 		}
 		workspaceRoot = cwd
 	}
 
-	homeDir := strings.TrimSpace(options.HomeDir)
-	if homeDir == "" {
-		resolvedHomeDir, err := os.UserHomeDir()
-		if err != nil {
-			return "", "", fmt.Errorf("resolve setup home directory: %w", err)
-		}
-		homeDir = resolvedHomeDir
-	}
-
-	return workspaceRoot, homeDir, nil
+	return workspaceRoot, nil
 }

--- a/internal/config/home.go
+++ b/internal/config/home.go
@@ -26,9 +26,14 @@ const (
 	DaemonLockName   = "daemon.lock"
 	DaemonInfoName   = "daemon.json"
 	DaemonLogName    = "daemon.log"
+
+	HomeEnvVar = "COMPOZY_HOME"
 )
 
 var osUserHomeDir = os.UserHomeDir
+
+// osLookupEnv mirrors os.LookupEnv for tests that need to stub env resolution.
+var osLookupEnv = os.LookupEnv
 
 // HomePaths captures the stable home-scoped Compozy layout.
 type HomePaths struct {
@@ -50,13 +55,37 @@ type HomePaths struct {
 	CacheDir      string
 }
 
-// ResolveHomeDir returns the canonical Compozy home root under the current user's home directory.
+// ResolveHomeDir returns the canonical Compozy home root.
+//
+// Precedence:
+//  1. COMPOZY_HOME environment variable, when set to a non-empty value
+//     (whitespace trimmed). A leading "~" or "~/" is expanded against the
+//     current user's home directory.
+//  2. The current user's home directory, joined with DirName (".compozy").
 func ResolveHomeDir() (string, error) {
+	if override, ok := lookupHomeOverride(); ok {
+		return ResolvePath(override)
+	}
 	homeDir, err := osUserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve user home directory: %w", err)
 	}
 	return ResolvePath(filepath.Join(homeDir, DirName))
+}
+
+// lookupHomeOverride reads COMPOZY_HOME and returns a trimmed, non-empty
+// value when it is set. The boolean is false when the variable is unset or
+// contains only whitespace, so callers can fall back to the user home.
+func lookupHomeOverride() (string, bool) {
+	value, ok := osLookupEnv(HomeEnvVar)
+	if !ok {
+		return "", false
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", false
+	}
+	return trimmed, true
 }
 
 // ResolveHomePaths resolves the canonical Compozy home layout from the current user's home directory.

--- a/internal/config/home_test.go
+++ b/internal/config/home_test.go
@@ -240,3 +240,111 @@ func stubConfigUserHomeDir(t *testing.T, fn func() (string, error)) {
 		osUserHomeDir = original
 	})
 }
+
+func TestResolveHomeDirUsesCompozyHomeEnv(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "custom-compozy")
+	t.Setenv(HomeEnvVar, override)
+
+	homeDir, err := ResolveHomeDir()
+	if err != nil {
+		t.Fatalf("ResolveHomeDir() error = %v", err)
+	}
+	if got, want := homeDir, override; got != want {
+		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomeDirCompozyHomeEnvTrimsWhitespace(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "custom-compozy")
+	t.Setenv(HomeEnvVar, "  "+override+" \t")
+
+	homeDir, err := ResolveHomeDir()
+	if err != nil {
+		t.Fatalf("ResolveHomeDir() error = %v", err)
+	}
+	if got, want := homeDir, override; got != want {
+		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomeDirIgnoresEmptyCompozyHomeEnv(t *testing.T) {
+	homeDir := t.TempDir()
+	stubConfigUserHomeDir(t, func() (string, error) {
+		return homeDir, nil
+	})
+	t.Setenv(HomeEnvVar, "")
+
+	got, err := ResolveHomeDir()
+	if err != nil {
+		t.Fatalf("ResolveHomeDir() error = %v", err)
+	}
+	if want := filepath.Join(homeDir, DirName); got != want {
+		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomeDirIgnoresWhitespaceCompozyHomeEnv(t *testing.T) {
+	homeDir := t.TempDir()
+	stubConfigUserHomeDir(t, func() (string, error) {
+		return homeDir, nil
+	})
+	t.Setenv(HomeEnvVar, "   \t  ")
+
+	got, err := ResolveHomeDir()
+	if err != nil {
+		t.Fatalf("ResolveHomeDir() error = %v", err)
+	}
+	if want := filepath.Join(homeDir, DirName); got != want {
+		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomeDirCompozyHomeEnvExpandsTilde(t *testing.T) {
+	homeDir := t.TempDir()
+	stubConfigUserHomeDir(t, func() (string, error) {
+		return homeDir, nil
+	})
+	t.Setenv(HomeEnvVar, "~/alt-compozy")
+
+	got, err := ResolveHomeDir()
+	if err != nil {
+		t.Fatalf("ResolveHomeDir() error = %v", err)
+	}
+	if want := filepath.Join(homeDir, "alt-compozy"); got != want {
+		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomePathsUsesCompozyHomeEnv(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "custom-compozy")
+	t.Setenv(HomeEnvVar, override)
+
+	paths, err := ResolveHomePaths()
+	if err != nil {
+		t.Fatalf("ResolveHomePaths() error = %v", err)
+	}
+	if got, want := paths.HomeDir, override; got != want {
+		t.Fatalf("paths.HomeDir = %q, want %q", got, want)
+	}
+	if got, want := paths.DaemonDir, filepath.Join(override, "daemon"); got != want {
+		t.Fatalf("paths.DaemonDir = %q, want %q", got, want)
+	}
+}
+
+func TestResolveHomeDirWithoutCompozyHomeFallsBackToUserHome(t *testing.T) {
+	homeDir := t.TempDir()
+	stubConfigUserHomeDir(t, func() (string, error) {
+		return homeDir, nil
+	})
+	if _, ok := osLookupEnv(HomeEnvVar); ok {
+		t.Fatalf("precondition: %s must be unset", HomeEnvVar)
+	}
+
+	got, err := ResolveHomeDir()
+	if err != nil {
+		t.Fatalf("ResolveHomeDir() error = %v", err)
+	}
+	if want := filepath.Join(homeDir, DirName); got != want {
+		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
+	}
+}

--- a/internal/config/home_test.go
+++ b/internal/config/home_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -62,6 +63,7 @@ func TestResolveHomePathsFromExpandsTilde(t *testing.T) {
 }
 
 func TestResolveHomePathsUsesUserHome(t *testing.T) {
+	t.Setenv(HomeEnvVar, "")
 	homeDir := t.TempDir()
 	stubConfigUserHomeDir(t, func() (string, error) {
 		return homeDir, nil
@@ -78,6 +80,7 @@ func TestResolveHomePathsUsesUserHome(t *testing.T) {
 }
 
 func TestResolveHomePathsUsesHomeIndependentlyOfWorkingDirectory(t *testing.T) {
+	t.Setenv(HomeEnvVar, "")
 	homeDir := t.TempDir()
 	stubConfigUserHomeDir(t, func() (string, error) {
 		return homeDir, nil
@@ -165,6 +168,7 @@ func TestEnsureHomeLayoutRejectsEmptyPaths(t *testing.T) {
 }
 
 func TestResolveHomeDirReturnsUserHomeErrors(t *testing.T) {
+	t.Setenv(HomeEnvVar, "")
 	homeErr := errors.New("home unavailable")
 	stubConfigUserHomeDir(t, func() (string, error) {
 		return "", homeErr
@@ -241,110 +245,107 @@ func stubConfigUserHomeDir(t *testing.T, fn func() (string, error)) {
 	})
 }
 
-func TestResolveHomeDirUsesCompozyHomeEnv(t *testing.T) {
-	override := filepath.Join(t.TempDir(), "custom-compozy")
-	t.Setenv(HomeEnvVar, override)
+func stubConfigLookupEnv(t *testing.T, fn func(string) (string, bool)) {
+	t.Helper()
 
-	homeDir, err := ResolveHomeDir()
-	if err != nil {
-		t.Fatalf("ResolveHomeDir() error = %v", err)
-	}
-	if got, want := homeDir, override; got != want {
-		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
-	}
-}
-
-func TestResolveHomeDirCompozyHomeEnvTrimsWhitespace(t *testing.T) {
-	override := filepath.Join(t.TempDir(), "custom-compozy")
-	t.Setenv(HomeEnvVar, "  "+override+" \t")
-
-	homeDir, err := ResolveHomeDir()
-	if err != nil {
-		t.Fatalf("ResolveHomeDir() error = %v", err)
-	}
-	if got, want := homeDir, override; got != want {
-		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
-	}
-}
-
-func TestResolveHomeDirIgnoresEmptyCompozyHomeEnv(t *testing.T) {
-	homeDir := t.TempDir()
-	stubConfigUserHomeDir(t, func() (string, error) {
-		return homeDir, nil
+	original := osLookupEnv
+	osLookupEnv = fn
+	t.Cleanup(func() {
+		osLookupEnv = original
 	})
-	t.Setenv(HomeEnvVar, "")
-
-	got, err := ResolveHomeDir()
-	if err != nil {
-		t.Fatalf("ResolveHomeDir() error = %v", err)
-	}
-	if want := filepath.Join(homeDir, DirName); got != want {
-		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
-	}
 }
 
-func TestResolveHomeDirIgnoresWhitespaceCompozyHomeEnv(t *testing.T) {
-	homeDir := t.TempDir()
-	stubConfigUserHomeDir(t, func() (string, error) {
-		return homeDir, nil
-	})
-	t.Setenv(HomeEnvVar, "   \t  ")
-
-	got, err := ResolveHomeDir()
-	if err != nil {
-		t.Fatalf("ResolveHomeDir() error = %v", err)
-	}
-	if want := filepath.Join(homeDir, DirName); got != want {
-		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
-	}
-}
-
-func TestResolveHomeDirCompozyHomeEnvExpandsTilde(t *testing.T) {
-	homeDir := t.TempDir()
-	stubConfigUserHomeDir(t, func() (string, error) {
-		return homeDir, nil
-	})
-	t.Setenv(HomeEnvVar, "~/alt-compozy")
-
-	got, err := ResolveHomeDir()
-	if err != nil {
-		t.Fatalf("ResolveHomeDir() error = %v", err)
-	}
-	if want := filepath.Join(homeDir, "alt-compozy"); got != want {
-		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
-	}
-}
-
-func TestResolveHomePathsUsesCompozyHomeEnv(t *testing.T) {
-	override := filepath.Join(t.TempDir(), "custom-compozy")
-	t.Setenv(HomeEnvVar, override)
-
-	paths, err := ResolveHomePaths()
-	if err != nil {
-		t.Fatalf("ResolveHomePaths() error = %v", err)
-	}
-	if got, want := paths.HomeDir, override; got != want {
-		t.Fatalf("paths.HomeDir = %q, want %q", got, want)
-	}
-	if got, want := paths.DaemonDir, filepath.Join(override, "daemon"); got != want {
-		t.Fatalf("paths.DaemonDir = %q, want %q", got, want)
-	}
-}
-
-func TestResolveHomeDirWithoutCompozyHomeFallsBackToUserHome(t *testing.T) {
-	homeDir := t.TempDir()
-	stubConfigUserHomeDir(t, func() (string, error) {
-		return homeDir, nil
-	})
-	if _, ok := osLookupEnv(HomeEnvVar); ok {
-		t.Fatalf("precondition: %s must be unset", HomeEnvVar)
+func TestResolveHomeDirAndPathsRespectCompozyHome(t *testing.T) {
+	tests := []struct {
+		name            string
+		envTemplate     string
+		stubHome        bool
+		stubLookupUnset bool
+		usePaths        bool
+		wantSubdir      string
+	}{
+		{
+			name:        "Should use COMPOZY_HOME env var when set",
+			envTemplate: "$TMP/custom-compozy",
+			wantSubdir:  "custom-compozy",
+		},
+		{
+			name:        "Should trim whitespace from COMPOZY_HOME",
+			envTemplate: "  $TMP/custom-compozy \t",
+			wantSubdir:  "custom-compozy",
+		},
+		{
+			name:        "Should fall back to user home when COMPOZY_HOME is empty",
+			envTemplate: "",
+			stubHome:    true,
+			wantSubdir:  DirName,
+		},
+		{
+			name:        "Should fall back to user home when COMPOZY_HOME is whitespace only",
+			envTemplate: "   \t  ",
+			stubHome:    true,
+			wantSubdir:  DirName,
+		},
+		{
+			name:        "Should expand tilde in COMPOZY_HOME",
+			envTemplate: "~/alt-compozy",
+			stubHome:    true,
+			wantSubdir:  "alt-compozy",
+		},
+		{
+			name:        "Should derive full home paths from COMPOZY_HOME",
+			envTemplate: "$TMP/custom-compozy",
+			usePaths:    true,
+			wantSubdir:  "custom-compozy",
+		},
+		{
+			name:            "Should fall back to user home when COMPOZY_HOME is unset",
+			stubHome:        true,
+			stubLookupUnset: true,
+			wantSubdir:      DirName,
+		},
 	}
 
-	got, err := ResolveHomeDir()
-	if err != nil {
-		t.Fatalf("ResolveHomeDir() error = %v", err)
-	}
-	if want := filepath.Join(homeDir, DirName); got != want {
-		t.Fatalf("ResolveHomeDir() = %q, want %q", got, want)
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			if tt.stubHome {
+				stubConfigUserHomeDir(t, func() (string, error) {
+					return tempDir, nil
+				})
+			}
+			if tt.stubLookupUnset {
+				stubConfigLookupEnv(t, func(string) (string, bool) {
+					return "", false
+				})
+			} else {
+				t.Setenv(HomeEnvVar, strings.ReplaceAll(tt.envTemplate, "$TMP", tempDir))
+			}
+
+			wantHomeDir := filepath.Join(tempDir, tt.wantSubdir)
+
+			if tt.usePaths {
+				paths, err := ResolveHomePaths()
+				if err != nil {
+					t.Fatalf("ResolveHomePaths() error = %v", err)
+				}
+				if got := paths.HomeDir; got != wantHomeDir {
+					t.Fatalf("paths.HomeDir = %q, want %q", got, wantHomeDir)
+				}
+				if got, want := paths.DaemonDir, filepath.Join(wantHomeDir, "daemon"); got != want {
+					t.Fatalf("paths.DaemonDir = %q, want %q", got, want)
+				}
+				return
+			}
+
+			homeDir, err := ResolveHomeDir()
+			if err != nil {
+				t.Fatalf("ResolveHomeDir() error = %v", err)
+			}
+			if got := homeDir; got != wantHomeDir {
+				t.Fatalf("ResolveHomeDir() = %q, want %q", got, wantHomeDir)
+			}
+		})
 	}
 }

--- a/internal/core/agents/agents.go
+++ b/internal/core/agents/agents.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	compozyconfig "github.com/compozy/compozy/internal/config"
 	runtimeagent "github.com/compozy/compozy/internal/core/agent"
 	"github.com/compozy/compozy/internal/core/frontmatter"
 	"github.com/compozy/compozy/internal/core/model"
@@ -165,7 +166,8 @@ func (c Catalog) Resolve(name string) (ResolvedAgent, error) {
 // Option configures a Registry.
 type Option func(*Registry)
 
-// WithHomeDir overrides how the registry resolves the global agent root.
+// WithHomeDir overrides how the registry resolves the Compozy home root that
+// anchors the global agents directory.
 func WithHomeDir(fn func() (string, error)) Option {
 	return func(r *Registry) {
 		if fn != nil {
@@ -192,7 +194,7 @@ type Registry struct {
 // New constructs a reusable agent registry with optional test hooks.
 func New(opts ...Option) *Registry {
 	registry := &Registry{
-		homeDir:   os.UserHomeDir,
+		homeDir:   compozyconfig.ResolveHomeDir,
 		lookupEnv: os.LookupEnv,
 	}
 	for _, opt := range opts {
@@ -614,9 +616,11 @@ func looksLikePath(command string) bool {
 }
 
 func (r *Registry) globalAgentsRoot() (string, error) {
+	// homeDir resolves the Compozy home root (".compozy" or COMPOZY_HOME), so the
+	// global agents directory tracks the same root the daemon isolates under.
 	home, err := r.homeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve global agents root: %w", err)
 	}
-	return filepath.Join(home, model.WorkflowRootDirName, agentDirName), nil
+	return filepath.Join(home, agentDirName), nil
 }

--- a/internal/core/agents/agents_test.go
+++ b/internal/core/agents/agents_test.go
@@ -516,7 +516,8 @@ func TestDiscoverSurfacesMalformedAgentWithoutCorruptingValidOnes(t *testing.T) 
 func newTestRegistry(homeDir string, env map[string]string) *Registry {
 	return New(
 		WithHomeDir(func() (string, error) {
-			return homeDir, nil
+			// homeDir is the OS-home temp; the registry expects the Compozy home root.
+			return filepath.Join(homeDir, model.WorkflowRootDirName), nil
 		}),
 		WithLookupEnv(func(key string) (string, bool) {
 			value, ok := env[key]

--- a/internal/core/extension/discovery.go
+++ b/internal/core/extension/discovery.go
@@ -15,7 +15,10 @@ import (
 
 // Discovery scans bundled, user, and workspace extension roots.
 type Discovery struct {
-	WorkspaceRoot   string
+	WorkspaceRoot string
+	// HomeDir is the Compozy home root (the ".compozy" directory or the
+	// COMPOZY_HOME override), not the OS user home. When empty it is resolved
+	// via config.ResolveHomeDir, so discovery honors COMPOZY_HOME.
 	HomeDir         string
 	IncludeDisabled bool
 	Enablement      *EnablementStore
@@ -164,7 +167,7 @@ func (d Discovery) scanDiscovered(
 		return nil, nil, err
 	}
 
-	userRoot := filepath.Join(homeDir, ".compozy", "extensions")
+	userRoot := filepath.Join(homeDir, "extensions")
 	discovered, failures, err = d.scanFilesystemRoot(
 		ctx,
 		store,

--- a/internal/core/extension/discovery_test.go
+++ b/internal/core/extension/discovery_test.go
@@ -414,7 +414,8 @@ func TestDiscoveryUsesDefaultStoreAndBundledFS(t *testing.T) {
 
 	homeDir := t.TempDir()
 	workspaceRoot := t.TempDir()
-	store, err := NewEnablementStore(context.Background(), homeDir)
+	compozyHome := filepath.Join(homeDir, ".compozy")
+	store, err := NewEnablementStore(context.Background(), compozyHome)
 	if err != nil {
 		t.Fatalf("NewEnablementStore() error = %v", err)
 	}
@@ -423,7 +424,7 @@ func TestDiscoveryUsesDefaultStoreAndBundledFS(t *testing.T) {
 	enableUserExtension(t, store, "user-enabled")
 
 	discovery := Discovery{
-		HomeDir:       homeDir,
+		HomeDir:       compozyHome,
 		WorkspaceRoot: workspaceRoot,
 	}
 
@@ -508,14 +509,15 @@ func newTestDiscovery(
 	workspaceRoot := t.TempDir()
 	bundledRoot := t.TempDir()
 
-	store, err := NewEnablementStore(context.Background(), homeDir)
+	compozyHome := filepath.Join(homeDir, ".compozy")
+	store, err := NewEnablementStore(context.Background(), compozyHome)
 	if err != nil {
 		t.Fatalf("NewEnablementStore() error = %v", err)
 	}
 
 	return Discovery{
 		WorkspaceRoot:   workspaceRoot,
-		HomeDir:         homeDir,
+		HomeDir:         compozyHome,
 		IncludeDisabled: includeDisabled,
 		Enablement:      store,
 		BundledFS:       os.DirFS(bundledRoot),

--- a/internal/core/extension/enablement.go
+++ b/internal/core/extension/enablement.go
@@ -9,14 +9,14 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	compozyconfig "github.com/compozy/compozy/internal/config"
 )
 
 const (
 	userEnablementStateFileName      = ".compozy-state.json"
 	workspaceEnablementStateFileName = "workspace-extensions.json"
 )
-
-var osUserHomeDir = os.UserHomeDir
 
 // Ref identifies an extension instance for local enablement resolution.
 type Ref struct {
@@ -37,7 +37,11 @@ type EnablementStore struct {
 	normalizeWorkspaceRoot func(string) (string, error)
 }
 
-// NewEnablementStore constructs a store rooted at homeDir or the current user's home.
+// NewEnablementStore constructs a store rooted at the Compozy home directory.
+//
+// homeDir is the Compozy home root (the ".compozy" directory or the COMPOZY_HOME
+// override), not the OS user home. When empty, it is resolved via
+// config.ResolveHomeDir so the store honors COMPOZY_HOME consistently.
 func NewEnablementStore(ctx context.Context, homeDir string) (*EnablementStore, error) {
 	if err := contextError(ctx, "create enablement store"); err != nil {
 		return nil, err
@@ -45,9 +49,9 @@ func NewEnablementStore(ctx context.Context, homeDir string) (*EnablementStore, 
 
 	resolvedHome := strings.TrimSpace(homeDir)
 	if resolvedHome == "" {
-		value, err := osUserHomeDir()
+		value, err := compozyconfig.ResolveHomeDir()
 		if err != nil {
-			return nil, fmt.Errorf("resolve home directory: %w", err)
+			return nil, fmt.Errorf("resolve compozy home directory: %w", err)
 		}
 		resolvedHome = strings.TrimSpace(value)
 	}
@@ -171,11 +175,11 @@ func (s *EnablementStore) Disable(ctx context.Context, ref Ref) error {
 }
 
 func (s *EnablementStore) userStatePath(name string) string {
-	return filepath.Join(s.homeDir, ".compozy", "extensions", name, userEnablementStateFileName)
+	return filepath.Join(s.homeDir, "extensions", name, userEnablementStateFileName)
 }
 
 func (s *EnablementStore) workspaceStatePath() string {
-	return filepath.Join(s.homeDir, ".compozy", "state", workspaceEnablementStateFileName)
+	return filepath.Join(s.homeDir, "state", workspaceEnablementStateFileName)
 }
 
 func defaultEnabled(source Source) bool {

--- a/internal/core/extension/enablement_test.go
+++ b/internal/core/extension/enablement_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	compozyconfig "github.com/compozy/compozy/internal/config"
 )
 
 func TestEnablementStoreDefaults(t *testing.T) {
@@ -16,7 +18,7 @@ func TestEnablementStoreDefaults(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceRoot := t.TempDir()
 
-	store, err := NewEnablementStore(context.Background(), homeDir)
+	store, err := NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 	if err != nil {
 		t.Fatalf("NewEnablementStore() error = %v", err)
 	}
@@ -98,7 +100,7 @@ func TestEnablementStorePersistsRoundTrip(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			store, err := NewEnablementStore(context.Background(), homeDir)
+			store, err := NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 			if err != nil {
 				t.Fatalf("NewEnablementStore() error = %v", err)
 			}
@@ -106,7 +108,7 @@ func TestEnablementStorePersistsRoundTrip(t *testing.T) {
 				t.Fatalf("Enable() error = %v", err)
 			}
 
-			reloadedStore, err := NewEnablementStore(context.Background(), homeDir)
+			reloadedStore, err := NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 			if err != nil {
 				t.Fatalf("NewEnablementStore() reload error = %v", err)
 			}
@@ -122,7 +124,7 @@ func TestEnablementStorePersistsRoundTrip(t *testing.T) {
 				t.Fatalf("Disable() error = %v", err)
 			}
 
-			finalStore, err := NewEnablementStore(context.Background(), homeDir)
+			finalStore, err := NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 			if err != nil {
 				t.Fatalf("NewEnablementStore() final error = %v", err)
 			}
@@ -148,7 +150,7 @@ func TestEnablementStoreLoadsWorkspaceStateAcrossCanonicalRootAliases(t *testing
 	legacyRoot := filepath.Clean("/Users/pedronauck/dev/compozy/agh2")
 	canonicalRoot := filepath.Clean("/Users/pedronauck/Dev/compozy/agh2")
 	store := &EnablementStore{
-		homeDir: homeDir,
+		homeDir: filepath.Join(homeDir, ".compozy"),
 		normalizeWorkspaceRoot: func(root string) (string, error) {
 			switch filepath.Clean(root) {
 			case legacyRoot, canonicalRoot:
@@ -232,22 +234,15 @@ func TestEnablementStoreRejectsBundledMutations(t *testing.T) {
 }
 
 func TestNewEnablementStoreResolvesHomeDir(t *testing.T) {
-	homeDir := t.TempDir()
-
-	previous := osUserHomeDir
-	osUserHomeDir = func() (string, error) {
-		return homeDir, nil
-	}
-	t.Cleanup(func() {
-		osUserHomeDir = previous
-	})
+	compozyHome := filepath.Join(t.TempDir(), ".compozy")
+	t.Setenv(compozyconfig.HomeEnvVar, compozyHome)
 
 	store, err := NewEnablementStore(context.Background(), "")
 	if err != nil {
 		t.Fatalf("NewEnablementStore() error = %v", err)
 	}
-	if store.homeDir != homeDir {
-		t.Fatalf("homeDir = %q, want %q", store.homeDir, homeDir)
+	if store.homeDir != filepath.Clean(compozyHome) {
+		t.Fatalf("homeDir = %q, want %q", store.homeDir, filepath.Clean(compozyHome))
 	}
 }
 
@@ -300,7 +295,7 @@ func TestEnablementStoreRejectsCorruptState(t *testing.T) {
 	homeDir := t.TempDir()
 	workspaceRoot := t.TempDir()
 
-	store, err := NewEnablementStore(context.Background(), homeDir)
+	store, err := NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 	if err != nil {
 		t.Fatalf("NewEnablementStore() error = %v", err)
 	}

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -15,7 +15,6 @@ import (
 	toml "github.com/pelletier/go-toml/v2"
 )
 
-var osUserHomeDir = os.UserHomeDir
 var discoverWorkspaceRoot = discoverWorkspaceRootFromStart
 var discoverCache sync.Map
 
@@ -141,16 +140,12 @@ func discoverWorkspaceRootFromStart(ctx context.Context, startDir string) (strin
 }
 
 func discoverGlobalWorkspaceMarkerDir() (string, bool) {
-	homeDir, err := osUserHomeDir()
-	if err != nil {
-		return "", false
-	}
-	resolvedHomeDir, err := resolveConfigBaseDir(homeDir)
+	// The home-scoped marker is the global Compozy root, which honors COMPOZY_HOME.
+	markerDir, err := compozyconfig.ResolveHomeDir()
 	if err != nil {
 		return "", false
 	}
 
-	markerDir := filepath.Join(resolvedHomeDir, model.WorkflowRootDirName)
 	resolvedMarkerDir, err := filepath.EvalSymlinks(markerDir)
 	if err == nil {
 		return filepath.Clean(resolvedMarkerDir), true
@@ -245,21 +240,15 @@ func resolveConfigPaths(workspaceRoot string) (configPaths, error) {
 		workspacePath: model.ConfigPathForWorkspace(workspaceRoot),
 	}
 
-	homeDir, err := osUserHomeDir()
+	// ResolveHomePaths honors COMPOZY_HOME so global config tracks the same root
+	// the daemon isolates under. globalRoot stays the parent of the Compozy home
+	// (the user home in the default layout) to preserve relative add_dirs bases.
+	homePaths, err := compozyconfig.ResolveHomePaths()
 	if err != nil {
-		return configPaths{}, fmt.Errorf("lookup user home directory: %w", err)
-	}
-	resolvedHomeDir, err := resolveConfigBaseDir(homeDir)
-	if err != nil {
-		return configPaths{}, fmt.Errorf("resolve global config base dir: %w", err)
-	}
-
-	homePaths, err := compozyconfig.ResolveHomePathsFrom(filepath.Join(resolvedHomeDir, compozyconfig.DirName))
-	if err != nil {
-		return configPaths{}, fmt.Errorf("resolve global config base dir: %w", err)
+		return configPaths{}, fmt.Errorf("resolve compozy home paths: %w", err)
 	}
 
-	paths.globalRoot = resolvedHomeDir
+	paths.globalRoot = filepath.Dir(homePaths.HomeDir)
 	paths.globalPath = homePaths.ConfigFile
 	return paths, nil
 }

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -7,12 +7,11 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
-)
 
-var workspaceUserHomeDirMu sync.Mutex
+	compozyconfig "github.com/compozy/compozy/internal/config"
+)
 
 func TestDiscoverFindsNearestWorkspaceRoot(t *testing.T) {
 	t.Parallel()
@@ -53,10 +52,7 @@ func TestDiscoverFallsBackToStartDirectoryWhenWorkspaceIsMissing(t *testing.T) {
 }
 
 func TestDiscoverIgnoresGlobalHomeCompozyMarker(t *testing.T) {
-	homeDir := t.TempDir()
-	stubWorkspaceUserHomeDir(t, func() (string, error) {
-		return homeDir, nil
-	})
+	homeDir := isolateWorkspaceConfigHome(t)
 	if err := os.MkdirAll(filepath.Join(homeDir, ".compozy"), 0o755); err != nil {
 		t.Fatalf("mkdir global .compozy: %v", err)
 	}
@@ -2038,41 +2034,15 @@ func TestLoadConfigReturnsErrorWhenHomeLookupFails(t *testing.T) {
 [defaults]
 ide = "claude"
 `)
-	homeErr := errors.New("home unavailable")
-	stubWorkspaceUserHomeDir(t, func() (string, error) {
-		return "", homeErr
-	})
+	// Force ResolveHomeDir to fail: no override and an undefined OS home.
+	t.Setenv(compozyconfig.HomeEnvVar, "")
+	t.Setenv("HOME", "")
 
 	_, _, err := LoadConfig(context.Background(), root)
 	if err == nil {
 		t.Fatal("expected load config error")
 	}
-	if !errors.Is(err, homeErr) {
-		t.Fatalf("expected home lookup error, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "resolve config paths: lookup user home directory") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestLoadConfigReturnsErrorWhenGlobalBaseDirCannotBeResolved(t *testing.T) {
-	root := t.TempDir()
-	writeWorkspaceConfig(t, root, `
-[defaults]
-ide = "claude"
-`)
-	stubWorkspaceUserHomeDir(t, func() (string, error) {
-		return " ", nil
-	})
-
-	_, _, err := LoadConfig(context.Background(), root)
-	if err == nil {
-		t.Fatal("expected load config error")
-	}
-	if !strings.Contains(err.Error(), "resolve config paths: resolve global config base dir") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(err.Error(), "base directory is empty") {
+	if !strings.Contains(err.Error(), "resolve user home directory") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -2181,37 +2151,16 @@ func isolateWorkspaceConfigHome(t *testing.T) string {
 
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
+	// Neutralize any ambient COMPOZY_HOME so the global root tracks the temp HOME.
+	t.Setenv(compozyconfig.HomeEnvVar, "")
 	return homeDir
 }
 
 func loadConfigWithIsolatedHome(t *testing.T, workspaceRoot string) (ProjectConfig, string, error) {
 	t.Helper()
 
-	homeDir := t.TempDir()
-	workspaceUserHomeDirMu.Lock()
-	defer workspaceUserHomeDirMu.Unlock()
-
-	original := osUserHomeDir
-	osUserHomeDir = func() (string, error) {
-		return homeDir, nil
-	}
-	defer func() {
-		osUserHomeDir = original
-	}()
-
+	isolateWorkspaceConfigHome(t)
 	return LoadConfig(context.Background(), workspaceRoot)
-}
-
-func stubWorkspaceUserHomeDir(t *testing.T, fn func() (string, error)) {
-	t.Helper()
-
-	workspaceUserHomeDirMu.Lock()
-	original := osUserHomeDir
-	osUserHomeDir = fn
-	t.Cleanup(func() {
-		osUserHomeDir = original
-		workspaceUserHomeDirMu.Unlock()
-	})
 }
 
 func mustEvalSymlinksWorkspaceTest(t *testing.T, path string) string {

--- a/internal/daemon/review_exec_transport_service_test.go
+++ b/internal/daemon/review_exec_transport_service_test.go
@@ -403,7 +403,9 @@ func installSDKReviewProviderExtension(
 
 	writeJSONFile(t, filepath.Join(extensionDir, extensions.ManifestFileNameJSON), manifest)
 
-	store, err := extensions.NewEnablementStore(context.Background(), homeDir)
+	// homeDir is the OS-home temp; the enablement store roots at the Compozy home,
+	// matching how the daemon's discovery resolves it via config.ResolveHomeDir.
+	store, err := extensions.NewEnablementStore(context.Background(), filepath.Join(homeDir, ".compozy"))
 	if err != nil {
 		t.Fatalf("NewEnablementStore() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

Adds a `COMPOZY_HOME` environment variable as an opt-in override for the Compozy home root. When set to a non-empty value, `ResolveHomeDir` resolves against that path instead of the implicit `$HOME/.compozy`, and every home-scoped consumer is routed through it so the override is honored consistently: `ResolveHomePaths` / `EnsureHomeLayout`, daemon startup, global config loading, global workspace-marker detection, extension discovery + enablement, and global reusable-agent discovery.

## Why

The daemon today is a singleton per `$HOME`: every workspace that talks to `~/.compozy/daemon/daemon.sock` serializes through one engine. As raised in #32 (comment from @rjsoux), users running multiple independent projects in parallel hit the same socket from every repo and have no first-class way to isolate them. Today the workaround is a "mirror home" that symlinks everything except `.compozy`, which is fragile and unsupported.

This PR delivers **Tier 1** of the request: an official, documented escape hatch. Operators point one shell at one `COMPOZY_HOME`, one at another, and each gets its own daemon, socket, lock, state, and global DB. The CLI `--home` flag and Tier 2 (true parallel runs across workspaces inside one daemon) are intentionally out of scope and can layer on top.

## What Changed

- `internal/config/home.go`
  - New const `HomeEnvVar = "COMPOZY_HOME"`.
  - New package-level `osLookupEnv` stub var, mirroring the existing `osUserHomeDir` pattern, so tests can override env resolution without touching the process.
  - New `lookupHomeOverride()` helper that returns `(value, true)` only when the variable is set to a non-empty, whitespace-trimmed string.
  - `ResolveHomeDir` precedence is now: `COMPOZY_HOME` (if set) → `$HOME/.compozy` (existing behavior).
  - `~` and `~/` prefixes inside `COMPOZY_HOME` are expanded against the current user's home via the existing `ResolvePath` / `expandUserPath` helpers, so `COMPOZY_HOME=~/alt-compozy` works.
- **Routed the remaining home-scoped consumers through `ResolveHomeDir` / `ResolveHomePaths`.** These previously rebuilt `$HOME/.compozy` from `os.UserHomeDir` directly, so a set `COMPOZY_HOME` split-brained — the daemon isolated but these consumers stayed on `$HOME/.compozy`:
  - `internal/core/workspace/config.go` — `resolveConfigPaths` (global config path) and `discoverGlobalWorkspaceMarkerDir` (global workspace-marker detection).
  - `internal/core/extension/discovery.go` + `internal/core/extension/enablement.go` — the enablement store and discovery now root at the Compozy home (the `.compozy` / `COMPOZY_HOME` root) instead of appending `.compozy` to the OS home.
  - `internal/cli/extension/root.go` + `internal/cli/extension/install.go` + `internal/cli/setup_assets.go` — the `ext` flow now separates the OS user home (used only for `setup.ResolverOptions`: `.claude` / `.codex` / `.config`) from the Compozy home (install target, enablement store, discovery), resolving the latter via `ResolveHomeDir`.
  - `internal/core/agents/agents.go` — the global reusable-agent root now honors the override.
- `internal/config/home_test.go` and the touched packages' tests
  - Coverage for: env override used, whitespace trimmed, empty ignored, whitespace-only ignored, `~` expansion, full `ResolveHomePaths` propagation, unset fallback.
  - Tests that touch env vars drop `t.Parallel()` (Go disallows combining it with `t.Setenv`); existing tests keep their parallelism.
  - Broadened `COMPOZY_HOME` guards across the affected packages' tests so an ambient `COMPOZY_HOME` in a developer's environment cannot leak into fixtures.

## Behavior Notes

- **Backward compatible.** No env var set → identical behavior to `main` (resolved against `os.UserHomeDir` + `DirName`).
- **Empty / whitespace-only** `COMPOZY_HOME` is treated as unset. No silent surprises if a script exports `COMPOZY_HOME=""`.
- **Relative paths** in `COMPOZY_HOME` are made absolute via `filepath.Abs`, matching the rest of `ResolvePath`.
- **Cross-platform.** Works on Linux, macOS, and Windows — env-var only, no shell expansion required.
- **Consistent isolation.** The daemon socket/lock/info/log/runs/state/global DB, global config, global workspace-marker detection, extension discovery + enablement, and global reusable agents all resolve against the same root, so two daemons with different `COMPOZY_HOME` values do not collide and there is no split-brain between the daemon and config/extensions.
- **OS home is left untouched.** Legitimate OS-home lookups — `.claude`, `.codex`, XDG (`~/.config/compozy/state.yml`), and path display — continue to use `os.UserHomeDir` and are intentionally unaffected by `COMPOZY_HOME`.
- **No CLI flag in this PR.** The environment variable is the contract. A `--home` flag can be added later as a thin wrapper around the same lookup.

## Testing

- `go test -race ./...` — green for the touched packages (`config`, `core/workspace`, `core/extension`, `core/agents`, `cli`, `cli/extension`, `daemon`).
- Several consumers previously rebuilt `$HOME/.compozy` via `os.UserHomeDir` and were explicitly routed through `ResolveHomeDir` / `ResolveHomePaths` so they honor the override consistently.

## Verification

```text
make fmt                          # clean
make lint                         # 0 issues
make go-build                     # clean
make test                         # green for the touched packages (-race)
```

## Related

- Addresses Tier 1 of the request in #32 (comment by @rjsoux).
- Crosses paths with the planned `parallel` multi-run mode (Tier 2 of the same request); orthogonal change.

## Checklist

- [x] `make fmt` clean
- [x] `make lint` clean (0 issues)
- [x] `make test` passes for the touched packages
- [x] Backward compatible (no env var → unchanged behavior)
- [x] Cross-platform (Linux/macOS/Windows)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now override the Compozy home directory with an environment variable (supports trimming whitespace and `~` path expansion).
* **Bug Fixes**
  * Empty or whitespace-only overrides are ignored, and the app falls back to the standard user home.
  * Compozy-home–derived paths (including derived subpaths) now consistently follow the override when present.
* **Improvements**
  * Extension discovery, enablement state storage, and related workspace/global configuration are now rooted in the Compozy home directory for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
