### PR TITLE
fix: isolate sync tests and clarify ignore checks

### DIFF
--- a/extensions/cy-capture-decisions/README.md
+++ b/extensions/cy-capture-decisions/README.md
@@ -115,9 +115,15 @@ The log is only useful if it is committed and shared. What you need depends on y
 The middle line (`!.compozy/decisions/`) re-includes the directory itself, which git requires before
 either `!.compozy/decisions/**` or the index negation can take effect — git will not re-include a file
 whose parent directory is still excluded. Verify the result independently of whether the files are
-already tracked: `git check-ignore -v --no-index .compozy/DECISIONS.md` (and the same for
-`.compozy/decisions/AD-001.md`) prints the matching negation rule — e.g.
-`.gitignore:2:!.compozy/DECISIONS.md` — and exits 0, confirming the path is no longer ignored.
+already tracked:
+
+```bash
+git check-ignore -v --no-index .compozy/DECISIONS.md
+git check-ignore -v --no-index .compozy/decisions/AD-001.md
+```
+
+Each command prints the matching negation rule — e.g. `.gitignore:2:!.compozy/DECISIONS.md` — and
+exits 0, confirming the path is no longer ignored.
 `--no-index` makes git evaluate paths that are already tracked; without it, git intentionally omits
 them. Without `-v`, a re-included path also prints nothing and exits 1, so silence is not a positive
 verification signal.

--- a/extensions/cy-capture-decisions/README.md
+++ b/extensions/cy-capture-decisions/README.md
@@ -114,11 +114,13 @@ The log is only useful if it is committed and shared. What you need depends on y
 
 The middle line (`!.compozy/decisions/`) re-includes the directory itself, which git requires before
 either `!.compozy/decisions/**` or the index negation can take effect — git will not re-include a file
-whose parent directory is still excluded. Verify the result with the `-v` form:
-`git check-ignore -v .compozy/DECISIONS.md` (and the same for `.compozy/decisions/AD-001.md`) prints the
-matching negation rule — e.g. `.gitignore:2:!.compozy/DECISIONS.md` — and exits 0, confirming the path
-is no longer ignored. Plain `git check-ignore` prints nothing and exits 1 for a re-included path, so its
-silence is the only "tracked" signal; the `-v` form is the unambiguous check.
+whose parent directory is still excluded. Verify the result independently of whether the files are
+already tracked: `git check-ignore -v --no-index .compozy/DECISIONS.md` (and the same for
+`.compozy/decisions/AD-001.md`) prints the matching negation rule — e.g.
+`.gitignore:2:!.compozy/DECISIONS.md` — and exits 0, confirming the path is no longer ignored.
+`--no-index` makes git evaluate paths that are already tracked; without it, git intentionally omits
+them. Without `-v`, a re-included path also prints nothing and exits 1, so silence is not a positive
+verification signal.
 
 If you skip this step in an ignore-heavy repo, capture still writes the log, but it stays uncommitted
 and non-durable — and the "review the diff before sharing" flow does not apply, because there is no

--- a/extensions/cy-capture-decisions/packaging/readme_test.go
+++ b/extensions/cy-capture-decisions/packaging/readme_test.go
@@ -15,6 +15,10 @@ func TestReadmeDocumentsGitignoreNegations(t *testing.T) {
 			t.Fatalf("durability section is missing gitignore negation %q", negation)
 		}
 	}
+	const verboseCheck = "git check-ignore -v --no-index"
+	if !strings.Contains(section, verboseCheck) {
+		t.Fatalf("durability section is missing index-independent verification command %q", verboseCheck)
+	}
 }
 
 // UT-010: the README documents the @import consumption wiring and covers both

--- a/extensions/cy-capture-decisions/packaging/readme_test.go
+++ b/extensions/cy-capture-decisions/packaging/readme_test.go
@@ -15,10 +15,17 @@ func TestReadmeDocumentsGitignoreNegations(t *testing.T) {
 			t.Fatalf("durability section is missing gitignore negation %q", negation)
 		}
 	}
-	const verboseCheck = "git check-ignore -v --no-index"
-	if !strings.Contains(section, verboseCheck) {
-		t.Fatalf("durability section is missing index-independent verification command %q", verboseCheck)
-	}
+	t.Run("Should document complete index-independent verification commands", func(t *testing.T) {
+		t.Parallel()
+		for _, command := range []string{
+			"git check-ignore -v --no-index .compozy/DECISIONS.md",
+			"git check-ignore -v --no-index .compozy/decisions/AD-001.md",
+		} {
+			if !strings.Contains(section, command) {
+				t.Fatalf("durability section is missing verification command %q", command)
+			}
+		}
+	})
 }
 
 // UT-010: the README documents the @import consumption wiring and covers both

--- a/internal/daemon/sync_transport_service_test.go
+++ b/internal/daemon/sync_transport_service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	apicore "github.com/compozy/compozy/internal/api/core"
+	compozyconfig "github.com/compozy/compozy/internal/config"
 )
 
 func TestSyncTransportService_ShouldResolveTargetsAndHandleUnavailableBranches(t *testing.T) {
@@ -15,6 +16,7 @@ func TestSyncTransportService_ShouldResolveTargetsAndHandleUnavailableBranches(t
 		t.Helper()
 
 		env := newRunManagerTestEnv(t, runManagerTestDeps{})
+		t.Setenv(compozyconfig.HomeEnvVar, env.paths.HomeDir)
 		env.writeWorkflowFile(t, env.workflowSlug, "task_01.md", daemonTaskBody("pending", "Sync task"))
 		return env, newTransportSyncService(env.globalDB)
 	}


### PR DESCRIPTION
## Summary

- isolate the sync transport service test from the developer's ambient `COMPOZY_HOME`
- document `git check-ignore -v --no-index` so negation checks work for tracked and untracked decision-log files
- add a README contract assertion for the index-independent verification command

## Root cause

The sync test injected a temporary `GlobalDB`, but `SyncDirect` still resolved its database through the ambient `COMPOZY_HOME`. That made the test read a developer's real database and fail when its schema was newer than the checked-out binary.

The follow-up review on #237 is partially correct: `-v` can show a matching negation rule for an untracked path, but Git omits already tracked paths unless `--no-index` is supplied. The updated command is unambiguous in both states.

## Verification

- `make verify` — PASS
- frontend lint: 0 warnings, 0 errors
- golangci-lint: 0 issues
- Go: 4,875 passed, 4 opt-in skips
- Playwright: 5 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved validation of durable documentation to ensure index-independent git ignore verification commands are present.
  * Enhanced synchronization service test setup by configuring the home environment variable for more reliable target resolution and branch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->