### PR TITLE
fix: restore run TUI elapsed timer across retry, failure, cancel, and remote paths

### DIFF
--- a/internal/api/contract/types.go
+++ b/internal/api/contract/types.go
@@ -409,6 +409,7 @@ type RunJobSummary struct {
 	ErrorText       string              `json:"error_text,omitempty"`
 	Session         SessionViewSnapshot `json:"session,omitempty"`
 	Usage           kinds.Usage         `json:"usage,omitempty"`
+	DurationMs      int64               `json:"duration_ms,omitempty"`
 }
 
 type RunJobState struct {

--- a/internal/core/run/executor/execution_acp_test.go
+++ b/internal/core/run/executor/execution_acp_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/compozy/compozy/internal/core/agent"
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/core/run/internal/acpshared"
+	"github.com/compozy/compozy/internal/core/run/journal"
 	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
 	"github.com/compozy/compozy/pkg/compozy/events/kinds"
 )
@@ -1448,6 +1449,69 @@ func TestJobLifecycleEmitsFailedEvent(t *testing.T) {
 	if payload.Error != "boom" {
 		t.Fatalf("expected job.failed payload error to carry failure reason, got %#v", payload)
 	}
+}
+
+func TestJobLifecycleTerminalEventsCarryDuration(t *testing.T) {
+	newLifecycle := func(runID string, runJournal *journal.Journal) *jobLifecycle {
+		execCtx := &jobExecutionContext{
+			ctx:     context.Background(),
+			cfg:     &config{MaxRetries: 2, RunArtifacts: model.RunArtifacts{RunID: runID}},
+			journal: runJournal,
+		}
+		return newJobLifecycle(0, &job{CodeFiles: []string{"task_01"}}, execCtx)
+	}
+
+	t.Run("failed job carries elapsed duration", func(t *testing.T) {
+		runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
+		defer cleanup()
+		lifecycle := newLifecycle(runID, runJournal)
+		lifecycle.startAttempt(1, 3, time.Second)
+		// Backdate the start so the reported elapsed is deterministically non-zero.
+		lifecycle.startedAt = lifecycle.startedAt.Add(-2 * time.Second)
+		lifecycle.markGiveUp(failInfo{CodeFile: "task_01", ExitCode: 23, Err: errors.New("boom")})
+
+		events := collectRuntimeEvents(t, eventsCh, 2)
+		var payload kinds.JobFailedPayload
+		decodeRuntimeEventPayload(t, events[1], &payload)
+		if payload.DurationMs <= 0 {
+			t.Fatalf("expected failed payload to carry elapsed duration, got %d", payload.DurationMs)
+		}
+	})
+
+	t.Run("canceled job carries elapsed duration", func(t *testing.T) {
+		runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
+		defer cleanup()
+		lifecycle := newLifecycle(runID, runJournal)
+		lifecycle.startAttempt(1, 1, time.Second)
+		lifecycle.startedAt = lifecycle.startedAt.Add(-2 * time.Second)
+		lifecycle.markCanceled(exitCodeCanceled)
+
+		events := collectRuntimeEvents(t, eventsCh, 2)
+		if got := events[1].Kind; got != eventspkg.EventKindJobCancelled {
+			t.Fatalf("expected job.cancelled event, got %s", got)
+		}
+		var payload kinds.JobCancelledPayload
+		decodeRuntimeEventPayload(t, events[1], &payload)
+		if payload.DurationMs <= 0 {
+			t.Fatalf("expected canceled payload to carry elapsed duration, got %d", payload.DurationMs)
+		}
+	})
+
+	t.Run("job terminated before any attempt reports zero duration", func(t *testing.T) {
+		runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
+		defer cleanup()
+		lifecycle := newLifecycle(runID, runJournal)
+		// No startAttempt: startedAt is the zero time, so elapsedMs must report 0
+		// rather than a bogus duration measured from Go's year-1 zero time.
+		lifecycle.markGiveUp(failInfo{CodeFile: "task_01", ExitCode: 1, Err: errors.New("early")})
+
+		events := collectRuntimeEvents(t, eventsCh, 1)
+		var payload kinds.JobFailedPayload
+		decodeRuntimeEventPayload(t, events[0], &payload)
+		if payload.DurationMs != 0 {
+			t.Fatalf("expected zero duration when no attempt started, got %d", payload.DurationMs)
+		}
+	})
 }
 
 func TestHandleNilExecutionReturnsSetupFailure(t *testing.T) {

--- a/internal/core/run/executor/execution_acp_test.go
+++ b/internal/core/run/executor/execution_acp_test.go
@@ -1461,7 +1461,8 @@ func TestJobLifecycleTerminalEventsCarryDuration(t *testing.T) {
 		return newJobLifecycle(0, &job{CodeFiles: []string{"task_01"}}, execCtx)
 	}
 
-	t.Run("failed job carries elapsed duration", func(t *testing.T) {
+	t.Run("Should carry elapsed duration for a failed job", func(t *testing.T) {
+		t.Parallel()
 		runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
 		defer cleanup()
 		lifecycle := newLifecycle(runID, runJournal)
@@ -1478,7 +1479,8 @@ func TestJobLifecycleTerminalEventsCarryDuration(t *testing.T) {
 		}
 	})
 
-	t.Run("canceled job carries elapsed duration", func(t *testing.T) {
+	t.Run("Should carry elapsed duration for a canceled job", func(t *testing.T) {
+		t.Parallel()
 		runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
 		defer cleanup()
 		lifecycle := newLifecycle(runID, runJournal)
@@ -1497,7 +1499,8 @@ func TestJobLifecycleTerminalEventsCarryDuration(t *testing.T) {
 		}
 	})
 
-	t.Run("job terminated before any attempt reports zero duration", func(t *testing.T) {
+	t.Run("Should report zero duration when terminated before any attempt", func(t *testing.T) {
+		t.Parallel()
 		runID, runJournal, eventsCh, cleanup := openRuntimeEventCapture(t)
 		defer cleanup()
 		lifecycle := newLifecycle(runID, runJournal)

--- a/internal/core/run/executor/lifecycle.go
+++ b/internal/core/run/executor/lifecycle.go
@@ -114,11 +114,12 @@ func (l *jobLifecycle) markGiveUp(failure failInfo) {
 				Attempt:     l.attempt,
 				MaxAttempts: l.maxAttempts(),
 			},
-			CodeFile: l.job.CodeFileLabel(),
-			ExitCode: l.lastExitCode,
-			OutLog:   l.job.OutLog,
-			ErrLog:   l.job.ErrLog,
-			Error:    l.job.Failure,
+			CodeFile:   l.job.CodeFileLabel(),
+			ExitCode:   l.lastExitCode,
+			OutLog:     l.job.OutLog,
+			ErrLog:     l.job.ErrLog,
+			Error:      l.job.Failure,
+			DurationMs: l.elapsedMs(),
 		},
 	)
 	if l.lastFailure != nil && l.humanOutputEnabled() {
@@ -193,7 +194,8 @@ func (l *jobLifecycle) markCanceled(exitCode int) {
 				Attempt:     l.attempt,
 				MaxAttempts: l.maxAttempts(),
 			},
-			Reason: reason,
+			Reason:     reason,
+			DurationMs: l.elapsedMs(),
 		},
 	)
 	if l.lastFailure != nil && l.humanOutputEnabled() {
@@ -205,6 +207,17 @@ func (l *jobLifecycle) markCanceled(exitCode int) {
 			l.lastFailure.Err,
 		)
 	}
+}
+
+// elapsedMs reports the wall-clock duration since the job's first attempt began,
+// or 0 when the job was terminated before any attempt started (l.startedAt is the
+// zero time). Mirrors the duration markSuccess reports on the completed path so
+// failed and canceled jobs carry an authoritative elapsed time too.
+func (l *jobLifecycle) elapsedMs() int64 {
+	if l.startedAt.IsZero() {
+		return 0
+	}
+	return time.Since(l.startedAt).Milliseconds()
 }
 
 func (l *jobLifecycle) execConfig() *config {

--- a/internal/core/run/ui/adapter_test.go
+++ b/internal/core/run/ui/adapter_test.go
@@ -277,6 +277,7 @@ func TestUIEventTranslatorAddsFailureTerminalMessage(t *testing.T) {
 			CodeFile:       "task_01.md",
 			ExitCode:       23,
 			Error:          "boom",
+			DurationMs:     90_000,
 		},
 	))
 	if len(msgs) != 2 {
@@ -291,6 +292,35 @@ func TestUIEventTranslatorAddsFailureTerminalMessage(t *testing.T) {
 	}
 	if finished.Success || finished.ExitCode != 23 {
 		t.Fatalf("unexpected terminal failure message: %#v", finished)
+	}
+	if finished.DurationMs != 90_000 {
+		t.Fatalf("expected failed terminal message to thread DurationMs=90000, got %#v", finished)
+	}
+}
+
+func TestTranslateEventJobCancelledThreadsDuration(t *testing.T) {
+	t.Parallel()
+
+	// The cancel arm must carry the authoritative duration so the sidebar timer
+	// is restored for a retried job that ends up canceled, mirroring success.
+	msg, ok := translateEventForTest(t, mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindJobCancelled,
+		kinds.JobCancelledPayload{
+			JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 2, MaxAttempts: 3},
+			Reason:         "canceled by shutdown",
+			DurationMs:     90_000,
+		},
+	))
+	if !ok {
+		t.Fatal("expected job.cancelled to translate")
+	}
+	finished, ok := msg.(jobFinishedMsg)
+	if !ok {
+		t.Fatalf("expected jobFinishedMsg, got %T", msg)
+	}
+	if finished.Success || finished.ExitCode != exitCodeCanceled || finished.DurationMs != 90_000 {
+		t.Fatalf("expected canceled terminal message with threaded DurationMs=90000, got %#v", finished)
 	}
 }
 

--- a/internal/core/run/ui/adapter_test.go
+++ b/internal/core/run/ui/adapter_test.go
@@ -44,29 +44,33 @@ func TestTranslateEventJobStarted(t *testing.T) {
 func TestTranslateEventJobCompletedThreadsDuration(t *testing.T) {
 	t.Parallel()
 
-	// Guards the translator edit the real remote/multi-run path depends on: the
-	// authoritative DurationMs must survive into jobFinishedMsg so the sidebar
-	// timer can be restored even when the UI never observed the job's start.
-	msg, ok := translateEventForTest(t, mustRuntimeEventUITest(
-		t,
-		eventspkg.EventKindJobCompleted,
-		kinds.JobCompletedPayload{
-			JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 2, MaxAttempts: 3},
-			ExitCode:       0,
-			DurationMs:     90_000,
-		},
-	))
-	if !ok {
-		t.Fatal("expected job.completed to translate")
-	}
+	t.Run("Should thread the authoritative duration into the completed message", func(t *testing.T) {
+		t.Parallel()
 
-	finished, ok := msg.(jobFinishedMsg)
-	if !ok {
-		t.Fatalf("expected jobFinishedMsg, got %T", msg)
-	}
-	if !finished.Success || finished.DurationMs != 90_000 {
-		t.Fatalf("expected threaded DurationMs=90000 on success, got %#v", finished)
-	}
+		// Guards the translator edit the real remote/multi-run path depends on: the
+		// authoritative DurationMs must survive into jobFinishedMsg so the sidebar
+		// timer can be restored even when the UI never observed the job's start.
+		msg, ok := translateEventForTest(t, mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindJobCompleted,
+			kinds.JobCompletedPayload{
+				JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 2, MaxAttempts: 3},
+				ExitCode:       0,
+				DurationMs:     90_000,
+			},
+		))
+		if !ok {
+			t.Fatal("expected job.completed to translate")
+		}
+
+		finished, ok := msg.(jobFinishedMsg)
+		if !ok {
+			t.Fatalf("expected jobFinishedMsg, got %T", msg)
+		}
+		if !finished.Success || finished.DurationMs != 90_000 {
+			t.Fatalf("expected threaded DurationMs=90000 on success, got %#v", finished)
+		}
+	})
 }
 
 func TestTranslateEventJobQueued(t *testing.T) {
@@ -301,27 +305,31 @@ func TestUIEventTranslatorAddsFailureTerminalMessage(t *testing.T) {
 func TestTranslateEventJobCancelledThreadsDuration(t *testing.T) {
 	t.Parallel()
 
-	// The cancel arm must carry the authoritative duration so the sidebar timer
-	// is restored for a retried job that ends up canceled, mirroring success.
-	msg, ok := translateEventForTest(t, mustRuntimeEventUITest(
-		t,
-		eventspkg.EventKindJobCancelled,
-		kinds.JobCancelledPayload{
-			JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 2, MaxAttempts: 3},
-			Reason:         "canceled by shutdown",
-			DurationMs:     90_000,
-		},
-	))
-	if !ok {
-		t.Fatal("expected job.cancelled to translate")
-	}
-	finished, ok := msg.(jobFinishedMsg)
-	if !ok {
-		t.Fatalf("expected jobFinishedMsg, got %T", msg)
-	}
-	if finished.Success || finished.ExitCode != exitCodeCanceled || finished.DurationMs != 90_000 {
-		t.Fatalf("expected canceled terminal message with threaded DurationMs=90000, got %#v", finished)
-	}
+	t.Run("Should thread the authoritative duration into the canceled message", func(t *testing.T) {
+		t.Parallel()
+
+		// The cancel arm must carry the authoritative duration so the sidebar timer
+		// is restored for a retried job that ends up canceled, mirroring success.
+		msg, ok := translateEventForTest(t, mustRuntimeEventUITest(
+			t,
+			eventspkg.EventKindJobCancelled,
+			kinds.JobCancelledPayload{
+				JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 2, MaxAttempts: 3},
+				Reason:         "canceled by shutdown",
+				DurationMs:     90_000,
+			},
+		))
+		if !ok {
+			t.Fatal("expected job.cancelled to translate")
+		}
+		finished, ok := msg.(jobFinishedMsg)
+		if !ok {
+			t.Fatalf("expected jobFinishedMsg, got %T", msg)
+		}
+		if finished.Success || finished.ExitCode != exitCodeCanceled || finished.DurationMs != 90_000 {
+			t.Fatalf("expected canceled terminal message with threaded DurationMs=90000, got %#v", finished)
+		}
+	})
 }
 
 func TestUIEventAdapterStopUnsubscribes(t *testing.T) {

--- a/internal/core/run/ui/adapter_test.go
+++ b/internal/core/run/ui/adapter_test.go
@@ -41,6 +41,34 @@ func TestTranslateEventJobStarted(t *testing.T) {
 	}
 }
 
+func TestTranslateEventJobCompletedThreadsDuration(t *testing.T) {
+	t.Parallel()
+
+	// Guards the translator edit the real remote/multi-run path depends on: the
+	// authoritative DurationMs must survive into jobFinishedMsg so the sidebar
+	// timer can be restored even when the UI never observed the job's start.
+	msg, ok := translateEventForTest(t, mustRuntimeEventUITest(
+		t,
+		eventspkg.EventKindJobCompleted,
+		kinds.JobCompletedPayload{
+			JobAttemptInfo: kinds.JobAttemptInfo{Index: 0, Attempt: 2, MaxAttempts: 3},
+			ExitCode:       0,
+			DurationMs:     90_000,
+		},
+	))
+	if !ok {
+		t.Fatal("expected job.completed to translate")
+	}
+
+	finished, ok := msg.(jobFinishedMsg)
+	if !ok {
+		t.Fatalf("expected jobFinishedMsg, got %T", msg)
+	}
+	if !finished.Success || finished.DurationMs != 90_000 {
+		t.Fatalf("expected threaded DurationMs=90000 on success, got %#v", finished)
+	}
+}
+
 func TestTranslateEventJobQueued(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/run/ui/model.go
+++ b/internal/core/run/ui/model.go
@@ -796,9 +796,10 @@ func (t *uiEventTranslator) translateMessages(ev events.Event) []uiMsg {
 			return msgs
 		}
 		msgs = append(msgs, jobFinishedMsg{
-			Index:    payload.Index,
-			Success:  false,
-			ExitCode: payload.ExitCode,
+			Index:      payload.Index,
+			Success:    false,
+			ExitCode:   payload.ExitCode,
+			DurationMs: payload.DurationMs,
 		})
 	}
 	return msgs
@@ -1182,9 +1183,10 @@ func translateJobCancelledEvent(ev events.Event) (uiMsg, bool) {
 		return nil, false
 	}
 	return jobFinishedMsg{
-		Index:    payload.Index,
-		Success:  false,
-		ExitCode: exitCodeCanceled,
+		Index:      payload.Index,
+		Success:    false,
+		ExitCode:   exitCodeCanceled,
+		DurationMs: payload.DurationMs,
 	}, true
 }
 

--- a/internal/core/run/ui/model.go
+++ b/internal/core/run/ui/model.go
@@ -1124,9 +1124,10 @@ func translateJobCompletedEvent(ev events.Event) (uiMsg, bool) {
 		return nil, false
 	}
 	return jobFinishedMsg{
-		Index:    payload.Index,
-		Success:  true,
-		ExitCode: payload.ExitCode,
+		Index:      payload.Index,
+		Success:    true,
+		ExitCode:   payload.ExitCode,
+		DurationMs: payload.DurationMs,
 	}, true
 }
 

--- a/internal/core/run/ui/remote.go
+++ b/internal/core/run/ui/remote.go
@@ -484,24 +484,27 @@ func remoteBootstrapTerminalMsgs(index int, status string, summary *apicore.RunJ
 	switch status {
 	case remoteRunStatusCompleted:
 		return []uiMsg{jobFinishedMsg{
-			Index:    index,
-			Success:  true,
-			ExitCode: summaryExitCode(summary),
+			Index:      index,
+			Success:    true,
+			ExitCode:   summaryExitCode(summary),
+			DurationMs: summaryDurationMs(summary),
 		}}
 	case remoteRunStatusFailed:
 		return []uiMsg{
 			jobFailureMsg{Failure: remoteFailureInfo(summary)},
 			jobFinishedMsg{
-				Index:    index,
-				Success:  false,
-				ExitCode: summaryExitCode(summary),
+				Index:      index,
+				Success:    false,
+				ExitCode:   summaryExitCode(summary),
+				DurationMs: summaryDurationMs(summary),
 			},
 		}
 	case remoteRunStatusCanceled:
 		return []uiMsg{jobFinishedMsg{
-			Index:    index,
-			Success:  false,
-			ExitCode: exitCodeCanceled,
+			Index:      index,
+			Success:    false,
+			ExitCode:   exitCodeCanceled,
+			DurationMs: summaryDurationMs(summary),
 		}}
 	default:
 		return nil
@@ -608,6 +611,13 @@ func summaryExitCode(summary *apicore.RunJobSummary) int {
 		return 0
 	}
 	return summary.ExitCode
+}
+
+func summaryDurationMs(summary *apicore.RunJobSummary) int64 {
+	if summary == nil {
+		return 0
+	}
+	return summary.DurationMs
 }
 
 func summaryString(summary *apicore.RunJobSummary, read func(*apicore.RunJobSummary) string) string {

--- a/internal/core/run/ui/remote_test.go
+++ b/internal/core/run/ui/remote_test.go
@@ -42,6 +42,7 @@ func TestRemoteSnapshotBootstrapHydratesUIStateBeforeLiveEvents(t *testing.T) {
 				Attempt:         1,
 				MaxAttempts:     1,
 				ExitCode:        0,
+				DurationMs:      90_000,
 				Usage:           kinds.Usage{InputTokens: 7, OutputTokens: 3, TotalTokens: 10},
 				Session:         apiSessionSnapshot(summarySnapshot),
 			},
@@ -62,6 +63,9 @@ func TestRemoteSnapshotBootstrapHydratesUIStateBeforeLiveEvents(t *testing.T) {
 	}
 	if got := mdl.jobs[0].state; got != jobSuccess {
 		t.Fatalf("expected restored completed job state, got %v", got)
+	}
+	if got := mdl.jobs[0].duration; got != 90*time.Second {
+		t.Fatalf("expected restored elapsed duration 90s from summary, got %v", got)
 	}
 	if got := mdl.aggregateUsage.TotalTokens; got != 10 {
 		t.Fatalf("expected restored aggregate usage total 10, got %d", got)
@@ -576,4 +580,27 @@ func eventPointer(event eventspkg.Event, seq uint64, ts time.Time) *eventspkg.Ev
 	event.Seq = seq
 	event.Timestamp = ts.UTC()
 	return &event
+}
+
+func TestRemoteBootstrapTerminalMsgsThreadsDuration(t *testing.T) {
+	t.Parallel()
+
+	// Every terminal bootstrap arm must carry the summary's authoritative duration
+	// so a remote tab attaching to an already-finished job renders the real elapsed
+	// time instead of a bogus ~00:00 measured from the bootstrap instant.
+	summary := &apicore.RunJobSummary{DurationMs: 90_000, ExitCode: 7}
+	terminalDuration := func(msgs []uiMsg) int64 {
+		for _, m := range msgs {
+			if fin, ok := m.(jobFinishedMsg); ok {
+				return fin.DurationMs
+			}
+		}
+		t.Fatalf("no jobFinishedMsg produced, got %#v", msgs)
+		return 0
+	}
+	for _, status := range []string{remoteRunStatusCompleted, remoteRunStatusFailed, remoteRunStatusCanceled} {
+		if got := terminalDuration(remoteBootstrapTerminalMsgs(0, status, summary)); got != 90_000 {
+			t.Fatalf("status %q: expected DurationMs 90000 threaded, got %d", status, got)
+		}
+	}
 }

--- a/internal/core/run/ui/types.go
+++ b/internal/core/run/ui/types.go
@@ -193,9 +193,10 @@ type jobResumedMsg struct {
 }
 
 type jobFinishedMsg struct {
-	Index    int
-	Success  bool
-	ExitCode int
+	Index      int
+	Success    bool
+	ExitCode   int
+	DurationMs int64
 }
 
 type jobUpdateMsg struct {

--- a/internal/core/run/ui/update.go
+++ b/internal/core/run/ui/update.go
@@ -947,9 +947,23 @@ func (m *uiModel) handleJobFinished(v jobFinishedMsg) tea.Cmd {
 			job.exitCode = v.ExitCode
 			m.failed++
 		}
-		if !job.startedAt.IsZero() {
+		// The sidebar timer is driven by job.duration. Prefer the authoritative
+		// duration reported with the completion, since the UI otherwise recomputes
+		// elapsed time from startedAt — which is never seeded when a job's first
+		// observed lifecycle message is a retry (retry attempts emit no fresh
+		// start). Without this, the timer stays blank after a retried job succeeds.
+		if v.DurationMs > 0 || !job.startedAt.IsZero() {
 			job.completedAt = finishedAt
-			job.duration = job.completedAt.Sub(job.startedAt)
+			if v.DurationMs > 0 {
+				job.duration = time.Duration(v.DurationMs) * time.Millisecond
+				// Backfill startedAt so the startedAt/completedAt/duration triple
+				// stays coherent for consumers other than the sidebar timer.
+				if job.startedAt.IsZero() {
+					job.startedAt = job.completedAt.Add(-job.duration)
+				}
+			} else {
+				job.duration = job.completedAt.Sub(job.startedAt)
+			}
 		}
 		if finishedAt.After(m.now) {
 			m.now = finishedAt

--- a/internal/core/run/ui/update_test.go
+++ b/internal/core/run/ui/update_test.go
@@ -909,6 +909,38 @@ func TestSelectNextRunningJobPrefersRunningThenPending(t *testing.T) {
 	}
 }
 
+func TestHandleJobFinishedRestoresTimerAfterRetrySuccess(t *testing.T) {
+	t.Parallel()
+
+	// Reproduces the multi-run/remote scenario where the UI first observes a job
+	// while it is retrying (a bootstrapped tab emits only a retry message, so
+	// startedAt is never seeded) and then receives the live JobCompleted event
+	// carrying the authoritative duration. The sidebar timer must reappear on
+	// success instead of staying blank.
+	m := newUIModel(1)
+	m.total = 1
+
+	m.handleJobRetry(jobRetryMsg{Index: 0, Attempt: 2, MaxAttempts: 3, Reason: "boom"})
+	if !m.jobs[0].startedAt.IsZero() {
+		t.Fatalf("precondition: expected zero startedAt after a retry-only bootstrap")
+	}
+	if got := m.jobs[0].state; got != jobRetrying {
+		t.Fatalf("precondition: expected jobRetrying state, got %v", got)
+	}
+
+	m.handleJobFinished(jobFinishedMsg{Index: 0, Success: true, DurationMs: 90_000})
+
+	if got := m.jobs[0].state; got != jobSuccess {
+		t.Fatalf("expected success state, got %v", got)
+	}
+	if got := m.jobs[0].duration; got <= 0 {
+		t.Fatalf("expected duration recorded from authoritative DurationMs, got %v", got)
+	}
+	if got := m.sidebarTimeString(&m.jobs[0]); got != "01:30" {
+		t.Fatalf("expected sidebar timer %q after retry-success, got %q", "01:30", got)
+	}
+}
+
 func TestHandleJobFinishedUpdatesCountsAndViewState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/run_snapshot.go
+++ b/internal/daemon/run_snapshot.go
@@ -28,9 +28,27 @@ type runSnapshotBuilder struct {
 const snapshotJobStatusQueued = "queued"
 
 type runSnapshotJob struct {
-	state   apicore.RunJobState
-	summary apicore.RunJobSummary
-	session *transcript.ViewModel
+	state     apicore.RunJobState
+	summary   apicore.RunJobSummary
+	session   *transcript.ViewModel
+	startedAt time.Time
+}
+
+// resolveDurationMs prefers the authoritative duration carried in the terminal
+// payload and falls back to the wall-clock span between the JobStarted event and
+// the terminal event, so historical journals (recorded before failed/canceled
+// payloads carried a duration) still render a real elapsed time.
+func (j *runSnapshotJob) resolveDurationMs(payloadMs int64, endedAt time.Time) int64 {
+	if payloadMs > 0 {
+		return payloadMs
+	}
+	if j.startedAt.IsZero() {
+		return 0
+	}
+	if d := endedAt.Sub(j.startedAt).Milliseconds(); d > 0 {
+		return d
+	}
+	return 0
 }
 
 func newRunSnapshotBuilder() *runSnapshotBuilder {
@@ -197,6 +215,9 @@ func (b *runSnapshotBuilder) applyJobStarted(item events.Event) error {
 	job.state.Status = runStatusRunning
 	job.state.AgentName = firstNonEmpty(strings.TrimSpace(payload.IDE), job.state.AgentName)
 	job.state.UpdatedAt = item.Timestamp.UTC()
+	if job.startedAt.IsZero() {
+		job.startedAt = item.Timestamp.UTC()
+	}
 
 	job.summary.Attempt = payload.Attempt
 	job.summary.MaxAttempts = payload.MaxAttempts
@@ -269,6 +290,7 @@ func (b *runSnapshotBuilder) applyJobCompleted(item events.Event) error {
 	job.summary.Attempt = payload.Attempt
 	job.summary.MaxAttempts = payload.MaxAttempts
 	job.summary.ExitCode = payload.ExitCode
+	job.summary.DurationMs = job.resolveDurationMs(payload.DurationMs, item.Timestamp.UTC())
 	return nil
 }
 
@@ -289,6 +311,7 @@ func (b *runSnapshotBuilder) applyJobFailed(item events.Event) error {
 	job.summary.OutLog = firstNonEmpty(strings.TrimSpace(payload.OutLog), job.summary.OutLog)
 	job.summary.ErrLog = firstNonEmpty(strings.TrimSpace(payload.ErrLog), job.summary.ErrLog)
 	job.summary.ErrorText = strings.TrimSpace(payload.Error)
+	job.summary.DurationMs = job.resolveDurationMs(payload.DurationMs, item.Timestamp.UTC())
 	return nil
 }
 
@@ -303,6 +326,7 @@ func (b *runSnapshotBuilder) applyJobCancelled(item events.Event) error {
 	job.state.UpdatedAt = item.Timestamp.UTC()
 
 	job.summary.ErrorText = strings.TrimSpace(payload.Reason)
+	job.summary.DurationMs = job.resolveDurationMs(payload.DurationMs, item.Timestamp.UTC())
 	return nil
 }
 

--- a/internal/daemon/run_snapshot_test.go
+++ b/internal/daemon/run_snapshot_test.go
@@ -11,6 +11,33 @@ import (
 	"github.com/compozy/compozy/pkg/compozy/events/kinds"
 )
 
+func TestRunSnapshotJobResolveDurationMs(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 4, 20, 22, 0, 0, 0, time.UTC)
+
+	t.Run("prefers the authoritative payload duration", func(t *testing.T) {
+		t.Parallel()
+		job := &runSnapshotJob{startedAt: base}
+		if got := job.resolveDurationMs(90_000, base.Add(2*time.Second)); got != 90_000 {
+			t.Fatalf("want payload duration 90000, got %d", got)
+		}
+	})
+	t.Run("falls back to the started->terminal timestamp span", func(t *testing.T) {
+		t.Parallel()
+		job := &runSnapshotJob{startedAt: base}
+		if got := job.resolveDurationMs(0, base.Add(3*time.Second)); got != 3000 {
+			t.Fatalf("want fallback duration 3000, got %d", got)
+		}
+	})
+	t.Run("reports zero when the job never started", func(t *testing.T) {
+		t.Parallel()
+		job := &runSnapshotJob{}
+		if got := job.resolveDurationMs(0, base.Add(3*time.Second)); got != 0 {
+			t.Fatalf("want zero duration without a start, got %d", got)
+		}
+	})
+}
+
 func TestRunSnapshotBuilderCoversLifecycleBranches(t *testing.T) {
 	t.Parallel()
 
@@ -189,6 +216,11 @@ func TestRunSnapshotBuilderCoversLifecycleBranches(t *testing.T) {
 	}
 	if states[0].Summary.Usage.TotalTokens != 7 {
 		t.Fatalf("job 1 usage = %#v, want session usage total 7", states[0].Summary.Usage)
+	}
+	// Failed job carried no duration in its payload, so the builder derives it from
+	// the JobStarted(+1s)->JobFailed(+4s) timestamp span.
+	if states[0].Summary.DurationMs != 3000 {
+		t.Fatalf("job 1 duration = %d, want 3000ms from timestamp fallback", states[0].Summary.DurationMs)
 	}
 
 	if states[1].Status != runStatusCancelled || states[1].Summary == nil ||

--- a/internal/daemon/run_snapshot_test.go
+++ b/internal/daemon/run_snapshot_test.go
@@ -15,21 +15,21 @@ func TestRunSnapshotJobResolveDurationMs(t *testing.T) {
 	t.Parallel()
 	base := time.Date(2026, 4, 20, 22, 0, 0, 0, time.UTC)
 
-	t.Run("prefers the authoritative payload duration", func(t *testing.T) {
+	t.Run("Should prefer the authoritative payload duration", func(t *testing.T) {
 		t.Parallel()
 		job := &runSnapshotJob{startedAt: base}
 		if got := job.resolveDurationMs(90_000, base.Add(2*time.Second)); got != 90_000 {
 			t.Fatalf("want payload duration 90000, got %d", got)
 		}
 	})
-	t.Run("falls back to the started->terminal timestamp span", func(t *testing.T) {
+	t.Run("Should fall back to the started-to-terminal timestamp span", func(t *testing.T) {
 		t.Parallel()
 		job := &runSnapshotJob{startedAt: base}
 		if got := job.resolveDurationMs(0, base.Add(3*time.Second)); got != 3000 {
 			t.Fatalf("want fallback duration 3000, got %d", got)
 		}
 	})
-	t.Run("reports zero when the job never started", func(t *testing.T) {
+	t.Run("Should report zero when the job never started", func(t *testing.T) {
 		t.Parallel()
 		job := &runSnapshotJob{}
 		if got := job.resolveDurationMs(0, base.Add(3*time.Second)); got != 0 {

--- a/pkg/compozy/events/kinds/job.go
+++ b/pkg/compozy/events/kinds/job.go
@@ -83,15 +83,17 @@ type JobCompletedPayload struct {
 // JobFailedPayload describes a failed job.
 type JobFailedPayload struct {
 	JobAttemptInfo
-	CodeFile string `json:"code_file,omitempty"`
-	ExitCode int    `json:"exit_code,omitempty"`
-	OutLog   string `json:"out_log,omitempty"`
-	ErrLog   string `json:"err_log,omitempty"`
-	Error    string `json:"error,omitempty"`
+	CodeFile   string `json:"code_file,omitempty"`
+	ExitCode   int    `json:"exit_code,omitempty"`
+	OutLog     string `json:"out_log,omitempty"`
+	ErrLog     string `json:"err_log,omitempty"`
+	Error      string `json:"error,omitempty"`
+	DurationMs int64  `json:"duration_ms,omitempty"`
 }
 
 // JobCancelledPayload describes a canceled job.
 type JobCancelledPayload struct {
 	JobAttemptInfo
-	Reason string `json:"reason,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+	DurationMs int64  `json:"duration_ms,omitempty"`
 }


### PR DESCRIPTION
## Summary

Fixes the run TUI bug where the elapsed **timer disappears after a retried job succeeds** — and completes the fix so the timer is correct for **every** terminal outcome (success, failure, cancel) and for **remote tabs that attach after a job already finished**.

Root cause: the UI derived a job's elapsed time from a locally-tracked `startedAt` that the retry flow never seeds (retry attempts emit no fresh `JobStarted`, and a remote tab can bootstrap a job mid-retry), while discarding the authoritative duration the executor already computes.

<img width="1167" height="838" alt="Screenshot 2026-07-01 at 13 42 19" src="https://github.com/user-attachments/assets/97157f57-610f-45e6-9963-afb63abfdffd" />

## What changed

**Core fix** — thread the executor's authoritative `JobCompletedPayload.DurationMs` into the UI:
- `jobFinishedMsg` gains `DurationMs`; `translateJobCompletedEvent` carries it; `handleJobFinished` prefers it and backfills `startedAt` for triple-coherence.

**Completion across all terminal outcomes** — no persistence/schema migration required:
- **Part A (live failure/cancel):** `DurationMs` added to `JobFailedPayload`/`JobCancelledPayload`, populated in `executor/lifecycle.go` via a **zero-guarded** `elapsedMs()` (guard matters: `markGiveUp`/`markCanceled` can fire before any attempt starts), threaded through the failure and cancel UI translators.
- **Part B (remote pre-attach):** `DurationMs` added to the `RunJobSummary` contract; the daemon snapshot builder populates it from the authoritative payload with a `JobStarted → terminal` **timestamp fallback** for historical journals; `remote.go` threads it into all three terminal bootstrap arms.

## Why this altitude

Duration was only carried on the live `JobCompleted` event. Generalizing it to all terminal payloads + the remote summary contract fixes the whole class (blank timer on retry→failure/cancel; ~`00:00` on remote pre-attach) instead of special-casing the success arm.

## Testing

- `gofmt -s`: clean · `go build ./...`: OK · `golangci-lint` (5 packages): **0 issues**
- `go test -race`: `pkg/compozy/events/kinds`, `internal/core/run/ui`, `internal/core/run/executor`, `internal/daemon`, `internal/api/contract` — all pass
- New tests: executor terminal-duration (failed/canceled/zero-guard), UI translator threading (failure + cancel), remote bootstrap threading (all 3 arms), daemon `resolveDurationMs` (payload-wins / timestamp-fallback / no-start), plus a translator guard and reproduction test in the core fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal job events (completed, failed, cancelled) now carry an elapsed duration value end-to-end.
  * Job timing is consistently shown in the UI, including for retries and remote-attach/snapshot restores.

* **Bug Fixes**
  * Fixed missing/incorrect duration values in terminal event handling and when rebuilding run snapshots.
  * Timer rendering is improved so the job timer reflects the authoritative duration instead of staying blank.

* **Tests**
  * Added/extended coverage to verify duration propagation through terminal, retry, and remote/bootstrap flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->