### PR TITLE
release: Release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## 0.2.15 - 2026-07-16
+
+### 🐛 Bug Fixes
+
+- Recover stalled and wedged multi-runs (#230)- Share parallel task status enum (#241)- Surface progress and bound the reviews-fix daemon start (#236)- Package cy-qa-workflow as a module and make host.tasks.create v2-aware (#234)
 ## 0.2.14 - 2026-07-15
 
 ### 🐛 Bug Fixes
@@ -367,6 +372,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
+[0.2.15]: https://github.com///compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com///compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com///compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com///compare/v0.2.11...v0.2.12

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,5 +1,5 @@
-## 0.2.14 - 2026-07-15
+## 0.2.15 - 2026-07-16
 
 ### 🐛 Bug Fixes
 
-- Acp integratoin
+- Recover stalled and wedged multi-runs (#230)- Share parallel task status enum (#241)- Surface progress and bound the reviews-fix daemon start (#236)- Package cy-qa-workflow as a module and make host.tasks.create v2-aware (#234)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+## 0.2.15 - 2026-07-16
+
+### 🐛 Bug Fixes
+
+- Recover stalled and wedged multi-runs (#230)- Share parallel task status enum (#241)- Surface progress and bound the reviews-fix daemon start (#236)- Package cy-qa-workflow as a module and make host.tasks.create v2-aware (#234)
+
 ## 0.2.14 - 2026-07-15
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:config": "bunx vitest run --config vitest.config.ts test/*.test.ts",
     "typecheck": "turbo run typecheck"
   },
-  "version": "0.2.14",
+  "version": "0.2.15",
   "workspaces": [
     "packages/ui",
     "web",


### PR DESCRIPTION

## Release v0.2.15

This PR prepares the release of version v0.2.15.

### Changelog

## 0.2.15 - 2026-07-16

### 🐛 Bug Fixes

- Recover stalled and wedged multi-runs (#230)- Share parallel task status enum (#241)- Surface progress and bound the reviews-fix daemon start (#236)- Package cy-qa-workflow as a module and make host.tasks.create v2-aware (#234)
