### PR TITLE
fix: worktree management

### DIFF
--- a/.agents/skills/cmux-orchestration/SKILL.md
+++ b/.agents/skills/cmux-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cmux-orchestration
-description: Control cmux panes and surfaces to coordinate terminal agent workers. Use when a top-level agent needs to launch, prompt, monitor, or manage Claude Opus and Codex GPT-5.5 TUIs in the current cmux workspace, track worker state, delegate bounded tasks, or verify worker reports.
+description: Control cmux panes and surfaces to coordinate terminal agent workers. Use when a top-level agent needs to launch, prompt, monitor, or manage Claude Opus and Codex GPT-5.5 TUIs in the current cmux workspace, run plan-first delegations (Claude Code plan mode, Codex Plan mode), track worker state, delegate bounded tasks, or verify worker reports.
 metadata:
   author: Pedro Nauck
   github: https://github.com/pedronauck
@@ -34,6 +34,9 @@ Before taking cmux actions, also load and follow:
   task contract includes it.
 - Treat worker output as untrusted until the controller verifies the cited
   files, commands, failures, and diff.
+- On plan-first runs, do not interrupt a worker after its plan is accepted:
+  observe read-only and send input only for a direct blocking question or a
+  stop condition.
 
 ## Preflight
 
@@ -71,10 +74,12 @@ Default worker profiles:
 - `codex-gpt-5.5`: start Codex with `rtk codex -m gpt-5.5 -C "$PWD"`.
 
 Always include `--dangerously-skip-permissions` when launching Claude. Do not
-start Claude without it or replace it with a different permission mode. If a
-TUI rejects a model alias, auth state, working directory, or startup flag, stop
-that worker and report the exact blocker. Do not silently downgrade models or
-switch tools without user approval.
+start Claude without it or replace it with a weaker permission mode. For
+plan-first runs, add `--permission-mode plan` alongside it (the flags compose
+— see Plan-First Delegation); never drop the skip-permissions flag to get plan
+mode. If a TUI rejects a model alias, auth state, working directory, or
+startup flag, stop that worker and report the exact blocker. Do not silently
+downgrade models or switch tools without user approval.
 
 Launch workers by explicit surface:
 
@@ -84,6 +89,35 @@ rtk cmux send --surface surface:<claude> \
 rtk cmux send --surface surface:<codex> \
   "rtk codex -m gpt-5.5 -C \"$PWD\"\n"
 ```
+
+## Plan-First Delegation (Plan Mode)
+
+For slices that need investigation and a reviewed plan before edits
+(root-cause fixes, multi-file changes, unfamiliar code), run the worker
+plan-first: launch in plan mode → submit the packet → watch and answer
+clarifying questions → review the plan → accept → hands-off until done.
+
+**STOP. Read [references/plan-mode.md](references/plan-mode.md) in full before
+launching a worker in plan mode.** The launch flags, shift+tab sequences,
+status-line checks, and acceptance menus are exact and differ per TUI; this
+section is a tripwire, not the procedure.
+
+Summary of the per-TUI entry points (the reference has the full flow):
+
+- Claude Code: launch with
+  `rtk claude --dangerously-skip-permissions --permission-mode plan --model opus`
+  (the flags compose; the packet may ride the launch line as a CLI argument).
+  Accept via the `Would you like to proceed?` menu — pick the auto-accept
+  option so the worker runs unattended.
+- Codex: no plan-mode CLI flag. Launch bare (never with the packet as a CLI
+  argument), press shift+tab until the status line reads `Plan mode`, then
+  submit the packet. Accept via `Implement this plan?` → option 1 (keeps the
+  investigation context).
+
+Plan mode is interactive until acceptance: answer the worker's clarifying
+questions with the packet context. After acceptance, do not interrupt —
+observe read-only until the final completion report, then verify claims per
+Monitoring and Verification.
 
 ## Prompt Submission to Running TUIs
 
@@ -97,7 +131,8 @@ Rules:
 - Prefer passing the initial prompt as a CLI argument at launch
   (`rtk claude --dangerously-skip-permissions "…prompt…"`,
   `rtk codex "…prompt…"`). This avoids the TUI-ready race and the submission
-  problem entirely.
+  problem entirely. Exception: Codex plan-first runs must launch bare — see
+  Plan-First Delegation.
 - For any follow-up prompt to an already-running TUI, always send the text and
   then submit with an explicit Enter:
 
@@ -116,6 +151,7 @@ Send worker prompts as standalone contracts. Include:
 
 - repo path and exact objective
 - worker role and model
+- execution mode: plan-first (plan mode) or direct
 - files, packages, or surfaces in scope
 - files and behaviors explicitly out of scope
 - claimed files or work slice to avoid conflicts
@@ -136,7 +172,8 @@ Maintain a compact registry in the task ledger or handoff:
 - worker role and model
 - `workspace:N`, `pane:N`, and `surface:N`
 - prompt/objective sent and start time
-- current status: starting, running, waiting, blocked, reported, verified
+- current status: starting, planning, plan-review, plan-accepted, running,
+  waiting, blocked, reported, verified
 - claimed files or work slice
 - worker-reported commands and results
 - controller verification performed
@@ -174,6 +211,9 @@ Stop and report instead of improvising when:
 - the requested model or startup flags are rejected
 - authentication blocks the TUI
 - worker output cannot be observed or controlled reliably
+- a plan-mode status line or acceptance menu cannot be confirmed via
+  `read-screen`, or a worker's plan stays out of scope after a re-planning
+  round
 - workers need overlapping edits that the controller cannot integrate safely
 - the task requires focus-changing cmux commands and the user has not approved
   them

--- a/.agents/skills/cmux-orchestration/references/plan-mode.md
+++ b/.agents/skills/cmux-orchestration/references/plan-mode.md
@@ -1,0 +1,177 @@
+# Plan Mode Launch & Acceptance (Claude Code & Codex)
+
+Mechanics to run a worker through an interactive planning phase before a
+hands-off implementation: launch the TUI in plan mode, submit the delegation
+packet, watch and answer clarifying questions, review the plan, accept it, and
+supervise hands-off until the worker reports done. Load `cmux`,
+`cmux-workspace`, and the parent `cmux-orchestration` SKILL.md for the
+underlying pane verbs. All commands are `rtk`-prefixed. Scope everything to the
+caller workspace; never change focus.
+
+## Contents
+
+- When to require plan-first
+- Shared rules (both TUIs)
+- Claude Code: launch in plan mode
+- Claude Code: accept the plan
+- Codex: launch and enter Plan mode
+- Codex: accept the plan
+- Watch plan mode & answer questions
+- Hands-off monitoring & completion
+
+## When to require plan-first
+
+Require plan mode when the slice needs investigation before edits: root-cause
+fixes, multi-file or cross-package changes, unfamiliar code, or anything where
+the controller wants to review intent before the worker touches files. Skip
+plan mode for trivially bounded slices (evidence gathering, read-only
+research, single-file mechanical edits) — the extra round trip only adds
+latency there.
+
+## Shared rules (both TUIs)
+
+- TUI strings (status lines, acceptance menus, option labels) are
+  build-specific. Verify them with `read-screen` on first use against the
+  installed version (`rtk claude --version` / `rtk codex --version`). If a
+  newer build renames a mode or menu, adapt the keys/labels before relying on
+  the flow rather than failing mid-loop.
+- Inside a running TUI a trailing `\n` is a soft newline and does NOT submit.
+  Send the packet as text, then `send-key enter`, then confirm with
+  `read-screen` (input line empty + working indicator active). Treat an
+  unconfirmed send as not delivered.
+- Plan mode is interactive. The worker may ask clarifying questions before
+  presenting a plan — watch for them and answer with the task context. Do not
+  answer questions it did not ask.
+- Review the plan before accepting: correctness, scope against the delegation
+  packet's file claims, and no out-of-scope edits. Scroll the transcript if
+  the plan is longer than one screen.
+- **After acceptance, do not interrupt.** From the moment the plan is accepted
+  until the worker reports done, only observe via read-only `read-screen`.
+  Send input only to answer a direct blocking question the worker surfaces or
+  to handle a stop condition.
+
+## Claude Code: launch in plan mode
+
+`claude` has a first-class flag: `--permission-mode plan`. It composes with
+`--dangerously-skip-permissions` (which stays mandatory for workers), so the
+worker plans first and runs unattended after acceptance.
+
+Prefer passing the packet as the CLI argument at launch — the session starts
+planning immediately and you skip the TUI-ready race entirely:
+
+```bash
+rtk cmux send --surface surface:<claude> \
+  "rtk claude --dangerously-skip-permissions --permission-mode plan --model opus \"<packet, single block>\"\n"
+```
+
+To launch without an initial prompt, drop the packet argument, wait for the
+TUI, and submit per the shared rules (send text → `send-key enter` → confirm).
+
+Confirm plan mode via `read-screen`: the input-box status area must indicate
+plan mode (current builds show `plan mode on`). If a session is already
+running outside plan mode, **shift+tab** cycles the permission modes
+(default → accept edits → plan → bypass) — press and re-check until plan mode
+shows:
+
+```bash
+rtk cmux send-key --surface surface:<claude> shift+tab
+```
+
+## Claude Code: accept the plan
+
+When the worker finishes planning it presents an acceptance menu (current
+builds title it `Would you like to proceed?`), typically:
+
+```
+> 1. Yes, and auto-accept edits
+  2. Yes, and manually approve edits
+  3. No, keep planning
+```
+
+Review the plan first, then select the **auto-accept** option — workers run
+unattended, and manual approval would stall the pane waiting for per-edit
+confirmations. Press Enter while the auto-accept option is highlighted (use
+arrow keys via `send-key down`/`send-key up` if another option is selected):
+
+```bash
+rtk cmux send-key --surface surface:<claude> enter
+```
+
+Confirm via `read-screen` that plan mode is off and the worker is working. To
+reject and keep planning, select the "keep planning" option and send feedback
+as a follow-up prompt.
+
+## Codex: launch and enter Plan mode
+
+Codex has no CLI flag for plan mode — it is entered inside the TUI with
+**shift+tab**. Because of that, do **not** pass the packet as a CLI argument
+(the session would start working in the default mode before you can switch).
+Launch bare, enter Plan mode, then submit the packet.
+
+The fresh pane is a plain shell, so a trailing `\n` submits the launch line:
+
+```bash
+rtk cmux send --surface surface:<codex> "rtk codex --yolo -m gpt-5.5 -C \"$PWD\"\n"
+```
+
+Wait ~6s, then `read-screen` to confirm the TUI is up (banner shows the model
++ permissions + the input box). Then enter Plan mode:
+
+```bash
+rtk cmux send-key --surface surface:<codex> shift+tab
+```
+
+`read-screen` again — the bottom status line must read **`Plan mode`**. If it
+does not, send shift+tab again and re-check (the key cycles modes). Do not
+submit the packet until `Plan mode` is confirmed.
+
+Submit the packet per the shared rules:
+
+```bash
+rtk cmux send --surface surface:<codex> "<packet, single block>"
+rtk cmux send-key --surface surface:<codex> enter
+rtk cmux read-screen --surface surface:<codex>   # input line empty + working indicator active
+```
+
+## Codex: accept the plan
+
+When the worker presents the menu:
+
+```
+Implement this plan?
+> 1. Yes, implement this plan          Switch to Default and start coding.
+  2. Yes, clear context and implement  Fresh thread.
+  3. No, stay in Plan mode             Continue planning with the model.
+```
+
+Review the plan first, then select option **1** (keeps the investigation
+context) by pressing Enter while it is highlighted:
+
+```bash
+rtk cmux send-key --surface surface:<codex> enter
+```
+
+Confirm the status line no longer shows `Plan mode` and the worker is
+`Working`. To reject, select option 3 and send feedback as a follow-up prompt.
+
+## Watch plan mode & answer questions
+
+Poll the worker surface read-only at calm intervals (`read-screen`, tail the
+last ~30 lines) while the status line still shows plan mode. If the worker
+asks a clarifying question, answer it the same way (send text →
+`send-key enter`) using the delegation-packet context. Update the state
+registry: `planning` while investigating, `plan-review` when the acceptance
+menu appears, `plan-accepted` once accepted.
+
+## Hands-off monitoring & completion
+
+After acceptance, only observe. Poll read-only at unhurried intervals —
+implementation, validation, and any QA each take minutes. Watch for:
+
+- a direct blocking question (answer it),
+- a stop condition (errors it cannot resolve, out-of-scope request),
+- the final completion report (worker idle, summary printed).
+
+Do not send input for anything else. When the worker reports done, verify its
+claims per the parent skill: re-open cited files, re-run the key commands
+yourself, and review the diff before accepting the patch.

--- a/.claude/specs/worktree-nested-execution-spec.md
+++ b/.claude/specs/worktree-nested-execution-spec.md
@@ -1,0 +1,221 @@
+# Spec: Parallel execution when Compozy is invoked from inside a git worktree
+
+- Status: investigation + fix spec (plan-first)
+- Branch: `worktree-fix` (already checked out, clean, base = main + docs commit `ca25626`)
+- Related commits: `cc626ba5f247` (fix: parallel execution, #217), `6fa1d4b0bf03` (feat: worktree-backed parallel multi-run for `tasks run --multiple`, #200)
+- Owning packages: `internal/daemon`, `internal/core/worktree`, `internal/core/run/parallel`, `internal/core/run/executor`, `internal/cli`
+
+## 1. Problem statement
+
+Commits `6fa1d4b` and `cc626ba` introduced worktree-backed parallel execution in two shapes:
+
+1. **Multi-workflow parallel** (`compozy tasks run --multiple` with mode `parallel`): each workflow slug gets its own detached git worktree.
+2. **Same-workflow parallel tasks** (`task.parallel.*` waves): each task file gets its own detached worktree, results are squash-merged into a dedicated integration worktree/branch, then fast-forwarded back onto the caller's branch.
+
+Both shapes assume the workspace root (the directory where the user invoked compozy, registered as `workspace.RootDir`) is a **primary checkout** — a repo whose `.git` is a directory. The case where compozy is invoked **from inside a linked git worktree** (`.git` is a file containing `gitdir: <main>/.git/worktrees/<name>`) was never designed for, and — verified by grep — **no test anywhere builds a linked-worktree fixture**. All git fixtures do plain `git init` in `t.TempDir()` (e.g. `internal/cli/tasks_run_parallel_e2e_test.go:568-573`).
+
+This matters because linked worktrees are exactly how power users run multiple agent sessions on one repo — and how compozy itself isolates child runs. Compozy running inside a worktree is the norm, not the exception:
+
+- a user `cd`s into `~/dev/proj/_worktrees/feature-x` and runs `compozy tasks run`;
+- an agent spawned by compozy inside a compozy-created child worktree invokes `compozy` again (bundled cy-\* skills call the CLI);
+- two compozy sessions run concurrently in the main checkout and in a linked worktree of the same repo, sharing `$GIT_COMMON_DIR`.
+
+## 2. Verified architecture (how it works today)
+
+All references verified on branch `worktree-fix` at `ca25626`.
+
+### 2.1 Worktree allocation (daemon)
+
+`internal/daemon/task_multi_worktree.go`
+
+- `ResolveBase()` (:130) — resolves parent branch + HEAD via `git -C <workspaceRoot> rev-parse --abbrev-ref HEAD`. **Rejects detached HEAD** (:146) with "a named branch is required for parallel multi-run".
+- `Allocate()` (:167) — plans a deterministic path and runs `git -C <workspaceRoot> worktree add --detach <path> <commit>` (:188).
+- `planTaskMultiWorktreePath()` (:744) — path scheme:
+  `<worktreesRoot>/<sha256(workspaceRoot)[:12]>/<runid[:12]>-<sha256(runid)[:8]>/<NN-slug>`
+  where `worktreesRoot = ~/.compozy/state/worktrees` (`internal/config/home.go:113`, `COMPOZY_HOME` override supported).
+- `CreateIntegrationBranch()` (:326) — `git worktree add -b compozy/parallel-<runid> <...>/integration <baseRef>` (:359; branch name from `internal/daemon/task_multi.go:451`).
+- `SquashMerge()` (:367), `FastForward()` (:427 — requires the workspace on the target branch and clean, then `merge --ff-only`), `DiscardIntegrationBranch()` (:475 — `worktree remove --force` + `branch -D`), `Remove()` (:637 — remove without force), `Prune()` (:714 — `git worktree prune`).
+- `removeIntegrationWorktreeForPurge()` (:590) — runs **`git worktree prune --expire now`** (:608) in the user's repo after removing the integration worktree.
+- `runTaskMultiWorktreeGitCommand()` (:987) — plain `exec.CommandContext(git, -C dir, ...)`. **Does NOT sanitize the environment** — inherits `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR` from the daemon process if set.
+
+### 2.2 Child scheduling (daemon)
+
+`internal/daemon/task_multi.go`
+
+- `resolveTaskMultiParallelBase()` (:1388) — base resolved once per parent run at `prepared.workspace.RootDir`.
+- `startTaskMultiWorktreeChild()` (:1545) — Allocate → `mirrorTaskMultiWorkflowArtifacts()` (copies `.compozy/tasks/<slug>` into the worktree; `internal/daemon/task_multi_artifacts.go`) → emits `task.multi.*` event **before** child start (crash-safe metadata) → registers the worktree path as its own workspace row (`resolveWorkflowContext`, :1577) → `remapTaskMultiChildRuntime()` (:1719) repoints `RuntimeConfig.WorkspaceRoot` at the worktree (:1740).
+- `startTaskWorktreeChild()` (:1620) — same per single task number (same-workflow parallel).
+- `planParallelIntegrationPath()` (:459) — `<worktreesRoot>/<hash>/<parent>/integration`.
+- Agent subprocesses inherit cwd from the runtime workspace root: `internal/core/subprocess/process.go:58` (`cmd.Dir = cfg.WorkingDir`).
+
+### 2.3 Orchestration (same-workflow waves)
+
+`internal/core/run/parallel/orchestrator.go` — `Run()` (:317): create integration branch (:350) → per wave, launch task worktree children → `CommitTask` (scoped to produced paths from the worktree scope artifact) → `SquashMerge` into integration (:656) → conflict resolution via resolver → `FastForward` workspace branch + `SyncTaskArtifacts` (:491-494). Scope capture: `internal/core/run/executor/review_hooks.go:115` → `worktree.BuildScope(ctx, cfg.WorkspaceRoot, preSnapshot)`.
+
+### 2.4 Snapshot/scope
+
+`internal/core/worktree/snapshot.go`
+
+- `Capture()` (:145) — `os.Stat(root/.git)` (:151) works for both dir and file, so linked worktrees pass this check.
+- `runGit()` (:682) — **does sanitize** env (strips `GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`, `GIT_NAMESPACE`, :695-710). Note the asymmetry with §2.1's daemon git runner.
+
+### 2.5 Purge / reconcile / shutdown
+
+`internal/daemon/worktree_purge.go`
+
+- Purge plan built from the run's own journal events (`task.multi.*` / `task.parallel.*` payloads carry `WorktreePath`, `BaseCommit`), :210-263.
+- `cleanOwnedWorktreePath()` (:389) — only paths under `worktreesRoot` are ever removed (symlink-aware). The caller's own worktree (outside `~/.compozy/state/worktrees`) cannot be selected.
+- `inspectTaskWorktreeForPurge()` (:311) — refuses removal when status is dirty or commits aren't retained by any branch (`git branch --contains` runs at `workspaceRoot`, :361).
+- Startup/shutdown paths: `internal/daemon/reconcile.go:69`, `internal/daemon/shutdown.go:300`.
+
+### 2.6 Workspace identity
+
+`internal/store/globaldb/registry.go` — workspaces keyed by cleaned `RootDir` (:164, :817). CLI resolves the root from `os.Getwd()` (`internal/cli/setup.go:1353`); nothing calls `git rev-parse --show-toplevel` in production code (grep-verified), so a linked worktree registers as its own independent workspace. Compozy's own child worktrees are also registered as workspaces (:1577 above), so "workspace root = linked worktree" already happens daily for children — but only for **detached, compozy-owned** worktrees driven by the daemon itself, never for a **user-initiated top-level run**.
+
+### 2.7 Live evidence
+
+The machine running this spec has stale compozy worktrees at
+`~/.compozy/state/worktrees/4b2e29c14cde/tasks-task-m-{1d6f0ca1,7d2f9620,9736262d}/01-multi-task-run` (all detached at `e43aa56`) — created by real runs of this feature, visible via `git worktree list` from the main checkout. A user worktree also exists at `~/Dev/compozy/_worktrees/pr-200-review` (detached).
+
+## 3. Scenario matrix (required behavior)
+
+| #   | Scenario                                                                                                                                       | Required behavior                                                                                                                                                                                                                                                                                                                         |
+| --- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| S1  | `compozy tasks run` with parallel tasks (same workflow), CWD = **linked worktree on a named branch**                                           | Fully supported. Worktrees allocated from the linked worktree's HEAD; merge-back fast-forwards the **worktree's** branch; artifacts land in the worktree. No interference with the main checkout or sibling worktrees.                                                                                                                    |
+| S2  | `compozy tasks run --multiple` mode `parallel`, CWD = linked worktree on a named branch                                                        | Fully supported, same guarantees as S1.                                                                                                                                                                                                                                                                                                   |
+| S3  | Parallel/multi run, CWD = worktree with **detached HEAD** (incl. compozy-created child worktrees)                                              | Rejected **early** (CLI/wizard preflight, before any run/journal rows are created) with an actionable message naming the fix (checkout a branch). Today the rejection happens deep in the daemon (`ResolveBase`) after the parent run started — verify where the failure surfaces in the wizard/TUI and make it a first-class validation. |
+| S4  | **Recursion**: compozy invoked inside a compozy-owned worktree (path under `<home>/state/worktrees/`) starts another parallel/multi run        | Explicitly detected and rejected with an actionable error (detached-HEAD rejection currently masks this by accident; make the guard intentional and the message truthful). Non-parallel commands (exec, runs, status) must keep working there.                                                                                            |
+| S5  | Two compozy runs concurrent on the **same repo family** (main checkout + linked worktree, or two worktrees), both allocating/purging worktrees | No cross-run interference: run A's purge/prune must never delete or prune run B's worktrees or admin metadata (`$GIT_COMMON_DIR/worktrees/*`). Investigate the `git worktree prune --expire now` (:608) and `Prune()` (:714) blast radius — prune is repo-wide by design.                                                                 |
+| S6  | Purge/reconcile when the registered workspace root (a linked worktree) **no longer exists** (user deleted it)                                  | Purge must degrade gracefully (skip with a logged reason), not error out the whole reconcile pass, and must not touch other checkouts.                                                                                                                                                                                                    |
+
+Product decisions encoded above: linked worktrees on a named branch are first-class (S1/S2); detached HEAD and recursion are rejected with intent (S3/S4); multi-checkout concurrency is safe (S5); missing roots degrade gracefully (S6).
+
+## 4. Suspected failure points (hypotheses — root-cause each, do not assume)
+
+These are leads, ranked. Each must be confirmed or refuted with a reproduction (test or command trace) before any fix. Symptom-patching without a confirmed mechanism is rejected.
+
+1. **Env leakage in the daemon git runner** — `runTaskMultiWorktreeGitCommand` (`internal/daemon/task_multi_worktree.go:987`) inherits `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE`/`GIT_COMMON_DIR` while `internal/core/worktree/snapshot.go:695` deliberately strips them. If the daemon (or `compozy --detach` re-exec) is started from a shell/hook/tool that exports any of these — common in worktree-heavy setups and inside git hooks — every allocator/merge/purge git call resolves against the wrong repo. The asymmetry between the two runners is itself a smell; decide one policy and apply it to all git invocations (also check `internal/daemon/review_watch_git.go`).
+2. **Repo-wide `git worktree prune --expire now`** (`task_multi_worktree.go:608`) and `Prune()` (:714) — prune operates on the whole repo family. Race: run A prunes while run B's `git worktree add` is mid-flight (admin dir exists, `gitdir` file not yet final), or a user's worktree sits on a temporarily-missing path (unmounted volume). Determine git's actual guarantees (worktree locks?) and scope compozy's prune to what it owns — or lock compozy-owned worktrees (`git worktree lock`) during runs.
+3. **Purge of a worktree that hosts a live nested run** — parent purge (`worktree_purge.go:108-139`) removes its child worktree once it is clean and its commits are branch-retained; a nested compozy process (agent-invoked) may still be running inside that path. Verify lifecycle ordering guarantees; consider `git worktree lock` or run-liveness checks before `Remove`.
+4. **Detached-HEAD failure surfaces too late and with git jargon** (S3) — `ResolveBase` (:130) fails only after the parent run exists (journal rows, TUI states, events already emitted). Trace the failure through `internal/cli/tasks_run_wizard.go` / `internal/core/run/ui/multi_remote.go` and check what the user actually sees; add preflight validation CLI-side.
+5. **`FastForward` semantics from a linked worktree** (:427-470) — requires the caller checkout on `BaseBranch` and clean. From a linked worktree: confirm `merge --ff-only` updates only the worktree's checked-out branch, that the branch is not checked out anywhere else (it can't be, git forbids it), and that failure modes (branch moved mid-run by another checkout) produce recoverable states — the integration branch must survive for manual recombination as documented.
+6. **`git branch --contains` / branch listing scope in purge** (`worktree_purge.go:361`) — runs at `workspaceRoot`; branch namespace is repo-wide so this is probably correct, but verify preserved-commit detection still holds when base commit info is missing and the retaining branch lives in a different checkout.
+7. **`mirrorTaskMultiWorkflowArtifacts`** (`internal/daemon/task_multi_artifacts.go`) — verify path assumptions when the source workspace is a linked worktree (artifacts under `.compozy/` are typically gitignored and live only in the checkout that ran the workflow — confirm mirror source is the caller's live filesystem, not the base commit).
+8. **Workspace registry double-identity** (§2.6) — main checkout and worktree register as unrelated workspaces of the same repo. Audit daemon features keyed by workspace (review watch, recovery, reconcile, purge) for hidden one-workspace-per-repo assumptions.
+9. **Snapshot/scope inside child worktrees when the child is itself nested** — `Capture` handles `.git`-as-file, but confirm `BuildScope` fingerprints behave with gitlinks/submodules and with `.git` file paths in deeper nesting (worktree-of-worktree after S4 guard should be unreachable — assert that).
+
+## 5. Success criteria
+
+1. **Repro first**: each S1-S6 scenario has a deterministic reproduction (failing test or documented command trace) executed **before** the fix; findings recorded in the plan/PR description. Hypotheses in §4 confirmed or explicitly refuted with evidence.
+2. S1 and S2 pass end-to-end from a linked-worktree CWD: run completes, merge-back lands on the worktree's branch, `git -C <main> worktree list` shows no leaked compozy worktrees after purge, sibling checkouts untouched (verify via `git status` + `worktree list` before/after in the test).
+3. S3: detached-HEAD rejection happens before parent-run creation, with a message that names the directory, states "detached HEAD", and says what to do. Covered by a CLI-level test.
+4. S4: recursion guard rejects parallel/multi runs whose workspace root is inside the home worktrees root, with an intentional error message. Non-parallel commands inside such worktrees keep working (test both).
+5. S5: concurrent allocate/purge across two checkouts of one repo family proven safe (integration test with two workspaces; no lost admin metadata, no failed adds caused by the sibling's prune).
+6. S6: purge/reconcile with a deleted workspace root logs and skips; other runs' purges still execute.
+7. Git-env policy unified: every production git invocation uses one documented environment policy (sanitized or intentionally inherited — decided at root cause, not per-call-site patched).
+8. No destructive behavior toward worktrees compozy does not own; `cleanOwnedWorktreePath` guarantees preserved and extended to any new removal path.
+9. `make verify` passes 100% (fmt + lint zero issues + tests with `-race` + build). No lint suppressions, no skipped tests, no `interface{}` shortcuts.
+10. Existing behavior for primary checkouts unchanged (full existing suites pass unmodified — any assertion change requires a stated reason rooted in a confirmed bug, per testing rules).
+
+## 6. User flows
+
+### Flow A (S1) — parallel tasks from a worktree
+
+1. User: `git -C ~/proj worktree add ../proj-wt feature-x && cd ../proj-wt`.
+2. `compozy tasks run`, picks a workflow with `_tasks.md` (schema `compozy.tasks/v2`), enables parallel tasks in the wizard (`internal/cli/tasks_run_wizard.go` fields `parallelTasks`, resolver IDE/model/reasoning).
+3. Daemon resolves base = `feature-x`@HEAD of the worktree; allocates per-task worktrees under `~/.compozy/state/worktrees/<hash(proj-wt)>/...`; agents run with cwd = task worktree.
+4. Waves complete → squash merges into `compozy/parallel-<runid>` → fast-forward `feature-x` in `~/proj-wt` → artifacts synced → worktrees purged → integration branch deleted.
+5. User sees completed run; `git log` in the worktree shows the squash commits; main checkout `~/proj` untouched.
+
+### Flow B (S2) — multi-workflow parallel from a worktree
+
+Same entry, `--multiple` + mode `parallel` + limit; per-slug worktrees; each slug's results preserved per ADR-005..008 (`.compozy/tasks/multi-task-run/adrs/`); worktrees preserved on non-finalized runs (status `preserved`).
+
+### Flow C (S3/S4) — rejection paths
+
+User in a detached worktree (or inside `~/.compozy/state/worktrees/...`) starts a parallel run → immediate CLI error naming the condition and remedy; exit non-zero; no run rows, no events, no worktrees created.
+
+## 7. Test plan
+
+Follow repo testing rules: table-driven, `t.Run`, `t.Parallel` where independent, `t.TempDir`, `-race`. Reuse canonical suites — extend the existing files; do not create parallel standalone suites. The goal of these tests is to catch the real bugs in §4, not to freeze current behavior.
+
+### 7.1 New shared fixture
+
+Add a linked-worktree fixture helper next to the existing git fixture in `internal/cli/tasks_run_parallel_e2e_test.go:568` (and a daemon-level equivalent where needed): init primary repo → commit seed → `git worktree add <dir> -b <branch>` → return both roots. This is the missing primitive every nested test needs.
+
+### 7.2 Unit (owning layer: allocator/purge/scheduling)
+
+Extend `internal/daemon/task_multi_worktree_test.go`:
+
+- `ResolveBase` from a linked worktree root (named branch) → correct branch/commit; from detached worktree → the named error.
+- `Allocate` with workspaceRoot = linked worktree (real git, in the style of `TestRunTaskMultiWorktreeGitCommand` :1573) → worktree created, registered in the **common** git dir, path scheme keyed by the worktree root hash.
+- Git runner env policy: with `GIT_DIR`/`GIT_WORK_TREE` exported in the test process env, allocator commands still target the `-C` directory (this is the regression test for §4.1).
+- `FastForward` executed against a linked worktree root.
+
+Extend `internal/daemon/worktree_purge` coverage in `purge_test.go`:
+
+- purge plan/removal when `workspaceRoot` is a linked worktree;
+- S6: workspace root missing → skip + no error propagation;
+- guard: recorded worktree path equal to the caller's own root is never removed.
+
+Extend `internal/core/worktree/snapshot_test.go`:
+
+- `Capture`/`BuildScope` where root's `.git` is a file (linked worktree fixture).
+
+New guard tests (wherever the S4 guard lands, likely `internal/daemon/task_multi.go` prepare path + CLI preflight):
+
+- workspace root under home worktrees root → parallel/multi rejected; enqueued/exec allowed.
+
+### 7.3 Integration / e2e (owning layer: CLI e2e)
+
+Extend `internal/cli/tasks_run_parallel_e2e_test.go`:
+
+- S1 e2e: full parallel run with CWD = linked worktree; assert merge-back on the worktree branch, purge cleanliness (`git worktree list` before/after), main checkout untouched.
+- S2 e2e: `--multiple` parallel from linked worktree.
+- S3 e2e: detached worktree → early validation error, no run created.
+- S5: two concurrent runs (main + worktree) — at minimum a daemon-level test driving both allocators concurrently against one repo family; assert both complete and both purges are clean.
+
+### 7.4 Non-goals for tests
+
+No snapshot tests of error prose beyond the key substrings; no tests freezing path-scheme internals except where the path contract is load-bearing (purge ownership).
+
+## 8. Data & API surfaces (do not break)
+
+- **Events** (`pkg/compozy/events/kinds/task.go`): `TaskRunMultiplePayload` / `TaskParallelPayload` carry `WorktreePath`, `BaseBranch`, `BaseCommit`, `WorktreeStatus` — purge reconstructs its plan from these; any new metadata must be additive (docs in `docs/events.md`, contract tests in `pkg/compozy/events/kinds/docs_test.go`, `payload_compat_test.go`).
+- **HTTP API** (`internal/api/contract/types.go`, `openapi/compozy-daemon.json`, `internal/api/client/client_contract_test.go`): `TaskRunRequest` mode/limit fields; `TaskRunMultipleItem` worktree metadata. Additive changes only; regenerate contract fixtures if touched.
+- **Config** (`internal/core/workspace/config_types.go`): `[tasks.run]` parallel limit + `ParallelTasksConfig` (max concurrency, resolver IDE/model/reasoning). There is currently **no** worktree-location or worktree-behavior config key (grep-verified) — if the fix needs one, follow existing validation patterns in `config_validate.go` + tests in `config_test.go`.
+- **Run artifacts**: journal DB per run (`internal/core/run/journal`), worktree scope JSON at `RunArtifacts.JobArtifacts(<job>).WorktreeScopePath` (`internal/core/run/executor/review_hooks.go:135`), home layout `~/.compozy/state/worktrees/...` (`internal/config/home.go`).
+
+## 9. File reference index
+
+| Area                                  | Files                                                                                                                |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Allocator + git runner                | `internal/daemon/task_multi_worktree.go` (+`_test.go`)                                                               |
+| Scheduling / remap / integration path | `internal/daemon/task_multi.go`, `internal/daemon/task_multi_artifacts.go` (+tests)                                  |
+| Purge / ownership guards              | `internal/daemon/worktree_purge.go`, `internal/daemon/purge_test.go`                                                 |
+| Reconcile / shutdown                  | `internal/daemon/reconcile.go`, `internal/daemon/shutdown.go`, `internal/daemon/run_manager.go`                      |
+| Wave orchestration                    | `internal/core/run/parallel/{orchestrator,resolver,waves,fsm,events}.go` (+tests)                                    |
+| Snapshot / scope                      | `internal/core/worktree/snapshot.go` (+`_test.go`)                                                                   |
+| Executor hooks                        | `internal/core/run/executor/review_hooks.go`, `internal/core/run/executor/runner.go`                                 |
+| Subprocess cwd/env                    | `internal/core/subprocess/process.go`, `internal/core/run/internal/acpshared/session_exec.go`                        |
+| CLI wizard / e2e                      | `internal/cli/tasks_run_wizard.go`, `internal/cli/tasks_run_parallel_e2e_test.go`, `internal/cli/daemon_commands.go` |
+| Workspace identity                    | `internal/store/globaldb/registry.go`, `internal/cli/setup.go:1353`                                                  |
+| Home paths                            | `internal/config/home.go`                                                                                            |
+| Events / API                          | `pkg/compozy/events/kinds/task.go`, `internal/api/contract/types.go`, `docs/events.md`                               |
+| Design history                        | `.compozy/tasks/multi-task-run/_techspec.md`, `adrs/adr-005..008.md`                                                 |
+
+## 10. Constraints
+
+- Root-cause fixes only — no symptom patches, no lint suppressions, no error swallowing, no timing hacks (`no-workarounds` gates apply).
+- Debugging must follow the systematic protocol: reproduce → instrument/trace → localize → confirm mechanism → then fix (`systematic-debugging`).
+- Never run `git restore/checkout/reset/clean/rm` against this working tree without explicit permission; test fixtures own their temp repos and may do anything inside `t.TempDir()`.
+- `go get` for any new dependency (none expected).
+- Completion gate: `make verify` at 100%, full output read. Zero lint issues, `-race` clean.
+- Commits: only if explicitly requested afterwards; the deliverable is the working tree on `worktree-fix` + summary of findings.
+
+## 11. Out of scope
+
+- Windows-specific worktree path semantics.
+- Submodule-heavy repos beyond keeping existing gitlink fingerprints working.
+- Redesigning the merge-back strategy (squash + ff-only stays as per ADR-005..008).
+- UI/TUI redesign beyond surfacing the new validation errors correctly.

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,7 +6,7 @@ inputs:
   go-version:
     description: "Go version to install"
     required: false
-    default: "1.26.3"
+    default: "1.26.4"
   install-tools:
     description: "Install common development tools"
     required: false

--- a/.github/versions.yml
+++ b/.github/versions.yml
@@ -4,7 +4,7 @@
 
 versions:
   # Language versions
-  go: "1.26.3"
+  go: "1.26.4"
   node: "22"
 
   # Package manager versions

--- a/.github/workflows/auto-docs.yml
+++ b/.github/workflows/auto-docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.3"
+          go-version: "1.26.4"
 
       - name: Get PR diff and context
         id: pr-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   CGO_ENABLED: 0
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.26.3"
+  GO_VERSION: "1.26.4"
   INITIAL_VERSION: "v0.1.0"
   NODE_VERSION: "22"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/compozy/compozy
 
-go 1.26.3
+go 1.26.4
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -18,6 +18,7 @@ import (
 	apicore "github.com/compozy/compozy/internal/api/core"
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	core "github.com/compozy/compozy/internal/core"
+	"github.com/compozy/compozy/internal/core/gitenv"
 	"github.com/compozy/compozy/internal/core/kernel"
 	"github.com/compozy/compozy/internal/core/model"
 	taskscore "github.com/compozy/compozy/internal/core/tasks"
@@ -772,6 +773,11 @@ func (s *commandState) runTaskWorkflowPrepared(ctx context.Context, cmd *cobra.C
 	if err := s.preflightTaskMetadata(ctx, cmd, cfg); err != nil {
 		return err
 	}
+	if s.parallelTasks {
+		if err := s.preflightParallelWorktreeMode(ctx); err != nil {
+			return err
+		}
+	}
 
 	presentationMode, err := s.resolveTaskPresentationMode(cmd)
 	if err != nil {
@@ -846,6 +852,11 @@ func (s *commandState) runTaskWorkflowsMultiplePrepared(
 		return withExitCode(2, errors.New(
 			`--parallel-limit requires parallel mode; pass --parallel or set run_multiple_mode = "parallel"`,
 		))
+	}
+	if mode == workspacecfg.TaskRunMultipleModeParallel {
+		if err := s.preflightParallelWorktreeMode(ctx); err != nil {
+			return err
+		}
 	}
 	runtimeOverrides, err := s.buildTaskRunRuntimeOverrides(cmd)
 	if err != nil {
@@ -928,6 +939,108 @@ func rejectMultipleOnlyParallelFlags(cmd *cobra.Command) error {
 		return errors.New("--parallel-limit is only valid with --multiple")
 	}
 	return nil
+}
+
+func (s *commandState) preflightParallelWorktreeMode(ctx context.Context) error {
+	root := strings.TrimSpace(s.workspaceRoot)
+	if root == "" {
+		return withExitCode(2, errors.New("parallel worktree-backed task runs require a workspace root"))
+	}
+	paths, err := resolveCLIDaemonHomePaths()
+	if err != nil {
+		return withExitCode(2, fmt.Errorf("resolve daemon home paths for parallel worktree preflight: %w", err))
+	}
+	inside, err := cliPathEqualOrInside(paths.WorktreesDir, root)
+	if err != nil {
+		return withExitCode(2, fmt.Errorf("inspect Compozy-managed worktree root for %s: %w", root, err))
+	}
+	if inside {
+		return withExitCode(
+			2,
+			fmt.Errorf(
+				"workspace %s is inside Compozy-managed worktree root %s; "+
+					"parallel task runs are not supported from a Compozy-managed worktree",
+				root,
+				paths.WorktreesDir,
+			),
+		)
+	}
+	branch, err := runTaskRunGitPreflight(ctx, root, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return withExitCode(
+			2,
+			fmt.Errorf(
+				"parallel worktree-backed task runs require a git workspace with a named branch at %s: %w",
+				root,
+				err,
+			),
+		)
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == "" || branch == "HEAD" {
+		return withExitCode(
+			2,
+			fmt.Errorf(
+				"workspace %s is on a detached HEAD; checkout a branch before starting parallel worktree-backed task runs",
+				root,
+			),
+		)
+	}
+	return nil
+}
+
+func runTaskRunGitPreflight(ctx context.Context, workspaceRoot string, args ...string) (string, error) {
+	cmdArgs := append([]string{"-C", strings.TrimSpace(workspaceRoot)}, args...)
+	cmd := exec.CommandContext(ctx, "git")
+	cmd.Args = append([]string{"git"}, cmdArgs...)
+	cmd.Env = gitenv.SanitizedEnv()
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = strings.TrimSpace(stdout.String())
+		}
+		if message != "" {
+			return "", fmt.Errorf("%w: %s", err, message)
+		}
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func cliPathEqualOrInside(parent string, child string) (bool, error) {
+	parentPath, err := cliCleanContainmentPath(parent)
+	if err != nil {
+		return false, err
+	}
+	childPath, err := cliCleanContainmentPath(child)
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(parentPath, childPath)
+	if err != nil {
+		return false, fmt.Errorf("relativize path %s to %s: %w", childPath, parentPath, err)
+	}
+	return rel == "." || (rel != "" && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))), nil
+}
+
+func cliCleanContainmentPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", errors.New("path is required")
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %s: %w", trimmed, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = resolved
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("resolve symlinks for %s: %w", absolute, err)
+	}
+	return filepath.Clean(absolute), nil
 }
 
 // resolveTaskRunMultipleMode resolves the multi-run scheduling mode with

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -990,24 +990,7 @@ func (s *commandState) preflightParallelWorktreeMode(ctx context.Context) error 
 }
 
 func runTaskRunGitPreflight(ctx context.Context, workspaceRoot string, args ...string) (string, error) {
-	cmdArgs := append([]string{"-C", strings.TrimSpace(workspaceRoot)}, args...)
-	cmd := exec.CommandContext(ctx, "git")
-	cmd.Args = append([]string{"git"}, cmdArgs...)
-	cmd.Env = gitenv.SanitizedEnv()
-	var stdout, stderr strings.Builder
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		message := strings.TrimSpace(stderr.String())
-		if message == "" {
-			message = strings.TrimSpace(stdout.String())
-		}
-		if message != "" {
-			return "", fmt.Errorf("%w: %s", err, message)
-		}
-		return "", err
-	}
-	return strings.TrimSpace(stdout.String()), nil
+	return gitenv.Run(ctx, workspaceRoot, args...)
 }
 
 func cliPathEqualOrInside(parent string, child string) (bool, error) {

--- a/internal/cli/root_command_execution_test.go
+++ b/internal/cli/root_command_execution_test.go
@@ -1410,6 +1410,7 @@ func runTasksRunMultipleParallelStubScenario(
 ) (apicore.TaskRunMultipleRequest, string, string) {
 	t.Helper()
 
+	requireGitForCLITests(t)
 	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
 	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
 		[]string{
@@ -1424,6 +1425,7 @@ func runTasksRunMultipleParallelStubScenario(
 	if strings.TrimSpace(config) != "" {
 		writeCLIWorkspaceConfig(t, workspaceRoot, config)
 	}
+	gitInitCommitCLIWorkspace(t, workspaceRoot)
 	withWorkingDir(t, workspaceRoot)
 
 	readyClient := &stubDaemonCommandClient{
@@ -1593,6 +1595,7 @@ func runTasksRunMultipleStreamScenario(
 ) (string, string, error) {
 	t.Helper()
 
+	requireGitForCLITests(t)
 	workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
 	writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
 		[]string{
@@ -1604,6 +1607,7 @@ func runTasksRunMultipleStreamScenario(
 		"# Task 1: Alpha Task",
 	))
 	writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+	gitInitCommitCLIWorkspace(t, workspaceRoot)
 	withWorkingDir(t, workspaceRoot)
 
 	readyClient := &stubDaemonCommandClient{
@@ -1900,6 +1904,7 @@ func TestTasksRunCommandStillCallsSingleRunClient(t *testing.T) {
 func TestTasksRunCommandForwardsParallelTasksOverride(t *testing.T) {
 	t.Run("Should forward --parallel-tasks on a single workflow run", func(t *testing.T) {
 		t.Parallel()
+		requireGitForCLITests(t)
 
 		workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
 		writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
@@ -1911,6 +1916,7 @@ func TestTasksRunCommandForwardsParallelTasksOverride(t *testing.T) {
 			},
 			"# Task 1: Demo Task",
 		))
+		gitInitCommitCLIWorkspace(t, workspaceRoot)
 		withWorkingDir(t, workspaceRoot)
 
 		readyClient := &stubDaemonCommandClient{
@@ -1953,6 +1959,194 @@ func TestTasksRunCommandForwardsParallelTasksOverride(t *testing.T) {
 			overrides.ParallelTasks.Enabled == nil ||
 			!*overrides.ParallelTasks.Enabled {
 			t.Fatalf("parallel task override = %#v, want enabled true", overrides.ParallelTasks)
+		}
+	})
+}
+
+func TestTasksRunCommandPreflightsParallelWorktreeBranch(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		workflows []string
+	}{
+		{
+			name:      "parallel tasks",
+			args:      []string{"tasks", "run", "demo", "--parallel-tasks", "--detach"},
+			workflows: []string{"demo"},
+		},
+		{
+			name:      "parallel multiple",
+			args:      []string{"tasks", "run", "--multiple", "demo,beta", "--parallel", "--detach"},
+			workflows: []string{"demo", "beta"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run("Should reject detached HEAD before daemon start for "+tc.name, func(t *testing.T) {
+			requireGitForCLITests(t)
+			workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
+			writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+				[]string{
+					"status: pending",
+					"title: Demo Task",
+					"type: backend",
+					"complexity: low",
+				},
+				"# Task 1: Demo Task",
+			))
+			if len(tc.workflows) > 1 {
+				writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+			}
+			gitInitCommitCLIWorkspace(t, workspaceRoot)
+			runGitForCLITests(t, workspaceRoot, "checkout", "-q", "--detach")
+			withWorkingDir(t, workspaceRoot)
+			installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
+				resolveHomePaths: func() (compozyconfig.HomePaths, error) {
+					t.Fatal("daemon bootstrap should not run when parallel worktree preflight rejects detached HEAD")
+					return compozyconfig.HomePaths{}, nil
+				},
+			})
+
+			defaults := allowBundledSkillsForExecutionTests()
+			defaults.isInteractive = func() bool { return false }
+			cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+			stdout, stderr, err := executeCommandCapturingProcessIO(t, cmd, nil, tc.args...)
+			if err == nil {
+				t.Fatalf("expected detached HEAD preflight rejection\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+			}
+			var exitErr *commandExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+				t.Fatalf("expected exit code 2 for preflight rejection, got %v", err)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			for _, want := range []string{workspaceRoot, "detached HEAD", "checkout a branch"} {
+				if !strings.Contains(stderr, want) {
+					t.Fatalf("stderr = %q, want substring %q", stderr, want)
+				}
+			}
+		})
+	}
+}
+
+func TestTasksRunCommandPreflightsManagedWorktreeRecursion(t *testing.T) {
+	t.Run("Should reject parallel mode inside Compozy-managed worktree before daemon start", func(t *testing.T) {
+		requireGitForCLITests(t)
+		prepareInProcessCLIDaemonHome(t)
+		paths, err := compozyconfig.ResolveHomePaths()
+		if err != nil {
+			t.Fatalf("ResolveHomePaths() error = %v", err)
+		}
+		workspaceRoot := filepath.Join(paths.WorktreesDir, "owned", "repo")
+		tasksDir := filepath.Join(workspaceRoot, ".compozy", "tasks", "demo")
+		if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+			t.Fatalf("mkdir tasks dir: %v", err)
+		}
+		writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Demo Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Demo Task",
+		))
+		gitInitCommitCLIWorkspace(t, workspaceRoot)
+		withWorkingDir(t, workspaceRoot)
+		installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
+			resolveHomePaths: func() (compozyconfig.HomePaths, error) {
+				t.Fatal("daemon bootstrap should not run when managed-worktree recursion is rejected")
+				return compozyconfig.HomePaths{}, nil
+			},
+		})
+
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(
+			t,
+			cmd,
+			nil,
+			"tasks",
+			"run",
+			"demo",
+			"--parallel-tasks",
+			"--detach",
+		)
+		if err == nil {
+			t.Fatalf("expected managed-worktree recursion rejection\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+		}
+		var exitErr *commandExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+			t.Fatalf("expected exit code 2 for recursion preflight rejection, got %v", err)
+		}
+		if stdout != "" {
+			t.Fatalf("stdout = %q, want empty", stdout)
+		}
+		for _, want := range []string{workspaceRoot, "Compozy-managed worktree", "parallel"} {
+			if !strings.Contains(stderr, want) {
+				t.Fatalf("stderr = %q, want substring %q", stderr, want)
+			}
+		}
+	})
+
+	t.Run("Should allow non-parallel task run inside Compozy-managed worktree", func(t *testing.T) {
+		requireGitForCLITests(t)
+		prepareInProcessCLIDaemonHome(t)
+		paths, err := compozyconfig.ResolveHomePaths()
+		if err != nil {
+			t.Fatalf("ResolveHomePaths() error = %v", err)
+		}
+		workspaceRoot := filepath.Join(paths.WorktreesDir, "owned", "repo")
+		tasksDir := filepath.Join(workspaceRoot, ".compozy", "tasks", "demo")
+		if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+			t.Fatalf("mkdir tasks dir: %v", err)
+		}
+		writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+			[]string{
+				"status: pending",
+				"title: Demo Task",
+				"type: backend",
+				"complexity: low",
+			},
+			"# Task 1: Demo Task",
+		))
+		gitInitCommitCLIWorkspace(t, workspaceRoot)
+		withWorkingDir(t, workspaceRoot)
+
+		readyClient := &stubDaemonCommandClient{
+			target: apiclient.Target{SocketPath: "/tmp/compozy-daemon.sock"},
+			health: apicore.DaemonHealth{Ready: true},
+			startRun: apicore.Run{
+				RunID:            "run-task-managed-nonparallel",
+				Mode:             string(core.ModePRDTasks),
+				Status:           "running",
+				PresentationMode: attachModeDetach,
+				StartedAt:        time.Date(2026, 4, 17, 13, 7, 30, 0, time.UTC),
+			},
+		}
+		installTestCLIReadyDaemonBootstrap(t, readyClient)
+
+		defaults := allowBundledSkillsForExecutionTests()
+		defaults.isInteractive = func() bool { return false }
+		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+		stdout, stderr, err := executeCommandCapturingProcessIO(
+			t,
+			cmd,
+			nil,
+			"tasks",
+			"run",
+			"demo",
+			"--detach",
+		)
+		if err != nil {
+			t.Fatalf("execute non-parallel managed-worktree run: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if readyClient.startCalls != 1 {
+			t.Fatalf("StartTaskRun calls = %d, want 1", readyClient.startCalls)
+		}
+		if !strings.Contains(stdout, "task run started: run-task-managed-nonparallel") {
+			t.Fatalf("stdout = %q, want task run started", stdout)
 		}
 	})
 }
@@ -2022,66 +2216,65 @@ func TestTasksRunMultipleCommandInProcessStreamReconstructsParentQueueState(t *t
 }
 
 func TestTasksRunMultipleCommandInProcessParallelModeRequiresGitWorkspace(t *testing.T) {
-	t.Run("Should attempt worktree-backed parallel execution and fail outside a git repo", func(t *testing.T) {
-		workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
-		writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
-			[]string{
-				"status: pending",
-				"title: Alpha Task",
-				"type: backend",
-				"complexity: low",
-			},
-			"# Task 1: Alpha Task",
-		))
-		writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
-		writeCLIWorkspaceConfig(t, workspaceRoot, `
+	t.Run(
+		"Should reject worktree-backed parallel execution outside a git repo before daemon start",
+		func(t *testing.T) {
+			workspaceRoot, alphaDir := makeValidateTasksWorkspace(t, "alpha")
+			writeRawTaskFileForCLI(t, alphaDir, "task_01.md", cliTaskMarkdown(
+				[]string{
+					"status: pending",
+					"title: Alpha Task",
+					"type: backend",
+					"complexity: low",
+				},
+				"# Task 1: Alpha Task",
+			))
+			writeTaskWorkflowForCLI(t, workspaceRoot, "beta")
+			writeCLIWorkspaceConfig(t, workspaceRoot, `
 [tasks.run]
 run_multiple_mode = "parallel"
 `)
-		withWorkingDir(t, workspaceRoot)
+			withWorkingDir(t, workspaceRoot)
+			installTestCLIDaemonBootstrap(t, cliDaemonBootstrap{
+				resolveHomePaths: func() (compozyconfig.HomePaths, error) {
+					t.Fatal("daemon bootstrap should not run when git preflight rejects a non-git workspace")
+					return compozyconfig.HomePaths{}, nil
+				},
+			})
 
-		installInProcessCLIDaemonBootstrapWithConfig(t, daemon.RunManagerConfig{})
-
-		defaults := allowBundledSkillsForExecutionTests()
-		defaults.isInteractive = func() bool { return false }
-		cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
-		stdout, stderr, err := executeCommandCapturingProcessIO(
-			t,
-			cmd,
-			nil,
-			"tasks",
-			"run",
-			"--multiple",
-			"alpha,beta",
-			"--stream",
-			"--dry-run",
-		)
-		// task_07 wires worktree-backed parallel execution: the daemon accepts the
-		// parallel mode, queues the items, and resolves the parent base branch before
-		// launching children. This workspace is not a git repository, so base
-		// resolution fails and the parent run fails cleanly instead of starting
-		// children in an ambiguous tree.
-		if err == nil {
-			t.Fatalf(
-				"expected parent run to fail without a git workspace\nstdout:\n%s\nstderr:\n%s",
-				stdout,
-				stderr,
+			defaults := allowBundledSkillsForExecutionTests()
+			defaults.isInteractive = func() bool { return false }
+			cmd := newRootCommandWithDefaults(newLazyRootDispatcher(), defaults)
+			stdout, stderr, err := executeCommandCapturingProcessIO(
+				t,
+				cmd,
+				nil,
+				"tasks",
+				"run",
+				"--multiple",
+				"alpha,beta",
+				"--stream",
+				"--dry-run",
 			)
-		}
-		var exitErr *commandExitError
-		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
-			t.Fatalf("expected exit code 1 for failed parent, got %v", err)
-		}
-		if !containsAll(
-			stdout,
-			"task multi-run started:",
-			"task queue started | mode=parallel total=2",
-			"resolve parent branch",
-			"run failed",
-		) {
-			t.Fatalf("expected parallel base-resolution failure output, got %q\nstderr:\n%s", stdout, stderr)
-		}
-	})
+			if err == nil {
+				t.Fatalf(
+					"expected preflight rejection without a git workspace\nstdout:\n%s\nstderr:\n%s",
+					stdout,
+					stderr,
+				)
+			}
+			var exitErr *commandExitError
+			if !errors.As(err, &exitErr) || exitErr.ExitCode() != 2 {
+				t.Fatalf("expected exit code 2 for preflight rejection, got %v", err)
+			}
+			if stdout != "" {
+				t.Fatalf("stdout = %q, want empty", stdout)
+			}
+			if !containsAll(stderr, workspaceRoot, "git workspace", "named branch") {
+				t.Fatalf("expected git workspace preflight failure, got stderr %q", stderr)
+			}
+		},
+	)
 }
 
 func TestTasksRunMultipleCommandStreamReturnsNonZeroOnParentFailure(t *testing.T) {

--- a/internal/cli/tasks_run_parallel_e2e_test.go
+++ b/internal/cli/tasks_run_parallel_e2e_test.go
@@ -221,6 +221,122 @@ func TestTasksRunParallelTasksEndToEndRoutesSingleWorkflowThroughParallelOrchest
 	})
 }
 
+func TestTasksRunParallelTasksEndToEndFromLinkedWorktree(t *testing.T) {
+	t.Run("Should merge parallel task output back into the linked worktree branch", func(t *testing.T) {
+		requireGitForCLITests(t)
+
+		const slug = "demo"
+		client, paths, primaryRoot, linkedRoot, _ := newLinkedParallelTasksCLIEnv(t, slug)
+		assertNoCompozyTaskFilesTrackedForCLI(t, linkedRoot)
+
+		stdout, stderr, err := runParallelMultiRunCLI(
+			t,
+			"tasks", "run", slug,
+			"--parallel-tasks",
+			"--stream",
+			"--dry-run",
+		)
+		if err != nil {
+			t.Fatalf("execute linked --parallel-tasks run: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !containsAll(stdout, "task run started:", "(mode=stream)", "run completed") {
+			t.Fatalf("expected started and completed output, got:\n%s\nstderr:\n%s", stdout, stderr)
+		}
+		runID := taskRunIDFromCLIOutput(t, stdout)
+		snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
+		}
+		if snapshot.Run.Mode != "task_multi" || snapshot.Run.Status != "completed" {
+			t.Fatalf(
+				"snapshot run = (mode=%q,status=%q), want (task_multi,completed)",
+				snapshot.Run.Mode,
+				snapshot.Run.Status,
+			)
+		}
+		for taskNumber := 1; taskNumber <= 3; taskNumber++ {
+			linkedPath := filepath.Join(linkedRoot, fmt.Sprintf("cli-task-%02d.txt", taskNumber))
+			if _, err := os.Stat(linkedPath); err != nil {
+				t.Fatalf("expected merged linked task output %s: %v", linkedPath, err)
+			}
+			primaryPath := filepath.Join(primaryRoot, fmt.Sprintf("cli-task-%02d.txt", taskNumber))
+			if _, err := os.Stat(primaryPath); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("primary checkout task output %s stat = %v, want absent", primaryPath, err)
+			}
+		}
+		if got := strings.TrimSpace(runGitOutputForCLITests(t, primaryRoot, "status", "--porcelain")); got != "" {
+			t.Fatalf("primary checkout status = %q, want clean", got)
+		}
+		assertNoCLIWorktreesUnderRoot(t, primaryRoot, paths.WorktreesDir)
+	})
+}
+
+func TestTasksRunMultipleParallelEndToEndFromLinkedWorktree(t *testing.T) {
+	t.Run("Should run multiple workflows in linked worktree and purge owned worktrees", func(t *testing.T) {
+		requireGitForCLITests(t)
+
+		client, paths, primaryRoot, linkedRoot, branch := newLinkedParallelMultiRunCLIEnv(t, []string{"alpha", "beta"})
+
+		stdout, stderr, err := runParallelMultiRunCLI(
+			t,
+			"tasks", "run", "--multiple", "alpha,beta", "--parallel", "--stream", "--dry-run",
+		)
+		if err != nil {
+			t.Fatalf("execute linked parallel multi-run: %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+		}
+		if !containsAll(
+			stdout,
+			"task multi-run started:",
+			"task queue started | mode=parallel total=2",
+			"task multi-run handoff:",
+			"branch="+branch,
+		) {
+			t.Fatalf("expected linked parallel start + worktree handoff output, got:\n%s\nstderr:\n%s", stdout, stderr)
+		}
+
+		runID := taskMultiRunIDFromCLIOutput(t, stdout)
+		snapshot, err := client.GetTaskRunMultipleSnapshot(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetTaskRunMultipleSnapshot(%q) error = %v", runID, err)
+		}
+		if snapshot.Run.Mode != "task_multi" || snapshot.Run.Status != "completed" {
+			t.Fatalf("snapshot parent = (mode=%q,status=%q), want (task_multi,completed)",
+				snapshot.Run.Mode, snapshot.Run.Status)
+		}
+		if len(snapshot.Items) != 2 {
+			t.Fatalf("snapshot item count = %d, want 2: %#v", len(snapshot.Items), snapshot.Items)
+		}
+		for i := range snapshot.Items {
+			item := &snapshot.Items[i]
+			if item.BaseBranch != branch {
+				t.Fatalf("snapshot item %q base branch = %q, want %q", item.Slug, item.BaseBranch, branch)
+			}
+			if !strings.HasPrefix(item.WorktreePath, paths.WorktreesDir) {
+				t.Fatalf("snapshot item %q worktree path = %q, want under %q",
+					item.Slug, item.WorktreePath, paths.WorktreesDir)
+			}
+		}
+		if got := strings.TrimSpace(runGitOutputForCLITests(t, primaryRoot, "status", "--porcelain")); got != "" {
+			t.Fatalf("primary checkout status = %q, want clean", got)
+		}
+		if got := strings.TrimSpace(runGitOutputForCLITests(t, linkedRoot, "status", "--porcelain")); got != "" {
+			t.Fatalf("linked checkout status = %q, want clean", got)
+		}
+
+		result, err := client.manager.Purge(context.Background(), daemon.RunLifecycleSettings{
+			KeepTerminalDays: 0,
+			KeepMax:          0,
+		})
+		if err != nil {
+			t.Fatalf("Purge() error = %v", err)
+		}
+		if !containsCLIString(result.PurgedRunIDs, runID) {
+			t.Fatalf("purged run ids = %v, want parent run %q included", result.PurgedRunIDs, runID)
+		}
+		assertNoCLIWorktreesUnderRoot(t, primaryRoot, paths.WorktreesDir)
+	})
+}
+
 func assertParallelWorktreeSnapshot(
 	t *testing.T,
 	snapshot apicore.TaskRunMultipleSnapshot,
@@ -350,6 +466,106 @@ func newParallelTasksCLIEnv(
 		},
 	})
 	return client, paths, workspaceRoot
+}
+
+func newLinkedParallelTasksCLIEnv(
+	t *testing.T,
+	slug string,
+) (*inProcessDaemonCommandClient, compozyconfig.HomePaths, string, string, string) {
+	t.Helper()
+
+	primaryRoot, linkedRoot, branch := initLinkedCLIWorkspace(t)
+	writeParallelTasksWorkflowForCLI(t, linkedRoot, slug)
+
+	prepareInProcessCLIDaemonHome(t)
+	paths, err := compozyconfig.ResolveHomePaths()
+	if err != nil {
+		t.Fatalf("ResolveHomePaths() error = %v", err)
+	}
+	withWorkingDir(t, linkedRoot)
+
+	client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{
+		WorktreesRoot: paths.WorktreesDir,
+		Prepare: func(
+			_ context.Context,
+			cfg *model.RuntimeConfig,
+			scope model.RunScope,
+		) (*model.SolvePreparation, error) {
+			taskNumber, err := requireCLITargetTaskNumber(cfg)
+			if err != nil {
+				return nil, err
+			}
+			if scope == nil {
+				return nil, errors.New("run scope is required")
+			}
+			return &model.SolvePreparation{
+				Jobs: []model.Job{{
+					SafeName: fmt.Sprintf("task-%02d", taskNumber),
+				}},
+				RunArtifacts: scope.RunArtifacts(),
+			}, nil
+		},
+		Execute: func(_ context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+			taskNumber, err := requireCLITargetTaskNumber(cfg)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(
+				filepath.Join(cfg.WorkspaceRoot, fmt.Sprintf("cli-task-%02d.txt", taskNumber)),
+				[]byte(fmt.Sprintf("task %02d\n", taskNumber)),
+				0o600,
+			); err != nil {
+				return err
+			}
+			return writeCLITaskResultFixture(cfg, "succeeded", 0, "")
+		},
+	})
+	return client, paths, primaryRoot, linkedRoot, branch
+}
+
+func newLinkedParallelMultiRunCLIEnv(
+	t *testing.T,
+	slugs []string,
+) (*inProcessDaemonCommandClient, compozyconfig.HomePaths, string, string, string) {
+	t.Helper()
+
+	primaryRoot, linkedRoot, branch := initLinkedCLIWorkspace(t)
+	for _, slug := range slugs {
+		writeTaskWorkflowForCLI(t, linkedRoot, slug)
+	}
+
+	prepareInProcessCLIDaemonHome(t)
+	paths, err := compozyconfig.ResolveHomePaths()
+	if err != nil {
+		t.Fatalf("ResolveHomePaths() error = %v", err)
+	}
+	withWorkingDir(t, linkedRoot)
+
+	client := installInProcessCLIDaemonBootstrapWithConfigClient(t, daemon.RunManagerConfig{
+		WorktreesRoot: paths.WorktreesDir,
+		Prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+			return &model.SolvePreparation{}, nil
+		},
+		Execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
+			return nil
+		},
+	})
+	return client, paths, primaryRoot, linkedRoot, branch
+}
+
+func initLinkedCLIWorkspace(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	primaryRoot := t.TempDir()
+	writeParallelTasksGitignoreForCLI(t, primaryRoot)
+	if err := os.WriteFile(filepath.Join(primaryRoot, "README.md"), []byte("primary\n"), 0o600); err != nil {
+		t.Fatalf("write primary README: %v", err)
+	}
+	gitInitCommitCLIWorkspace(t, primaryRoot)
+	linkedRoot := filepath.Join(t.TempDir(), "linked")
+	branch := "feature-cli-linked"
+	runGitForCLITests(t, primaryRoot, "worktree", "add", "-q", "-b", branch, linkedRoot)
+	return primaryRoot, linkedRoot, branch
 }
 
 func writeParallelTasksGitignoreForCLI(t *testing.T, workspaceRoot string) {
@@ -595,4 +811,28 @@ func runGitOutputForCLITests(t *testing.T, dir string, args ...string) string {
 		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
 	}
 	return string(out)
+}
+
+func assertNoCLIWorktreesUnderRoot(t *testing.T, repo string, worktreesRoot string) {
+	t.Helper()
+	list := runGitOutputForCLITests(t, repo, "worktree", "list", "--porcelain")
+	for _, line := range strings.Split(list, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		path := strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+		if strings.HasPrefix(path, worktreesRoot) {
+			t.Fatalf("found leaked Compozy worktree under %s in list:\n%s", worktreesRoot, list)
+		}
+	}
+}
+
+func containsCLIString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/core/gitenv/gitenv.go
+++ b/internal/core/gitenv/gitenv.go
@@ -1,0 +1,42 @@
+// Package gitenv centralizes process environment sanitization for internal git
+// commands that explicitly select their repository with -C or Cmd.Dir.
+package gitenv
+
+import (
+	"os"
+	"strings"
+)
+
+// SanitizedEnv returns the current process environment without repository-local
+// Git variables. Transport and credential variables such as GIT_SSH_COMMAND are
+// intentionally preserved.
+func SanitizedEnv() []string {
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		if IsRepositoryEnvName(name) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+// IsRepositoryEnvName reports whether name points Git at an inherited repository,
+// index, object store, or namespace that can override an explicit worktree path.
+func IsRepositoryEnvName(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "GIT_DIR",
+		"GIT_WORK_TREE",
+		"GIT_INDEX_FILE",
+		"GIT_COMMON_DIR",
+		"GIT_OBJECT_DIRECTORY",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES",
+		"GIT_NAMESPACE",
+		"GIT_PREFIX":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/core/gitenv/gitenv.go
+++ b/internal/core/gitenv/gitenv.go
@@ -3,7 +3,11 @@
 package gitenv
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 )
 
@@ -21,6 +25,34 @@ func SanitizedEnv() []string {
 		filtered = append(filtered, entry)
 	}
 	return filtered
+}
+
+// Command constructs a git subprocess pinned to dir with inherited repository
+// variables removed from the environment.
+func Command(ctx context.Context, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = strings.TrimSpace(dir)
+	cmd.Env = SanitizedEnv()
+	return cmd
+}
+
+// Run executes a sanitized git subprocess and returns trimmed stdout.
+func Run(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := Command(ctx, dir, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = strings.TrimSpace(stdout.String())
+		}
+		if message != "" {
+			return "", fmt.Errorf("%w: %s", err, message)
+		}
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 // IsRepositoryEnvName reports whether name points Git at an inherited repository,

--- a/internal/core/gitenv/gitenv.go
+++ b/internal/core/gitenv/gitenv.go
@@ -47,10 +47,7 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 		if message == "" {
 			message = strings.TrimSpace(stdout.String())
 		}
-		command := "git"
-		if len(args) > 0 {
-			command += " " + strings.Join(args, " ")
-		}
+		command := strings.Join(cmd.Args, " ")
 		if message != "" {
 			return "", fmt.Errorf("%s in %q failed: %w: %s", command, cmd.Dir, err, message)
 		}

--- a/internal/core/gitenv/gitenv.go
+++ b/internal/core/gitenv/gitenv.go
@@ -47,10 +47,14 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 		if message == "" {
 			message = strings.TrimSpace(stdout.String())
 		}
-		if message != "" {
-			return "", fmt.Errorf("%w: %s", err, message)
+		command := "git"
+		if len(args) > 0 {
+			command += " " + strings.Join(args, " ")
 		}
-		return "", err
+		if message != "" {
+			return "", fmt.Errorf("%s in %q failed: %w: %s", command, cmd.Dir, err, message)
+		}
+		return "", fmt.Errorf("%s in %q failed: %w", command, cmd.Dir, err)
 	}
 	return strings.TrimSpace(stdout.String()), nil
 }

--- a/internal/core/gitenv/gitenv_test.go
+++ b/internal/core/gitenv/gitenv_test.go
@@ -2,7 +2,10 @@ package gitenv
 
 import (
 	"context"
+	"errors"
+	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -65,6 +68,68 @@ func TestCommand(t *testing.T) {
 		}
 		if hasEnvName(cmd.Env, "GIT_DIR") {
 			t.Fatal("Command() retained GIT_DIR")
+		}
+	})
+}
+
+func TestRun(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+
+	t.Run("Should return trimmed stdout on success", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := Run(context.Background(), dir, "init", "-q"); err != nil {
+			t.Fatalf("Run(init) error = %v", err)
+		}
+
+		out, err := Run(context.Background(), dir, "rev-parse", "--show-toplevel")
+		if err != nil {
+			t.Fatalf("Run(rev-parse) error = %v", err)
+		}
+		if out == "" {
+			t.Fatal("Run(rev-parse) returned empty output")
+		}
+		if strings.TrimSpace(out) != out {
+			t.Fatalf("Run(rev-parse) output = %q, want trimmed output", out)
+		}
+	})
+
+	t.Run("Should wrap error with stderr message on failure", func(t *testing.T) {
+		dir := t.TempDir()
+		if _, err := Run(context.Background(), dir, "init", "-q"); err != nil {
+			t.Fatalf("Run(init) error = %v", err)
+		}
+
+		_, err := Run(context.Background(), dir, "rev-parse", "--verify", "nope")
+		if err == nil {
+			t.Fatal("Run(rev-parse) error = nil, want error")
+		}
+		got := err.Error()
+		for _, want := range []string{"git rev-parse --verify nope", dir, "nope"} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("Run(rev-parse) error = %q, want it to contain %q", got, want)
+			}
+		}
+	})
+
+	t.Run("Should wrap empty output errors with command context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		dir := t.TempDir()
+		_, err := Run(ctx, dir, "status", "--short")
+		if err == nil {
+			t.Fatal("Run(status) error = nil, want error")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run(status) error = %v, want context.Canceled", err)
+		}
+		got := err.Error()
+		for _, want := range []string{"git status --short", dir} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("Run(status) error = %q, want it to contain %q", got, want)
+			}
 		}
 	})
 }

--- a/internal/core/gitenv/gitenv_test.go
+++ b/internal/core/gitenv/gitenv_test.go
@@ -1,0 +1,88 @@
+package gitenv
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestSanitizedEnv(t *testing.T) {
+	t.Run("Should remove repository env vars and preserve transport env vars", func(t *testing.T) {
+		t.Setenv("GIT_DIR", "/wrong/.git")
+		t.Setenv("GIT_WORK_TREE", "/wrong")
+		t.Setenv("GIT_INDEX_FILE", "/wrong/.git/index")
+		t.Setenv("GIT_SSH_COMMAND", "ssh -i key")
+
+		env := SanitizedEnv()
+		for _, name := range []string{"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE"} {
+			if hasEnvName(env, name) {
+				t.Fatalf("SanitizedEnv() retained %s", name)
+			}
+		}
+		if !hasEnvName(env, "GIT_SSH_COMMAND") {
+			t.Fatal("SanitizedEnv() removed GIT_SSH_COMMAND")
+		}
+	})
+}
+
+func TestIsRepositoryEnvName(t *testing.T) {
+	t.Run("Should identify repository-scoped git env vars", func(t *testing.T) {
+		tests := []struct {
+			name string
+			want bool
+		}{
+			{name: "GIT_DIR", want: true},
+			{name: " GIT_WORK_TREE ", want: true},
+			{name: "GIT_INDEX_FILE", want: true},
+			{name: "GIT_COMMON_DIR", want: true},
+			{name: "GIT_OBJECT_DIRECTORY", want: true},
+			{name: "GIT_ALTERNATE_OBJECT_DIRECTORIES", want: true},
+			{name: "GIT_NAMESPACE", want: true},
+			{name: "GIT_PREFIX", want: true},
+			{name: "GIT_SSH_COMMAND", want: false},
+			{name: "HOME", want: false},
+			{name: "", want: false},
+		}
+		for _, tt := range tests {
+			if got := IsRepositoryEnvName(tt.name); got != tt.want {
+				t.Fatalf("IsRepositoryEnvName(%q) = %t, want %t", tt.name, got, tt.want)
+			}
+		}
+	})
+}
+
+func TestCommand(t *testing.T) {
+	t.Run("Should pin git to the provided directory with sanitized env", func(t *testing.T) {
+		t.Setenv("GIT_DIR", "/wrong/.git")
+
+		cmd := Command(context.Background(), " /repo ", "status", "--short")
+		wantArgs := []string{"git", "status", "--short"}
+		if !reflect.DeepEqual(cmd.Args, wantArgs) {
+			t.Fatalf("Command() args = %#v, want %#v", cmd.Args, wantArgs)
+		}
+		if cmd.Dir != "/repo" {
+			t.Fatalf("Command() dir = %q, want /repo", cmd.Dir)
+		}
+		if hasEnvName(cmd.Env, "GIT_DIR") {
+			t.Fatal("Command() retained GIT_DIR")
+		}
+	})
+}
+
+func hasEnvName(env []string, name string) bool {
+	for _, entry := range env {
+		if envEntryName(entry) == name {
+			return true
+		}
+	}
+	return false
+}
+
+func envEntryName(entry string) string {
+	for index, char := range entry {
+		if char == '=' {
+			return entry[:index]
+		}
+	}
+	return entry
+}

--- a/internal/core/gitenv/gitenv_test.go
+++ b/internal/core/gitenv/gitenv_test.go
@@ -32,24 +32,37 @@ func TestIsRepositoryEnvName(t *testing.T) {
 	t.Run("Should identify repository-scoped git env vars", func(t *testing.T) {
 		tests := []struct {
 			name string
+			env  string
 			want bool
 		}{
-			{name: "GIT_DIR", want: true},
-			{name: " GIT_WORK_TREE ", want: true},
-			{name: "GIT_INDEX_FILE", want: true},
-			{name: "GIT_COMMON_DIR", want: true},
-			{name: "GIT_OBJECT_DIRECTORY", want: true},
-			{name: "GIT_ALTERNATE_OBJECT_DIRECTORIES", want: true},
-			{name: "GIT_NAMESPACE", want: true},
-			{name: "GIT_PREFIX", want: true},
-			{name: "GIT_SSH_COMMAND", want: false},
-			{name: "HOME", want: false},
-			{name: "", want: false},
+			{name: "Should identify GIT_DIR as repository scoped", env: "GIT_DIR", want: true},
+			{name: "Should trim and identify GIT_WORK_TREE as repository scoped", env: " GIT_WORK_TREE ", want: true},
+			{name: "Should identify GIT_INDEX_FILE as repository scoped", env: "GIT_INDEX_FILE", want: true},
+			{name: "Should identify GIT_COMMON_DIR as repository scoped", env: "GIT_COMMON_DIR", want: true},
+			{
+				name: "Should identify GIT_OBJECT_DIRECTORY as repository scoped",
+				env:  "GIT_OBJECT_DIRECTORY",
+				want: true,
+			},
+			{
+				name: "Should identify GIT_ALTERNATE_OBJECT_DIRECTORIES as repository scoped",
+				env:  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+				want: true,
+			},
+			{name: "Should identify GIT_NAMESPACE as repository scoped", env: "GIT_NAMESPACE", want: true},
+			{name: "Should identify GIT_PREFIX as repository scoped", env: "GIT_PREFIX", want: true},
+			{name: "Should preserve GIT_SSH_COMMAND as transport scoped", env: "GIT_SSH_COMMAND", want: false},
+			{name: "Should ignore HOME as unrelated", env: "HOME", want: false},
+			{name: "Should ignore an empty env name", env: "", want: false},
 		}
 		for _, tt := range tests {
-			if got := IsRepositoryEnvName(tt.name); got != tt.want {
-				t.Fatalf("IsRepositoryEnvName(%q) = %t, want %t", tt.name, got, tt.want)
-			}
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				if got := IsRepositoryEnvName(tt.env); got != tt.want {
+					t.Fatalf("IsRepositoryEnvName(%q) = %t, want %t", tt.env, got, tt.want)
+				}
+			})
 		}
 	})
 }
@@ -78,6 +91,8 @@ func TestRun(t *testing.T) {
 	}
 
 	t.Run("Should return trimmed stdout on success", func(t *testing.T) {
+		t.Parallel()
+
 		dir := t.TempDir()
 		if _, err := Run(context.Background(), dir, "init", "-q"); err != nil {
 			t.Fatalf("Run(init) error = %v", err)
@@ -96,6 +111,8 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("Should wrap error with stderr message on failure", func(t *testing.T) {
+		t.Parallel()
+
 		dir := t.TempDir()
 		if _, err := Run(context.Background(), dir, "init", "-q"); err != nil {
 			t.Fatalf("Run(init) error = %v", err)
@@ -114,6 +131,8 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("Should wrap empty output errors with command context", func(t *testing.T) {
+		t.Parallel()
+
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 

--- a/internal/core/run/parallel/orchestrator.go
+++ b/internal/core/run/parallel/orchestrator.go
@@ -95,7 +95,6 @@ type WorktreeLifecycle interface {
 		integrationBranch string,
 	) error
 	Remove(ctx context.Context, workspaceRoot string, path string) error
-	Prune(ctx context.Context, workspaceRoot string) error
 }
 
 // TaskCommitSpec constrains a task worktree commit to paths the child run
@@ -791,10 +790,9 @@ func (o *ExecutionOrchestrator) rollback(
 		plan.IntegrationPath,
 		plan.IntegrationBranch,
 	)
-	pruneErr := o.worktrees.Prune(rollbackCtx, plan.WorkspaceRoot)
 	transitionErr := o.transition(rollbackCtx, machine, parallelEventRollback, -1)
 	o.emitRolledBack(rollbackCtx, plan, waveIndex)
-	return errors.Join(cause, discardErr, pruneErr, transitionErr)
+	return errors.Join(cause, discardErr, transitionErr)
 }
 
 func (o *ExecutionOrchestrator) fail(
@@ -835,9 +833,6 @@ func (o *ExecutionOrchestrator) cleanupCompleted(
 		plan.IntegrationBranch,
 	); err != nil {
 		return fmt.Errorf("discard integration branch %s: %w", plan.IntegrationBranch, err)
-	}
-	if err := o.worktrees.Prune(ctx, plan.WorkspaceRoot); err != nil {
-		return fmt.Errorf("prune worktrees for %s: %w", plan.WorkspaceRoot, err)
 	}
 	return nil
 }

--- a/internal/core/run/parallel/orchestrator_test.go
+++ b/internal/core/run/parallel/orchestrator_test.go
@@ -256,8 +256,11 @@ func runParallelExecutionOrchestratorDoesNotPruneAfterScopedCleanup(t *testing.T
 	if outcome.Status != ParallelOutcomeCompleted {
 		t.Fatalf("status = %q, want completed", outcome.Status)
 	}
-	if worktrees.wasPruned() {
-		t.Fatal("completed scoped cleanup invoked repo-wide worktree prune")
+	if got := worktrees.removedPaths(); !reflect.DeepEqual(got, []string{"/worktree/task_01"}) {
+		t.Fatalf("removed worktrees = %#v, want scoped task worktree only", got)
+	}
+	if !worktrees.wasDiscarded() {
+		t.Fatal("expected completed cleanup to discard integration branch")
 	}
 }
 
@@ -977,7 +980,6 @@ type fakeWorktreeLifecycle struct {
 	fastForwarded      bool
 	syncedArtifacts    []TaskID
 	discardedBranch    bool
-	pruned             bool
 }
 
 func newFakeWorktreeLifecycle() *fakeWorktreeLifecycle {
@@ -1071,13 +1073,6 @@ func (f *fakeWorktreeLifecycle) Remove(_ context.Context, _ string, path string)
 	return nil
 }
 
-func (f *fakeWorktreeLifecycle) Prune(context.Context, string) error {
-	f.mu.Lock()
-	f.pruned = true
-	f.mu.Unlock()
-	return nil
-}
-
 func (f *fakeWorktreeLifecycle) commitOrder() []int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -1108,10 +1103,10 @@ func (f *fakeWorktreeLifecycle) wasDiscarded() bool {
 	return f.discardedBranch
 }
 
-func (f *fakeWorktreeLifecycle) wasPruned() bool {
+func (f *fakeWorktreeLifecycle) removedPaths() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.pruned
+	return append([]string(nil), f.removed...)
 }
 
 func (f *fakeWorktreeLifecycle) integrationCommitCount() int {

--- a/internal/core/run/parallel/orchestrator_test.go
+++ b/internal/core/run/parallel/orchestrator_test.go
@@ -30,6 +30,10 @@ func TestParallelExecutionOrchestratorScenarios(t *testing.T) {
 		runParallelExecutionOrchestratorMergesWaveSeriallyInTaskOrder,
 	)
 	t.Run(
+		"Should not prune the repo family during completed scoped cleanup",
+		runParallelExecutionOrchestratorDoesNotPruneAfterScopedCleanup,
+	)
+	t.Run(
 		"Should allocate the next wave from the post-merge integration head",
 		runParallelExecutionOrchestratorAllocatesNextWaveFromPostMergeHead,
 	)
@@ -231,6 +235,29 @@ func runParallelExecutionOrchestratorMergesWaveSeriallyInTaskOrder(t *testing.T)
 		[]TaskID{"task_01", "task_02", "task_03"},
 	) {
 		t.Fatalf("synced artifact tasks = %#v, want merged task order", got)
+	}
+}
+
+func runParallelExecutionOrchestratorDoesNotPruneAfterScopedCleanup(t *testing.T) {
+	t.Parallel()
+
+	plan := testParallelPlan(t, []model.TaskEntry{
+		testTaskEntry("task_01"),
+	}, 1)
+	worktrees := newFakeWorktreeLifecycle()
+	launcher := fakeTaskLauncherFunc(func(_ context.Context, spec TaskLaunchSpec) (PreparedTaskRun, error) {
+		return successfulPreparedTaskRun(spec), nil
+	})
+
+	outcome, err := NewParallelExecutionOrchestrator(worktrees, launcher).Run(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if outcome.Status != ParallelOutcomeCompleted {
+		t.Fatalf("status = %q, want completed", outcome.Status)
+	}
+	if worktrees.wasPruned() {
+		t.Fatal("completed scoped cleanup invoked repo-wide worktree prune")
 	}
 }
 
@@ -1079,6 +1106,12 @@ func (f *fakeWorktreeLifecycle) wasDiscarded() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.discardedBranch
+}
+
+func (f *fakeWorktreeLifecycle) wasPruned() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.pruned
 }
 
 func (f *fakeWorktreeLifecycle) integrationCommitCount() int {

--- a/internal/core/worktree/snapshot.go
+++ b/internal/core/worktree/snapshot.go
@@ -17,6 +17,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/compozy/compozy/internal/core/gitenv"
 )
 
 const (
@@ -682,7 +684,7 @@ func gitAvailable() bool {
 func runGit(ctx context.Context, root string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = root
-	cmd.Env = append(sanitizedGitEnv(), "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
+	cmd.Env = append(gitenv.SanitizedEnv(), "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -690,23 +692,6 @@ func runGit(ctx context.Context, root string, args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.Bytes(), nil
-}
-
-func sanitizedGitEnv() []string {
-	env := os.Environ()
-	filtered := make([]string, 0, len(env))
-	for _, kv := range env {
-		switch {
-		case strings.HasPrefix(kv, "GIT_DIR="),
-			strings.HasPrefix(kv, "GIT_WORK_TREE="),
-			strings.HasPrefix(kv, "GIT_COMMON_DIR="),
-			strings.HasPrefix(kv, "GIT_INDEX_FILE="),
-			strings.HasPrefix(kv, "GIT_NAMESPACE="):
-			continue
-		}
-		filtered = append(filtered, kv)
-	}
-	return filtered
 }
 
 func isExecLookupError(err error) bool {

--- a/internal/core/worktree/snapshot.go
+++ b/internal/core/worktree/snapshot.go
@@ -682,9 +682,8 @@ func gitAvailable() bool {
 }
 
 func runGit(ctx context.Context, root string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Dir = root
-	cmd.Env = append(gitenv.SanitizedEnv(), "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
+	cmd := gitenv.Command(ctx, root, args...)
+	cmd.Env = append(cmd.Env, "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/core/worktree/snapshot_test.go
+++ b/internal/core/worktree/snapshot_test.go
@@ -144,6 +144,46 @@ func TestBuildScope(t *testing.T) {
 		}
 	})
 
+	t.Run("Should capture produced paths from linked worktree gitfile roots", func(t *testing.T) {
+		t.Parallel()
+		requireScopeGit(t)
+
+		primary := initScopeGitRepo(t)
+		linked := filepath.Join(t.TempDir(), "linked")
+		mustScopeGit(t, primary, "worktree", "add", "-q", "-b", "feature-scope", linked)
+		gitFile, err := os.ReadFile(filepath.Join(linked, ".git"))
+		if err != nil {
+			t.Fatalf("read linked .git file: %v", err)
+		}
+		if !strings.HasPrefix(string(gitFile), "gitdir: ") {
+			t.Fatalf("linked .git file = %q, want gitdir pointer", gitFile)
+		}
+		baseline, err := Capture(context.Background(), linked)
+		if err != nil {
+			t.Fatalf("Capture linked baseline: %v", err)
+		}
+		if !baseline.Document().Supported {
+			t.Fatalf("baseline supported = false: %#v", baseline.Document())
+		}
+		if err := os.WriteFile(filepath.Join(linked, "produced.txt"), []byte("agent output"), 0o600); err != nil {
+			t.Fatalf("write produced: %v", err)
+		}
+
+		scope, err := BuildScope(context.Background(), linked, baseline)
+		if err != nil {
+			t.Fatalf("BuildScope linked: %v", err)
+		}
+		if !scope.Supported {
+			t.Fatalf("scope supported = false: %#v", scope)
+		}
+		if got, want := strings.Join(scope.ProducedPaths, ","), "produced.txt"; got != want {
+			t.Fatalf("produced paths = %q, want %q", got, want)
+		}
+		if len(scope.PreExistingChangedPaths) != 0 {
+			t.Fatalf("pre-existing changed paths = %#v, want none", scope.PreExistingChangedPaths)
+		}
+	})
+
 	t.Run("Should fingerprint dirty submodules from gitlink state", func(t *testing.T) {
 		t.Parallel()
 		requireScopeGit(t)

--- a/internal/daemon/purge_test.go
+++ b/internal/daemon/purge_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	apicore "github.com/compozy/compozy/internal/api/core"
 	"github.com/compozy/compozy/internal/core/model"
 	"github.com/compozy/compozy/internal/store/globaldb"
 	eventspkg "github.com/compozy/compozy/pkg/compozy/events"
@@ -470,6 +471,88 @@ func TestRunManagerPurgePreflightsAllTaskWorktreesBeforeRemovingAny(t *testing.T
 	})
 }
 
+func TestRunManagerPurgePreservesWorktreeHostingActiveNestedRun(t *testing.T) {
+	t.Run("Should preserve worktree and parent metadata while nested run is active", func(t *testing.T) {
+		requireGitForTaskMulti(t)
+		started := make(chan string, 1)
+		release := make(chan struct{})
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			prepare: func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error) {
+				return &model.SolvePreparation{}, nil
+			},
+			execute: func(ctx context.Context, _ *model.SolvePreparation, cfg *model.RuntimeConfig) error {
+				started <- cfg.RunID
+				select {
+				case <-release:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+		})
+		defer close(release)
+		env.writeWorkflowFile(t, env.workflowSlug, "task_01.md", validPurgeTaskMarkdown())
+		writeFileForTest(t, filepath.Join(env.workspaceRoot, "README.md"), "seed\n")
+		commitTaskMultiGitWorkspace(t, env.workspaceRoot)
+
+		workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
+		if err != nil {
+			t.Fatalf("ResolveOrRegister(%q) error = %v", env.workspaceRoot, err)
+		}
+		runID := "purge-parent-with-live-nested"
+		seedTerminalRunForPurge(
+			t,
+			env.globalDB,
+			workspace.ID,
+			runID,
+			runStatusCompleted,
+			time.Now().UTC().Add(-time.Hour),
+		)
+		allocation := allocatePurgeTaskWorktree(t, env, runID, "nested", 1)
+		appendPurgeRunEvent(t, runID, eventspkg.EventKindTaskRunMultipleChildCompleted, kinds.TaskRunMultiplePayload{
+			RunID:          runID,
+			Slug:           "nested",
+			WorktreePath:   allocation.Path,
+			BaseBranch:     allocation.BaseBranch,
+			BaseCommit:     allocation.BaseCommit,
+			WorktreeStatus: allocation.WorktreeStatus,
+		})
+
+		nestedRun, err := env.manager.StartTaskRun(
+			context.Background(),
+			allocation.Path,
+			env.workflowSlug,
+			apicore.TaskRunRequest{
+				Workspace:        allocation.Path,
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: rawJSON(t, `{"run_id":"nested-live-run"}`),
+			},
+		)
+		if err != nil {
+			t.Fatalf("StartTaskRun(nested) error = %v", err)
+		}
+		waitForString(t, started, nestedRun.RunID)
+
+		result, err := env.manager.Purge(context.Background(), RunLifecycleSettings{
+			KeepTerminalDays: 0,
+			KeepMax:          0,
+		})
+		if err != nil {
+			t.Fatalf("Purge() error = %v", err)
+		}
+		if len(result.PurgedRunIDs) != 0 {
+			t.Fatalf("purged run ids = %v, want none while nested run is active", result.PurgedRunIDs)
+		}
+		if len(result.PurgedWorktreePaths) != 0 {
+			t.Fatalf("purged worktree paths = %v, want none while nested run is active", result.PurgedWorktreePaths)
+		}
+		assertPathPresent(t, allocation.Path)
+		if _, err := env.globalDB.GetRun(context.Background(), runID); err != nil {
+			t.Fatalf("GetRun(%q) error = %v, want parent metadata preserved", runID, err)
+		}
+	})
+}
+
 func TestRunManagerPurgeCommitsEarlierRunsBeforeLaterDirtyWorktreeFails(t *testing.T) {
 	t.Run("Should commit earlier runs before later dirty worktree fails", func(t *testing.T) {
 		requireGitForTaskMulti(t)
@@ -541,6 +624,105 @@ func TestRunManagerPurgeCommitsEarlierRunsBeforeLaterDirtyWorktreeFails(t *testi
 		assertPathMissing(t, cleanArtifacts.RunDir)
 		assertPathPresent(t, dirtyAllocation.Path)
 		assertPathPresent(t, dirtyArtifacts.RunDir)
+	})
+}
+
+func TestRunManagerPurgeSkipsDeletedWorkspaceRootAndContinues(t *testing.T) {
+	t.Run("Should skip missing registered workspace root without blocking other purges", func(t *testing.T) {
+		requireGitForTaskMulti(t)
+		env := newRunManagerTestEnv(t, runManagerTestDeps{})
+		env.writeWorkflowFile(t, env.workflowSlug, "task_01.md", validPurgeTaskMarkdown())
+		writeFileForTest(t, filepath.Join(env.workspaceRoot, "README.md"), "seed\n")
+		commitTaskMultiGitWorkspace(t, env.workspaceRoot)
+
+		missingWorkspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
+		if err != nil {
+			t.Fatalf("ResolveOrRegister(%q) error = %v", env.workspaceRoot, err)
+		}
+		missingRunID := "purge-missing-workspace-root"
+		seedTerminalRunForPurge(
+			t,
+			env.globalDB,
+			missingWorkspace.ID,
+			missingRunID,
+			runStatusCompleted,
+			time.Now().UTC().Add(-2*time.Hour),
+		)
+		missingAllocation := allocatePurgeTaskWorktree(t, env, missingRunID, "missing", 1)
+		appendPurgeRunEvent(
+			t,
+			missingRunID,
+			eventspkg.EventKindTaskRunMultipleChildCompleted,
+			kinds.TaskRunMultiplePayload{
+				RunID:          missingRunID,
+				Slug:           "missing",
+				WorktreePath:   missingAllocation.Path,
+				BaseBranch:     missingAllocation.BaseBranch,
+				BaseCommit:     missingAllocation.BaseCommit,
+				WorktreeStatus: missingAllocation.WorktreeStatus,
+			},
+		)
+
+		otherRoot := filepath.Join(t.TempDir(), "other-workspace")
+		writeFileForTest(
+			t,
+			filepath.Join(otherRoot, ".compozy", "tasks", env.workflowSlug, "task_01.md"),
+			validPurgeTaskMarkdown(),
+		)
+		writeFileForTest(t, filepath.Join(otherRoot, "README.md"), "other\n")
+		commitTaskMultiGitWorkspace(t, otherRoot)
+		otherWorkspace, err := env.globalDB.ResolveOrRegister(context.Background(), otherRoot)
+		if err != nil {
+			t.Fatalf("ResolveOrRegister(%q) error = %v", otherRoot, err)
+		}
+		otherRunID := "purge-other-workspace-root"
+		seedTerminalRunForPurge(
+			t,
+			env.globalDB,
+			otherWorkspace.ID,
+			otherRunID,
+			runStatusCompleted,
+			time.Now().UTC().Add(-time.Hour),
+		)
+		otherAllocation := allocatePurgeTaskWorktreeForRoot(t, env, otherRoot, otherRunID, "other", 1)
+		appendPurgeRunEvent(
+			t,
+			otherRunID,
+			eventspkg.EventKindTaskRunMultipleChildCompleted,
+			kinds.TaskRunMultiplePayload{
+				RunID:          otherRunID,
+				Slug:           "other",
+				WorktreePath:   otherAllocation.Path,
+				BaseBranch:     otherAllocation.BaseBranch,
+				BaseCommit:     otherAllocation.BaseCommit,
+				WorktreeStatus: otherAllocation.WorktreeStatus,
+			},
+		)
+
+		if err := os.RemoveAll(env.workspaceRoot); err != nil {
+			t.Fatalf("remove missing workspace root: %v", err)
+		}
+		result, err := env.manager.Purge(context.Background(), RunLifecycleSettings{
+			KeepTerminalDays: 0,
+			KeepMax:          0,
+		})
+		if err != nil {
+			t.Fatalf("Purge() error = %v", err)
+		}
+		if got, want := result.PurgedRunIDs, []string{otherRunID}; !equalStrings(got, want) {
+			t.Fatalf("purged run ids = %v, want %v", got, want)
+		}
+		if got, want := result.PurgedWorktreePaths, []string{otherAllocation.Path}; !equalStrings(got, want) {
+			t.Fatalf("purged worktree paths = %v, want %v", got, want)
+		}
+		assertPathPresent(t, missingAllocation.Path)
+		if _, err := env.globalDB.GetRun(context.Background(), missingRunID); err != nil {
+			t.Fatalf("GetRun(%q) error = %v, want missing-root run metadata preserved", missingRunID, err)
+		}
+		assertPathMissing(t, otherAllocation.Path)
+		if _, err := env.globalDB.GetRun(context.Background(), otherRunID); !errors.Is(err, globaldb.ErrRunNotFound) {
+			t.Fatalf("GetRun(%q) error = %v, want ErrRunNotFound", otherRunID, err)
+		}
 	})
 }
 
@@ -709,13 +891,25 @@ func allocatePurgeTaskWorktree(
 	taskNumber int,
 ) taskMultiWorktreeAllocation {
 	t.Helper()
+	return allocatePurgeTaskWorktreeForRoot(t, env, env.workspaceRoot, runID, slug, taskNumber)
+}
 
-	base, err := env.manager.worktreeAllocator.ResolveBase(context.Background(), env.workspaceRoot)
+func allocatePurgeTaskWorktreeForRoot(
+	t *testing.T,
+	env *runManagerTestEnv,
+	workspaceRoot string,
+	runID string,
+	slug string,
+	taskNumber int,
+) taskMultiWorktreeAllocation {
+	t.Helper()
+
+	base, err := env.manager.worktreeAllocator.ResolveBase(context.Background(), workspaceRoot)
 	if err != nil {
 		t.Fatalf("ResolveBase() error = %v", err)
 	}
 	allocation, err := env.manager.worktreeAllocator.Allocate(context.Background(), taskMultiWorktreeSpec{
-		WorkspaceRoot: env.workspaceRoot,
+		WorkspaceRoot: workspaceRoot,
 		ParentRunID:   runID,
 		Slug:          slug,
 		Index:         taskNumber - 1,
@@ -726,6 +920,20 @@ func allocatePurgeTaskWorktree(
 		t.Fatalf("Allocate(%q) error = %v", slug, err)
 	}
 	return allocation
+}
+
+func validPurgeTaskMarkdown() string {
+	return strings.Join([]string{
+		"---",
+		"status: pending",
+		"title: Demo Task",
+		"type: backend",
+		"complexity: low",
+		"---",
+		"",
+		"# Task 1: Demo Task",
+		"",
+	}, "\n")
 }
 
 func appendPurgeRunEvent(t *testing.T, runID string, kind eventspkg.EventKind, payload any) {

--- a/internal/daemon/review_watch_git.go
+++ b/internal/daemon/review_watch_git.go
@@ -1,11 +1,9 @@
 package daemon
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"strconv"
 	"strings"
 
@@ -111,25 +109,7 @@ func (g *execReviewWatchGit) Push(
 }
 
 func runReviewWatchGitCommand(ctx context.Context, workspaceRoot string, args ...string) (string, error) {
-	cmdArgs := append([]string{"-C", strings.TrimSpace(workspaceRoot)}, args...)
-	cmd := exec.CommandContext(ctx, "git")
-	cmd.Args = append([]string{"git"}, cmdArgs...)
-	cmd.Env = gitenv.SanitizedEnv()
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		message := strings.TrimSpace(stderr.String())
-		if message == "" {
-			message = strings.TrimSpace(stdout.String())
-		}
-		if message != "" {
-			return "", fmt.Errorf("%w: %s", err, message)
-		}
-		return "", err
-	}
-	return strings.TrimSpace(stdout.String()), nil
+	return gitenv.Run(ctx, workspaceRoot, args...)
 }
 
 func splitGitUpstream(value string) (string, string) {

--- a/internal/daemon/review_watch_git.go
+++ b/internal/daemon/review_watch_git.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/compozy/compozy/internal/core/gitenv"
 )
 
 // ReviewWatchGit is the narrow git boundary used by daemon review-watch runs.
@@ -110,7 +112,9 @@ func (g *execReviewWatchGit) Push(
 
 func runReviewWatchGitCommand(ctx context.Context, workspaceRoot string, args ...string) (string, error) {
 	cmdArgs := append([]string{"-C", strings.TrimSpace(workspaceRoot)}, args...)
-	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	cmd := exec.CommandContext(ctx, "git")
+	cmd.Args = append([]string{"git"}, cmdArgs...)
+	cmd.Env = gitenv.SanitizedEnv()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/daemon/review_watch_git_test.go
+++ b/internal/daemon/review_watch_git_test.go
@@ -3,6 +3,10 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -144,6 +148,52 @@ func TestReviewWatchGitCommandRunnerAndParsers(t *testing.T) {
 		}
 		if got := parseGitCount("bad"); got != 0 {
 			t.Fatalf("parseGitCount(invalid) = %d, want 0", got)
+		}
+	})
+}
+
+func TestRunReviewWatchGitCommandIgnoresInheritedGitEnv(t *testing.T) {
+	if os.Getenv("COMPOZY_REVIEW_WATCH_GIT_HELPER") == "1" {
+		out, err := runReviewWatchGitCommand(
+			context.Background(),
+			os.Getenv("COMPOZY_REVIEW_WATCH_GIT_HELPER_DIR"),
+			"rev-parse",
+			"--show-toplevel",
+		)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		fmt.Fprintln(os.Stdout, out)
+		os.Exit(0)
+	}
+
+	t.Run("Should ignore inherited git repository env vars", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git binary not available")
+		}
+		wrongRepo := initTaskMultiWorktreeRepo(t)
+		targetRepo := initTaskMultiWorktreeRepo(t)
+		cmd := exec.CommandContext(
+			t.Context(),
+			os.Args[0],
+			"-test.run",
+			"^TestRunReviewWatchGitCommandIgnoresInheritedGitEnv$",
+		)
+		cmd.Env = append(os.Environ(),
+			"COMPOZY_REVIEW_WATCH_GIT_HELPER=1",
+			"COMPOZY_REVIEW_WATCH_GIT_HELPER_DIR="+targetRepo,
+			"GIT_DIR="+filepath.Join(wrongRepo, ".git"),
+			"GIT_WORK_TREE="+wrongRepo,
+			"GIT_INDEX_FILE="+filepath.Join(wrongRepo, ".git", "index"),
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("helper git command error = %v\n%s", err, out)
+		}
+		want := runGitOutput(t, targetRepo, "rev-parse", "--show-toplevel")
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Fatalf("git helper top-level = %q, want target repo %q", got, want)
 		}
 	})
 }

--- a/internal/daemon/shutdown.go
+++ b/internal/daemon/shutdown.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -299,6 +300,10 @@ func (m *RunManager) Purge(ctx context.Context, settings RunLifecycleSettings) (
 		}
 		purgedWorktrees, err := m.purgeRunWorktrees(listCtx, run, settings)
 		if err != nil {
+			if errors.Is(err, errRunPurgeDeferred) {
+				slog.Default().Warn("daemon: run purge deferred", "run_id", run.RunID, "error", err)
+				continue
+			}
 			return result, fmt.Errorf("purge worktrees for run %s: %w", run.RunID, err)
 		}
 

--- a/internal/daemon/task_multi.go
+++ b/internal/daemon/task_multi.go
@@ -856,13 +856,6 @@ func (l parallelWorktreeLifecycle) Remove(ctx context.Context, workspaceRoot str
 	return l.allocator.Remove(ctx, workspaceRoot, path)
 }
 
-func (l parallelWorktreeLifecycle) Prune(ctx context.Context, workspaceRoot string) error {
-	if l.allocator == nil {
-		return errors.New("daemon: task worktree allocator is not configured")
-	}
-	return l.allocator.Prune(ctx, workspaceRoot)
-}
-
 type parallelTaskLauncher struct {
 	manager           *RunManager
 	active            *activeRun

--- a/internal/daemon/task_multi_worktree.go
+++ b/internal/daemon/task_multi_worktree.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/compozy/compozy/internal/core/gitenv"
 	runparallel "github.com/compozy/compozy/internal/core/run/parallel"
 )
 
@@ -71,7 +72,6 @@ type WorktreeLifecycle interface {
 		integrationBranch string,
 	) error
 	Remove(ctx context.Context, workspaceRoot string, path string) error
-	Prune(ctx context.Context, workspaceRoot string) error
 }
 
 // taskMultiWorktreeBase captures the parent workspace branch and commit resolved
@@ -605,9 +605,6 @@ func (a *taskMultiWorktreeAllocator) removeIntegrationWorktreeForPurge(
 		} else if !errors.Is(statErr, os.ErrNotExist) {
 			return false, fmt.Errorf("stat integration worktree %s after removal: %w", path, statErr)
 		}
-		if _, err := run(ctx, workspaceRoot, "worktree", "prune", "--expire", "now"); err != nil {
-			return false, fmt.Errorf("prune integration worktree metadata for %s: %w", path, err)
-		}
 		pathRemoved = true
 	} else if !errors.Is(statErr, os.ErrNotExist) {
 		return false, fmt.Errorf("stat integration worktree %s: %w", path, statErr)
@@ -708,22 +705,6 @@ func (a *taskMultiWorktreeAllocator) integrationWorktreePathForBranch(
 		}
 	}
 	return "", nil
-}
-
-// Prune removes stale git worktree administrative references.
-func (a *taskMultiWorktreeAllocator) Prune(ctx context.Context, workspaceRoot string) error {
-	run, err := a.requireGitRunner()
-	if err != nil {
-		return err
-	}
-	workspace, err := requireTaskMultiWorktreeValue(workspaceRoot, "workspace root")
-	if err != nil {
-		return err
-	}
-	if _, err := run(ctx, workspace, "worktree", "prune"); err != nil {
-		return fmt.Errorf("prune worktrees for %s: %w", workspace, err)
-	}
-	return nil
 }
 
 // Head resolves HEAD in the supplied worktree path.
@@ -986,7 +967,9 @@ func taskMultiUniqueSorted(values []string) []string {
 
 func runTaskMultiWorktreeGitCommand(ctx context.Context, dir string, args ...string) (string, error) {
 	cmdArgs := append([]string{"-C", strings.TrimSpace(dir)}, args...)
-	cmd := exec.CommandContext(ctx, "git", cmdArgs...)
+	cmd := exec.CommandContext(ctx, "git")
+	cmd.Args = append([]string{"git"}, cmdArgs...)
+	cmd.Env = gitenv.SanitizedEnv()
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/daemon/task_multi_worktree.go
+++ b/internal/daemon/task_multi_worktree.go
@@ -1,14 +1,12 @@
 package daemon
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -966,22 +964,5 @@ func taskMultiUniqueSorted(values []string) []string {
 }
 
 func runTaskMultiWorktreeGitCommand(ctx context.Context, dir string, args ...string) (string, error) {
-	cmdArgs := append([]string{"-C", strings.TrimSpace(dir)}, args...)
-	cmd := exec.CommandContext(ctx, "git")
-	cmd.Args = append([]string{"git"}, cmdArgs...)
-	cmd.Env = gitenv.SanitizedEnv()
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		message := strings.TrimSpace(stderr.String())
-		if message == "" {
-			message = strings.TrimSpace(stdout.String())
-		}
-		if message != "" {
-			return "", fmt.Errorf("%w: %s", err, message)
-		}
-		return "", err
-	}
-	return strings.TrimSpace(stdout.String()), nil
+	return gitenv.Run(ctx, dir, args...)
 }

--- a/internal/daemon/task_multi_worktree_test.go
+++ b/internal/daemon/task_multi_worktree_test.go
@@ -1810,32 +1810,34 @@ func TestRunTaskMultiWorktreeGitCommandIgnoresInheritedGitEnv(t *testing.T) {
 		fmt.Fprintln(os.Stdout, out)
 		os.Exit(0)
 	}
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git binary not available")
-	}
-	wrongRepo := initTaskMultiWorktreeRepo(t)
-	targetRepo := initTaskMultiWorktreeRepo(t)
-	cmd := exec.CommandContext(
-		t.Context(),
-		os.Args[0],
-		"-test.run",
-		"^TestRunTaskMultiWorktreeGitCommandIgnoresInheritedGitEnv$",
-	)
-	cmd.Env = append(os.Environ(),
-		"COMPOZY_TASK_MULTI_GIT_HELPER=1",
-		"COMPOZY_TASK_MULTI_GIT_HELPER_DIR="+targetRepo,
-		"GIT_DIR="+filepath.Join(wrongRepo, ".git"),
-		"GIT_WORK_TREE="+wrongRepo,
-		"GIT_INDEX_FILE="+filepath.Join(wrongRepo, ".git", "index"),
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("helper git command error = %v\n%s", err, out)
-	}
-	want := runGitOutput(t, targetRepo, "rev-parse", "--show-toplevel")
-	if got := strings.TrimSpace(string(out)); got != want {
-		t.Fatalf("git helper top-level = %q, want target repo %q", got, want)
-	}
+	t.Run("Should ignore inherited git repository env vars", func(t *testing.T) {
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git binary not available")
+		}
+		wrongRepo := initTaskMultiWorktreeRepo(t)
+		targetRepo := initTaskMultiWorktreeRepo(t)
+		cmd := exec.CommandContext(
+			t.Context(),
+			os.Args[0],
+			"-test.run",
+			"^TestRunTaskMultiWorktreeGitCommandIgnoresInheritedGitEnv$",
+		)
+		cmd.Env = append(os.Environ(),
+			"COMPOZY_TASK_MULTI_GIT_HELPER=1",
+			"COMPOZY_TASK_MULTI_GIT_HELPER_DIR="+targetRepo,
+			"GIT_DIR="+filepath.Join(wrongRepo, ".git"),
+			"GIT_WORK_TREE="+wrongRepo,
+			"GIT_INDEX_FILE="+filepath.Join(wrongRepo, ".git", "index"),
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("helper git command error = %v\n%s", err, out)
+		}
+		want := runGitOutput(t, targetRepo, "rev-parse", "--show-toplevel")
+		if got := strings.TrimSpace(string(out)); got != want {
+			t.Fatalf("git helper top-level = %q, want target repo %q", got, want)
+		}
+	})
 }
 
 type linkedTaskMultiWorktreeFixture struct {

--- a/internal/daemon/task_multi_worktree_test.go
+++ b/internal/daemon/task_multi_worktree_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 
 	reusableagents "github.com/compozy/compozy/internal/core/agents"
@@ -676,10 +677,6 @@ func TestTaskMultiWorktreeAllocatorLifecycleValidationUnit(t *testing.T) {
 			!strings.Contains(err.Error(), "worktree path is required") {
 			t.Fatalf("Remove(empty path) error = %v, want path validation", err)
 		}
-		if err := allocator.Prune(context.Background(), " "); err == nil ||
-			!strings.Contains(err.Error(), "workspace root is required") {
-			t.Fatalf("Prune(empty workspace) error = %v, want workspace validation", err)
-		}
 	})
 }
 
@@ -932,6 +929,23 @@ func TestTaskMultiWorktreeAllocatorRealRepo(t *testing.T) {
 		}
 	})
 
+	t.Run("Should resolve a named linked worktree branch and HEAD", func(t *testing.T) {
+		t.Parallel()
+		fixture := initTaskMultiLinkedWorktreeRepo(t)
+		wantCommit := runGitOutput(t, fixture.Linked, "rev-parse", "HEAD")
+		allocator := newTaskMultiWorktreeAllocator(t.TempDir())
+		base, err := allocator.ResolveBase(context.Background(), fixture.Linked)
+		if err != nil {
+			t.Fatalf("ResolveBase(linked) error = %v", err)
+		}
+		if base.Branch != fixture.Branch {
+			t.Fatalf("base.Branch = %q, want %q", base.Branch, fixture.Branch)
+		}
+		if base.Commit != wantCommit {
+			t.Fatalf("base.Commit = %q, want %q", base.Commit, wantCommit)
+		}
+	})
+
 	t.Run("Should reject a detached parent checkout", func(t *testing.T) {
 		t.Parallel()
 		repo := initTaskMultiWorktreeRepo(t)
@@ -940,6 +954,50 @@ func TestTaskMultiWorktreeAllocatorRealRepo(t *testing.T) {
 		_, err := allocator.ResolveBase(context.Background(), repo)
 		if err == nil || !strings.Contains(err.Error(), "detached HEAD") {
 			t.Fatalf("ResolveBase() error = %v, want detached HEAD validation", err)
+		}
+	})
+
+	t.Run("Should create a detached child worktree from a linked worktree root", func(t *testing.T) {
+		t.Parallel()
+		fixture := initTaskMultiLinkedWorktreeRepo(t)
+		root := t.TempDir()
+		allocator := newTaskMultiWorktreeAllocator(root)
+		base, err := allocator.ResolveBase(context.Background(), fixture.Linked)
+		if err != nil {
+			t.Fatalf("ResolveBase(linked) error = %v", err)
+		}
+		spec := taskMultiWorktreeSpec{
+			WorkspaceRoot: fixture.Linked,
+			ParentRunID:   "task-multi-linked-root",
+			Slug:          "task_01",
+			Index:         0,
+			TaskNumber:    1,
+			Base:          base,
+		}
+		alloc, err := allocator.Allocate(context.Background(), spec)
+		if err != nil {
+			t.Fatalf("Allocate(linked) error = %v", err)
+		}
+		if !strings.HasPrefix(alloc.Path, filepath.Join(root, taskMultiWorkspaceHash(fixture.Linked))) {
+			t.Fatalf("allocation path = %q, want keyed by linked root %q", alloc.Path, fixture.Linked)
+		}
+		if strings.HasPrefix(alloc.Path, filepath.Join(root, taskMultiWorkspaceHash(fixture.Primary))) {
+			t.Fatalf("allocation path = %q, must not be keyed by primary root %q", alloc.Path, fixture.Primary)
+		}
+		if gotHead := runGitOutput(t, alloc.Path, "rev-parse", "HEAD"); gotHead != base.Commit {
+			t.Fatalf("worktree HEAD = %q, want %q", gotHead, base.Commit)
+		}
+		if list := runGitOutput(
+			t,
+			fixture.Primary,
+			"worktree",
+			"list",
+			"--porcelain",
+		); !strings.Contains(
+			list,
+			alloc.Path,
+		) {
+			t.Fatalf("primary common git dir worktree list missing allocation %q:\n%s", alloc.Path, list)
 		}
 	})
 
@@ -987,6 +1045,59 @@ func TestTaskMultiWorktreeAllocatorRealRepo(t *testing.T) {
 		if _, err := allocator.Allocate(context.Background(), spec); err == nil ||
 			!strings.Contains(err.Error(), "already exists") {
 			t.Fatalf("second Allocate() error = %v, want collision error", err)
+		}
+	})
+
+	t.Run("Should fast-forward a linked worktree branch without touching main checkout files", func(t *testing.T) {
+		t.Parallel()
+		fixture := initTaskMultiLinkedWorktreeRepo(t)
+		ctx := context.Background()
+		allocator := newTaskMultiWorktreeAllocator(t.TempDir())
+		base, err := allocator.ResolveBase(ctx, fixture.Linked)
+		if err != nil {
+			t.Fatalf("ResolveBase(linked) error = %v", err)
+		}
+		initialMain := runGitOutput(t, fixture.Primary, "rev-parse", "main")
+		integrationBranch := "compozy/parallel-linked-ff"
+		integrationPath := filepath.Join(t.TempDir(), "integration")
+		if err := allocator.CreateIntegrationBranch(
+			ctx,
+			fixture.Linked,
+			integrationPath,
+			integrationBranch,
+			base.Commit,
+		); err != nil {
+			t.Fatalf("CreateIntegrationBranch(linked) error = %v", err)
+		}
+		worktree := allocateTaskMultiWorktreeForTest(t, allocator, fixture.Linked, base, "task_01", 1)
+		writeTaskMultiWorktreeFile(t, worktree.Path, "linked-output.txt", "from linked branch\n")
+		ref, err := allocator.CommitTask(ctx, runparallel.TaskCommitSpec{
+			Path:           worktree.Path,
+			Message:        "capture linked task",
+			ScopeSupported: true,
+			ProducedPaths:  []string{"linked-output.txt"},
+		})
+		if err != nil {
+			t.Fatalf("CommitTask(linked) error = %v", err)
+		}
+		conflicts, err := allocator.SquashMerge(ctx, integrationPath, ref, "task 01: linked output")
+		if err != nil {
+			t.Fatalf("SquashMerge(linked) error = %v", err)
+		}
+		if !conflicts.Clean {
+			t.Fatalf("SquashMerge(linked) conflicts = %#v, want clean", conflicts)
+		}
+		if err := allocator.FastForward(ctx, fixture.Linked, fixture.Branch, integrationBranch); err != nil {
+			t.Fatalf("FastForward(linked) error = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(fixture.Linked, "linked-output.txt")); err != nil {
+			t.Fatalf("linked worktree output missing after fast-forward: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(fixture.Primary, "linked-output.txt")); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("main checkout output stat = %v, want absent", err)
+		}
+		if got := runGitOutput(t, fixture.Primary, "rev-parse", "main"); got != initialMain {
+			t.Fatalf("main branch head = %q, want unchanged %q", got, initialMain)
 		}
 	})
 
@@ -1088,9 +1199,6 @@ func TestTaskMultiWorktreeAllocatorRealRepo(t *testing.T) {
 		}
 		if err := allocator.DiscardIntegrationBranch(ctx, repo, integrationPath, integrationBranch); err != nil {
 			t.Fatalf("DiscardIntegrationBranch() error = %v", err)
-		}
-		if err := allocator.Prune(ctx, repo); err != nil {
-			t.Fatalf("Prune() error = %v", err)
 		}
 		for _, path := range []string{first.Path, second.Path, integrationPath} {
 			if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
@@ -1331,6 +1439,102 @@ func TestTaskMultiWorktreeAllocatorRealRepo(t *testing.T) {
 			t.Fatalf("Remove(second) error = %v", err)
 		}
 	})
+}
+
+func TestTaskMultiWorktreeAllocatorConcurrentLinkedFamilyLifecycle(t *testing.T) {
+	t.Run(
+		"Should preserve sibling worktree metadata across concurrent linked-family allocation and cleanup",
+		func(t *testing.T) {
+			t.Parallel()
+			fixture := initTaskMultiLinkedWorktreeRepo(t)
+			allocator := newTaskMultiWorktreeAllocator(t.TempDir())
+			ctx := context.Background()
+			primaryBase, err := allocator.ResolveBase(ctx, fixture.Primary)
+			if err != nil {
+				t.Fatalf("ResolveBase(primary) error = %v", err)
+			}
+			linkedBase, err := allocator.ResolveBase(ctx, fixture.Linked)
+			if err != nil {
+				t.Fatalf("ResolveBase(linked) error = %v", err)
+			}
+			specs := []taskMultiWorktreeSpec{
+				{
+					WorkspaceRoot: fixture.Primary,
+					ParentRunID:   "concurrent-primary",
+					Slug:          "alpha",
+					Index:         0,
+					TaskNumber:    1,
+					Base:          primaryBase,
+				},
+				{
+					WorkspaceRoot: fixture.Linked,
+					ParentRunID:   "concurrent-linked",
+					Slug:          "beta",
+					Index:         0,
+					TaskNumber:    1,
+					Base:          linkedBase,
+				},
+			}
+
+			allocations := make([]taskMultiWorktreeAllocation, len(specs))
+			errs := make([]error, len(specs))
+			var wg sync.WaitGroup
+			for idx := range specs {
+				idx := idx
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					allocations[idx], errs[idx] = allocator.Allocate(ctx, specs[idx])
+				}()
+			}
+			wg.Wait()
+			if err := errors.Join(errs...); err != nil {
+				t.Fatalf("concurrent Allocate() error = %v", err)
+			}
+
+			if err := allocator.Remove(ctx, fixture.Primary, allocations[0].Path); err != nil {
+				t.Fatalf("Remove(primary allocation) error = %v", err)
+			}
+			if _, err := os.Stat(allocations[0].Path); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("primary allocation stat error = %v, want missing after remove", err)
+			}
+			if _, err := os.Stat(allocations[1].Path); err != nil {
+				t.Fatalf("linked allocation stat error = %v, want still present after sibling remove", err)
+			}
+			list := runGitOutput(t, fixture.Primary, "worktree", "list", "--porcelain")
+			if !taskMultiWorktreeListContainsPath(t, list, allocations[1].Path) {
+				t.Fatalf("linked allocation missing from worktree list after sibling remove:\n%s", list)
+			}
+			if _, err := runGitOutputContext(ctx, allocations[1].Path, "rev-parse", "HEAD"); err != nil {
+				t.Fatalf("linked allocation git metadata unusable after sibling remove: %v", err)
+			}
+			if err := allocator.Remove(ctx, fixture.Linked, allocations[1].Path); err != nil {
+				t.Fatalf("Remove(linked allocation) error = %v", err)
+			}
+		},
+	)
+}
+
+func taskMultiWorktreeListContainsPath(t *testing.T, list string, want string) bool {
+	t.Helper()
+	wantPath, err := cleanContainmentPath(want)
+	if err != nil {
+		t.Fatalf("canonicalize expected worktree path %q: %v", want, err)
+	}
+	for _, line := range strings.Split(list, "\n") {
+		path, ok := strings.CutPrefix(line, "worktree ")
+		if !ok {
+			continue
+		}
+		gotPath, err := cleanContainmentPath(path)
+		if err != nil {
+			t.Fatalf("canonicalize listed worktree path %q: %v", path, err)
+		}
+		if gotPath == wantPath {
+			return true
+		}
+	}
+	return false
 }
 
 func TestParallelOrchestratorConflictResolverIntegration(t *testing.T) {
@@ -1589,6 +1793,64 @@ func TestRunTaskMultiWorktreeGitCommand(t *testing.T) {
 	); err == nil {
 		t.Fatal("runTaskMultiWorktreeGitCommand(invalid) error = nil, want error")
 	}
+}
+
+func TestRunTaskMultiWorktreeGitCommandIgnoresInheritedGitEnv(t *testing.T) {
+	if os.Getenv("COMPOZY_TASK_MULTI_GIT_HELPER") == "1" {
+		out, err := runTaskMultiWorktreeGitCommand(
+			context.Background(),
+			os.Getenv("COMPOZY_TASK_MULTI_GIT_HELPER_DIR"),
+			"rev-parse",
+			"--show-toplevel",
+		)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		fmt.Fprintln(os.Stdout, out)
+		os.Exit(0)
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	wrongRepo := initTaskMultiWorktreeRepo(t)
+	targetRepo := initTaskMultiWorktreeRepo(t)
+	cmd := exec.CommandContext(
+		t.Context(),
+		os.Args[0],
+		"-test.run",
+		"^TestRunTaskMultiWorktreeGitCommandIgnoresInheritedGitEnv$",
+	)
+	cmd.Env = append(os.Environ(),
+		"COMPOZY_TASK_MULTI_GIT_HELPER=1",
+		"COMPOZY_TASK_MULTI_GIT_HELPER_DIR="+targetRepo,
+		"GIT_DIR="+filepath.Join(wrongRepo, ".git"),
+		"GIT_WORK_TREE="+wrongRepo,
+		"GIT_INDEX_FILE="+filepath.Join(wrongRepo, ".git", "index"),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper git command error = %v\n%s", err, out)
+	}
+	want := runGitOutput(t, targetRepo, "rev-parse", "--show-toplevel")
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Fatalf("git helper top-level = %q, want target repo %q", got, want)
+	}
+}
+
+type linkedTaskMultiWorktreeFixture struct {
+	Primary string
+	Linked  string
+	Branch  string
+}
+
+func initTaskMultiLinkedWorktreeRepo(t *testing.T) linkedTaskMultiWorktreeFixture {
+	t.Helper()
+	primary := initTaskMultiWorktreeRepo(t)
+	linked := filepath.Join(t.TempDir(), "linked")
+	branch := "feature-linked"
+	runGitOutput(t, primary, "worktree", "add", "-q", "-b", branch, linked)
+	return linkedTaskMultiWorktreeFixture{Primary: primary, Linked: linked, Branch: branch}
 }
 
 // initTaskMultiWorktreeRepo prepares a temporary git repository on branch main

--- a/internal/daemon/worktree_purge.go
+++ b/internal/daemon/worktree_purge.go
@@ -21,6 +21,8 @@ const (
 	taskParallelEventPrefix = "task.parallel."
 )
 
+var errRunPurgeDeferred = errors.New("daemon: run purge deferred")
+
 type runWorktreePurgePlan struct {
 	taskWorktrees []taskWorktreePurgeTarget
 	integration   *integrationWorktreePurgeTarget
@@ -37,6 +39,7 @@ type integrationWorktreePurgeTarget struct {
 }
 
 type preparedRunWorktreePurge struct {
+	manager       *RunManager
 	allocator     *taskMultiWorktreeAllocator
 	workspaceRoot string
 	worktreesRoot string
@@ -82,7 +85,11 @@ func (m *RunManager) prepareRunWorktreePurge(
 	if len(plan.taskWorktrees) == 0 && plan.integration == nil {
 		return nil, false, nil
 	}
+	if err := ensurePurgeWorkspaceRootAvailable(workspace.RootDir); err != nil {
+		return nil, false, err
+	}
 	return &preparedRunWorktreePurge{
+		manager:       m,
 		allocator:     allocator,
 		workspaceRoot: workspace.RootDir,
 		worktreesRoot: worktreesRoot,
@@ -91,6 +98,11 @@ func (m *RunManager) prepareRunWorktreePurge(
 }
 
 func (p preparedRunWorktreePurge) execute(ctx context.Context, runID string) ([]string, error) {
+	if path, activeRunID, blocked, err := p.taskWorktreeHostingActiveRun(ctx, runID); err != nil {
+		return nil, err
+	} else if blocked {
+		return nil, deferRunPurge("worktree %s hosts active run %s", path, activeRunID)
+	}
 	purged, err := p.removeTaskWorktrees(ctx, runID)
 	if err != nil {
 		return purged, err
@@ -157,6 +169,119 @@ func (p preparedRunWorktreePurge) removeIntegrationWorktree(ctx context.Context,
 	}
 	removeEmptyWorktreeParents(p.worktreesRoot, removedPath)
 	return removedPath, nil
+}
+
+func (p preparedRunWorktreePurge) taskWorktreeHostingActiveRun(
+	ctx context.Context,
+	parentRunID string,
+) (string, string, bool, error) {
+	if p.manager == nil || len(p.plan.taskWorktrees) == 0 {
+		return "", "", false, nil
+	}
+	activeRoots, err := p.manager.activeRunWorkspaceRoots(ctx)
+	if err != nil {
+		return "", "", false, err
+	}
+	if len(activeRoots) == 0 {
+		return "", "", false, nil
+	}
+	parentRunID = strings.TrimSpace(parentRunID)
+	for _, target := range p.plan.taskWorktrees {
+		for _, active := range activeRoots {
+			if active.runID == "" || active.runID == parentRunID || strings.TrimSpace(active.rootDir) == "" {
+				continue
+			}
+			inside, err := pathEqualOrInside(target.Path, active.rootDir)
+			if err != nil {
+				return "", "", false, err
+			}
+			if inside {
+				return target.Path, active.runID, true, nil
+			}
+		}
+	}
+	return "", "", false, nil
+}
+
+type activeRunWorkspaceRoot struct {
+	runID   string
+	rootDir string
+}
+
+func (m *RunManager) activeRunWorkspaceRoots(ctx context.Context) ([]activeRunWorkspaceRoot, error) {
+	if m == nil || m.globalDB == nil {
+		return nil, nil
+	}
+	activeRuns := m.activeSnapshot()
+	roots := make([]activeRunWorkspaceRoot, 0, len(activeRuns))
+	for _, active := range activeRuns {
+		if active == nil || strings.TrimSpace(active.workspaceID) == "" {
+			continue
+		}
+		workspace, err := m.globalDB.Get(ctx, active.workspaceID)
+		if err != nil {
+			if errors.Is(err, globaldb.ErrWorkspaceNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("load active workspace for run %s: %w", active.runID, err)
+		}
+		roots = append(roots, activeRunWorkspaceRoot{
+			runID:   strings.TrimSpace(active.runID),
+			rootDir: strings.TrimSpace(workspace.RootDir),
+		})
+	}
+	return roots, nil
+}
+
+func ensurePurgeWorkspaceRootAvailable(workspaceRoot string) error {
+	root := strings.TrimSpace(workspaceRoot)
+	if root == "" {
+		return deferRunPurge("workspace root is empty")
+	}
+	if _, err := os.Stat(root); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return deferRunPurge("workspace root %s is missing", root)
+		}
+		return fmt.Errorf("stat workspace root %s for purge: %w", root, err)
+	}
+	return nil
+}
+
+func deferRunPurge(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", errRunPurgeDeferred, fmt.Sprintf(format, args...))
+}
+
+func pathEqualOrInside(parent string, child string) (bool, error) {
+	parentPath, err := cleanContainmentPath(parent)
+	if err != nil {
+		return false, err
+	}
+	childPath, err := cleanContainmentPath(child)
+	if err != nil {
+		return false, err
+	}
+	rel, err := filepath.Rel(parentPath, childPath)
+	if err != nil {
+		return false, fmt.Errorf("relativize path %s to %s: %w", childPath, parentPath, err)
+	}
+	return rel == "." || isRelativeChildPath(rel), nil
+}
+
+func cleanContainmentPath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", errors.New("path is required")
+	}
+	absolute, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("resolve path %s: %w", trimmed, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = resolved
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("resolve symlinks for %s: %w", absolute, err)
+	}
+	return filepath.Clean(absolute), nil
 }
 
 func (m *RunManager) purgeWorktreeAllocator(

--- a/skeeper.lock
+++ b/skeeper.lock
@@ -1,15 +1,15 @@
 {
   "version": 1,
   "sidecar": "git@github.com:compozy/specs.git",
-  "source_branch": "fix-parallel",
+  "source_branch": "worktree-fix",
   "namespaces": [
     {
       "name": "compozy",
-      "sidecar_branch": "compozy/__branches__/fix-parallel",
-      "commit": "ade61057137a09fb9d40de0e065dfa003b1ac5b8",
-      "digest": "sha256:d5d7ee6daad42da43b08aa8f7fc2099decfd8adca55b9b6d127223ccaaf6ca84",
-      "files": 1403,
-      "bytes": 11819394
+      "sidecar_branch": "compozy/__branches__/worktree-fix",
+      "commit": "ea38d7b34113644f7590c02074c2f8107694037b",
+      "digest": "sha256:f9cf7a0089e6c32bfda285c310e367449655416eb5a68f91e040ddbad84e2415",
+      "files": 1402,
+      "bytes": 11816815
     }
   ]
 }

--- a/skeeper.lock
+++ b/skeeper.lock
@@ -6,10 +6,10 @@
     {
       "name": "compozy",
       "sidecar_branch": "compozy/__branches__/worktree-fix",
-      "commit": "d38a62099829fd6ad655841e79119dc7ede18da3",
-      "digest": "sha256:3fd095ae75e1539745efe494b4e02e4864dc796100ae6cd9a3be36f4e46c2fcb",
-      "files": 1409,
-      "bytes": 11848455
+      "commit": "8d6be147a5ef530311ee08fc8af5bd6d5162bf87",
+      "digest": "sha256:f7072d2d35bc86740a4385f9be26ae82e406b2897309575cb04a203658945dc5",
+      "files": 1410,
+      "bytes": 11849399
     }
   ]
 }

--- a/skeeper.lock
+++ b/skeeper.lock
@@ -6,10 +6,10 @@
     {
       "name": "compozy",
       "sidecar_branch": "compozy/__branches__/worktree-fix",
-      "commit": "ea38d7b34113644f7590c02074c2f8107694037b",
-      "digest": "sha256:f9cf7a0089e6c32bfda285c310e367449655416eb5a68f91e040ddbad84e2415",
-      "files": 1402,
-      "bytes": 11816815
+      "commit": "d826f87bbc840137ea356c9c178908cf4a85d1c3",
+      "digest": "sha256:2aab5eb5a513c3c3f50fcbbdfc508b996dacd6396e8f8e97f3c04e4eeaceaf6f",
+      "files": 1404,
+      "bytes": 11831973
     }
   ]
 }

--- a/skeeper.lock
+++ b/skeeper.lock
@@ -6,10 +6,10 @@
     {
       "name": "compozy",
       "sidecar_branch": "compozy/__branches__/worktree-fix",
-      "commit": "d826f87bbc840137ea356c9c178908cf4a85d1c3",
-      "digest": "sha256:2aab5eb5a513c3c3f50fcbbdfc508b996dacd6396e8f8e97f3c04e4eeaceaf6f",
-      "files": 1404,
-      "bytes": 11831973
+      "commit": "d38a62099829fd6ad655841e79119dc7ede18da3",
+      "digest": "sha256:3fd095ae75e1539745efe494b4e02e4864dc796100ae6cd9a3be36f4e46c2fcb",
+      "files": 1409,
+      "bytes": 11848455
     }
   ]
 }

--- a/skeeper.lock
+++ b/skeeper.lock
@@ -6,10 +6,10 @@
     {
       "name": "compozy",
       "sidecar_branch": "compozy/__branches__/worktree-fix",
-      "commit": "8d6be147a5ef530311ee08fc8af5bd6d5162bf87",
-      "digest": "sha256:f7072d2d35bc86740a4385f9be26ae82e406b2897309575cb04a203658945dc5",
-      "files": 1410,
-      "bytes": 11849399
+      "commit": "656eb3d96f44a76eabfd90a9ad4ca3dfa08073eb",
+      "digest": "sha256:6aacafb049d6579dd024a5426bde4c61c7e5e44f39c56448a4b6d793b47c469e",
+      "files": 1414,
+      "bytes": 11856803
     }
   ]
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -15,7 +15,7 @@
             "source": "pedronauck/skills",
             "sourceType": "github",
             "skillPath": "skills/mine/cmux-orchestration/SKILL.md",
-            "computedHash": "5ea0eccfcf5e08b2bd85841ab2183f77dfbfdda0732a8ff9285653cbef504264"
+            "computedHash": "3e9486f6ba76b5912cb78ccab4f117c79444e6356543fa918bd691cec28e589f"
         },
         "context7": {
             "source": "pedronauck/skills",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter preflight checks for `--parallel-tasks` / `--multiple --parallel`, rejecting detached HEAD and preventing parallel runs inside managed worktrees before daemon contact.
  * Improved worktree purge behavior with deferred handling, safer containment checks, and correct behavior for nested active runs and missing workspace roots.
  * Updated git subprocess execution to ignore inherited repository-scoped Git environment variables.
* **Tests**
  * Expanded unit and end-to-end coverage for parallel execution, linked worktrees, purge guards, and git env isolation.
* **Chores**
  * Bumped Go toolchain patch version (1.26.3 → 1.26.4).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->