### PR TITLE
release: Release v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## 0.2.16 - 2026-07-20
+
+### 🐛 Bug Fixes
+
+- *(cli)* Reap leaked test daemons and artifacts (#253)
+
 ## 0.2.15 - 2026-07-17
 
 ### 🎉 Features
@@ -378,6 +384,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - *(release)* Prepare release v0.1.0 (#21)
 - *(repo)* Fix tests
 
+[0.2.16]: https://github.com///compare/v0.2.15...v0.2.16
 [0.2.15]: https://github.com///compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com///compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com///compare/v0.2.12...v0.2.13

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,31 +1,5 @@
-## 0.2.15 - 2026-07-17
+## 0.2.16 - 2026-07-20
 
-### 🎉 Features
-
-- Cy-capture-decisions — skill-only extension for durable decision capture (#237)
 ### 🐛 Bug Fixes
 
-- Recover stalled and wedged multi-runs (#230)- Share parallel task status enum (#241)- Surface progress and bound the reviews-fix daemon start (#236)- Package cy-qa-workflow as a module and make host.tasks.create v2-aware (#234)- Correct Kiro CLI ACP model handling (#226)- Isolate sync tests and clarify ignore checks (#248)- Isolate task artifacts and add complexity runtime defaults (#250)
-### 📚 Documentation
-
-- Add v0.2.15 release highlights
-
-### Release Notes
-
-#### Features
-
-##### Durable architecture decisions
-The new cy-capture-decisions skill-only extension reconciles accepted ADRs against the code and review outcome, then promotes only proven, cross-feature decisions into a compact project index with detailed records on demand. The log survives workflow archival and is safe to rerun. (PR #237)
-
-##### Runtime defaults by task complexity
-Workspace defaults can now select IDE, model, and reasoning effort for low, medium, high, and critical tasks, with field-wise workspace merging and complexity to type to task-ID precedence while preserving explicit CLI choices. Parallel child snapshots also stop reporting mirrored runtime task artifacts as agent output. (PR #250)
-
-#### Fixes
-
-##### More reliable task and review workflows
-QA task injection now supports compozy.tasks/v2 graphs and the cy-qa-workflow extension ships as a verified standalone module. Kiro ACP runs use a valid bootstrap model, slow reviews fix startup is visible and bounded, and parallel task settlement uses one canonical status contract. Test isolation and decision-log ignore guidance were tightened as well. (PRs #234, #226, #236, #241, #248)
-
-#### Highlights
-
-##### Runs that recover instead of hanging
-Compozy now detects silent ACP stalls, retries once from a clean worktree, and parks persistent failures with journals and worktrees preserved for triage. Parallel parents can reap wedged children, terminal commands are cancellable and bounded, and the UI reports stalled, retrying, recovered, and parked outcomes. (PR #230)
+- *(cli)* Reap leaked test daemons and artifacts (#253)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,9 @@
+## 0.2.16 - 2026-07-20
+
+### 🐛 Bug Fixes
+
+- *(cli)* Reap leaked test daemons and artifacts (#253)
+
 ## 0.2.15 - 2026-07-17
 
 ### 🎉 Features

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:config": "bunx vitest run --config vitest.config.ts test/*.test.ts",
     "typecheck": "turbo run typecheck"
   },
-  "version": "0.2.15",
+  "version": "0.2.16",
   "workspaces": [
     "packages/ui",
     "web",


### PR DESCRIPTION

## Release v0.2.16

This PR prepares the release of version v0.2.16.

### Changelog

## 0.2.16 - 2026-07-20

### 🐛 Bug Fixes

- *(cli)* Reap leaked test daemons and artifacts (#253)
