### PR TITLE
fix: surface progress and bound the reviews-fix daemon start

### DIFF
--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -61,6 +61,7 @@ type daemonCommandClient interface {
 	DeleteWorkspace(context.Context, string) error
 	ResolveWorkspace(context.Context, string) (apicore.Workspace, error)
 	ListRuns(context.Context, apiclient.RunListOptions) ([]apicore.Run, error)
+	GetRun(context.Context, string) (apicore.Run, error)
 	ListTaskWorkflows(context.Context, string) ([]apicore.WorkflowSummary, error)
 	ArchiveTaskWorkflow(context.Context, string, string) (apicore.ArchiveResult, error)
 	SyncWorkflow(context.Context, apicore.SyncRequest) (apicore.SyncResult, error)

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -77,6 +77,8 @@ type stubDaemonCommandClient struct {
 	runs                 []apicore.Run
 	runsErr              error
 	runListRequests      []apiclient.RunListOptions
+	getRun               apicore.Run
+	getRunErr            error
 	deleteRef            string
 	deleteErr            error
 	workflows            []apicore.WorkflowSummary
@@ -268,6 +270,16 @@ func (c *stubDaemonCommandClient) ListRuns(
 		}
 	}
 	return runs, nil
+}
+
+func (c *stubDaemonCommandClient) GetRun(_ context.Context, _ string) (apicore.Run, error) {
+	if c == nil {
+		return apicore.Run{}, errors.New("stub daemon client is required")
+	}
+	if c.getRunErr != nil {
+		return apicore.Run{}, c.getRunErr
+	}
+	return c.getRun, nil
 }
 
 func stubRunListStatuses(opts apiclient.RunListOptions) []string {

--- a/internal/cli/daemon_exec_test_helpers_test.go
+++ b/internal/cli/daemon_exec_test_helpers_test.go
@@ -290,6 +290,13 @@ func (c *inProcessDaemonCommandClient) ListRuns(
 	})
 }
 
+func (c *inProcessDaemonCommandClient) GetRun(ctx context.Context, runID string) (apicore.Run, error) {
+	if c == nil || c.manager == nil {
+		return apicore.Run{}, errors.New("GetRun requires an in-process run manager")
+	}
+	return c.manager.Get(ctx, runID)
+}
+
 func (*inProcessDaemonCommandClient) ListTaskWorkflows(context.Context, string) ([]apicore.WorkflowSummary, error) {
 	return nil, errors.New("ListTaskWorkflows not implemented for in-process exec tests")
 }

--- a/internal/cli/reviews_exec_daemon.go
+++ b/internal/cli/reviews_exec_daemon.go
@@ -44,9 +44,8 @@ const (
 const reviewRunPreparingMessage = "Preparing review run (syncing workflow state into the daemon catalog)…"
 
 const (
-	// reviewRunStartTimeout bounds the daemon-side review-run start, which
-	// synchronously syncs workflow state into the single-writer global.db. A slow
-	// or contended write would otherwise freeze the CLI indefinitely.
+	// reviewRunStartTimeout bounds the cancellable daemon-side workflow sync that
+	// completes before a review run is committed.
 	reviewRunStartTimeout = 60 * time.Second
 	// reviewRunFeedbackDelay is how long the start may take before the preparing
 	// message is shown, so the common fast path stays quiet and only a genuinely
@@ -468,15 +467,9 @@ func startReviewRunWithFeedback(
 	<-finished
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
-			// The daemon detaches the run start from this request context, so it can
-			// finish creating and starting the run in the background after we give up
-			// here. Warn against a blind retry, which would launch a duplicate run.
 			return apicore.Run{}, fmt.Errorf(
-				"review run did not start within %s: the daemon may still be syncing "+
-					"workflow state and can finish starting this run in the background, so "+
-					"retrying now risks a duplicate run — wait for the daemon to settle and "+
-					"confirm no run is active before retrying, or run `compozy runs purge` "+
-					"to clear stale runs and reduce contention",
+				"review run did not start within %s: the daemon canceled the start before "+
+					"creating a durable run; retry after workflow sync contention clears",
 				timeout,
 			)
 		}

--- a/internal/cli/reviews_exec_daemon.go
+++ b/internal/cli/reviews_exec_daemon.go
@@ -468,9 +468,15 @@ func startReviewRunWithFeedback(
 	<-finished
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			// The daemon detaches the run start from this request context, so it can
+			// finish creating and starting the run in the background after we give up
+			// here. Warn against a blind retry, which would launch a duplicate run.
 			return apicore.Run{}, fmt.Errorf(
-				"review run did not start within %s: the daemon may be busy syncing "+
-					"workflow state — retry, or run `compozy runs purge` to reduce contention",
+				"review run did not start within %s: the daemon may still be syncing "+
+					"workflow state and can finish starting this run in the background, so "+
+					"retrying now risks a duplicate run — wait for the daemon to settle and "+
+					"confirm no run is active before retrying, or run `compozy runs purge` "+
+					"to clear stale runs and reduce contention",
 				timeout,
 			)
 		}

--- a/internal/cli/reviews_exec_daemon.go
+++ b/internal/cli/reviews_exec_daemon.go
@@ -38,6 +38,22 @@ const (
 	daemonRunTerminalPollInterval = 10 * time.Millisecond
 )
 
+// reviewRunPreparingMessage tells the operator the review run is being prepared,
+// so a slow daemon-side workflow sync reads as progress rather than a silent
+// freeze.
+const reviewRunPreparingMessage = "Preparing review run (syncing workflow state into the daemon catalog)…"
+
+const (
+	// reviewRunStartTimeout bounds the daemon-side review-run start, which
+	// synchronously syncs workflow state into the single-writer global.db. A slow
+	// or contended write would otherwise freeze the CLI indefinitely.
+	reviewRunStartTimeout = 60 * time.Second
+	// reviewRunFeedbackDelay is how long the start may take before the preparing
+	// message is shown, so the common fast path stays quiet and only a genuinely
+	// slow (contended) start surfaces feedback.
+	reviewRunFeedbackDelay = time.Second
+)
+
 func newReviewsCommand() *cobra.Command {
 	return newReviewsCommandWithDefaults(defaultCommandStateDefaults())
 }
@@ -374,12 +390,22 @@ func (s *commandState) runReviewWorkflowDaemon(cmd *cobra.Command, args []string
 		return withExitCode(2, err)
 	}
 
-	run, err := client.StartReviewRun(ctx, s.workspaceRoot, s.name, s.round, apicore.ReviewRunRequest{
-		Workspace:        s.workspaceRoot,
-		PresentationMode: presentationMode,
-		RuntimeOverrides: runtimeOverrides,
-		Batching:         batching,
-	})
+	run, err := startReviewRunWithFeedback(
+		ctx,
+		reviewRunStatusWriter(cmd, s.outputFormat),
+		client,
+		s.workspaceRoot,
+		s.name,
+		s.round,
+		apicore.ReviewRunRequest{
+			Workspace:        s.workspaceRoot,
+			PresentationMode: presentationMode,
+			RuntimeOverrides: runtimeOverrides,
+			Batching:         batching,
+		},
+		reviewRunStartTimeout,
+		reviewRunFeedbackDelay,
+	)
 	if err != nil {
 		return mapDaemonCommandError(err)
 	}
@@ -392,6 +418,65 @@ func (s *commandState) runReviewWorkflowDaemon(cmd *cobra.Command, args []string
 	default:
 		return handleStartedTaskRun(ctx, cmd, client, run)
 	}
+}
+
+// reviewRunStatusWriter routes the preparing status to stderr for human output
+// and discards it for machine formats so json/raw-json stay clean.
+func reviewRunStatusWriter(cmd *cobra.Command, outputFormat string) io.Writer {
+	switch strings.TrimSpace(outputFormat) {
+	case string(core.OutputFormatJSON), string(core.OutputFormatRawJSON):
+		return io.Discard
+	default:
+		return cmd.ErrOrStderr()
+	}
+}
+
+// startReviewRunWithFeedback starts the daemon-backed review run. It prints a
+// preparing status so the operator sees progress while the daemon synchronously
+// syncs workflow state into its catalog, and bounds the call with a timeout so a
+// stuck or contended global.db write fails with an actionable error instead of
+// freezing the CLI indefinitely. Non-timeout errors are returned unchanged for
+// the caller to map.
+func startReviewRunWithFeedback(
+	ctx context.Context,
+	statusW io.Writer,
+	client daemonCommandClient,
+	workspaceRoot string,
+	name string,
+	round int,
+	req apicore.ReviewRunRequest,
+	timeout time.Duration,
+	feedbackDelay time.Duration,
+) (apicore.Run, error) {
+	startCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	// Show the preparing message only if the start is slow (a contended global.db
+	// write), so the common fast path stays quiet. The goroutine always exits
+	// before this function returns, so nothing writes to statusW afterwards.
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		select {
+		case <-time.After(feedbackDelay):
+			fmt.Fprintln(statusW, reviewRunPreparingMessage)
+		case <-done:
+		}
+	}()
+	run, err := client.StartReviewRun(startCtx, workspaceRoot, name, round, req)
+	close(done)
+	<-finished
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			return apicore.Run{}, fmt.Errorf(
+				"review run did not start within %s: the daemon may be busy syncing "+
+					"workflow state — retry, or run `compozy runs purge` to reduce contention",
+				timeout,
+			)
+		}
+		return apicore.Run{}, err
+	}
+	return run, nil
 }
 
 func (s *commandState) runReviewWatchDaemon(cmd *cobra.Command, args []string) error {

--- a/internal/cli/reviews_exec_daemon.go
+++ b/internal/cli/reviews_exec_daemon.go
@@ -51,6 +51,9 @@ const (
 	// message is shown, so the common fast path stays quiet and only a genuinely
 	// slow (contended) start surfaces feedback.
 	reviewRunFeedbackDelay = time.Second
+	// reviewRunRecoveryTimeout bounds the fresh lookup used when the start response
+	// loses the race with the client deadline after the daemon commits the run.
+	reviewRunRecoveryTimeout = 5 * time.Second
 )
 
 func newReviewsCommand() *cobra.Command {
@@ -447,6 +450,10 @@ func startReviewRunWithFeedback(
 	timeout time.Duration,
 	feedbackDelay time.Duration,
 ) (apicore.Run, error) {
+	request, runID, err := ensureReviewRunID(name, round, req)
+	if err != nil {
+		return apicore.Run{}, err
+	}
 	startCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	// Show the preparing message only if the start is slow (a contended global.db
@@ -462,20 +469,71 @@ func startReviewRunWithFeedback(
 		case <-done:
 		}
 	}()
-	run, err := client.StartReviewRun(startCtx, workspaceRoot, name, round, req)
+	run, err := client.StartReviewRun(startCtx, workspaceRoot, name, round, request)
 	close(done)
 	<-finished
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) && ctx.Err() == nil {
+			recoveryCtx, recoveryCancel := context.WithTimeout(ctx, reviewRunRecoveryTimeout)
+			recovered, recoveryErr := client.GetRun(recoveryCtx, runID)
+			recoveryCancel()
+			if recoveryErr == nil && strings.TrimSpace(recovered.RunID) == runID {
+				return recovered, nil
+			}
+			if recoveryErr == nil {
+				recoveryErr = fmt.Errorf("daemon returned run id %q", recovered.RunID)
+			}
 			return apicore.Run{}, fmt.Errorf(
-				"review run did not start within %s: the daemon canceled the start before "+
-					"creating a durable run; retry after workflow sync contention clears",
+				"review run start outcome was not confirmed within %s; run ID %q belongs to this start "+
+					"and the daemon may still complete it; inspect it before starting another run with "+
+					"`compozy runs watch %s` or `compozy runs attach %s` (recovery lookup: %v): %w",
 				timeout,
+				runID,
+				runID,
+				runID,
+				recoveryErr,
+				err,
 			)
 		}
 		return apicore.Run{}, err
 	}
 	return run, nil
+}
+
+func ensureReviewRunID(
+	name string,
+	round int,
+	req apicore.ReviewRunRequest,
+) (apicore.ReviewRunRequest, string, error) {
+	overrides := daemonRuntimeOverrides{}
+	if len(req.RuntimeOverrides) > 0 {
+		if err := json.Unmarshal(req.RuntimeOverrides, &overrides); err != nil {
+			return apicore.ReviewRunRequest{}, "", fmt.Errorf("decode review runtime overrides: %w", err)
+		}
+	}
+
+	runID := ""
+	if overrides.RunID != nil {
+		runID = strings.TrimSpace(*overrides.RunID)
+	}
+	if runID == "" {
+		generated, err := model.BuildRunID(&model.RuntimeConfig{
+			Name:  strings.TrimSpace(name),
+			Round: round,
+			Mode:  model.ExecutionModePRReview,
+		})
+		if err != nil {
+			return apicore.ReviewRunRequest{}, "", fmt.Errorf("build review run id: %w", err)
+		}
+		runID = generated
+	}
+	overrides.RunID = stringPointer(runID)
+	payload, err := json.Marshal(overrides)
+	if err != nil {
+		return apicore.ReviewRunRequest{}, "", fmt.Errorf("encode review runtime overrides: %w", err)
+	}
+	req.RuntimeOverrides = payload
+	return req, runID, nil
 }
 
 func (s *commandState) runReviewWatchDaemon(cmd *cobra.Command, args []string) error {

--- a/internal/cli/reviews_exec_start_feedback_test.go
+++ b/internal/cli/reviews_exec_start_feedback_test.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +18,7 @@ import (
 // single-writer global.db lock.
 type blockingReviewStartClient struct {
 	*stubDaemonCommandClient
+	request apicore.ReviewRunRequest
 }
 
 func (c *blockingReviewStartClient) StartReviewRun(
@@ -23,17 +26,80 @@ func (c *blockingReviewStartClient) StartReviewRun(
 	_ string,
 	_ string,
 	_ int,
-	_ apicore.ReviewRunRequest,
+	req apicore.ReviewRunRequest,
 ) (apicore.Run, error) {
+	c.request = req
 	<-ctx.Done()
 	return apicore.Run{}, ctx.Err()
+}
+
+type lostReviewStartResponseClient struct {
+	*stubDaemonCommandClient
+	durableRun apicore.Run
+}
+
+func (c *lostReviewStartResponseClient) StartReviewRun(
+	ctx context.Context,
+	_ string,
+	_ string,
+	_ int,
+	req apicore.ReviewRunRequest,
+) (apicore.Run, error) {
+	runID, err := testReviewRunID(req)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	c.durableRun = apicore.Run{RunID: runID, Status: "starting"}
+	<-ctx.Done()
+	return apicore.Run{}, ctx.Err()
+}
+
+func (c *lostReviewStartResponseClient) GetRun(ctx context.Context, runID string) (apicore.Run, error) {
+	if err := ctx.Err(); err != nil {
+		return apicore.Run{}, fmt.Errorf("recovery context: %w", err)
+	}
+	if runID != c.durableRun.RunID {
+		return apicore.Run{}, fmt.Errorf("get run %q: want %q", runID, c.durableRun.RunID)
+	}
+	return c.durableRun, nil
+}
+
+type echoReviewStartClient struct {
+	*stubDaemonCommandClient
+	request apicore.ReviewRunRequest
+}
+
+func (c *echoReviewStartClient) StartReviewRun(
+	_ context.Context,
+	_ string,
+	_ string,
+	_ int,
+	req apicore.ReviewRunRequest,
+) (apicore.Run, error) {
+	c.request = req
+	runID, err := testReviewRunID(req)
+	if err != nil {
+		return apicore.Run{}, err
+	}
+	return apicore.Run{RunID: runID}, nil
+}
+
+func testReviewRunID(req apicore.ReviewRunRequest) (string, error) {
+	var overrides daemonRuntimeOverrides
+	if err := json.Unmarshal(req.RuntimeOverrides, &overrides); err != nil {
+		return "", fmt.Errorf("decode review runtime overrides: %w", err)
+	}
+	if overrides.RunID == nil || strings.TrimSpace(*overrides.RunID) == "" {
+		return "", errors.New("review runtime overrides are missing run_id")
+	}
+	return strings.TrimSpace(*overrides.RunID), nil
 }
 
 func TestStartReviewRunWithFeedback(t *testing.T) {
 	t.Run("Should stay quiet and return the run on the fast common path", func(t *testing.T) {
 		t.Parallel()
 		var status bytes.Buffer
-		client := &stubDaemonCommandClient{reviewRun: apicore.Run{RunID: "run-1"}}
+		client := &echoReviewStartClient{stubDaemonCommandClient: &stubDaemonCommandClient{}}
 		run, err := startReviewRunWithFeedback(
 			context.Background(), &status, client, "root", "wf", 1, apicore.ReviewRunRequest{},
 			time.Second, time.Minute,
@@ -41,8 +107,12 @@ func TestStartReviewRunWithFeedback(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if run.RunID != "run-1" {
-			t.Fatalf("run id = %q, want run-1", run.RunID)
+		requestRunID, requestErr := testReviewRunID(client.request)
+		if requestErr != nil {
+			t.Fatalf("request run id: %v", requestErr)
+		}
+		if run.RunID != requestRunID || !strings.HasPrefix(run.RunID, "reviews-wf-") {
+			t.Fatalf("run id = %q, request run id = %q, want matching generated review id", run.RunID, requestRunID)
 		}
 		if status.Len() != 0 {
 			t.Fatalf("expected a quiet fast path, got %q", status.String())
@@ -51,7 +121,9 @@ func TestStartReviewRunWithFeedback(t *testing.T) {
 	t.Run("Should surface preparing feedback and an actionable timeout when the start blocks", func(t *testing.T) {
 		t.Parallel()
 		var status bytes.Buffer
-		client := &blockingReviewStartClient{stubDaemonCommandClient: &stubDaemonCommandClient{}}
+		client := &blockingReviewStartClient{
+			stubDaemonCommandClient: &stubDaemonCommandClient{getRunErr: errors.New("run not found")},
+		}
 		_, err := startReviewRunWithFeedback(
 			context.Background(), &status, client, "root", "wf", 1, apicore.ReviewRunRequest{},
 			120*time.Millisecond, 10*time.Millisecond,
@@ -59,17 +131,37 @@ func TestStartReviewRunWithFeedback(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected a timeout error, got nil")
 		}
-		if !strings.Contains(err.Error(), "did not start within") {
+		if !strings.Contains(err.Error(), "outcome was not confirmed within") {
 			t.Fatalf("error missing timeout context: %v", err)
 		}
-		if !strings.Contains(err.Error(), "before creating a durable run") {
-			t.Fatalf("error missing canceled-start guarantee: %v", err)
+		requestRunID, requestErr := testReviewRunID(client.request)
+		if requestErr != nil {
+			t.Fatalf("request run id: %v", requestErr)
 		}
-		if !strings.Contains(err.Error(), "retry after workflow sync contention clears") {
-			t.Fatalf("error missing actionable hint: %v", err)
+		if !strings.Contains(err.Error(), requestRunID) ||
+			!strings.Contains(err.Error(), "compozy runs watch "+requestRunID) {
+			t.Fatalf("error missing stable recovery handle: %v", err)
+		}
+		if strings.Contains(err.Error(), "before creating a durable run") {
+			t.Fatalf("error makes an unsafe pre-commit claim: %v", err)
 		}
 		if !strings.Contains(status.String(), "Preparing review run") {
 			t.Fatalf("expected preparing feedback on a slow start, got %q", status.String())
+		}
+	})
+	t.Run("Should recover the durable run when the start response loses the deadline race", func(t *testing.T) {
+		t.Parallel()
+		var status bytes.Buffer
+		client := &lostReviewStartResponseClient{stubDaemonCommandClient: &stubDaemonCommandClient{}}
+		run, err := startReviewRunWithFeedback(
+			context.Background(), &status, client, "root", "wf", 1, apicore.ReviewRunRequest{},
+			120*time.Millisecond, time.Minute,
+		)
+		if err != nil {
+			t.Fatalf("recover durable review run: %v", err)
+		}
+		if run.RunID == "" || run.RunID != client.durableRun.RunID {
+			t.Fatalf("recovered run id = %q, durable run id = %q", run.RunID, client.durableRun.RunID)
 		}
 	})
 	t.Run("Should propagate a non-timeout daemon error unchanged", func(t *testing.T) {

--- a/internal/cli/reviews_exec_start_feedback_test.go
+++ b/internal/cli/reviews_exec_start_feedback_test.go
@@ -62,6 +62,9 @@ func TestStartReviewRunWithFeedback(t *testing.T) {
 		if !strings.Contains(err.Error(), "did not start within") {
 			t.Fatalf("error missing timeout context: %v", err)
 		}
+		if !strings.Contains(err.Error(), "duplicate") {
+			t.Fatalf("error missing duplicate-run warning against a blind retry: %v", err)
+		}
 		if !strings.Contains(err.Error(), "compozy runs purge") {
 			t.Fatalf("error missing actionable hint: %v", err)
 		}

--- a/internal/cli/reviews_exec_start_feedback_test.go
+++ b/internal/cli/reviews_exec_start_feedback_test.go
@@ -62,10 +62,10 @@ func TestStartReviewRunWithFeedback(t *testing.T) {
 		if !strings.Contains(err.Error(), "did not start within") {
 			t.Fatalf("error missing timeout context: %v", err)
 		}
-		if !strings.Contains(err.Error(), "duplicate") {
-			t.Fatalf("error missing duplicate-run warning against a blind retry: %v", err)
+		if !strings.Contains(err.Error(), "before creating a durable run") {
+			t.Fatalf("error missing canceled-start guarantee: %v", err)
 		}
-		if !strings.Contains(err.Error(), "compozy runs purge") {
+		if !strings.Contains(err.Error(), "retry after workflow sync contention clears") {
 			t.Fatalf("error missing actionable hint: %v", err)
 		}
 		if !strings.Contains(status.String(), "Preparing review run") {

--- a/internal/cli/reviews_exec_start_feedback_test.go
+++ b/internal/cli/reviews_exec_start_feedback_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	apicore "github.com/compozy/compozy/internal/api/core"
+)
+
+// blockingReviewStartClient blocks StartReviewRun until the passed context is
+// canceled, simulating a daemon whose synchronous workflow sync is stuck on the
+// single-writer global.db lock.
+type blockingReviewStartClient struct {
+	*stubDaemonCommandClient
+}
+
+func (c *blockingReviewStartClient) StartReviewRun(
+	ctx context.Context,
+	_ string,
+	_ string,
+	_ int,
+	_ apicore.ReviewRunRequest,
+) (apicore.Run, error) {
+	<-ctx.Done()
+	return apicore.Run{}, ctx.Err()
+}
+
+func TestStartReviewRunWithFeedback(t *testing.T) {
+	t.Run("Should stay quiet and return the run on the fast common path", func(t *testing.T) {
+		t.Parallel()
+		var status bytes.Buffer
+		client := &stubDaemonCommandClient{reviewRun: apicore.Run{RunID: "run-1"}}
+		run, err := startReviewRunWithFeedback(
+			context.Background(), &status, client, "root", "wf", 1, apicore.ReviewRunRequest{},
+			time.Second, time.Minute,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if run.RunID != "run-1" {
+			t.Fatalf("run id = %q, want run-1", run.RunID)
+		}
+		if status.Len() != 0 {
+			t.Fatalf("expected a quiet fast path, got %q", status.String())
+		}
+	})
+	t.Run("Should surface preparing feedback and an actionable timeout when the start blocks", func(t *testing.T) {
+		t.Parallel()
+		var status bytes.Buffer
+		client := &blockingReviewStartClient{stubDaemonCommandClient: &stubDaemonCommandClient{}}
+		_, err := startReviewRunWithFeedback(
+			context.Background(), &status, client, "root", "wf", 1, apicore.ReviewRunRequest{},
+			120*time.Millisecond, 10*time.Millisecond,
+		)
+		if err == nil {
+			t.Fatal("expected a timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "did not start within") {
+			t.Fatalf("error missing timeout context: %v", err)
+		}
+		if !strings.Contains(err.Error(), "compozy runs purge") {
+			t.Fatalf("error missing actionable hint: %v", err)
+		}
+		if !strings.Contains(status.String(), "Preparing review run") {
+			t.Fatalf("expected preparing feedback on a slow start, got %q", status.String())
+		}
+	})
+	t.Run("Should propagate a non-timeout daemon error unchanged", func(t *testing.T) {
+		t.Parallel()
+		var status bytes.Buffer
+		boom := errors.New("start rejected")
+		client := &stubDaemonCommandClient{reviewRunErr: boom}
+		_, err := startReviewRunWithFeedback(
+			context.Background(), &status, client, "root", "wf", 1, apicore.ReviewRunRequest{},
+			time.Second, time.Minute,
+		)
+		if !errors.Is(err, boom) {
+			t.Fatalf("expected the daemon error to propagate, got %v", err)
+		}
+	})
+	t.Run("Should not misreport a caller cancellation as a start timeout", func(t *testing.T) {
+		t.Parallel()
+		var status bytes.Buffer
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		client := &blockingReviewStartClient{stubDaemonCommandClient: &stubDaemonCommandClient{}}
+		_, err := startReviewRunWithFeedback(
+			ctx, &status, client, "root", "wf", 1, apicore.ReviewRunRequest{},
+			time.Minute, time.Minute,
+		)
+		if err == nil {
+			t.Fatal("expected a cancellation error, got nil")
+		}
+		if strings.Contains(err.Error(), "did not start within") {
+			t.Fatalf("caller cancellation misreported as start timeout: %v", err)
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	})
+}

--- a/internal/cli/workspace_config_test.go
+++ b/internal/cli/workspace_config_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	compozyconfig "github.com/compozy/compozy/internal/config"
 	core "github.com/compozy/compozy/internal/core"
 	"github.com/compozy/compozy/internal/core/agent"
 	extensions "github.com/compozy/compozy/internal/core/extension"
@@ -1281,6 +1282,7 @@ func isolateCLIConfigHome(t *testing.T) string {
 	t.Helper()
 
 	homeDir := t.TempDir()
+	t.Setenv(compozyconfig.HomeEnvVar, "")
 	t.Setenv("HOME", homeDir)
 	return homeDir
 }

--- a/internal/cli/workspace_config_test.go
+++ b/internal/cli/workspace_config_test.go
@@ -312,7 +312,7 @@ tui = false
 }
 
 func TestApplyWorkspaceDefaultsFetchReviewsNitpicks(t *testing.T) {
-	t.Parallel()
+	isolateCLIConfigHome(t)
 
 	cases := []struct {
 		name          string
@@ -344,8 +344,6 @@ nitpicks = true
 	for _, tc := range cases {
 		tc := tc
 		t.Run("Should "+tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			root := t.TempDir()
 			startDir := filepath.Join(root, "pkg", "feature")
 			if err := os.MkdirAll(startDir, 0o755); err != nil {

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -1214,7 +1214,7 @@ types = ["frontend", "backend"]
 
 	for _, tt := range tests {
 		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run("Should "+tt.name, func(t *testing.T) {
 			root := t.TempDir()
 			writeWorkspaceConfig(t, root, tt.content)
 

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -1164,7 +1164,7 @@ output_format = "raw-json"
 }
 
 func TestLoadConfigTaskTypes(t *testing.T) {
-	t.Parallel()
+	isolateWorkspaceConfigHome(t)
 
 	tests := []struct {
 		name      string
@@ -1215,8 +1215,6 @@ types = ["frontend", "backend"]
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			root := t.TempDir()
 			writeWorkspaceConfig(t, root, tt.content)
 

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -1358,47 +1358,39 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	}
 
 	startedAt := m.now().UTC()
-	row, createdRun, resumedRun, err := m.prepareRunRow(
+	requestID := apicore.RequestIDFromContext(ctx)
+	row, createdRun, _, err := m.prepareRunRow(
 		ctx,
 		spec,
 		explicitRunID,
 		startedAt,
-		apicore.RequestIDFromContext(ctx),
+		requestID,
 	)
 	if err != nil {
 		return apicore.Run{}, err
 	}
-	m.publishRunWorkspaceEvent(ctx, row, spec.workflowSlug, apicore.WorkspaceEventKindRunCreated)
-
-	runID := row.RunID
-	runtimeCfg.RunID = runID
-	runtimeCfg.JobControls = model.NewJobControlRegistry()
-	scope, err := m.openRunScopeForStart(ctx, runtimeCfg, spec.workspace.RootDir)
-	if err != nil {
-		if resumedRun {
-			return apicore.Run{}, m.failStartRun(ctx, row, 0, nil, createdRun, err)
-		}
-		if createdRun {
-			cleanupRunDirectory(m.runArtifacts(runID).RunDir)
-			if deleteErr := m.globalDB.DeleteRun(detachContext(ctx), runID); deleteErr != nil {
-				err = errors.Join(err, deleteErr)
-			}
-		}
-		return apicore.Run{}, err
-	}
-
-	runCtx, cancel := context.WithCancel(withRequestID(m.lifecycleCtx, apicore.RequestIDFromContext(ctx)))
+	runCtx, cancel := context.WithCancel(withRequestID(m.lifecycleCtx, requestID))
 	started := false
 	defer func() {
 		if !started {
 			cancel()
 		}
 	}()
+	m.publishRunWorkspaceEvent(runCtx, row, spec.workflowSlug, apicore.WorkspaceEventKindRunCreated)
+
+	runID := row.RunID
+	runtimeCfg.RunID = runID
+	runtimeCfg.JobControls = model.NewJobControlRegistry()
+	scope, err := m.openRunScopeForStart(runCtx, runtimeCfg, spec.workspace.RootDir)
+	if err != nil {
+		return apicore.Run{}, m.failStartRun(runCtx, row, 0, nil, createdRun, err)
+	}
+
 	active := newActiveRun(runCtx, cancel, row, spec, scope)
 	active.jobControls = runtimeCfg.JobControls
 	if err := m.startWatcher(active); err != nil {
 		active.cancel()
-		return apicore.Run{}, m.failStartRun(ctx, row, active.currentCloseTimeout(), scope, createdRun, err)
+		return apicore.Run{}, m.failStartRun(runCtx, row, active.currentCloseTimeout(), scope, createdRun, err)
 	}
 	m.setActive(active)
 
@@ -1406,7 +1398,7 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	go m.runAsync(active, row, runtimeCfg)
 	started = true
 
-	return m.toCoreRun(detachContext(ctx), row, active.workflowSlug)
+	return m.toCoreRun(runCtx, row, active.workflowSlug)
 }
 
 func (m *RunManager) prepareRunRow(
@@ -1594,7 +1586,10 @@ func (m *RunManager) openRunScopeForStart(
 	runtimeCfg *model.RuntimeConfig,
 	workspaceRoot string,
 ) (model.RunScope, error) {
-	scopeCtx := detachContext(ctx)
+	scopeCtx := ctx
+	if scopeCtx == nil {
+		scopeCtx = context.Background()
+	}
 	if runtimeCfg != nil && runtimeCfg.EnableExecutableExtensions {
 		resolvedRoot := strings.TrimSpace(runtimeCfg.WorkspaceRoot)
 		if resolvedRoot == "" {

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -61,6 +61,13 @@ const (
 	maxImplicitRunIDAllocationAttempts = 8
 )
 
+type syncWorkflowFunc func(
+	context.Context,
+	*globaldb.GlobalDB,
+	globaldb.Workspace,
+	model.SyncConfig,
+) (*corepkg.SyncResult, error)
+
 // RunManagerConfig wires the daemon-owned run manager dependencies.
 type RunManagerConfig struct {
 	GlobalDB               *globaldb.GlobalDB
@@ -70,6 +77,7 @@ type RunManagerConfig struct {
 	ShutdownDrainTimeout   time.Duration
 	Now                    func() time.Time
 	BuildRunID             func(*model.RuntimeConfig) (string, error)
+	SyncWorkflow           syncWorkflowFunc
 	OpenRunScope           func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error)
 	Prepare                func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error)
 	Execute                func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error
@@ -92,6 +100,7 @@ type RunManager struct {
 	homePaths              compozyconfig.HomePaths
 	now                    func() time.Time
 	buildRunID             func(*model.RuntimeConfig) (string, error)
+	syncWorkflow           syncWorkflowFunc
 	openRunScope           func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error)
 	prepare                func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error)
 	execute                func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error
@@ -259,6 +268,7 @@ func NewRunManager(cfg RunManagerConfig) (*RunManager, error) {
 		homePaths:              homePaths,
 		now:                    resolveRunManagerNow(cfg.Now),
 		buildRunID:             resolveRunManagerBuildRunID(cfg.BuildRunID),
+		syncWorkflow:           resolveRunManagerSyncWorkflow(cfg.SyncWorkflow),
 		openRunScope:           resolveRunManagerOpenRunScope(cfg.OpenRunScope),
 		prepare:                resolveRunManagerPrepare(cfg.Prepare),
 		execute:                resolveRunManagerExecute(cfg.Execute),
@@ -326,6 +336,15 @@ func resolveRunManagerBuildRunID(
 		return buildRunID
 	}
 	return model.BuildRunID
+}
+
+func resolveRunManagerSyncWorkflow(
+	syncWorkflow syncWorkflowFunc,
+) syncWorkflowFunc {
+	if syncWorkflow != nil {
+		return syncWorkflow
+	}
+	return corepkg.SyncWithDB
 }
 
 func resolveRunManagerOpenRunScope(
@@ -458,7 +477,7 @@ func (m *RunManager) StartTaskRun(
 	req apicore.TaskRunRequest,
 ) (apicore.Run, error) {
 	workspaceRow, workflowID, runtimeCfg, recoveryCfg, parallelCfg, presentationMode, err := m.prepareTaskStart(
-		detachContext(ctx),
+		ctx,
 		workspaceRef,
 		workflowSlug,
 		req,
@@ -547,7 +566,7 @@ func (m *RunManager) startReviewRun(
 	parentRunID string,
 ) (apicore.Run, error) {
 	workspaceRow, workflowID, runtimeCfg, recoveryCfg, presentationMode, err := m.prepareReviewStart(
-		detachContext(ctx),
+		ctx,
 		workspaceRef,
 		workflowSlug,
 		round,
@@ -575,7 +594,7 @@ func (m *RunManager) StartExecRun(
 	ctx context.Context,
 	req apicore.ExecRequest,
 ) (apicore.Run, error) {
-	workspaceRow, runtimeCfg, recoveryCfg, presentationMode, err := m.prepareExecStart(detachContext(ctx), req)
+	workspaceRow, runtimeCfg, recoveryCfg, presentationMode, err := m.prepareExecStart(ctx, req)
 	if err != nil {
 		return apicore.Run{}, err
 	}
@@ -1133,24 +1152,24 @@ func (m *RunManager) prepareReviewStart(
 	return workspaceRow, workflowID, runtimeCfg, recoveryCfg, presentationMode, nil
 }
 
-func (m *RunManager) syncWorkflowBeforeRun(ctx context.Context, active *activeRun) error {
-	if active == nil || strings.TrimSpace(active.workflowRoot) == "" {
+func (m *RunManager) syncWorkflowBeforeRun(ctx context.Context, spec startRunSpec) error {
+	if strings.TrimSpace(spec.workflowRoot) == "" {
 		return nil
 	}
-	result, err := corepkg.SyncWithDB(
+	result, err := m.syncWorkflow(
 		ctx,
 		m.globalDB,
-		globaldb.Workspace{ID: active.workspaceID, RootDir: active.workspaceRoot},
-		model.SyncConfig{TasksDir: active.workflowRoot},
+		spec.workspace,
+		model.SyncConfig{TasksDir: spec.workflowRoot},
 	)
 	if err != nil {
-		return fmt.Errorf("daemon: sync workflow %s before run: %w", active.workflowRoot, err)
+		return fmt.Errorf("daemon: sync workflow %s before run: %w", spec.workflowRoot, err)
 	}
 	m.publishWorkflowSyncWorkspaceEvent(
 		ctx,
-		active.workspaceID,
-		active.workflowID,
-		active.workflowSlug,
+		spec.workspace.ID,
+		spec.workflowID,
+		spec.workflowSlug,
 		result.SyncedPaths,
 	)
 	return nil
@@ -1319,6 +1338,9 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	if spec.runtimeCfg == nil {
 		return apicore.Run{}, errors.New("daemon: runtime config is required")
 	}
+	if err := ctx.Err(); err != nil {
+		return apicore.Run{}, err
+	}
 	if err := ensureHomeLayout(m.homePaths); err != nil {
 		return apicore.Run{}, err
 	}
@@ -1328,10 +1350,16 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	runtimeCfg.ApplyDefaults()
 	explicitRunID := strings.TrimSpace(runtimeCfg.RunID) != ""
 	spec.runtimeCfg = runtimeCfg
+	if err := m.syncWorkflowBeforeRun(ctx, spec); err != nil {
+		return apicore.Run{}, err
+	}
+	if err := ctx.Err(); err != nil {
+		return apicore.Run{}, err
+	}
 
 	startedAt := m.now().UTC()
 	row, createdRun, resumedRun, err := m.prepareRunRow(
-		detachContext(ctx),
+		ctx,
 		spec,
 		explicitRunID,
 		startedAt,
@@ -1368,10 +1396,6 @@ func (m *RunManager) startRun(ctx context.Context, spec startRunSpec) (apicore.R
 	}()
 	active := newActiveRun(runCtx, cancel, row, spec, scope)
 	active.jobControls = runtimeCfg.JobControls
-	if err := m.syncWorkflowBeforeRun(runCtx, active); err != nil {
-		active.cancel()
-		return apicore.Run{}, m.failStartRun(ctx, row, active.currentCloseTimeout(), scope, createdRun, err)
-	}
 	if err := m.startWatcher(active); err != nil {
 		active.cancel()
 		return apicore.Run{}, m.failStartRun(ctx, row, active.currentCloseTimeout(), scope, createdRun, err)

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -70,6 +70,150 @@ func TestRunManagerStartTaskRunAllocatesRunDBAndRejectsDuplicateRunID(t *testing
 	}
 }
 
+func TestRunManagerCanceledContendedReviewStartLeavesNoRun(t *testing.T) {
+	const runID = "review-run-canceled-before-commit"
+
+	type writerLockResult struct {
+		tx  *sql.Tx
+		err error
+	}
+	writerLockCh := make(chan writerLockResult, 1)
+	var writerDB *sql.DB
+	var executed atomic.Bool
+	env := newRunManagerTestEnv(t, runManagerTestDeps{
+		syncWorkflow: func(
+			ctx context.Context,
+			db *globaldb.GlobalDB,
+			workspace globaldb.Workspace,
+			cfg model.SyncConfig,
+		) (*corepkg.SyncResult, error) {
+			writerTx, err := writerDB.BeginTx(context.Background(), nil)
+			if err == nil {
+				_, err = writerTx.ExecContext(
+					context.Background(),
+					`UPDATE workspaces SET updated_at = updated_at WHERE id = ?`,
+					workspace.ID,
+				)
+			}
+			if err != nil && writerTx != nil {
+				_ = writerTx.Rollback()
+				writerTx = nil
+			}
+			writerLockCh <- writerLockResult{tx: writerTx, err: err}
+			if err != nil {
+				return nil, err
+			}
+			return corepkg.SyncWithDB(ctx, db, workspace, cfg)
+		},
+		execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
+			executed.Store(true)
+			return nil
+		},
+	})
+	env.createReviewRound(t, 1)
+
+	workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
+	if err != nil {
+		t.Fatalf("ResolveOrRegister() error = %v", err)
+	}
+	if _, err := corepkg.SyncWithDB(
+		context.Background(),
+		env.globalDB,
+		workspace,
+		model.SyncConfig{TasksDir: env.workflowDir(env.workflowSlug)},
+	); err != nil {
+		t.Fatalf("initial SyncWithDB() error = %v", err)
+	}
+
+	writerDB, err = store.OpenSQLiteDatabase(context.Background(), env.paths.GlobalDBPath, nil)
+	if err != nil {
+		t.Fatalf("OpenSQLiteDatabase(writer) error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = writerDB.Close()
+	})
+	var writerTx *sql.Tx
+	writerReleased := false
+	t.Cleanup(func() {
+		if writerTx != nil && !writerReleased {
+			_ = writerTx.Rollback()
+		}
+	})
+
+	type startResult struct {
+		run apicore.Run
+		err error
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	runtimeOverrides := rawJSON(t, `{"run_id":"`+runID+`","dry_run":true}`)
+	resultCh := make(chan startResult, 1)
+	go func() {
+		run, startErr := env.manager.StartReviewRun(
+			ctx,
+			env.workspaceRoot,
+			env.workflowSlug,
+			1,
+			apicore.ReviewRunRequest{
+				Workspace:        env.workspaceRoot,
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: runtimeOverrides,
+			},
+		)
+		resultCh <- startResult{run: run, err: startErr}
+	}()
+
+	select {
+	case lockResult := <-writerLockCh:
+		if lockResult.err != nil {
+			t.Fatalf("hold global.db writer lock: %v", lockResult.err)
+		}
+		writerTx = lockResult.tx
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartReviewRun() did not enter pre-run sync")
+	}
+	cancel()
+
+	var result startResult
+	returnedWhileLocked := false
+	select {
+	case result = <-resultCh:
+		returnedWhileLocked = true
+	case <-time.After(time.Second):
+	}
+
+	if writerTx == nil {
+		t.Fatal("global.db writer transaction = nil")
+	}
+	if err := writerTx.Rollback(); err != nil {
+		t.Fatalf("release global.db writer lock: %v", err)
+	}
+	writerReleased = true
+	if !returnedWhileLocked {
+		select {
+		case result = <-resultCh:
+		case <-time.After(5 * time.Second):
+			t.Fatal("StartReviewRun() did not return after releasing writer lock")
+		}
+		t.Fatal("StartReviewRun() ignored cancellation while blocked on global.db")
+	}
+
+	if !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("StartReviewRun() error = %v, want context.Canceled", result.err)
+	}
+	if result.run.RunID != "" {
+		t.Fatalf("StartReviewRun() run id = %q, want empty", result.run.RunID)
+	}
+	if _, err := env.globalDB.GetRun(context.Background(), runID); !errors.Is(err, globaldb.ErrRunNotFound) {
+		t.Fatalf("GetRun(%q) error = %v, want ErrRunNotFound", runID, err)
+	}
+	if _, err := os.Stat(env.manager.runArtifacts(runID).RunDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stat canceled run directory error = %v, want os.ErrNotExist", err)
+	}
+	if executed.Load() {
+		t.Fatal("canceled review start executed after returning an error")
+	}
+}
+
 func TestRunManagerRejectsCompletedTaskWorkflowBeforeCreatingRun(t *testing.T) {
 	env := newRunManagerTestEnv(t, runManagerTestDeps{})
 	env.writeWorkflowFile(t, env.workflowSlug, "task_01.md", daemonTaskBody("completed", "Done task"))
@@ -1525,7 +1669,7 @@ func TestRunManagerStartExecRunOpenRunScopeFailureMarksResumedRowFailed(t *testi
 	})
 }
 
-func TestRunManagerStartRunSyncFailureMarksRunFailed(t *testing.T) {
+func TestRunManagerStartRunSyncFailureLeavesNoRun(t *testing.T) {
 	env := newRunManagerTestEnv(t, runManagerTestDeps{})
 
 	workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
@@ -1557,14 +1701,11 @@ func TestRunManagerStartRunSyncFailureMarksRunFailed(t *testing.T) {
 		t.Fatalf("startRun(sync failure) error = %v, want sync workflow context", err)
 	}
 
-	row := waitForRun(t, env.globalDB, runID, func(row globaldb.Run) bool {
-		return row.Status == runStatusFailed
-	})
-	if row.EndedAt == nil {
-		t.Fatal("EndedAt = nil, want terminal timestamp")
+	if _, err := env.globalDB.GetRun(context.Background(), runID); !errors.Is(err, globaldb.ErrRunNotFound) {
+		t.Fatalf("GetRun(%q) error = %v, want ErrRunNotFound", runID, err)
 	}
-	if !strings.Contains(row.ErrorText, "sync workflow") {
-		t.Fatalf("row.ErrorText = %q, want sync workflow context", row.ErrorText)
+	if _, err := os.Stat(env.manager.runArtifacts(runID).RunDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stat failed-sync run directory error = %v, want os.ErrNotExist", err)
 	}
 	if active := env.manager.getActive(runID); active != nil {
 		t.Fatalf("active run after sync failure = %#v, want nil", active)
@@ -2663,6 +2804,7 @@ type runManagerTestEnv struct {
 type runManagerTestDeps struct {
 	now                    func() time.Time
 	buildRunID             func(*model.RuntimeConfig) (string, error)
+	syncWorkflow           syncWorkflowFunc
 	openRunScope           func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error)
 	prepare                func(context.Context, *model.RuntimeConfig, model.RunScope) (*model.SolvePreparation, error)
 	execute                func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error
@@ -2718,6 +2860,7 @@ func newRunManagerTestEnv(tb testing.TB, deps runManagerTestDeps) *runManagerTes
 		ShutdownDrainTimeout:   deps.shutdownDrainTimeout,
 		Now:                    deps.now,
 		BuildRunID:             deps.buildRunID,
+		SyncWorkflow:           deps.syncWorkflow,
 		OpenRunScope:           firstOpenRunScope(deps.openRunScope),
 		Prepare:                firstPrepare(deps.prepare),
 		Execute:                firstExecute(deps.execute),

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -71,147 +71,236 @@ func TestRunManagerStartTaskRunAllocatesRunDBAndRejectsDuplicateRunID(t *testing
 }
 
 func TestRunManagerCanceledContendedReviewStartLeavesNoRun(t *testing.T) {
-	const runID = "review-run-canceled-before-commit"
+	t.Run("Should leave no run when a contended start is canceled", func(t *testing.T) {
+		const runID = "review-run-canceled-before-commit"
 
-	type writerLockResult struct {
-		tx  *sql.Tx
-		err error
-	}
-	writerLockCh := make(chan writerLockResult, 1)
-	var writerDB *sql.DB
-	var executed atomic.Bool
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		syncWorkflow: func(
-			ctx context.Context,
-			db *globaldb.GlobalDB,
-			workspace globaldb.Workspace,
-			cfg model.SyncConfig,
-		) (*corepkg.SyncResult, error) {
-			writerTx, err := writerDB.BeginTx(context.Background(), nil)
-			if err == nil {
-				_, err = writerTx.ExecContext(
-					context.Background(),
-					`UPDATE workspaces SET updated_at = updated_at WHERE id = ?`,
-					workspace.ID,
-				)
-			}
-			if err != nil && writerTx != nil {
-				_ = writerTx.Rollback()
-				writerTx = nil
-			}
-			writerLockCh <- writerLockResult{tx: writerTx, err: err}
-			if err != nil {
-				return nil, err
-			}
-			return corepkg.SyncWithDB(ctx, db, workspace, cfg)
-		},
-		execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
-			executed.Store(true)
-			return nil
-		},
-	})
-	env.createReviewRound(t, 1)
-
-	workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
-	if err != nil {
-		t.Fatalf("ResolveOrRegister() error = %v", err)
-	}
-	if _, err := corepkg.SyncWithDB(
-		context.Background(),
-		env.globalDB,
-		workspace,
-		model.SyncConfig{TasksDir: env.workflowDir(env.workflowSlug)},
-	); err != nil {
-		t.Fatalf("initial SyncWithDB() error = %v", err)
-	}
-
-	writerDB, err = store.OpenSQLiteDatabase(context.Background(), env.paths.GlobalDBPath, nil)
-	if err != nil {
-		t.Fatalf("OpenSQLiteDatabase(writer) error = %v", err)
-	}
-	t.Cleanup(func() {
-		_ = writerDB.Close()
-	})
-	var writerTx *sql.Tx
-	writerReleased := false
-	t.Cleanup(func() {
-		if writerTx != nil && !writerReleased {
-			_ = writerTx.Rollback()
+		type writerLockResult struct {
+			tx  *sql.Tx
+			err error
 		}
-	})
-
-	type startResult struct {
-		run apicore.Run
-		err error
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	runtimeOverrides := rawJSON(t, `{"run_id":"`+runID+`","dry_run":true}`)
-	resultCh := make(chan startResult, 1)
-	go func() {
-		run, startErr := env.manager.StartReviewRun(
-			ctx,
-			env.workspaceRoot,
-			env.workflowSlug,
-			1,
-			apicore.ReviewRunRequest{
-				Workspace:        env.workspaceRoot,
-				PresentationMode: defaultPresentationMode,
-				RuntimeOverrides: runtimeOverrides,
+		writerLockCh := make(chan writerLockResult, 1)
+		var writerDB *sql.DB
+		var executed atomic.Bool
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			syncWorkflow: func(
+				ctx context.Context,
+				db *globaldb.GlobalDB,
+				workspace globaldb.Workspace,
+				cfg model.SyncConfig,
+			) (*corepkg.SyncResult, error) {
+				writerTx, err := writerDB.BeginTx(context.Background(), nil)
+				if err == nil {
+					_, err = writerTx.ExecContext(
+						context.Background(),
+						`UPDATE workspaces SET updated_at = updated_at WHERE id = ?`,
+						workspace.ID,
+					)
+				}
+				if err != nil && writerTx != nil {
+					if rollbackErr := writerTx.Rollback(); rollbackErr != nil {
+						err = errors.Join(err, fmt.Errorf("rollback failed writer transaction: %w", rollbackErr))
+					}
+					writerTx = nil
+				}
+				writerLockCh <- writerLockResult{tx: writerTx, err: err}
+				if err != nil {
+					return nil, err
+				}
+				return corepkg.SyncWithDB(ctx, db, workspace, cfg)
 			},
-		)
-		resultCh <- startResult{run: run, err: startErr}
-	}()
+			execute: func(context.Context, *model.SolvePreparation, *model.RuntimeConfig) error {
+				executed.Store(true)
+				return nil
+			},
+		})
+		env.createReviewRound(t, 1)
 
-	select {
-	case lockResult := <-writerLockCh:
-		if lockResult.err != nil {
-			t.Fatalf("hold global.db writer lock: %v", lockResult.err)
+		workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
+		if err != nil {
+			t.Fatalf("ResolveOrRegister() error = %v", err)
 		}
-		writerTx = lockResult.tx
-	case <-time.After(5 * time.Second):
-		t.Fatal("StartReviewRun() did not enter pre-run sync")
-	}
-	cancel()
+		if _, err := corepkg.SyncWithDB(
+			context.Background(),
+			env.globalDB,
+			workspace,
+			model.SyncConfig{TasksDir: env.workflowDir(env.workflowSlug)},
+		); err != nil {
+			t.Fatalf("initial SyncWithDB() error = %v", err)
+		}
 
-	var result startResult
-	returnedWhileLocked := false
-	select {
-	case result = <-resultCh:
-		returnedWhileLocked = true
-	case <-time.After(time.Second):
-	}
+		writerDB, err = store.OpenSQLiteDatabase(context.Background(), env.paths.GlobalDBPath, nil)
+		if err != nil {
+			t.Fatalf("OpenSQLiteDatabase(writer) error = %v", err)
+		}
+		t.Cleanup(func() {
+			if closeErr := writerDB.Close(); closeErr != nil {
+				t.Errorf("close writer database: %v", closeErr)
+			}
+		})
+		var writerTx *sql.Tx
+		writerReleased := false
+		t.Cleanup(func() {
+			if writerTx != nil && !writerReleased {
+				if rollbackErr := writerTx.Rollback(); rollbackErr != nil {
+					t.Errorf("rollback writer transaction during cleanup: %v", rollbackErr)
+				}
+			}
+		})
 
-	if writerTx == nil {
-		t.Fatal("global.db writer transaction = nil")
-	}
-	if err := writerTx.Rollback(); err != nil {
-		t.Fatalf("release global.db writer lock: %v", err)
-	}
-	writerReleased = true
-	if !returnedWhileLocked {
+		type startResult struct {
+			run apicore.Run
+			err error
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		runtimeOverrides := rawJSON(t, `{"run_id":"`+runID+`","dry_run":true}`)
+		resultCh := make(chan startResult, 1)
+		go func() {
+			run, startErr := env.manager.StartReviewRun(
+				ctx,
+				env.workspaceRoot,
+				env.workflowSlug,
+				1,
+				apicore.ReviewRunRequest{
+					Workspace:        env.workspaceRoot,
+					PresentationMode: defaultPresentationMode,
+					RuntimeOverrides: runtimeOverrides,
+				},
+			)
+			resultCh <- startResult{run: run, err: startErr}
+		}()
+
+		select {
+		case lockResult := <-writerLockCh:
+			if lockResult.err != nil {
+				t.Fatalf("hold global.db writer lock: %v", lockResult.err)
+			}
+			writerTx = lockResult.tx
+		case <-time.After(5 * time.Second):
+			t.Fatal("StartReviewRun() did not enter pre-run sync")
+		}
+		cancel()
+
+		var result startResult
+		returnedWhileLocked := false
+		select {
+		case result = <-resultCh:
+			returnedWhileLocked = true
+		case <-time.After(time.Second):
+		}
+
+		if writerTx == nil {
+			t.Fatal("global.db writer transaction = nil")
+		}
+		if err := writerTx.Rollback(); err != nil {
+			t.Fatalf("release global.db writer lock: %v", err)
+		}
+		writerReleased = true
+		if !returnedWhileLocked {
+			select {
+			case result = <-resultCh:
+			case <-time.After(5 * time.Second):
+				t.Fatal("StartReviewRun() did not return after releasing writer lock")
+			}
+			t.Fatal("StartReviewRun() ignored cancellation while blocked on global.db")
+		}
+
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("StartReviewRun() error = %v, want context.Canceled", result.err)
+		}
+		if result.run.RunID != "" {
+			t.Fatalf("StartReviewRun() run id = %q, want empty", result.run.RunID)
+		}
+		if _, err := env.globalDB.GetRun(context.Background(), runID); !errors.Is(err, globaldb.ErrRunNotFound) {
+			t.Fatalf("GetRun(%q) error = %v, want ErrRunNotFound", runID, err)
+		}
+		if _, err := os.Stat(env.manager.runArtifacts(runID).RunDir); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat canceled run directory error = %v, want os.ErrNotExist", err)
+		}
+		if executed.Load() {
+			t.Fatal("canceled review start executed after returning an error")
+		}
+	})
+}
+
+func TestRunManagerCallerCancellationAfterCommitDoesNotOwnStartup(t *testing.T) {
+	t.Run("Should complete daemon-owned startup after caller cancellation", func(t *testing.T) {
+		const runID = "review-run-daemon-owned-after-commit"
+
+		scopeEntered := make(chan struct{})
+		releaseScope := make(chan struct{})
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			openRunScope: func(
+				ctx context.Context,
+				cfg *model.RuntimeConfig,
+				_ model.OpenRunScopeOptions,
+			) (model.RunScope, error) {
+				close(scopeEntered)
+				<-releaseScope
+				if ctx.Done() == nil {
+					return nil, errors.New("post-commit startup context has no daemon cancellation")
+				}
+				return model.OpenBaseRunScope(ctx, cfg)
+			},
+		})
+		env.createReviewRound(t, 1)
+
+		type startResult struct {
+			run apicore.Run
+			err error
+		}
+		callerCtx, cancelCaller := context.WithCancel(context.Background())
+		runtimeOverrides := rawJSON(t, `{"run_id":"`+runID+`","dry_run":true}`)
+		resultCh := make(chan startResult, 1)
+		go func() {
+			run, err := env.manager.StartReviewRun(
+				callerCtx,
+				env.workspaceRoot,
+				env.workflowSlug,
+				1,
+				apicore.ReviewRunRequest{
+					Workspace:        env.workspaceRoot,
+					PresentationMode: defaultPresentationMode,
+					RuntimeOverrides: runtimeOverrides,
+				},
+			)
+			resultCh <- startResult{run: run, err: err}
+		}()
+
+		select {
+		case <-scopeEntered:
+		case <-time.After(5 * time.Second):
+			t.Fatal("StartReviewRun() did not reach post-commit scope initialization")
+		}
+		row, err := env.globalDB.GetRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("GetRun(%q) after scope entry error = %v", runID, err)
+		}
+		if row.Status != runStatusStarting {
+			t.Fatalf("committed row status = %q, want %q", row.Status, runStatusStarting)
+		}
+
+		cancelCaller()
+		close(releaseScope)
+
+		var result startResult
 		select {
 		case result = <-resultCh:
 		case <-time.After(5 * time.Second):
-			t.Fatal("StartReviewRun() did not return after releasing writer lock")
+			t.Fatal("StartReviewRun() did not finish daemon-owned startup")
 		}
-		t.Fatal("StartReviewRun() ignored cancellation while blocked on global.db")
-	}
-
-	if !errors.Is(result.err, context.Canceled) {
-		t.Fatalf("StartReviewRun() error = %v, want context.Canceled", result.err)
-	}
-	if result.run.RunID != "" {
-		t.Fatalf("StartReviewRun() run id = %q, want empty", result.run.RunID)
-	}
-	if _, err := env.globalDB.GetRun(context.Background(), runID); !errors.Is(err, globaldb.ErrRunNotFound) {
-		t.Fatalf("GetRun(%q) error = %v, want ErrRunNotFound", runID, err)
-	}
-	if _, err := os.Stat(env.manager.runArtifacts(runID).RunDir); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("stat canceled run directory error = %v, want os.ErrNotExist", err)
-	}
-	if executed.Load() {
-		t.Fatal("canceled review start executed after returning an error")
-	}
+		if result.err != nil {
+			t.Fatalf("StartReviewRun() after caller cancellation error = %v", result.err)
+		}
+		if result.run.RunID != runID {
+			t.Fatalf("StartReviewRun() run id = %q, want %q", result.run.RunID, runID)
+		}
+		terminal := waitForRun(t, env.globalDB, runID, func(row globaldb.Run) bool {
+			return isTerminalRunStatus(row.Status)
+		})
+		if terminal.Status != runStatusCompleted {
+			t.Fatalf("terminal status = %q, want %q", terminal.Status, runStatusCompleted)
+		}
+	})
 }
 
 func TestRunManagerRejectsCompletedTaskWorkflowBeforeCreatingRun(t *testing.T) {
@@ -1550,41 +1639,44 @@ func TestRunManagerStartExecRunAllocatesDistinctImplicitRunIDsInParallel(t *test
 	})
 }
 
-func TestRunManagerOpenRunScopeFailureCleansReservedDirectory(t *testing.T) {
-	scopeErr := errors.New("scope unavailable")
-	env := newRunManagerTestEnv(t, runManagerTestDeps{
-		openRunScope: func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error) {
-			return nil, scopeErr
-		},
+func TestRunManagerOpenRunScopeFailurePreservesFailedRun(t *testing.T) {
+	t.Run("Should preserve a failed row and clean its reserved directory", func(t *testing.T) {
+		scopeErr := errors.New("scope unavailable")
+		env := newRunManagerTestEnv(t, runManagerTestDeps{
+			openRunScope: func(context.Context, *model.RuntimeConfig, model.OpenRunScopeOptions) (model.RunScope, error) {
+				return nil, scopeErr
+			},
+		})
+		const runID = "scope-open-failure"
+
+		_, err := env.manager.StartTaskRun(
+			context.Background(),
+			env.workspaceRoot,
+			env.workflowSlug,
+			apicore.TaskRunRequest{
+				Workspace:        env.workspaceRoot,
+				PresentationMode: defaultPresentationMode,
+				RuntimeOverrides: rawJSON(t, `{"run_id":"`+runID+`"}`),
+			},
+		)
+		if !errors.Is(err, scopeErr) {
+			t.Fatalf("StartTaskRun(open scope failure) error = %v, want %v", err, scopeErr)
+		}
+
+		runArtifacts := env.manager.runArtifacts(runID)
+		if _, err := os.Stat(runArtifacts.RunDir); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("run dir stat error = %v, want not exist", err)
+		}
+		row := waitForRun(t, env.globalDB, runID, func(row globaldb.Run) bool {
+			return row.Status == runStatusFailed
+		})
+		if row.EndedAt == nil {
+			t.Fatal("EndedAt = nil, want terminal timestamp")
+		}
+		if !strings.Contains(row.ErrorText, scopeErr.Error()) {
+			t.Fatalf("row.ErrorText = %q, want %q", row.ErrorText, scopeErr.Error())
+		}
 	})
-
-	_, err := env.manager.StartTaskRun(
-		context.Background(),
-		env.workspaceRoot,
-		env.workflowSlug,
-		apicore.TaskRunRequest{
-			Workspace:        env.workspaceRoot,
-			PresentationMode: defaultPresentationMode,
-			RuntimeOverrides: rawJSON(t, `{"run_id":"scope-open-failure"}`),
-		},
-	)
-	if !errors.Is(err, scopeErr) {
-		t.Fatalf("StartTaskRun(open scope failure) error = %v, want %v", err, scopeErr)
-	}
-
-	runArtifacts := env.manager.runArtifacts("scope-open-failure")
-	if _, err := os.Stat(runArtifacts.RunDir); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("run dir stat error = %v, want not exist", err)
-	}
-	if _, err := env.globalDB.GetRun(
-		context.Background(),
-		"scope-open-failure",
-	); !errors.Is(
-		err,
-		globaldb.ErrRunNotFound,
-	) {
-		t.Fatalf("GetRun(open scope failure) error = %v, want ErrRunNotFound", err)
-	}
 }
 
 func TestRunManagerStartExecRunOpenRunScopeFailureMarksResumedRowFailed(t *testing.T) {
@@ -1670,46 +1762,48 @@ func TestRunManagerStartExecRunOpenRunScopeFailureMarksResumedRowFailed(t *testi
 }
 
 func TestRunManagerStartRunSyncFailureLeavesNoRun(t *testing.T) {
-	env := newRunManagerTestEnv(t, runManagerTestDeps{})
+	t.Run("Should leave no run when workflow synchronization fails", func(t *testing.T) {
+		env := newRunManagerTestEnv(t, runManagerTestDeps{})
 
-	workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
-	if err != nil {
-		t.Fatalf("ResolveOrRegister() error = %v", err)
-	}
+		workspace, err := env.globalDB.ResolveOrRegister(context.Background(), env.workspaceRoot)
+		if err != nil {
+			t.Fatalf("ResolveOrRegister() error = %v", err)
+		}
 
-	runID := "sync-failure-run"
-	workflowRoot := filepath.Join(env.workspaceRoot, ".compozy", "tasks", "missing-workflow")
-	_, err = env.manager.startRun(context.Background(), startRunSpec{
-		workspace:        workspace,
-		workflowSlug:     "missing-workflow",
-		workflowRoot:     workflowRoot,
-		mode:             runModeTask,
-		presentationMode: defaultPresentationMode,
-		runtimeCfg: &model.RuntimeConfig{
-			RunID:         runID,
-			WorkspaceRoot: env.workspaceRoot,
-			Name:          "missing-workflow",
-			TasksDir:      workflowRoot,
-			Mode:          model.ExecutionModePRDTasks,
-			DaemonOwned:   true,
-		},
+		runID := "sync-failure-run"
+		workflowRoot := filepath.Join(env.workspaceRoot, ".compozy", "tasks", "missing-workflow")
+		_, err = env.manager.startRun(context.Background(), startRunSpec{
+			workspace:        workspace,
+			workflowSlug:     "missing-workflow",
+			workflowRoot:     workflowRoot,
+			mode:             runModeTask,
+			presentationMode: defaultPresentationMode,
+			runtimeCfg: &model.RuntimeConfig{
+				RunID:         runID,
+				WorkspaceRoot: env.workspaceRoot,
+				Name:          "missing-workflow",
+				TasksDir:      workflowRoot,
+				Mode:          model.ExecutionModePRDTasks,
+				DaemonOwned:   true,
+			},
+		})
+		if err == nil {
+			t.Fatal("startRun(sync failure) error = nil, want non-nil")
+		}
+		if !strings.Contains(err.Error(), "sync workflow") {
+			t.Fatalf("startRun(sync failure) error = %v, want sync workflow context", err)
+		}
+
+		if _, err := env.globalDB.GetRun(context.Background(), runID); !errors.Is(err, globaldb.ErrRunNotFound) {
+			t.Fatalf("GetRun(%q) error = %v, want ErrRunNotFound", runID, err)
+		}
+		if _, err := os.Stat(env.manager.runArtifacts(runID).RunDir); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stat failed-sync run directory error = %v, want os.ErrNotExist", err)
+		}
+		if active := env.manager.getActive(runID); active != nil {
+			t.Fatalf("active run after sync failure = %#v, want nil", active)
+		}
 	})
-	if err == nil {
-		t.Fatal("startRun(sync failure) error = nil, want non-nil")
-	}
-	if !strings.Contains(err.Error(), "sync workflow") {
-		t.Fatalf("startRun(sync failure) error = %v, want sync workflow context", err)
-	}
-
-	if _, err := env.globalDB.GetRun(context.Background(), runID); !errors.Is(err, globaldb.ErrRunNotFound) {
-		t.Fatalf("GetRun(%q) error = %v, want ErrRunNotFound", runID, err)
-	}
-	if _, err := os.Stat(env.manager.runArtifacts(runID).RunDir); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("stat failed-sync run directory error = %v, want os.ErrNotExist", err)
-	}
-	if active := env.manager.getActive(runID); active != nil {
-		t.Fatalf("active run after sync failure = %#v, want nil", active)
-	}
 }
 
 func TestRunManagerStartTaskRunBindsDaemonHostBridgeToRunScopeContext(t *testing.T) {


### PR DESCRIPTION
## Summary

`compozy reviews fix` could **freeze with no feedback and no timeout**. The CLI
blocks on the daemon-side `StartReviewRun`, which synchronously syncs workflow
state into the single-writer `global.db` (`syncWorkflowBeforeRun`). On a
healthy/small catalog that sync is instant, but under write-lock contention it
can block for a long time — the CLI just sat there with no output until the
operator hit Ctrl+C and retried (or ran `compozy sync` first).

This PR makes that block **visible and bounded** on the CLI side. It is
deliberately a focused, low-risk change; the deeper root fix (removing the
daemon-side contention) is called out as a follow-up.

## The issue

- Running `compozy reviews fix <slug>` after creating a review round would freeze
  on the first attempt with no output. `Ctrl+C` + retry — or a preceding
  `compozy sync` — worked around it.
- It happened intermittently, tied to a large/contended daemon catalog rather
  than to any specific input.

## Root cause (confirmed)

- `runReviewWorkflowDaemon` → `client.StartReviewRun` blocks until the daemon
  returns the run handle, which is **after** the synchronous
  `syncWorkflowBeforeRun` (`internal/daemon/run_manager.go`).
- `global.db` is SQLite (WAL, `_txlock=immediate`, `busy_timeout=5s`, **single
  writer**). Concurrent writers — the per-run `workflowWatcher` fsnotify sync,
  `ReconcileStartup`, parallel runs — contend for the one write lock (the store
  layer already documents this contention).
- **Verified:** on a healthy state a review run starts in **milliseconds** (warm
  *and* cold, from a live repro). The freeze appears only on a degraded/heavy
  catalog where the contended write waits on `busy_timeout`. A preceding
  `compozy sync` "fixes it" by pre-settling the catalog so the in-run sync has
  nothing to contend for.

## Reproducing it

Because it is contention-driven, there is no one-line repro — a clean catalog
starts instantly. To force it, run a heavy `compozy sync` (or a large parallel
run) concurrently with `reviews fix` so the in-run `syncWorkflowBeforeRun` waits
on the write lock. This PR is framed as **hardening for the real-world degraded
state**, not a change to the happy path.

## What changed

`internal/cli/reviews_exec_daemon.go`:

- **Delayed progress feedback** — a `Preparing review run…` message is printed
  **only if the start takes longer than `reviewRunFeedbackDelay` (1s)**. The fast
  common path stays **quiet** (the existing "quiet flow before UI attach"
  behavior and tests are unchanged); only a genuinely slow (contended) start
  surfaces feedback.
- **Bounded start** — `StartReviewRun` runs under a `reviewRunStartTimeout` (60s)
  context. On timeout it returns an actionable error (*"the daemon may be busy
  syncing workflow state — retry, or run `compozy runs purge` to reduce
  contention"*) instead of hanging indefinitely. A caller `Ctrl+C` is never
  misreported as a start timeout.
- **`reviewRunStatusWriter`** routes the message to stderr for human output and
  to `io.Discard` for `json`/`raw-json`, keeping machine output clean.

## Testing / result

- **Unit** — `internal/cli/reviews_exec_start_feedback_test.go` (stdlib,
  `-race`): quiet fast path; slow start → preparing feedback + actionable timeout
  error; non-timeout error propagated unchanged; caller cancellation not
  misreported.
- **Gates** — `make lint` → **0 issues**, `go build ./...` → **success**,
  `go test ./internal/cli/...` passes.
- **Live** — validated end-to-end against a real review round: `reviews fix`
  started on the **first attempt with no `compozy sync` needed** and no freeze;
  the fast path stayed quiet as designed.

## Scope, risk, and follow-up

- **CLI-side only, low risk.** It does not touch the shared daemon run-start path
  (`syncWorkflowBeforeRun`), so task/review/exec run behavior is unchanged.
- **Root-cause follow-up (separate PR):** reduce the daemon-side write
  contention — e.g. make `syncWorkflowBeforeRun` non-blocking for the run-start
  response, or reduce how often the `workflowWatcher` writes `global.db`. That
  touches the shared run lifecycle and deserves its own change; happy to discuss
  the approach.
- **Immediate mitigation** for a bloated catalog: `compozy runs purge`.

## Notes

- **Unrelated pre-existing failure:** `TestApplyWorkspaceDefaultsFetchReviewsNitpicks`
  fails on `main` independently of this change (isolated-HOME test; confirmed by
  stashing this change). Not introduced here.
- Independent of the `cy-qa-workflow` `compozy.tasks/v2` fix (#234) — different
  subsystem, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-visible “preparing review run” progress feedback when startup exceeds the expected delay, suppressed for JSON and raw JSON modes.

* **Bug Fixes**
  * Improved review-run startup timeout handling with clearer, actionable guidance when startup is blocked, including safe recovery/confirmation behavior.
  * Ensures cancellation/deadline propagation doesn’t leave leftover run records or directories, including during workflow sync and run-scope setup.

* **Tests**
  * Added/updated coverage for fast start, delayed/timeout behavior, non-timeout error passthrough, cancellation handling, and “leave no run” semantics; also improved CLI/workspace test isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->