### PR TITLE
fix: isolate task artifacts and add complexity runtime defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ auto_commit = false
 max_retries = 2
 retry_backoff_multiplier = 1.5
 
+[defaults.by_complexity.low]
+model = "haiku"
+reasoning_effort = "low"
+
+[defaults.by_complexity.high]
+reasoning_effort = "high"
+
 [tasks]
 types = ["frontend", "backend", "docs", "test", "infra", "refactor", "chore", "bugfix"]
 
@@ -220,6 +227,7 @@ nitpicks = false
 Supported sections:
 
 - `[defaults]` for shared execution defaults such as `ide`, `model`, `reasoning_effort`, `access_mode`, `timeout`, `tail_lines`, `add_dirs`, `auto_commit`, `max_retries`, and `retry_backoff_multiplier`
+- `[defaults.by_complexity.low|medium|high|critical]` for per-task `ide`, `model`, and `reasoning_effort` defaults used by PRD task runs
 - `[exec]` for `output_format` plus exec-specific runtime overrides such as `ide`, `model`, `reasoning_effort`, `access_mode`, `timeout`, `tail_lines`, `add_dirs`, `max_retries`, and `retry_backoff_multiplier`
 - `[tasks]` for the allowed task `type` list used by `cy-create-tasks` and `compozy tasks validate`
 - `[tasks.run]` for workflow-run defaults used by `compozy tasks run`, such as `include_completed`, `run_multiple_mode`, and `run_multiple_parallel_limit`
@@ -235,6 +243,7 @@ Notes:
 - `.compozy/tasks` remains the fixed workflow root in this version; the config file does not change the workflow root path.
 - Unknown keys and invalid value types are rejected during config loading.
 - Relative `add_dirs` are resolved against the owning config scope: the user home directory for `~/.compozy/config.toml` and the workspace root for `.compozy/config.toml`.
+- Complexity defaults merge field by field from global to workspace config. A missing field falls back to `[defaults]`; matching task-type and task-id runtime rules remain more specific, and explicit `--ide`, `--model`, or `--reasoning-effort` flags override complexity defaults for that invocation.
 - `[tasks.run] run_multiple_mode` controls `tasks run --multiple` scheduling. Valid values are `"enqueued"` and `"parallel"`; when unset, the built-in default is `"enqueued"`.
 - `run_multiple_mode = "parallel"` runs the batch concurrently, with each child in its own isolated git worktree. The CLI `--parallel` flag overrides this config value for a single invocation.
 - `[tasks.run] run_multiple_parallel_limit` caps how many children run at once in parallel mode. It must be a positive integer and defaults to `2`. The CLI `--parallel-limit <n>` flag overrides it for a single invocation. The limit has no effect in enqueued mode, which always runs one child at a time.

--- a/docs/extensibility/hook-reference.md
+++ b/docs/extensibility/hook-reference.md
@@ -105,6 +105,7 @@ These are not `execute_hook` events but they are part of the public author surfa
 - `{}` and `{"patch": {}}` are both treated as no-op responses.
 - Arrays are replaced wholesale, not merged.
 - Returning a patch from an observe-only hook is allowed for forward compatibility but ignored by the host.
+- The `task` object sent to `plan.pre_resolve_task_runtime` includes `id`, `safe_name`, `title`, `type`, and `complexity`.
 - `plan.pre_resolve_task_runtime` is the only supported seam for extension-driven task runtime selection. Do not change runtime in `plan.post_prepare_jobs` or `job.pre_execute`.
 - In workflow runs, `run.pre_start` is late in the pipeline. It can still tune output/runtime behavior such as timeout, retries, or sound settings, but it cannot rewrite fields already consumed by planning.
 - Review-watch hooks cannot declare a PR clean or skip provider-current detection. The daemon waits for provider-current status before `review.watch_pre_round`, and immutable provider/head/status fields are rejected if a hook tries to mutate them.

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -1585,6 +1585,10 @@ func (s *commandState) buildTaskRunRuntimeOverrides(cmd *cobra.Command) (json.Ra
 		}
 		overrides.TaskRuntimeRules = &rules
 	})
+	if explicit := explicitRuntimeOverridesPayload(s.explicitRuntime); explicit != nil {
+		overrides.ExplicitRuntime = explicit
+		hasOverrides = true
+	}
 	recovery, err := s.recoveryFlagOverrides(cmd)
 	if err != nil {
 		return nil, err

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -3781,6 +3781,7 @@ func TestBuildTaskRunRuntimeOverridesIncludesAllExplicitRuntimeFlags(t *testing.
 	mustSetFlag("retry-backoff-multiplier", "2.5")
 	state.retryBackoffMultiplier = 2.5
 	mustSetFlag("task-runtime", "id=task_01,model=codex-fast")
+	state.explicitRuntime = captureExplicitRuntimeFlags(cmd)
 
 	raw, err := state.buildTaskRunRuntimeOverrides(cmd)
 	if err != nil {
@@ -3817,6 +3818,11 @@ func TestBuildTaskRunRuntimeOverridesIncludesAllExplicitRuntimeFlags(t *testing.
 	}
 	if overrides.RetryBackoffMultiplier == nil || *overrides.RetryBackoffMultiplier != 2.5 {
 		t.Fatalf("expected retry-backoff-multiplier override, got %#v", overrides)
+	}
+	if overrides.ExplicitRuntime == nil || !overrides.ExplicitRuntime.IDE ||
+		!overrides.ExplicitRuntime.Model || !overrides.ExplicitRuntime.ReasoningEffort ||
+		!overrides.ExplicitRuntime.AccessMode {
+		t.Fatalf("expected explicit runtime markers, got %#v", overrides.ExplicitRuntime)
 	}
 	if overrides.TaskRuntimeRules == nil || len(*overrides.TaskRuntimeRules) != 1 {
 		t.Fatalf("expected task-runtime override, got %#v", overrides)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -499,9 +499,11 @@ func editRuntimeDefaultsSelection(
 	}
 
 	return workspace.DefaultsConfig{
-		IDE:             stringPtr(strings.TrimSpace(selectedIDE)),
-		Model:           stringPtr(strings.TrimSpace(selectedModel)),
-		ReasoningEffort: stringPtr(strings.TrimSpace(selectedReasoning)),
+		RuntimeOverrides: workspace.RuntimeOverrides{
+			IDE:             stringPtr(strings.TrimSpace(selectedIDE)),
+			Model:           stringPtr(strings.TrimSpace(selectedModel)),
+			ReasoningEffort: stringPtr(strings.TrimSpace(selectedReasoning)),
+		},
 	}, nil
 }
 

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -421,7 +421,9 @@ func TestPreferredRuntimeIDEUsesSelectedAgentsWhenConfigUnset(t *testing.T) {
 func TestPreferredRuntimeModelFollowsConfiguredIDE(t *testing.T) {
 	t.Parallel()
 
-	defaults := workspace.DefaultsConfig{IDE: stringPtr(model.IDECursor)}
+	defaults := workspace.DefaultsConfig{
+		RuntimeOverrides: workspace.RuntimeOverrides{IDE: stringPtr(model.IDECursor)},
+	}
 	if got := preferredRuntimeModel(defaults, model.IDECursor); got != model.DefaultCursorModel {
 		t.Fatalf("unexpected cursor model default: %q", got)
 	}
@@ -463,7 +465,9 @@ func TestPersistRuntimeDefaultsPreservesOtherConfigSections(t *testing.T) {
 	provider := "coderabbit"
 	accessMode := "full"
 	if err := workspace.WriteConfig(context.Background(), configPath, workspace.ProjectConfig{
-		Defaults:     workspace.DefaultsConfig{AccessMode: &accessMode},
+		Defaults: workspace.DefaultsConfig{
+			RuntimeOverrides: workspace.RuntimeOverrides{AccessMode: &accessMode},
+		},
 		FetchReviews: workspace.FetchReviewsConfig{Provider: &provider},
 	}); err != nil {
 		t.Fatalf("write initial config: %v", err)
@@ -474,9 +478,11 @@ func TestPersistRuntimeDefaultsPreservesOtherConfigSections(t *testing.T) {
 		Enabled:    true,
 		ConfigPath: configPath,
 		Defaults: workspace.DefaultsConfig{
-			IDE:             stringPtr("codex"),
-			Model:           stringPtr("gpt-5.4"),
-			ReasoningEffort: stringPtr("medium"),
+			RuntimeOverrides: workspace.RuntimeOverrides{
+				IDE:             stringPtr("codex"),
+				Model:           stringPtr("gpt-5.4"),
+				ReasoningEffort: stringPtr("medium"),
+			},
 		},
 	}
 
@@ -572,9 +578,11 @@ func TestPersistRuntimeDefaultsUsesProvidedContextForLoadAndWrite(t *testing.T) 
 		Enabled:    true,
 		ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
 		Defaults: workspace.DefaultsConfig{
-			IDE:             stringPtr("codex"),
-			Model:           stringPtr("gpt-5.4"),
-			ReasoningEffort: stringPtr("medium"),
+			RuntimeOverrides: workspace.RuntimeOverrides{
+				IDE:             stringPtr("codex"),
+				Model:           stringPtr("gpt-5.4"),
+				ReasoningEffort: stringPtr("medium"),
+			},
 		},
 	})
 	if err != nil {
@@ -598,9 +606,11 @@ func TestPersistRuntimeDefaultsWrapsWriteErrors(t *testing.T) {
 		Enabled:    true,
 		ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
 		Defaults: workspace.DefaultsConfig{
-			IDE:             stringPtr("codex"),
-			Model:           stringPtr("gpt-5.4"),
-			ReasoningEffort: stringPtr("medium"),
+			RuntimeOverrides: workspace.RuntimeOverrides{
+				IDE:             stringPtr("codex"),
+				Model:           stringPtr("gpt-5.4"),
+				ReasoningEffort: stringPtr("medium"),
+			},
 		},
 	})
 	if err == nil {
@@ -706,7 +716,9 @@ func TestRuntimeDefaultsExistingTracksManagedFields(t *testing.T) {
 			name:   "missing file",
 			exists: false,
 			config: workspace.ProjectConfig{
-				Defaults: workspace.DefaultsConfig{Model: &modelName},
+				Defaults: workspace.DefaultsConfig{
+					RuntimeOverrides: workspace.RuntimeOverrides{Model: &modelName},
+				},
 			},
 			want: false,
 		},
@@ -714,7 +726,9 @@ func TestRuntimeDefaultsExistingTracksManagedFields(t *testing.T) {
 			name:   "blank managed field",
 			exists: true,
 			config: workspace.ProjectConfig{
-				Defaults: workspace.DefaultsConfig{IDE: &blank},
+				Defaults: workspace.DefaultsConfig{
+					RuntimeOverrides: workspace.RuntimeOverrides{IDE: &blank},
+				},
 			},
 			want: false,
 		},
@@ -722,7 +736,9 @@ func TestRuntimeDefaultsExistingTracksManagedFields(t *testing.T) {
 			name:   "unmanaged defaults field ignored",
 			exists: true,
 			config: workspace.ProjectConfig{
-				Defaults: workspace.DefaultsConfig{AccessMode: &accessMode},
+				Defaults: workspace.DefaultsConfig{
+					RuntimeOverrides: workspace.RuntimeOverrides{AccessMode: &accessMode},
+				},
 			},
 			want: false,
 		},
@@ -730,7 +746,9 @@ func TestRuntimeDefaultsExistingTracksManagedFields(t *testing.T) {
 			name:   "managed defaults field present",
 			exists: true,
 			config: workspace.ProjectConfig{
-				Defaults: workspace.DefaultsConfig{Model: &modelName},
+				Defaults: workspace.DefaultsConfig{
+					RuntimeOverrides: workspace.RuntimeOverrides{Model: &modelName},
+				},
 			},
 			want: true,
 		},
@@ -750,9 +768,11 @@ func TestRuntimeDefaultsExistingTracksManagedFields(t *testing.T) {
 			}
 			state.editRuntimeDefaults = func(string, string, string, string) (workspace.DefaultsConfig, error) {
 				return workspace.DefaultsConfig{
-					IDE:             stringPtr("codex"),
-					Model:           stringPtr("gpt-5.4"),
-					ReasoningEffort: stringPtr("medium"),
+					RuntimeOverrides: workspace.RuntimeOverrides{
+						IDE:             stringPtr("codex"),
+						Model:           stringPtr("gpt-5.4"),
+						ReasoningEffort: stringPtr("medium"),
+					},
 				}, nil
 			}
 
@@ -807,9 +827,11 @@ func TestExecuteInstallDoesNotPersistDefaultsWhenInstallFails(t *testing.T) {
 			Enabled:    true,
 			ConfigPath: filepath.Join(t.TempDir(), ".compozy", "config.toml"),
 			Defaults: workspace.DefaultsConfig{
-				IDE:             stringPtr("codex"),
-				Model:           stringPtr("gpt-5.4"),
-				ReasoningEffort: stringPtr("medium"),
+				RuntimeOverrides: workspace.RuntimeOverrides{
+					IDE:             stringPtr("codex"),
+					Model:           stringPtr("gpt-5.4"),
+					ReasoningEffort: stringPtr("medium"),
+				},
 			},
 		},
 	})

--- a/internal/cli/workspace_config.go
+++ b/internal/cli/workspace_config.go
@@ -178,9 +178,9 @@ func (s *commandState) applyTasksRunConfig(cmd *cobra.Command, cfg workspace.Pro
 	applyConfig(cmd, "format", cfg.Tasks.Run.OutputFormat, func(val string) { s.outputFormat = val })
 	applyConfig(cmd, "tui", cfg.Tasks.Run.TUI, func(val bool) { s.tui = val })
 	s.applyParallelTasksConfig(cmd, cfg.Tasks.Run.Parallel)
-	s.configuredTaskRuntimeRules = model.CloneTaskRuntimeRules(
-		derefTaskRuntimeRulesConfig(cfg.Tasks.Run.TaskRuntimeRules),
-	)
+	rules := cfg.Defaults.ComplexityRuntimeRules()
+	rules = append(rules, derefTaskRuntimeRulesConfig(cfg.Tasks.Run.TaskRuntimeRules)...)
+	s.configuredTaskRuntimeRules = model.CloneTaskRuntimeRules(rules)
 	applyConfig(
 		cmd,
 		"include-completed",

--- a/internal/core/model/model_test.go
+++ b/internal/core/model/model_test.go
@@ -540,6 +540,12 @@ func TestRuntimeConfigRuntimeForTask(t *testing.T) {
 			ReasoningEffort: "medium",
 			TaskRuntimeRules: []model.TaskRuntimeRule{
 				{
+					Complexity:      testStringPointer("low"),
+					IDE:             testStringPointer(model.IDEGemini),
+					Model:           testStringPointer("flash"),
+					ReasoningEffort: testStringPointer("low"),
+				},
+				{
 					Type:            testStringPointer("frontend"),
 					IDE:             testStringPointer(model.IDEClaude),
 					Model:           testStringPointer("sonnet"),
@@ -554,21 +560,53 @@ func TestRuntimeConfigRuntimeForTask(t *testing.T) {
 			},
 		}
 
-		frontendOnly := cfg.RuntimeForTask(model.TaskRuntimeTarget{ID: "task_01", Type: "frontend"})
+		frontendOnly := cfg.RuntimeForTask(model.TaskRuntimeTarget{
+			ID: "task_01", Type: "frontend", Complexity: "low",
+		})
 		if frontendOnly.IDE != model.IDEClaude || frontendOnly.Model != "sonnet" ||
 			frontendOnly.ReasoningEffort != "high" {
 			t.Fatalf("unexpected type-resolved runtime: %#v", frontendOnly)
 		}
 
-		idOverride := cfg.RuntimeForTask(model.TaskRuntimeTarget{ID: "task_02", Type: "frontend"})
+		idOverride := cfg.RuntimeForTask(model.TaskRuntimeTarget{
+			ID: "task_02", Type: "frontend", Complexity: "low",
+		})
 		if idOverride.IDE != model.IDECursor || idOverride.Model != "cursor-model" ||
 			idOverride.ReasoningEffort != "xhigh" {
 			t.Fatalf("unexpected id-resolved runtime: %#v", idOverride)
 		}
 
-		baseOnly := cfg.RuntimeForTask(model.TaskRuntimeTarget{ID: "task_03", Type: "backend"})
+		baseOnly := cfg.RuntimeForTask(model.TaskRuntimeTarget{
+			ID: "task_03", Type: "backend", Complexity: "medium",
+		})
 		if baseOnly.IDE != model.IDECodex || baseOnly.Model != "gpt-5.5" || baseOnly.ReasoningEffort != "medium" {
 			t.Fatalf("unexpected base runtime: %#v", baseOnly)
+		}
+	})
+
+	t.Run("Should apply complexity defaults without overriding explicit runtime fields", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := &model.RuntimeConfig{
+			IDE:             model.IDECodex,
+			Model:           "explicit-model",
+			ReasoningEffort: "medium",
+			ExplicitRuntime: model.ExplicitRuntimeFlags{Model: true},
+			TaskRuntimeRules: []model.TaskRuntimeRule{{
+				Complexity:      testStringPointer("low"),
+				IDE:             testStringPointer(model.IDEClaude),
+				Model:           testStringPointer("haiku"),
+				ReasoningEffort: testStringPointer("low"),
+			}},
+		}
+
+		resolved := cfg.RuntimeForTask(model.TaskRuntimeTarget{Complexity: "low"})
+		if resolved.IDE != model.IDEClaude || resolved.Model != "explicit-model" ||
+			resolved.ReasoningEffort != "low" {
+			t.Fatalf("unexpected complexity-resolved runtime: %#v", resolved)
+		}
+		if cfg.IDE != model.IDECodex || cfg.Model != "explicit-model" || cfg.ReasoningEffort != "medium" {
+			t.Fatalf("complexity resolution mutated base runtime: %#v", cfg)
 		}
 	})
 

--- a/internal/core/model/task_runtime.go
+++ b/internal/core/model/task_runtime.go
@@ -9,6 +9,7 @@ type TaskRuntimeRule struct {
 	Workflow        *string `toml:"workflow"         json:"workflow,omitempty"`
 	ID              *string `toml:"id"               json:"id,omitempty"`
 	Type            *string `toml:"type"             json:"type,omitempty"`
+	Complexity      *string `toml:"complexity"       json:"complexity,omitempty"`
 	IDE             *string `toml:"ide"              json:"ide,omitempty"`
 	Model           *string `toml:"model"            json:"model,omitempty"`
 	ReasoningEffort *string `toml:"reasoning_effort" json:"reasoning_effort,omitempty"`
@@ -16,9 +17,10 @@ type TaskRuntimeRule struct {
 
 // TaskRuntimeTarget identifies the task being resolved against runtime rules.
 type TaskRuntimeTarget struct {
-	Workflow string
-	ID       string
-	Type     string
+	Workflow   string
+	ID         string
+	Type       string
+	Complexity string
 }
 
 // TaskRuntime describes the effective runtime fields that may vary per task.
@@ -30,10 +32,11 @@ type TaskRuntime struct {
 
 // TaskRuntimeTask identifies the PRD task whose runtime is being resolved.
 type TaskRuntimeTask struct {
-	ID       string `json:"id,omitempty"`
-	SafeName string `json:"safe_name,omitempty"`
-	Title    string `json:"title,omitempty"`
-	Type     string `json:"type,omitempty"`
+	ID         string `json:"id,omitempty"`
+	SafeName   string `json:"safe_name,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Complexity string `json:"complexity,omitempty"`
 }
 
 // CloneTaskRuntimeRules returns a deep copy of runtime rules so callers can
@@ -55,6 +58,7 @@ func (r TaskRuntimeRule) clone() TaskRuntimeRule {
 		Workflow:        cloneTrimmedOptionalString(r.Workflow),
 		ID:              cloneTrimmedOptionalString(r.ID),
 		Type:            cloneTrimmedOptionalString(r.Type),
+		Complexity:      cloneTrimmedOptionalString(r.Complexity),
 		IDE:             cloneTrimmedOptionalString(r.IDE),
 		Model:           cloneTrimmedOptionalString(r.Model),
 		ReasoningEffort: cloneTrimmedOptionalString(r.ReasoningEffort),
@@ -62,7 +66,7 @@ func (r TaskRuntimeRule) clone() TaskRuntimeRule {
 }
 
 func (r TaskRuntimeRule) HasSelector() bool {
-	return r.ID != nil || r.Type != nil
+	return r.ID != nil || r.Type != nil || r.Complexity != nil
 }
 
 func (r TaskRuntimeRule) HasOverride() bool {
@@ -77,6 +81,10 @@ func (r TaskRuntimeRule) IsTypeRule() bool {
 	return r.Type != nil
 }
 
+func (r TaskRuntimeRule) IsComplexityRule() bool {
+	return r.Complexity != nil
+}
+
 func (r TaskRuntimeRule) Matches(target TaskRuntimeTarget) bool {
 	if r.Workflow != nil {
 		workflow := strings.TrimSpace(*r.Workflow)
@@ -89,6 +97,9 @@ func (r TaskRuntimeRule) Matches(target TaskRuntimeTarget) bool {
 		return strings.TrimSpace(target.ID) != "" && strings.TrimSpace(*r.ID) == strings.TrimSpace(target.ID)
 	case r.Type != nil:
 		return strings.TrimSpace(target.Type) != "" && strings.TrimSpace(*r.Type) == strings.TrimSpace(target.Type)
+	case r.Complexity != nil:
+		return strings.TrimSpace(target.Complexity) != "" &&
+			strings.TrimSpace(*r.Complexity) == strings.TrimSpace(target.Complexity)
 	default:
 		return false
 	}
@@ -118,14 +129,21 @@ func (cfg *RuntimeConfig) Clone() *RuntimeConfig {
 	return &cloned
 }
 
-// RuntimeForTask resolves the effective runtime for one task. Type selectors
-// apply before id selectors, and later rules win within the same specificity.
+// RuntimeForTask resolves the effective runtime for one task. Complexity
+// defaults apply before type and id selectors, and later rules win within the
+// same specificity.
 func (cfg *RuntimeConfig) RuntimeForTask(target TaskRuntimeTarget) *RuntimeConfig {
 	cloned := cfg.Clone()
 	if cloned == nil {
 		return nil
 	}
 
+	for _, rule := range cloned.TaskRuntimeRules {
+		if !rule.IsComplexityRule() || !rule.Matches(target) {
+			continue
+		}
+		applyTaskComplexityRuntimeRule(cloned, rule)
+	}
 	for _, rule := range cloned.TaskRuntimeRules {
 		if !rule.IsTypeRule() || !rule.Matches(target) {
 			continue
@@ -140,6 +158,21 @@ func (cfg *RuntimeConfig) RuntimeForTask(target TaskRuntimeTarget) *RuntimeConfi
 	}
 	cloned.TaskRuntimeRules = nil
 	return cloned
+}
+
+func applyTaskComplexityRuntimeRule(cfg *RuntimeConfig, rule TaskRuntimeRule) {
+	if cfg == nil {
+		return
+	}
+	if rule.IDE != nil && !cfg.ExplicitRuntime.IDE {
+		cfg.IDE = strings.TrimSpace(*rule.IDE)
+	}
+	if rule.Model != nil && !cfg.ExplicitRuntime.Model {
+		cfg.Model = strings.TrimSpace(*rule.Model)
+	}
+	if rule.ReasoningEffort != nil && !cfg.ExplicitRuntime.ReasoningEffort {
+		cfg.ReasoningEffort = strings.TrimSpace(*rule.ReasoningEffort)
+	}
 }
 
 func applyTaskRuntimeRule(cfg *RuntimeConfig, rule TaskRuntimeRule) {

--- a/internal/core/plan/prepare.go
+++ b/internal/core/plan/prepare.go
@@ -587,10 +587,11 @@ func resolveBatchJobRuntime(
 			manager,
 			runID,
 			model.TaskRuntimeTask{
-				ID:       target.ID,
-				SafeName: safeName,
-				Title:    taskData.Title,
-				Type:     target.Type,
+				ID:         target.ID,
+				SafeName:   safeName,
+				Title:      taskData.Title,
+				Type:       target.Type,
+				Complexity: target.Complexity,
 			},
 			jobRuntime,
 		)
@@ -641,12 +642,14 @@ func resolveTaskRuntimeTarget(
 		workflow = taskRuntimeWorkflowName(cfg)
 	}
 	target := model.TaskRuntimeTarget{
-		Workflow: workflow,
-		ID:       safeName,
-		Type:     taskData.TaskType,
+		Workflow:   workflow,
+		ID:         safeName,
+		Type:       taskData.TaskType,
+		Complexity: taskData.Complexity,
 	}
 	if cfg != nil && cfg.Mode != model.ExecutionModePRDTasks {
 		target.Type = ""
+		target.Complexity = ""
 		return target
 	}
 	if len(batchIssues) > 0 {

--- a/internal/core/plan/prepare_test.go
+++ b/internal/core/plan/prepare_test.go
@@ -513,6 +513,11 @@ func TestPrepareJobsResolvesPerTaskRuntimeOverrides(t *testing.T) {
 		Mode:            model.ExecutionModePRDTasks,
 		TaskRuntimeRules: []model.TaskRuntimeRule{
 			{
+				Complexity:      testStringPointer("low"),
+				Model:           testStringPointer("complexity-model"),
+				ReasoningEffort: testStringPointer("low"),
+			},
+			{
 				Type:            testStringPointer("frontend"),
 				IDE:             testStringPointer(model.IDEClaude),
 				Model:           testStringPointer("sonnet"),
@@ -543,7 +548,7 @@ func TestPrepareJobsResolvesPerTaskRuntimeOverrides(t *testing.T) {
 	if jobs[0].IDE != model.IDEClaude || jobs[0].Model != "sonnet" || jobs[0].ReasoningEffort != "high" {
 		t.Fatalf("unexpected frontend runtime: %#v", jobs[0])
 	}
-	if jobs[1].IDE != model.IDEClaude || jobs[1].Model != "codex-fast" || jobs[1].ReasoningEffort != "medium" {
+	if jobs[1].IDE != model.IDEClaude || jobs[1].Model != "codex-fast" || jobs[1].ReasoningEffort != "low" {
 		t.Fatalf("unexpected backend runtime: %#v", jobs[1])
 	}
 }
@@ -1478,6 +1483,9 @@ complexity: low
 				}
 				if !strings.HasPrefix(payload.Task.SafeName, "task_01") {
 					t.Fatalf("unexpected task safe name: %q", payload.Task.SafeName)
+				}
+				if payload.Task.Complexity != "low" {
+					t.Fatalf("unexpected task complexity: %q", payload.Task.Complexity)
 				}
 				payload.Runtime = model.TaskRuntime{
 					IDE:             model.IDECodex,

--- a/internal/core/run/executor/execution.go
+++ b/internal/core/run/executor/execution.go
@@ -431,6 +431,7 @@ func equalTaskRuntimeRules(left []model.TaskRuntimeRule, right []model.TaskRunti
 	for idx := range left {
 		if !equalOptionalString(left[idx].ID, right[idx].ID) ||
 			!equalOptionalString(left[idx].Type, right[idx].Type) ||
+			!equalOptionalString(left[idx].Complexity, right[idx].Complexity) ||
 			!equalOptionalString(left[idx].IDE, right[idx].IDE) ||
 			!equalOptionalString(left[idx].Model, right[idx].Model) ||
 			!equalOptionalString(left[idx].ReasoningEffort, right[idx].ReasoningEffort) {

--- a/internal/core/run/executor/execution_test.go
+++ b/internal/core/run/executor/execution_test.go
@@ -1007,6 +1007,49 @@ func TestAfterTaskJobSuccessWritesProducedWorktreeScope(t *testing.T) {
 	}
 }
 
+func TestCaptureWorkspaceSnapshotExcludesPRDTaskArtifacts(t *testing.T) {
+	t.Parallel()
+
+	workspace := initTaskWorkspaceRepo(t)
+	tasksDir := filepath.Join(workspace, ".compozy", "tasks", "demo")
+	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+		t.Fatalf("mkdir tasks dir: %v", err)
+	}
+	taskPath := filepath.Join(tasksDir, "task_01.md")
+	if err := os.WriteFile(taskPath, []byte("status: pending\n"), 0o600); err != nil {
+		t.Fatalf("write mirrored task artifact: %v", err)
+	}
+	runner := newJobRunner(0, &job{}, &jobExecutionContext{
+		cfg: &config{
+			Mode:          model.ExecutionModePRDTasks,
+			TasksDir:      tasksDir,
+			WorkspaceRoot: workspace,
+		},
+	})
+
+	baseline := runner.captureWorkspaceSnapshot(context.Background())
+	if !baseline.IsSupported() {
+		t.Fatalf("baseline supported = false: %#v", baseline.Document())
+	}
+	if err := os.WriteFile(taskPath, []byte("status: completed\n"), 0o600); err != nil {
+		t.Fatalf("update mirrored task artifact: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "produced.go"), []byte("package produced\n"), 0o600); err != nil {
+		t.Fatalf("write agent output: %v", err)
+	}
+
+	scope, err := worktree.BuildScope(context.Background(), workspace, baseline)
+	if err != nil {
+		t.Fatalf("BuildScope: %v", err)
+	}
+	if got, want := strings.Join(scope.ProducedPaths, ","), "produced.go"; got != want {
+		t.Fatalf("produced paths = %q, want %q", got, want)
+	}
+	if len(scope.PreExistingChangedPaths) != 0 {
+		t.Fatalf("pre-existing changed paths = %#v, want none", scope.PreExistingChangedPaths)
+	}
+}
+
 func initTaskWorkspaceRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/core/run/executor/execution_test.go
+++ b/internal/core/run/executor/execution_test.go
@@ -1008,46 +1008,52 @@ func TestAfterTaskJobSuccessWritesProducedWorktreeScope(t *testing.T) {
 }
 
 func TestCaptureWorkspaceSnapshotExcludesPRDTaskArtifacts(t *testing.T) {
-	t.Parallel()
+	t.Run("Should exclude PRD task artifacts from the workspace snapshot", func(t *testing.T) {
+		t.Parallel()
 
-	workspace := initTaskWorkspaceRepo(t)
-	tasksDir := filepath.Join(workspace, ".compozy", "tasks", "demo")
-	if err := os.MkdirAll(tasksDir, 0o755); err != nil {
-		t.Fatalf("mkdir tasks dir: %v", err)
-	}
-	taskPath := filepath.Join(tasksDir, "task_01.md")
-	if err := os.WriteFile(taskPath, []byte("status: pending\n"), 0o600); err != nil {
-		t.Fatalf("write mirrored task artifact: %v", err)
-	}
-	runner := newJobRunner(0, &job{}, &jobExecutionContext{
-		cfg: &config{
-			Mode:          model.ExecutionModePRDTasks,
-			TasksDir:      tasksDir,
-			WorkspaceRoot: workspace,
-		},
+		workspace := initTaskWorkspaceRepo(t)
+		tasksDir := filepath.Join(workspace, ".compozy", "tasks", "demo")
+		if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+			t.Fatalf("mkdir tasks dir: %v", err)
+		}
+		taskPath := filepath.Join(tasksDir, "task_01.md")
+		if err := os.WriteFile(taskPath, []byte("status: pending\n"), 0o600); err != nil {
+			t.Fatalf("write mirrored task artifact: %v", err)
+		}
+		runner := newJobRunner(0, &job{}, &jobExecutionContext{
+			cfg: &config{
+				Mode:          model.ExecutionModePRDTasks,
+				TasksDir:      tasksDir,
+				WorkspaceRoot: workspace,
+			},
+		})
+
+		baseline := runner.captureWorkspaceSnapshot(context.Background())
+		if !baseline.IsSupported() {
+			t.Fatalf("baseline supported = false: %#v", baseline.Document())
+		}
+		if err := os.WriteFile(taskPath, []byte("status: completed\n"), 0o600); err != nil {
+			t.Fatalf("update mirrored task artifact: %v", err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(workspace, "produced.go"),
+			[]byte("package produced\n"),
+			0o600,
+		); err != nil {
+			t.Fatalf("write agent output: %v", err)
+		}
+
+		scope, err := worktree.BuildScope(context.Background(), workspace, baseline)
+		if err != nil {
+			t.Fatalf("BuildScope: %v", err)
+		}
+		if got, want := strings.Join(scope.ProducedPaths, ","), "produced.go"; got != want {
+			t.Fatalf("produced paths = %q, want %q", got, want)
+		}
+		if len(scope.PreExistingChangedPaths) != 0 {
+			t.Fatalf("pre-existing changed paths = %#v, want none", scope.PreExistingChangedPaths)
+		}
 	})
-
-	baseline := runner.captureWorkspaceSnapshot(context.Background())
-	if !baseline.IsSupported() {
-		t.Fatalf("baseline supported = false: %#v", baseline.Document())
-	}
-	if err := os.WriteFile(taskPath, []byte("status: completed\n"), 0o600); err != nil {
-		t.Fatalf("update mirrored task artifact: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workspace, "produced.go"), []byte("package produced\n"), 0o600); err != nil {
-		t.Fatalf("write agent output: %v", err)
-	}
-
-	scope, err := worktree.BuildScope(context.Background(), workspace, baseline)
-	if err != nil {
-		t.Fatalf("BuildScope: %v", err)
-	}
-	if got, want := strings.Join(scope.ProducedPaths, ","), "produced.go"; got != want {
-		t.Fatalf("produced paths = %q, want %q", got, want)
-	}
-	if len(scope.PreExistingChangedPaths) != 0 {
-		t.Fatalf("pre-existing changed paths = %#v, want none", scope.PreExistingChangedPaths)
-	}
 }
 
 func initTaskWorkspaceRepo(t *testing.T) string {

--- a/internal/core/run/executor/runner.go
+++ b/internal/core/run/executor/runner.go
@@ -170,7 +170,19 @@ func (r *jobRunner) captureWorkspaceSnapshot(ctx context.Context) worktree.Snaps
 	if r.execCtx.cfg.Mode != model.ExecutionModePRDTasks && !r.canAttemptCleanReset() {
 		return worktree.Snapshot{}
 	}
-	snap, err := worktree.Capture(ctx, r.execCtx.cfg.WorkspaceRoot)
+	var (
+		snap worktree.Snapshot
+		err  error
+	)
+	if r.execCtx.cfg.Mode == model.ExecutionModePRDTasks {
+		snap, err = worktree.CaptureExcluding(
+			ctx,
+			r.execCtx.cfg.WorkspaceRoot,
+			r.execCtx.cfg.TasksDir,
+		)
+	} else {
+		snap, err = worktree.Capture(ctx, r.execCtx.cfg.WorkspaceRoot)
+	}
 	if err != nil {
 		r.execCtx.runtimeLogger().Warn(
 			"failed to capture pre-run workspace snapshot; falling back to legacy completion behavior",

--- a/internal/core/run/executor/runtime_guard_test.go
+++ b/internal/core/run/executor/runtime_guard_test.go
@@ -49,6 +49,54 @@ func TestPrepareExecutionConfigRunPreStartRejectsPreparedStateMutation(t *testin
 	}
 }
 
+func TestPrepareExecutionConfigRunPreStartRejectsComplexityRuleMutation(t *testing.T) {
+	t.Parallel()
+
+	low := "low"
+	high := "high"
+	manager := &executionHookManager{
+		mutators: map[string]func(any) (any, error){
+			"run.pre_start": func(input any) (any, error) {
+				payload := input.(runPreStartPayload)
+				payload.Config.TaskRuntimeRules[0].Complexity = &high
+				return payload, nil
+			},
+		},
+	}
+
+	cfg := &model.RuntimeConfig{
+		WorkspaceRoot:          "/tmp/workspace",
+		Name:                   "demo",
+		TasksDir:               "/tmp/workspace/.compozy/tasks/demo",
+		Mode:                   model.ExecutionModePRDTasks,
+		IDE:                    model.IDECodex,
+		Model:                  "gpt-5.5",
+		ReasoningEffort:        "medium",
+		AccessMode:             model.AccessModeFull,
+		Timeout:                time.Minute,
+		RetryBackoffMultiplier: 1.5,
+		TaskRuntimeRules: []model.TaskRuntimeRule{{
+			Complexity: &low,
+		}},
+	}
+
+	_, err := prepareExecutionConfig(
+		context.Background(),
+		cfg,
+		model.RunArtifacts{RunID: "run-1"},
+		manager,
+	)
+	if err == nil {
+		t.Fatal("prepareExecutionConfig error = nil, want task-runtime mutation failure")
+	}
+	if !strings.Contains(
+		err.Error(),
+		"run.pre_start cannot mutate task_runtime_rules after workflow state preparation",
+	) {
+		t.Fatalf("prepareExecutionConfig error = %q, want task-runtime mutation guard", err.Error())
+	}
+}
+
 func TestPrepareExecutionConfigRunPreStartAllowsLateMutableFields(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/run/executor/runtime_guard_test.go
+++ b/internal/core/run/executor/runtime_guard_test.go
@@ -50,51 +50,53 @@ func TestPrepareExecutionConfigRunPreStartRejectsPreparedStateMutation(t *testin
 }
 
 func TestPrepareExecutionConfigRunPreStartRejectsComplexityRuleMutation(t *testing.T) {
-	t.Parallel()
+	t.Run("Should reject complexity rule mutation after workflow state preparation", func(t *testing.T) {
+		t.Parallel()
 
-	low := "low"
-	high := "high"
-	manager := &executionHookManager{
-		mutators: map[string]func(any) (any, error){
-			"run.pre_start": func(input any) (any, error) {
-				payload := input.(runPreStartPayload)
-				payload.Config.TaskRuntimeRules[0].Complexity = &high
-				return payload, nil
+		low := "low"
+		high := "high"
+		manager := &executionHookManager{
+			mutators: map[string]func(any) (any, error){
+				"run.pre_start": func(input any) (any, error) {
+					payload := input.(runPreStartPayload)
+					payload.Config.TaskRuntimeRules[0].Complexity = &high
+					return payload, nil
+				},
 			},
-		},
-	}
+		}
 
-	cfg := &model.RuntimeConfig{
-		WorkspaceRoot:          "/tmp/workspace",
-		Name:                   "demo",
-		TasksDir:               "/tmp/workspace/.compozy/tasks/demo",
-		Mode:                   model.ExecutionModePRDTasks,
-		IDE:                    model.IDECodex,
-		Model:                  "gpt-5.5",
-		ReasoningEffort:        "medium",
-		AccessMode:             model.AccessModeFull,
-		Timeout:                time.Minute,
-		RetryBackoffMultiplier: 1.5,
-		TaskRuntimeRules: []model.TaskRuntimeRule{{
-			Complexity: &low,
-		}},
-	}
+		cfg := &model.RuntimeConfig{
+			WorkspaceRoot:          "/tmp/workspace",
+			Name:                   "demo",
+			TasksDir:               "/tmp/workspace/.compozy/tasks/demo",
+			Mode:                   model.ExecutionModePRDTasks,
+			IDE:                    model.IDECodex,
+			Model:                  "gpt-5.5",
+			ReasoningEffort:        "medium",
+			AccessMode:             model.AccessModeFull,
+			Timeout:                time.Minute,
+			RetryBackoffMultiplier: 1.5,
+			TaskRuntimeRules: []model.TaskRuntimeRule{{
+				Complexity: &low,
+			}},
+		}
 
-	_, err := prepareExecutionConfig(
-		context.Background(),
-		cfg,
-		model.RunArtifacts{RunID: "run-1"},
-		manager,
-	)
-	if err == nil {
-		t.Fatal("prepareExecutionConfig error = nil, want task-runtime mutation failure")
-	}
-	if !strings.Contains(
-		err.Error(),
-		"run.pre_start cannot mutate task_runtime_rules after workflow state preparation",
-	) {
-		t.Fatalf("prepareExecutionConfig error = %q, want task-runtime mutation guard", err.Error())
-	}
+		_, err := prepareExecutionConfig(
+			context.Background(),
+			cfg,
+			model.RunArtifacts{RunID: "run-1"},
+			manager,
+		)
+		if err == nil {
+			t.Fatal("prepareExecutionConfig error = nil, want task-runtime mutation failure")
+		}
+		if !strings.Contains(
+			err.Error(),
+			"run.pre_start cannot mutate task_runtime_rules after workflow state preparation",
+		) {
+			t.Fatalf("prepareExecutionConfig error = %q, want task-runtime mutation guard", err.Error())
+		}
+	})
 }
 
 func TestPrepareExecutionConfigRunPreStartAllowsLateMutableFields(t *testing.T) {

--- a/internal/core/workspace/config.go
+++ b/internal/core/workspace/config.go
@@ -321,6 +321,14 @@ func loadConfigFile(
 	var cfg ProjectConfig
 	decoder := toml.NewDecoder(bytes.NewReader(content)).DisallowUnknownFields()
 	if err := decoder.Decode(&cfg); err != nil {
+		if fields := strictMissingFields(err); len(fields) > 0 {
+			return ProjectConfig{}, true, fmt.Errorf(
+				"decode %s: unknown fields %s: %w",
+				scope,
+				strings.Join(fields, ", "),
+				err,
+			)
+		}
 		return ProjectConfig{}, true, fmt.Errorf("decode %s: %w", scope, err)
 	}
 
@@ -332,6 +340,21 @@ func loadConfigFile(
 		return ProjectConfig{}, true, err
 	}
 	return cfg, true, nil
+}
+
+func strictMissingFields(err error) []string {
+	var strictErr *toml.StrictMissingError
+	if !errors.As(err, &strictErr) {
+		return nil
+	}
+
+	fields := make([]string, 0, len(strictErr.Errors))
+	for i := range strictErr.Errors {
+		if field := strings.Join(strictErr.Errors[i].Key(), "."); field != "" {
+			fields = append(fields, field)
+		}
+	}
+	return fields
 }
 
 func rejectLegacyConfigSections(content []byte, scope string) error {

--- a/internal/core/workspace/config_merge.go
+++ b/internal/core/workspace/config_merge.go
@@ -29,7 +29,30 @@ func buildEffectiveProjectConfig(global, workspace ProjectConfig) ProjectConfig 
 }
 
 func mergeDefaultsConfig(base, overlay DefaultsConfig) DefaultsConfig {
-	return DefaultsConfig(mergeRuntimeOverrides(RuntimeOverrides(base), RuntimeOverrides(overlay)))
+	return DefaultsConfig{
+		RuntimeOverrides: mergeRuntimeOverrides(base.RuntimeOverrides, overlay.RuntimeOverrides),
+		ByComplexity:     mergeTaskRuntimeByComplexity(base.ByComplexity, overlay.ByComplexity),
+	}
+}
+
+func mergeTaskRuntimeByComplexity(
+	base TaskRuntimeByComplexityConfig,
+	overlay TaskRuntimeByComplexityConfig,
+) TaskRuntimeByComplexityConfig {
+	return TaskRuntimeByComplexityConfig{
+		Low:      mergeTaskRuntimeOverrides(base.Low, overlay.Low),
+		Medium:   mergeTaskRuntimeOverrides(base.Medium, overlay.Medium),
+		High:     mergeTaskRuntimeOverrides(base.High, overlay.High),
+		Critical: mergeTaskRuntimeOverrides(base.Critical, overlay.Critical),
+	}
+}
+
+func mergeTaskRuntimeOverrides(base, overlay TaskRuntimeOverrides) TaskRuntimeOverrides {
+	return TaskRuntimeOverrides{
+		IDE:             cloneOptionalValue(preferOverlay(base.IDE, overlay.IDE)),
+		Model:           cloneOptionalValue(preferOverlay(base.Model, overlay.Model)),
+		ReasoningEffort: cloneOptionalValue(preferOverlay(base.ReasoningEffort, overlay.ReasoningEffort)),
+	}
 }
 
 func buildEffectiveTasksConfig(

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -1389,9 +1389,10 @@ reasoning_effort = "xhigh"
 }
 
 func TestLoadConfigMergesDefaultsByComplexityFieldByField(t *testing.T) {
-	homeDir := isolateWorkspaceConfigHome(t)
-	root := t.TempDir()
-	writeGlobalConfig(t, homeDir, `
+	t.Run("Should merge complexity defaults field by field", func(t *testing.T) {
+		homeDir := isolateWorkspaceConfigHome(t)
+		root := t.TempDir()
+		writeGlobalConfig(t, homeDir, `
 [defaults.by_complexity.low]
 ide = "claude"
 model = "haiku"
@@ -1401,7 +1402,7 @@ reasoning_effort = "low"
 ide = "codex"
 reasoning_effort = "high"
 `)
-	writeWorkspaceConfig(t, root, `
+		writeWorkspaceConfig(t, root, `
 [defaults.by_complexity.low]
 model = "sonnet"
 
@@ -1409,39 +1410,59 @@ model = "sonnet"
 model = "gpt-5.5"
 `)
 
-	cfg, _, err := LoadConfig(context.Background(), root)
-	if err != nil {
-		t.Fatalf("load config: %v", err)
-	}
-	assertOptionalString(t, "defaults.by_complexity.low.ide", cfg.Defaults.ByComplexity.Low.IDE, ptrString("claude"))
-	assertOptionalString(
-		t,
-		"defaults.by_complexity.low.model",
-		cfg.Defaults.ByComplexity.Low.Model,
-		ptrString("sonnet"),
-	)
-	assertOptionalString(
-		t,
-		"defaults.by_complexity.low.reasoning_effort",
-		cfg.Defaults.ByComplexity.Low.ReasoningEffort,
-		ptrString("low"),
-	)
-	assertOptionalString(t, "defaults.by_complexity.high.ide", cfg.Defaults.ByComplexity.High.IDE, ptrString("codex"))
-	assertOptionalString(
-		t,
-		"defaults.by_complexity.high.model",
-		cfg.Defaults.ByComplexity.High.Model,
-		ptrString("gpt-5.5"),
-	)
-	assertOptionalString(
-		t,
-		"defaults.by_complexity.high.reasoning_effort",
-		cfg.Defaults.ByComplexity.High.ReasoningEffort,
-		ptrString("high"),
-	)
-	if rules := cfg.Defaults.ComplexityRuntimeRules(); len(rules) != 2 {
-		t.Fatalf("complexity runtime rules = %#v, want low and high", rules)
-	}
+		cfg, _, err := LoadConfig(context.Background(), root)
+		if err != nil {
+			t.Fatalf("load config: %v", err)
+		}
+		assertOptionalString(
+			t,
+			"defaults.by_complexity.low.ide",
+			cfg.Defaults.ByComplexity.Low.IDE,
+			ptrString("claude"),
+		)
+		assertOptionalString(
+			t,
+			"defaults.by_complexity.low.model",
+			cfg.Defaults.ByComplexity.Low.Model,
+			ptrString("sonnet"),
+		)
+		assertOptionalString(
+			t,
+			"defaults.by_complexity.low.reasoning_effort",
+			cfg.Defaults.ByComplexity.Low.ReasoningEffort,
+			ptrString("low"),
+		)
+		assertOptionalString(
+			t,
+			"defaults.by_complexity.high.ide",
+			cfg.Defaults.ByComplexity.High.IDE,
+			ptrString("codex"),
+		)
+		assertOptionalString(
+			t,
+			"defaults.by_complexity.high.model",
+			cfg.Defaults.ByComplexity.High.Model,
+			ptrString("gpt-5.5"),
+		)
+		assertOptionalString(
+			t,
+			"defaults.by_complexity.high.reasoning_effort",
+			cfg.Defaults.ByComplexity.High.ReasoningEffort,
+			ptrString("high"),
+		)
+		rules := cfg.Defaults.ComplexityRuntimeRules()
+		if len(rules) != 2 {
+			t.Fatalf("complexity runtime rules = %#v, want low and high", rules)
+		}
+		assertOptionalString(t, "low complexity rule selector", rules[0].Complexity, ptrString("low"))
+		assertOptionalString(t, "low complexity rule ide", rules[0].IDE, ptrString("claude"))
+		assertOptionalString(t, "low complexity rule model", rules[0].Model, ptrString("sonnet"))
+		assertOptionalString(t, "low complexity rule reasoning", rules[0].ReasoningEffort, ptrString("low"))
+		assertOptionalString(t, "high complexity rule selector", rules[1].Complexity, ptrString("high"))
+		assertOptionalString(t, "high complexity rule ide", rules[1].IDE, ptrString("codex"))
+		assertOptionalString(t, "high complexity rule model", rules[1].Model, ptrString("gpt-5.5"))
+		assertOptionalString(t, "high complexity rule reasoning", rules[1].ReasoningEffort, ptrString("high"))
+	})
 }
 
 func TestLoadConfigRejectsInvalidDefaultsByComplexity(t *testing.T) {
@@ -1469,7 +1490,7 @@ model = "expensive"
 `)
 
 		_, _, err := loadConfigWithIsolatedHome(t, root)
-		if err == nil || !strings.Contains(err.Error(), "decode workspace config") {
+		if err == nil || !strings.Contains(err.Error(), "defaults.by_complexity.extreme") {
 			t.Fatalf("unsupported complexity error = %v", err)
 		}
 	})
@@ -1555,10 +1576,11 @@ ide = "codex"
 }
 
 func TestLoadConfigRejectsUnsupportedStartTaskRuntimeRuleComplexity(t *testing.T) {
-	isolateWorkspaceConfigHome(t)
+	t.Run("Should reject complexity selectors in task runtime rules", func(t *testing.T) {
+		isolateWorkspaceConfigHome(t)
 
-	root := t.TempDir()
-	writeWorkspaceConfig(t, root, `
+		root := t.TempDir()
+		writeWorkspaceConfig(t, root, `
 [tasks.run]
 [[tasks.run.task_runtime_rules]]
 type = "frontend"
@@ -1566,13 +1588,14 @@ complexity = "high"
 ide = "codex"
 `)
 
-	_, _, err := LoadConfig(context.Background(), root)
-	if err == nil {
-		t.Fatal("expected unsupported tasks.run.task_runtime_rules complexity error")
-	}
-	if !strings.Contains(err.Error(), "tasks.run.task_runtime_rules[0].complexity is not supported") {
-		t.Fatalf("unexpected error: %v", err)
-	}
+		_, _, err := LoadConfig(context.Background(), root)
+		if err == nil {
+			t.Fatal("expected unsupported tasks.run.task_runtime_rules complexity error")
+		}
+		if !strings.Contains(err.Error(), "tasks.run.task_runtime_rules[0].complexity is not supported") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestLoadConfigRejectsInvalidStartTaskRuntimeRuleReasoningEffort(t *testing.T) {

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -200,9 +200,11 @@ func TestWriteConfigRoundTripsDefaultsWithoutEmptySections(t *testing.T) {
 	accessMode := "default"
 	cfg := ProjectConfig{
 		Defaults: DefaultsConfig{
-			IDE:        &ide,
-			Model:      &modelName,
-			AccessMode: &accessMode,
+			RuntimeOverrides: RuntimeOverrides{
+				IDE:        &ide,
+				Model:      &modelName,
+				AccessMode: &accessMode,
+			},
 		},
 	}
 
@@ -1386,6 +1388,93 @@ reasoning_effort = "xhigh"
 	}
 }
 
+func TestLoadConfigMergesDefaultsByComplexityFieldByField(t *testing.T) {
+	homeDir := isolateWorkspaceConfigHome(t)
+	root := t.TempDir()
+	writeGlobalConfig(t, homeDir, `
+[defaults.by_complexity.low]
+ide = "claude"
+model = "haiku"
+reasoning_effort = "low"
+
+[defaults.by_complexity.high]
+ide = "codex"
+reasoning_effort = "high"
+`)
+	writeWorkspaceConfig(t, root, `
+[defaults.by_complexity.low]
+model = "sonnet"
+
+[defaults.by_complexity.high]
+model = "gpt-5.5"
+`)
+
+	cfg, _, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	assertOptionalString(t, "defaults.by_complexity.low.ide", cfg.Defaults.ByComplexity.Low.IDE, ptrString("claude"))
+	assertOptionalString(
+		t,
+		"defaults.by_complexity.low.model",
+		cfg.Defaults.ByComplexity.Low.Model,
+		ptrString("sonnet"),
+	)
+	assertOptionalString(
+		t,
+		"defaults.by_complexity.low.reasoning_effort",
+		cfg.Defaults.ByComplexity.Low.ReasoningEffort,
+		ptrString("low"),
+	)
+	assertOptionalString(t, "defaults.by_complexity.high.ide", cfg.Defaults.ByComplexity.High.IDE, ptrString("codex"))
+	assertOptionalString(
+		t,
+		"defaults.by_complexity.high.model",
+		cfg.Defaults.ByComplexity.High.Model,
+		ptrString("gpt-5.5"),
+	)
+	assertOptionalString(
+		t,
+		"defaults.by_complexity.high.reasoning_effort",
+		cfg.Defaults.ByComplexity.High.ReasoningEffort,
+		ptrString("high"),
+	)
+	if rules := cfg.Defaults.ComplexityRuntimeRules(); len(rules) != 2 {
+		t.Fatalf("complexity runtime rules = %#v, want low and high", rules)
+	}
+}
+
+func TestLoadConfigRejectsInvalidDefaultsByComplexity(t *testing.T) {
+	t.Run("Should reject an unsupported reasoning effort", func(t *testing.T) {
+		root := t.TempDir()
+		writeWorkspaceConfig(t, root, `
+[defaults.by_complexity.critical]
+reasoning_effort = "impossible"
+`)
+
+		_, _, err := loadConfigWithIsolatedHome(t, root)
+		if err == nil || !strings.Contains(
+			err.Error(),
+			"defaults.by_complexity.critical.reasoning_effort must be one of",
+		) {
+			t.Fatalf("invalid reasoning effort error = %v", err)
+		}
+	})
+
+	t.Run("Should reject an unsupported complexity key", func(t *testing.T) {
+		root := t.TempDir()
+		writeWorkspaceConfig(t, root, `
+[defaults.by_complexity.extreme]
+model = "expensive"
+`)
+
+		_, _, err := loadConfigWithIsolatedHome(t, root)
+		if err == nil || !strings.Contains(err.Error(), "decode workspace config") {
+			t.Fatalf("unsupported complexity error = %v", err)
+		}
+	})
+}
+
 func TestLoadConfigMergesStartTaskRuntimeRulesByType(t *testing.T) {
 	homeDir := isolateWorkspaceConfigHome(t)
 	root := t.TempDir()
@@ -1461,6 +1550,27 @@ ide = "codex"
 		t.Fatal("expected unsupported tasks.run.task_runtime_rules workflow error")
 	}
 	if !strings.Contains(err.Error(), "tasks.run.task_runtime_rules[0].workflow is not supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadConfigRejectsUnsupportedStartTaskRuntimeRuleComplexity(t *testing.T) {
+	isolateWorkspaceConfigHome(t)
+
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, `
+[tasks.run]
+[[tasks.run.task_runtime_rules]]
+type = "frontend"
+complexity = "high"
+ide = "codex"
+`)
+
+	_, _, err := LoadConfig(context.Background(), root)
+	if err == nil {
+		t.Fatal("expected unsupported tasks.run.task_runtime_rules complexity error")
+	}
+	if !strings.Contains(err.Error(), "tasks.run.task_runtime_rules[0].complexity is not supported") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -73,7 +73,55 @@ type StallOverrides struct {
 	Retries                *int    `toml:"retries,omitempty"                  json:"retries,omitempty"`
 }
 
-type DefaultsConfig RuntimeOverrides
+// TaskRuntimeOverrides are the runtime fields that may vary with task
+// complexity. Execution-wide fields stay in RuntimeOverrides.
+type TaskRuntimeOverrides struct {
+	IDE             *string `toml:"ide,omitempty"`
+	Model           *string `toml:"model,omitempty"`
+	ReasoningEffort *string `toml:"reasoning_effort,omitempty"`
+}
+
+// TaskRuntimeByComplexityConfig declares optional runtime defaults for the four
+// task complexities accepted by the v2 task schema.
+type TaskRuntimeByComplexityConfig struct {
+	Low      TaskRuntimeOverrides `toml:"low,omitempty"`
+	Medium   TaskRuntimeOverrides `toml:"medium,omitempty"`
+	High     TaskRuntimeOverrides `toml:"high,omitempty"`
+	Critical TaskRuntimeOverrides `toml:"critical,omitempty"`
+}
+
+type DefaultsConfig struct {
+	RuntimeOverrides
+	ByComplexity TaskRuntimeByComplexityConfig `toml:"by_complexity,omitempty"`
+}
+
+// ComplexityRuntimeRules converts defaults into the shared task-runtime rule
+// representation used by planning. The stable order is the task schema order.
+func (cfg DefaultsConfig) ComplexityRuntimeRules() []model.TaskRuntimeRule {
+	entries := []struct {
+		complexity string
+		overrides  TaskRuntimeOverrides
+	}{
+		{complexity: "low", overrides: cfg.ByComplexity.Low},
+		{complexity: "medium", overrides: cfg.ByComplexity.Medium},
+		{complexity: "high", overrides: cfg.ByComplexity.High},
+		{complexity: "critical", overrides: cfg.ByComplexity.Critical},
+	}
+	rules := make([]model.TaskRuntimeRule, 0, len(entries))
+	for _, entry := range entries {
+		complexity := entry.complexity
+		rule := model.TaskRuntimeRule{
+			Complexity:      &complexity,
+			IDE:             entry.overrides.IDE,
+			Model:           entry.overrides.Model,
+			ReasoningEffort: entry.overrides.ReasoningEffort,
+		}
+		if rule.HasOverride() {
+			rules = append(rules, rule)
+		}
+	}
+	return model.CloneTaskRuntimeRules(rules)
+}
 
 type TaskRunConfig struct {
 	IncludeCompleted         *bool                    `toml:"include_completed"`

--- a/internal/core/workspace/config_validate.go
+++ b/internal/core/workspace/config_validate.go
@@ -83,11 +83,41 @@ func validateSoundField(field string, value *string) error {
 }
 
 func validateDefaults(scope string, cfg DefaultsConfig) error {
-	overrides := RuntimeOverrides(cfg)
+	overrides := cfg.RuntimeOverrides
 	if err := validateRuntimeOverrides(scope, "defaults", overrides); err != nil {
 		return err
 	}
-	return validateRuntimeAddDirs(scope, "defaults", overrides, nil)
+	if err := validateRuntimeAddDirs(scope, "defaults", overrides, nil); err != nil {
+		return err
+	}
+	return validateTaskRuntimeByComplexity(scope, cfg.ByComplexity)
+}
+
+func validateTaskRuntimeByComplexity(scope string, cfg TaskRuntimeByComplexityConfig) error {
+	entries := []struct {
+		complexity string
+		overrides  TaskRuntimeOverrides
+	}{
+		{complexity: "low", overrides: cfg.Low},
+		{complexity: "medium", overrides: cfg.Medium},
+		{complexity: "high", overrides: cfg.High},
+		{complexity: "critical", overrides: cfg.Critical},
+	}
+	for _, entry := range entries {
+		prefix := configFieldName(scope, "defaults.by_complexity."+entry.complexity)
+		rule := model.TaskRuntimeRule{
+			IDE:             entry.overrides.IDE,
+			Model:           entry.overrides.Model,
+			ReasoningEffort: entry.overrides.ReasoningEffort,
+		}
+		if !rule.HasOverride() {
+			continue
+		}
+		if err := validateTaskRuntimeRuleRuntime(prefix, rule); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateTaskRun(scope string, defaults DefaultsConfig, cfg TaskRunConfig) error {
@@ -657,6 +687,12 @@ func validateTaskRunRuntimeRules(scope string, rules *[]model.TaskRuntimeRule) e
 		}
 		if rule.ID != nil {
 			return fmt.Errorf("%s.id is not supported; use CLI --task-runtime for per-task ids", fieldPrefix)
+		}
+		if rule.Complexity != nil {
+			return fmt.Errorf(
+				"%s.complexity is not supported; use defaults.by_complexity for complexity defaults",
+				fieldPrefix,
+			)
 		}
 		if rule.Type == nil || strings.TrimSpace(*rule.Type) == "" {
 			return fmt.Errorf("%s.type is required", fieldPrefix)

--- a/internal/core/worktree/snapshot.go
+++ b/internal/core/worktree/snapshot.go
@@ -59,6 +59,7 @@ type Snapshot struct {
 	porcelain         []byte
 	entries           []StatusEntry
 	trackedSymlinks   map[string]string
+	excludedPaths     []string
 	unsupportedReason UnsupportedReason
 	gitAvailable      bool
 	gitRepo           bool
@@ -145,9 +146,20 @@ func (s Scope) Unchanged() bool {
 
 // Capture fingerprints the workspace at root using git.
 func Capture(ctx context.Context, root string) (Snapshot, error) {
+	return CaptureExcluding(ctx, root)
+}
+
+// CaptureExcluding fingerprints the workspace while omitting paths owned by
+// the runtime rather than the agent. Exclusions are scoped to this snapshot and
+// do not mutate repository ignore configuration.
+func CaptureExcluding(ctx context.Context, root string, excludedPaths ...string) (Snapshot, error) {
 	root = strings.TrimSpace(root)
 	if root == "" {
 		return Snapshot{gitAvailable: gitAvailable(), unsupportedReason: UnsupportedReasonBlankRoot}, nil
+	}
+	normalizedExclusions, err := normalizeCaptureExcludedPaths(root, excludedPaths)
+	if err != nil {
+		return Snapshot{}, err
 	}
 	snapshot := Snapshot{gitAvailable: gitAvailable()}
 	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
@@ -185,7 +197,7 @@ func Capture(ctx context.Context, root string) (Snapshot, error) {
 		return snapshot, fmt.Errorf("worktree: git branch in %s: %w", root, err)
 	}
 	snapshot.branch = string(bytes.TrimSpace(branch))
-	porcelain, entries, err := captureStatusEntries(ctx, root)
+	porcelain, entries, err := captureStatusEntries(ctx, root, normalizedExclusions)
 	if err != nil {
 		if isExecLookupError(err) {
 			snapshot.gitAvailable = false
@@ -198,11 +210,27 @@ func Capture(ctx context.Context, root string) (Snapshot, error) {
 	if err != nil {
 		return snapshot, fmt.Errorf("worktree: capture tracked symlinks in %s: %w", root, err)
 	}
-	return buildSupportedSnapshot(root, snapshot.head, snapshot.branch, porcelain, entries, trackedSymlinks), nil
+	trackedSymlinks = filterExcludedTrackedSymlinks(trackedSymlinks, normalizedExclusions)
+	return buildSupportedSnapshot(
+		root,
+		snapshot.head,
+		snapshot.branch,
+		porcelain,
+		entries,
+		trackedSymlinks,
+		normalizedExclusions,
+	), nil
 }
 
-func captureStatusEntries(ctx context.Context, root string) ([]byte, []StatusEntry, error) {
-	porcelain, err := runGit(ctx, root, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+func captureStatusEntries(ctx context.Context, root string, excludedPaths []string) ([]byte, []StatusEntry, error) {
+	args := []string{"status", "--porcelain=v1", "-z", "--untracked-files=all"}
+	if len(excludedPaths) > 0 {
+		args = append(args, "--")
+		for _, path := range excludedPaths {
+			args = append(args, ":(top,exclude,literal)"+path)
+		}
+	}
+	porcelain, err := runGit(ctx, root, args...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("worktree: git status in %s: %w", root, err)
 	}
@@ -222,7 +250,7 @@ func captureStatusEntries(ctx context.Context, root string) ([]byte, []StatusEnt
 
 // BuildScope captures the final workspace state and compares it to baseline.
 func BuildScope(ctx context.Context, root string, baseline Snapshot) (Scope, error) {
-	final, err := Capture(ctx, root)
+	final, err := CaptureExcluding(ctx, root, baseline.excludedPaths...)
 	scope := CompareSnapshots(baseline, final)
 	if err != nil {
 		scope.Supported = false
@@ -347,6 +375,7 @@ func buildSupportedSnapshot(
 	porcelain []byte,
 	entries []StatusEntry,
 	trackedSymlinks map[string]string,
+	excludedPaths []string,
 ) Snapshot {
 	h := sha256.New()
 	h.Write([]byte(captureSchemaVersion))
@@ -354,6 +383,11 @@ func buildSupportedSnapshot(
 	h.Write([]byte(head))
 	h.Write([]byte{0})
 	h.Write(porcelain)
+	for _, path := range excludedPaths {
+		h.Write([]byte{0})
+		h.Write([]byte("exclude:"))
+		h.Write([]byte(path))
+	}
 	for _, entry := range entries {
 		h.Write([]byte{0})
 		h.Write([]byte(entry.Path))
@@ -368,11 +402,65 @@ func buildSupportedSnapshot(
 		porcelain:       append([]byte(nil), porcelain...),
 		entries:         append([]StatusEntry(nil), entries...),
 		trackedSymlinks: copyStringMap(trackedSymlinks),
+		excludedPaths:   append([]string(nil), excludedPaths...),
 		gitAvailable:    true,
 		gitRepo:         true,
 		hasCommits:      true,
 		supported:       true,
 	}
+}
+
+func normalizeCaptureExcludedPaths(root string, paths []string) ([]string, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("worktree: resolve snapshot root %s: %w", root, err)
+	}
+	normalized := make([]string, 0, len(paths))
+	for _, path := range paths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			continue
+		}
+		if !filepath.IsAbs(trimmed) {
+			trimmed = filepath.Join(absRoot, trimmed)
+		}
+		absPath, err := filepath.Abs(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("worktree: resolve snapshot exclusion %s: %w", path, err)
+		}
+		rel, err := filepath.Rel(absRoot, absPath)
+		if err != nil {
+			return nil, fmt.Errorf("worktree: relativize snapshot exclusion %s: %w", path, err)
+		}
+		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("worktree: snapshot exclusion %s must be inside %s", path, root)
+		}
+		normalized = append(normalized, filepath.ToSlash(filepath.Clean(rel)))
+	}
+	return uniqueSorted(normalized), nil
+}
+
+func filterExcludedTrackedSymlinks(links map[string]string, excludedPaths []string) map[string]string {
+	if len(links) == 0 || len(excludedPaths) == 0 {
+		return links
+	}
+	filtered := make(map[string]string, len(links))
+	for path, target := range links {
+		if !capturePathExcluded(path, excludedPaths) {
+			filtered[path] = target
+		}
+	}
+	return filtered
+}
+
+func capturePathExcluded(path string, excludedPaths []string) bool {
+	normalized := filepath.ToSlash(filepath.Clean(path))
+	for _, excluded := range excludedPaths {
+		if normalized == excluded || strings.HasPrefix(normalized, excluded+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func captureTrackedSymlinks(ctx context.Context, root string) (map[string]string, error) {

--- a/internal/core/worktree/snapshot_test.go
+++ b/internal/core/worktree/snapshot_test.go
@@ -184,6 +184,56 @@ func TestBuildScope(t *testing.T) {
 		}
 	})
 
+	t.Run("Should exclude mirrored task artifacts without hiding agent output", func(t *testing.T) {
+		t.Parallel()
+		requireScopeGit(t)
+
+		primary := initScopeGitRepo(t)
+		linked := filepath.Join(t.TempDir(), "linked")
+		mustScopeGit(t, primary, "worktree", "add", "-q", "-b", "feature-task-artifacts", linked)
+		tasksDir := filepath.Join(linked, ".compozy", "tasks", "demo")
+		if err := os.MkdirAll(tasksDir, 0o755); err != nil {
+			t.Fatalf("mkdir task artifacts: %v", err)
+		}
+		taskPath := filepath.Join(tasksDir, "task_01.md")
+		if err := os.WriteFile(taskPath, []byte("status: pending\n"), 0o600); err != nil {
+			t.Fatalf("write mirrored task artifact: %v", err)
+		}
+
+		baseline, err := CaptureExcluding(context.Background(), linked, tasksDir)
+		if err != nil {
+			t.Fatalf("CaptureExcluding baseline: %v", err)
+		}
+		if err := os.WriteFile(taskPath, []byte("status: completed\n"), 0o600); err != nil {
+			t.Fatalf("update mirrored task artifact: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(linked, "produced.go"), []byte("package produced\n"), 0o600); err != nil {
+			t.Fatalf("write agent output: %v", err)
+		}
+
+		scope, err := BuildScope(context.Background(), linked, baseline)
+		if err != nil {
+			t.Fatalf("BuildScope: %v", err)
+		}
+		if got, want := strings.Join(scope.ProducedPaths, ","), "produced.go"; got != want {
+			t.Fatalf("produced paths = %q, want %q", got, want)
+		}
+		if len(scope.PreExistingPaths) != 0 || len(scope.PreExistingChangedPaths) != 0 {
+			t.Fatalf("task artifacts leaked into scope: %#v", scope)
+		}
+	})
+
+	t.Run("Should reject snapshot exclusions outside the workspace", func(t *testing.T) {
+		t.Parallel()
+		requireScopeGit(t)
+
+		root := initScopeGitRepo(t)
+		outside := t.TempDir()
+		if _, err := CaptureExcluding(context.Background(), root, outside); err == nil {
+			t.Fatal("CaptureExcluding outside path error = nil, want error")
+		}
+	})
+
 	t.Run("Should fingerprint dirty submodules from gitlink state", func(t *testing.T) {
 		t.Parallel()
 		requireScopeGit(t)

--- a/internal/core/worktree/snapshot_test.go
+++ b/internal/core/worktree/snapshot_test.go
@@ -229,8 +229,9 @@ func TestBuildScope(t *testing.T) {
 
 		root := initScopeGitRepo(t)
 		outside := t.TempDir()
-		if _, err := CaptureExcluding(context.Background(), root, outside); err == nil {
-			t.Fatal("CaptureExcluding outside path error = nil, want error")
+		if _, err := CaptureExcluding(context.Background(), root, outside); err == nil ||
+			!strings.Contains(err.Error(), "must be inside") {
+			t.Fatalf("CaptureExcluding outside path error = %v, want inside-workspace context", err)
 		}
 	})
 

--- a/internal/daemon/review_watch_test.go
+++ b/internal/daemon/review_watch_test.go
@@ -204,7 +204,7 @@ func TestRunManagerReviewWatchChildRunMaxRetriesPrecedence(t *testing.T) {
 	t.Run("Should preserve project default max retries over watch child default", func(t *testing.T) {
 		projectCfg := workspacecfg.ProjectConfig{
 			Defaults: workspacecfg.DefaultsConfig{
-				MaxRetries: intPtr(0),
+				RuntimeOverrides: workspacecfg.RuntimeOverrides{MaxRetries: intPtr(0)},
 			},
 			WatchReviews: workspacecfg.WatchReviewsConfig{
 				UntilClean: boolPtr(true),

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -997,12 +997,12 @@ func (m *RunManager) prepareTaskStart(
 	applySoundConfig(runtimeCfg, projectCfg.Sound)
 	if err := applyRuntimeOverridesFromProject(
 		runtimeCfg,
-		workspacecfg.RuntimeOverrides(projectCfg.Defaults),
+		projectCfg.Defaults.RuntimeOverrides,
 		"defaults",
 	); err != nil {
 		return globaldb.Workspace{}, nil, nil, workspacecfg.AgentRecoveryConfig{}, workspacecfg.ParallelTasksConfig{}, "", err
 	}
-	applyTaskProjectConfig(runtimeCfg, projectCfg.Tasks.Run)
+	applyTaskProjectConfig(runtimeCfg, projectCfg.Defaults, projectCfg.Tasks.Run)
 	if err := applyRuntimeOverrideInput(runtimeCfg, overrides); err != nil {
 		return globaldb.Workspace{}, nil, nil, workspacecfg.AgentRecoveryConfig{}, workspacecfg.ParallelTasksConfig{}, "", err
 	}
@@ -1134,7 +1134,7 @@ func (m *RunManager) prepareReviewStart(
 	applySoundConfig(runtimeCfg, projectCfg.Sound)
 	if err := applyRuntimeOverridesFromProject(
 		runtimeCfg,
-		workspacecfg.RuntimeOverrides(projectCfg.Defaults),
+		projectCfg.Defaults.RuntimeOverrides,
 		"defaults",
 	); err != nil {
 		return globaldb.Workspace{}, nil, nil, workspacecfg.AgentRecoveryConfig{}, "", err
@@ -1247,7 +1247,7 @@ func (m *RunManager) prepareExecStart(
 	applySoundConfig(runtimeCfg, projectCfg.Sound)
 	if err := applyRuntimeOverridesFromProject(
 		runtimeCfg,
-		workspacecfg.RuntimeOverrides(projectCfg.Defaults),
+		projectCfg.Defaults.RuntimeOverrides,
 		"defaults",
 	); err != nil {
 		return globaldb.Workspace{}, nil, workspacecfg.AgentRecoveryConfig{}, "", err
@@ -3047,7 +3047,11 @@ func applyRuntimeOverridesFromProject(
 	return nil
 }
 
-func applyTaskProjectConfig(cfg *model.RuntimeConfig, projectCfg workspacecfg.TaskRunConfig) {
+func applyTaskProjectConfig(
+	cfg *model.RuntimeConfig,
+	defaults workspacecfg.DefaultsConfig,
+	projectCfg workspacecfg.TaskRunConfig,
+) {
 	if cfg == nil {
 		return
 	}
@@ -3058,7 +3062,9 @@ func applyTaskProjectConfig(cfg *model.RuntimeConfig, projectCfg workspacecfg.Ta
 	if projectCfg.Recursive != nil {
 		cfg.Recursive = *projectCfg.Recursive
 	}
-	cfg.TaskRuntimeRules = model.CloneTaskRuntimeRules(derefTaskRuntimeRules(projectCfg.TaskRuntimeRules))
+	rules := defaults.ComplexityRuntimeRules()
+	rules = append(rules, derefTaskRuntimeRules(projectCfg.TaskRuntimeRules)...)
+	cfg.TaskRuntimeRules = model.CloneTaskRuntimeRules(rules)
 }
 
 func applyReviewProjectConfig(cfg *model.RuntimeConfig, projectCfg workspacecfg.FixReviewsConfig) {

--- a/internal/daemon/run_manager_test.go
+++ b/internal/daemon/run_manager_test.go
@@ -2369,7 +2369,11 @@ func TestRunManagerHelperOverridesAndUtilities(t *testing.T) {
 		}, "defaults"); err != nil {
 			t.Fatalf("applyRuntimeOverridesFromProject() error = %v", err)
 		}
-		applyTaskProjectConfig(cfg, workspacecfg.TaskRunConfig{
+		applyTaskProjectConfig(cfg, workspacecfg.DefaultsConfig{
+			ByComplexity: workspacecfg.TaskRuntimeByComplexityConfig{
+				Low: workspacecfg.TaskRuntimeOverrides{ReasoningEffort: stringPtr("low")},
+			},
+		}, workspacecfg.TaskRunConfig{
 			IncludeCompleted: boolPtr(true),
 			OutputFormat:     stringPtr(string(model.OutputFormatRawJSON)),
 			TaskRuntimeRules: &rules,
@@ -2445,9 +2449,10 @@ func TestRunManagerHelperOverridesAndUtilities(t *testing.T) {
 		if !cfg.SoundEnabled || cfg.SoundOnCompleted != "glass" || cfg.SoundOnFailed != "basso" {
 			t.Fatalf("sound config application failed: %#v", cfg)
 		}
-		if len(cfg.TaskRuntimeRules) != 1 || cfg.TaskRuntimeRules[0].Type == nil ||
-			*cfg.TaskRuntimeRules[0].Type != "backend" {
-			t.Fatalf("task runtime rules = %#v, want cloned backend rule", cfg.TaskRuntimeRules)
+		if len(cfg.TaskRuntimeRules) != 2 || cfg.TaskRuntimeRules[0].Complexity == nil ||
+			*cfg.TaskRuntimeRules[0].Complexity != "low" || cfg.TaskRuntimeRules[1].Type == nil ||
+			*cfg.TaskRuntimeRules[1].Type != "backend" {
+			t.Fatalf("task runtime rules = %#v, want complexity then cloned backend rule", cfg.TaskRuntimeRules)
 		}
 	})
 
@@ -2583,7 +2588,7 @@ func TestRunManagerHelperOverridesAndUtilities(t *testing.T) {
 		applySoundConfig(cfg, projectCfg.Sound)
 		if err := applyRuntimeOverridesFromProject(
 			cfg,
-			workspacecfg.RuntimeOverrides(projectCfg.Defaults),
+			projectCfg.Defaults.RuntimeOverrides,
 			"defaults",
 		); err != nil {
 			t.Fatalf("applyRuntimeOverridesFromProject() error = %v", err)

--- a/sdk/extension/types.go
+++ b/sdk/extension/types.go
@@ -492,16 +492,18 @@ type TaskRuntime struct {
 
 // TaskRuntimeTask mirrors the PRD task whose runtime is being resolved.
 type TaskRuntimeTask struct {
-	ID       string `json:"id,omitempty"`
-	SafeName string `json:"safe_name,omitempty"`
-	Title    string `json:"title,omitempty"`
-	Type     string `json:"type,omitempty"`
+	ID         string `json:"id,omitempty"`
+	SafeName   string `json:"safe_name,omitempty"`
+	Title      string `json:"title,omitempty"`
+	Type       string `json:"type,omitempty"`
+	Complexity string `json:"complexity,omitempty"`
 }
 
 // TaskRuntimeRule mirrors one task-scoped runtime override rule.
 type TaskRuntimeRule struct {
 	ID              *string `json:"id,omitempty"`
 	Type            *string `json:"type,omitempty"`
+	Complexity      *string `json:"complexity,omitempty"`
 	IDE             *string `json:"ide,omitempty"`
 	Model           *string `json:"model,omitempty"`
 	ReasoningEffort *string `json:"reasoning_effort,omitempty"`


### PR DESCRIPTION
## Summary

- exclude mirrored `.compozy/tasks/<workflow>` artifacts from worktree snapshots without mutating shared Git ignore state
- add field-wise `[defaults.by_complexity.low|medium|high|critical]` runtime defaults with complexity → type → task-id resolution
- preserve explicit CLI runtime precedence and propagate task complexity through the extension hook/SDK surface

## Root causes

The parallel child snapshot was captured after task artifacts were mirrored into the linked worktree, so runtime-owned files were classified as agent output. Repository-level `info/exclude` would leak across linked worktrees; snapshot-scoped negative pathspecs isolate only the runtime capture.

Task complexity already existed in task metadata, but config decoding, effective-config merging, runtime targeting, daemon/CLI transport, and hook payloads did not carry a complexity selector end to end.

## Verification

- `make fmt`
- `make lint` — 0 issues
- `make build`
- 535 focused tests across model, workspace, plan, worktree, executor, and extension SDK packages
- 14 focused CLI/daemon override tests

The local host has exhausted `fs.inotify.max_user_instances=128`, so an isolated daemon watcher reproduces `no space left on device` despite free disk/inodes. The required CI workflow runs the canonical `make verify` in a clean environment and remains the merge gate.

Closes #228
Closes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-task runtime overrides by complexity (low/medium/high/critical), including IDE, model, and reasoning effort.
  * Complexity is now propagated through task runtime resolution and extension workflows.
* **Bug Fixes**
  * Prevented generated task artifacts (including PRD task artifacts) from being reported as pre-existing or user changes.
  * Preserves explicit runtime selections when complexity defaults apply, and rejects unsupported complexity configuration.
* **Other**
  * Improved config validation errors for unknown or missing fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->