### PR TITLE
fix: share parallel task status enum

### DIFF
--- a/internal/core/run/parallel/orchestrator.go
+++ b/internal/core/run/parallel/orchestrator.go
@@ -229,14 +229,14 @@ type TaskOutcome struct {
 }
 
 // TaskOutcomeStatus is the per-task status reported by the parallel run.
-type TaskOutcomeStatus string
+type TaskOutcomeStatus = kinds.TaskParallelTaskStatus
 
 const (
-	TaskOutcomeMerged    TaskOutcomeStatus = "merged"
-	TaskOutcomeRecovered TaskOutcomeStatus = "recovered"
-	TaskOutcomeFailed    TaskOutcomeStatus = "failed"
-	TaskOutcomeSkipped   TaskOutcomeStatus = "skipped"
-	TaskOutcomeCanceled  TaskOutcomeStatus = "canceled"
+	TaskOutcomeMerged    = kinds.TaskParallelTaskStatusMerged
+	TaskOutcomeRecovered = kinds.TaskParallelTaskStatusRecovered
+	TaskOutcomeFailed    = kinds.TaskParallelTaskStatusFailed
+	TaskOutcomeSkipped   = kinds.TaskParallelTaskStatusSkipped
+	TaskOutcomeCanceled  = kinds.TaskParallelTaskStatusCanceled
 )
 
 // StatusReport returns the user-facing per-task status string.
@@ -973,7 +973,7 @@ func (o *ExecutionOrchestrator) cleanupTaskOutcomes(
 			WorkspaceRoot:     plan.WorkspaceRoot,
 			Path:              task.WorktreePath,
 			BaseCommit:        task.BaseCommit,
-			ContentIntegrated: contentIntegrated && task.Status.removesWorktree(),
+			ContentIntegrated: contentIntegrated && task.Status.IsIntegrated(),
 		})
 		if err != nil {
 			task.WorktreeStatus = string(WorktreeCleanupStatusPreserved)
@@ -1505,10 +1505,6 @@ func mergedStatus(execution taskExecution) TaskOutcomeStatus {
 		return TaskOutcomeRecovered
 	}
 	return TaskOutcomeMerged
-}
-
-func (s TaskOutcomeStatus) removesWorktree() bool {
-	return s == TaskOutcomeMerged || s == TaskOutcomeRecovered
 }
 
 func sortTaskOutcomes(outcomes []TaskOutcome) {

--- a/internal/core/run/ui/integration.go
+++ b/internal/core/run/ui/integration.go
@@ -573,7 +573,7 @@ func waveStatusLabel(status waveStatus) string {
 	case waveStatusConflict:
 		return "conflict"
 	case waveStatusMerged:
-		return string(kinds.TaskParallelTaskStatusMerged)
+		return "merged"
 	default:
 		return "pending"
 	}

--- a/internal/core/run/ui/integration.go
+++ b/internal/core/run/ui/integration.go
@@ -231,7 +231,7 @@ func (m *uiModel) handleParallelTaskCompleted(v parallelTaskCompletedMsg) {
 		m.sidebarDirty = true
 		return
 	}
-	success := kinds.TaskParallelTaskStatus(strings.TrimSpace(v.Status)).IsIntegrated()
+	success := kinds.TaskParallelTaskStatus(v.Status).IsIntegrated()
 	finishParallelAggregateTask(m, index, success)
 	m.sidebarDirty = true
 }

--- a/internal/core/run/ui/integration.go
+++ b/internal/core/run/ui/integration.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/compozy/compozy/internal/core/tasks"
+	"github.com/compozy/compozy/pkg/compozy/events/kinds"
 
 	"charm.land/lipgloss/v2"
 )
@@ -230,7 +231,7 @@ func (m *uiModel) handleParallelTaskCompleted(v parallelTaskCompletedMsg) {
 		m.sidebarDirty = true
 		return
 	}
-	success := v.Status == "merged" || v.Status == "recovered"
+	success := kinds.TaskParallelTaskStatus(strings.TrimSpace(v.Status)).IsIntegrated()
 	finishParallelAggregateTask(m, index, success)
 	m.sidebarDirty = true
 }
@@ -572,7 +573,7 @@ func waveStatusLabel(status waveStatus) string {
 	case waveStatusConflict:
 		return "conflict"
 	case waveStatusMerged:
-		return "merged"
+		return string(kinds.TaskParallelTaskStatusMerged)
 	default:
 		return "pending"
 	}

--- a/internal/core/run/ui/integration_test.go
+++ b/internal/core/run/ui/integration_test.go
@@ -331,6 +331,17 @@ func TestParallelConflictResolvingThenMergedUpdatesPaneAndWaveHeader(t *testing.
 	}
 }
 
+func TestParallelTaskCompletedRequiresCanonicalIntegratedStatus(t *testing.T) {
+	t.Parallel()
+
+	m := newParallelTestModel(t, tea.WindowSizeMsg{Width: 120, Height: 30}, 1)
+	m.applyUIMsg(parallelTaskCompletedMsg{WaveIndex: 0, TaskID: "task_01", Status: " merged "})
+
+	if got := m.jobs[0].state; got != jobFailed {
+		t.Fatalf("task state = %v, want failed for non-canonical status", got)
+	}
+}
+
 func TestParallelRolledBackRendersWithoutPanic(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/run/ui/integration_test.go
+++ b/internal/core/run/ui/integration_test.go
@@ -334,12 +334,16 @@ func TestParallelConflictResolvingThenMergedUpdatesPaneAndWaveHeader(t *testing.
 func TestParallelTaskCompletedRequiresCanonicalIntegratedStatus(t *testing.T) {
 	t.Parallel()
 
-	m := newParallelTestModel(t, tea.WindowSizeMsg{Width: 120, Height: 30}, 1)
-	m.applyUIMsg(parallelTaskCompletedMsg{WaveIndex: 0, TaskID: "task_01", Status: " merged "})
+	t.Run("Should reject non-canonical integrated status", func(t *testing.T) {
+		t.Parallel()
 
-	if got := m.jobs[0].state; got != jobFailed {
-		t.Fatalf("task state = %v, want failed for non-canonical status", got)
-	}
+		m := newParallelTestModel(t, tea.WindowSizeMsg{Width: 120, Height: 30}, 1)
+		m.applyUIMsg(parallelTaskCompletedMsg{WaveIndex: 0, TaskID: "task_01", Status: " merged "})
+
+		if got := m.jobs[0].state; got != jobFailed {
+			t.Fatalf("task state = %v, want failed for non-canonical status", got)
+		}
+	})
 }
 
 func TestParallelRolledBackRendersWithoutPanic(t *testing.T) {

--- a/internal/core/run/ui/multi_remote.go
+++ b/internal/core/run/ui/multi_remote.go
@@ -1035,7 +1035,7 @@ func applyParallelAggregateTaskOutcome(child *uiModel, ev events.Event) {
 		return
 	}
 	success := ev.Kind == events.EventKindTaskParallelMerged ||
-		kinds.TaskParallelTaskStatus(strings.TrimSpace(payload.Status)).IsIntegrated()
+		kinds.TaskParallelTaskStatus(payload.Status).IsIntegrated()
 	for idx := range child.jobs {
 		if child.jobs[idx].taskNumber != number {
 			continue

--- a/internal/core/run/ui/multi_remote.go
+++ b/internal/core/run/ui/multi_remote.go
@@ -1035,7 +1035,7 @@ func applyParallelAggregateTaskOutcome(child *uiModel, ev events.Event) {
 		return
 	}
 	success := ev.Kind == events.EventKindTaskParallelMerged ||
-		payload.Status == "merged" || payload.Status == "recovered"
+		kinds.TaskParallelTaskStatus(strings.TrimSpace(payload.Status)).IsIntegrated()
 	for idx := range child.jobs {
 		if child.jobs[idx].taskNumber != number {
 			continue

--- a/internal/daemon/task_multi_artifacts.go
+++ b/internal/daemon/task_multi_artifacts.go
@@ -164,7 +164,7 @@ func syncCompletedParallelTaskArtifacts(
 			return err
 		}
 		task := tasks[index]
-		if !parallelTaskStatusSyncsArtifact(task.Status) {
+		if !task.Status.IsIntegrated() {
 			continue
 		}
 		if err := syncParallelTaskArtifact(workspaceRoot, task, destinationsBySlug); err != nil {
@@ -172,15 +172,6 @@ func syncCompletedParallelTaskArtifacts(
 		}
 	}
 	return nil
-}
-
-func parallelTaskStatusSyncsArtifact(status runparallel.TaskOutcomeStatus) bool {
-	switch status {
-	case runparallel.TaskOutcomeMerged, runparallel.TaskOutcomeRecovered:
-		return true
-	default:
-		return false
-	}
 }
 
 // syncParallelTaskArtifact copies only the completed task's canonical

--- a/pkg/compozy/events/kinds/task.go
+++ b/pkg/compozy/events/kinds/task.go
@@ -2,6 +2,22 @@ package kinds
 
 import "time"
 
+// TaskParallelTaskStatus is the terminal status of one task in a parallel run.
+type TaskParallelTaskStatus string
+
+const (
+	TaskParallelTaskStatusMerged    TaskParallelTaskStatus = "merged"
+	TaskParallelTaskStatusRecovered TaskParallelTaskStatus = "recovered"
+	TaskParallelTaskStatusFailed    TaskParallelTaskStatus = "failed"
+	TaskParallelTaskStatusSkipped   TaskParallelTaskStatus = "skipped"
+	TaskParallelTaskStatusCanceled  TaskParallelTaskStatus = "canceled"
+)
+
+// IsIntegrated reports whether the task content reached the integration branch.
+func (s TaskParallelTaskStatus) IsIntegrated() bool {
+	return s == TaskParallelTaskStatusMerged || s == TaskParallelTaskStatusRecovered
+}
+
 // TaskFileUpdatedPayload describes a rewritten task file.
 type TaskFileUpdatedPayload struct {
 	TasksDir  string `json:"tasks_dir"`

--- a/pkg/compozy/events/kinds/task_test.go
+++ b/pkg/compozy/events/kinds/task_test.go
@@ -14,14 +14,14 @@ func TestTaskParallelTaskStatusIsIntegrated(t *testing.T) {
 		status TaskParallelTaskStatus
 		want   bool
 	}{
-		{name: "merged", status: TaskParallelTaskStatusMerged, want: true},
-		{name: "recovered", status: TaskParallelTaskStatusRecovered, want: true},
-		{name: "failed", status: TaskParallelTaskStatusFailed},
-		{name: "skipped", status: TaskParallelTaskStatusSkipped},
-		{name: "canceled", status: TaskParallelTaskStatusCanceled},
-		{name: "unknown", status: TaskParallelTaskStatus("unknown")},
-		{name: "empty", status: TaskParallelTaskStatus("")},
-		{name: "non-canonical whitespace", status: TaskParallelTaskStatus(" merged ")},
+		{name: "Should report merged as integrated", status: TaskParallelTaskStatusMerged, want: true},
+		{name: "Should report recovered as integrated", status: TaskParallelTaskStatusRecovered, want: true},
+		{name: "Should reject failed", status: TaskParallelTaskStatusFailed},
+		{name: "Should reject skipped", status: TaskParallelTaskStatusSkipped},
+		{name: "Should reject canceled", status: TaskParallelTaskStatusCanceled},
+		{name: "Should reject unknown", status: TaskParallelTaskStatus("unknown")},
+		{name: "Should reject empty", status: TaskParallelTaskStatus("")},
+		{name: "Should reject non-canonical whitespace", status: TaskParallelTaskStatus(" merged ")},
 	}
 
 	for _, tc := range tests {

--- a/pkg/compozy/events/kinds/task_test.go
+++ b/pkg/compozy/events/kinds/task_test.go
@@ -1,0 +1,36 @@
+// Suite: Parallel task status semantics.
+// Invariant: Only canonical merged and recovered statuses report integrated content.
+// Boundary IN: TaskParallelTaskStatus values and IsIntegrated.
+// Boundary OUT: Event transport and UI rendering, covered by their package suites.
+package kinds
+
+import "testing"
+
+func TestTaskParallelTaskStatusIsIntegrated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status TaskParallelTaskStatus
+		want   bool
+	}{
+		{name: "merged", status: TaskParallelTaskStatusMerged, want: true},
+		{name: "recovered", status: TaskParallelTaskStatusRecovered, want: true},
+		{name: "failed", status: TaskParallelTaskStatusFailed},
+		{name: "skipped", status: TaskParallelTaskStatusSkipped},
+		{name: "canceled", status: TaskParallelTaskStatusCanceled},
+		{name: "unknown", status: TaskParallelTaskStatus("unknown")},
+		{name: "empty", status: TaskParallelTaskStatus("")},
+		{name: "non-canonical whitespace", status: TaskParallelTaskStatus(" merged ")},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.status.IsIntegrated(); got != tc.want {
+				t.Fatalf("IsIntegrated() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The canonical `verify` gate is blocked under Go 1.26.4 by:

```text
internal/core/run/ui/multi_remote.go:1038:21: string `merged` has 4 occurrences, make it a constant (goconst)
```

This is a base failure rather than a defect introduced by downstream PRs such as #234: the affected UI file is identical to `main`. Because `verify` is required and the repository has a zero-issue policy, downstream PRs cannot merge while inheriting this failure.

## Root cause

Parallel-task terminal values—`merged`, `recovered`, `failed`, `skipped`, and `canceled`—form one domain, but consumers interpreted them through repeated string literals. The repeated `merged` value triggers `goconst` under the Go 1.26.4 lint environment.

## Fix

- Define `TaskParallelTaskStatus` in the shared event contract with all five terminal per-task values.
- Reuse that type from the parallel orchestrator.
- Centralize the semantic rule that only `merged` and `recovered` mean task content reached the integration branch.
- Reuse `IsIntegrated()` in UI task settlement, worktree outcome decisions, and daemon artifact synchronization.
- Treat incoming status text as an exact protocol value; malformed whitespace is not normalized into a valid status.
- Keep wave display status independent from per-task outcome status despite their shared `merged` label.

No lint suppression or unrelated workaround is included.

## Tests

- Add a table-driven truth table covering all five statuses, empty, unknown, and non-canonical whitespace.
- Add UI boundary coverage proving malformed status text cannot settle a task successfully.
- Existing UI and daemon suites continue to cover event handling and artifact synchronization.

## Impact

This removes the base `goconst` failure so #234 and other downstream PRs can update from `main`, rerun CI, and be evaluated on their own changes.

## Verification

- Red phase: the new UI boundary test failed because `" merged "` was accepted.
- Focused green phase: 14 tests passed across event kinds, UI, and daemon packages.
- `make verify`

Fresh local results on Go 1.26.4:

- golangci-lint: 0 issues
- Go: 4,528 tests passed, 4 explicitly skipped
- build: passed
- E2E: 5 passed
- final result: `All verification checks passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a standardized parallel task terminal status type, along with a shared `IsIntegrated` helper (integrated = merged/recovered).
* **Bug Fixes**
  * Updated parallel task completion, cleanup, and artifact synchronization to rely on the shared integrated definition and reject non-canonical statuses (including whitespace variants).
* **Tests**
  * Added integration and unit tests to verify canonical integrated statuses are accepted and invalid variants are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->