### PR TITLE
release: Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 - 2026-07-28
+## 0.3.0 - 2026-07-29
+
+### ♻️ Refactoring
+
+- State management with xstate-store (#268)
 
 ### 🎉 Features
 
 - Introducing CompozyOS beta
 - **BREAKING:** introducing CompozyOS beta
+- Add provider-neutral ACP speed control (#267)
 
 ### 🐛 Bug Fixes
 
-- _(cli)_ Reap leaked test daemons and artifacts (#253)
-- Archive without tasks
-- Resolve inherited cross-runtime models against runtime defaults (#259)
+- Align release and process test contracts
+- Workspace params (#266)
+- Onboarding workspace selection
 
 ### 📚 Documentation
 
 - Update readme
+- Change copy
+- Opendesign
 
 ### 📦 Build System
 
@@ -30,11 +37,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Delete not need things
 - Fix tests
 - Align release body heading with the published version
+- Fix beta release recovery
+- Restore beta release recovery
+- Recover partial releases
+- Model release recovery states
+- Load recovery tools for old refs
+- Fix release receipt subject
+- Publish site changelog receipt v0.3.0-beta.1
+- Repo clone
+- Fix storybook
+- Changelog fix
 
 ### 🔧 CI/CD
 
 - Fix tests
 - Fix release workflow
+- Fix release process
+- Improve release dry run
 
 ## 0.2.15 - 2026-07-17
 

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,19 +1,26 @@
-## 0.3.0 - 2026-07-28
+## 0.3.0 - 2026-07-29
+
+### ♻️ Refactoring
+
+- State management with xstate-store (#268)
 
 ### 🎉 Features
 
 - Introducing CompozyOS beta
 - **BREAKING:** introducing CompozyOS beta
+- Add provider-neutral ACP speed control (#267)
 
 ### 🐛 Bug Fixes
 
-- _(cli)_ Reap leaked test daemons and artifacts (#253)
-- Archive without tasks
-- Resolve inherited cross-runtime models against runtime defaults (#259)
+- Align release and process test contracts
+- Workspace params (#266)
+- Onboarding workspace selection
 
 ### 📚 Documentation
 
 - Update readme
+- Change copy
+- Opendesign
 
 ### 📦 Build System
 
@@ -23,11 +30,23 @@
 - Delete not need things
 - Fix tests
 - Align release body heading with the published version
+- Fix beta release recovery
+- Restore beta release recovery
+- Recover partial releases
+- Model release recovery states
+- Load recovery tools for old refs
+- Fix release receipt subject
+- Publish site changelog receipt v0.3.0-beta.1
+- Repo clone
+- Fix storybook
+- Changelog fix
 
 ### 🔧 CI/CD
 
 - Fix tests
 - Fix release workflow
+- Fix release process
+- Improve release dry run
 
 ### Release Notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,19 +1,26 @@
-## 0.3.0 - 2026-07-28
+## 0.3.0 - 2026-07-29
+
+### ♻️ Refactoring
+
+- State management with xstate-store (#268)
 
 ### 🎉 Features
 
 - Introducing CompozyOS beta
 - **BREAKING:** introducing CompozyOS beta
+- Add provider-neutral ACP speed control (#267)
 
 ### 🐛 Bug Fixes
 
-- _(cli)_ Reap leaked test daemons and artifacts (#253)
-- Archive without tasks
-- Resolve inherited cross-runtime models against runtime defaults (#259)
+- Align release and process test contracts
+- Workspace params (#266)
+- Onboarding workspace selection
 
 ### 📚 Documentation
 
 - Update readme
+- Change copy
+- Opendesign
 
 ### 📦 Build System
 
@@ -23,11 +30,23 @@
 - Delete not need things
 - Fix tests
 - Align release body heading with the published version
+- Fix beta release recovery
+- Restore beta release recovery
+- Recover partial releases
+- Model release recovery states
+- Load recovery tools for old refs
+- Fix release receipt subject
+- Publish site changelog receipt v0.3.0-beta.1
+- Repo clone
+- Fix storybook
+- Changelog fix
 
 ### 🔧 CI/CD
 
 - Fix tests
 - Fix release workflow
+- Fix release process
+- Improve release dry run
 
 ### Release Notes
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/compozy/compozy-web-assets v0.0.9
+	github.com/compozy/compozy-web-assets v0.0.21
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/daytonaio/daytona/libs/sdk-go v0.190.0
 	github.com/getkin/kin-openapi v0.140.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb h1:EDmT6Q9Zs+SbUo
 github.com/codahale/rfc6979 v0.0.0-20141003034818-6a90f24967eb/go.mod h1:ZjrT6AXHbDs86ZSdt/osfBi5qfexBrKUdONk989Wnk4=
 github.com/coder/acp-go-sdk v0.13.5 h1:LI9jq5xon7xslaYlnoktvTVyDlE37yIk2daT7N9ASYk=
 github.com/coder/acp-go-sdk v0.13.5/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
-github.com/compozy/compozy-web-assets v0.0.9 h1:uGrJpFj+3As2Al/7BrL9Ho72LMTshqgWVplcNFkGImY=
-github.com/compozy/compozy-web-assets v0.0.9/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
+github.com/compozy/compozy-web-assets v0.0.21 h1:+kLVCjspuArXyVREMutFl9YPw0iXj8K1mSU98iqz3cE=
+github.com/compozy/compozy-web-assets v0.0.21/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=


### PR DESCRIPTION
## Release v0.3.0
This PR prepares the release of version v0.3.0.
### Changelog
## 0.3.0 - 2026-07-29
### ♻️ Refactoring
- State management with xstate-store (#268)
### 🎉 Features
- Introducing CompozyOS beta
- **BREAKING:** introducing CompozyOS beta
- Add provider-neutral ACP speed control (#267)
### 🐛 Bug Fixes
- Align release and process test contracts
- Workspace params (#266)
- Onboarding workspace selection