### PR TITLE
fix: restore Windows daemon support (PR #163 regression + new fixes)

### DIFF
--- a/internal/daemon/info.go
+++ b/internal/daemon/info.go
@@ -160,20 +160,3 @@ func RemoveInfo(path string) error {
 	}
 	return nil
 }
-
-func syncDir(path string) (returnErr error) {
-	dir, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("daemon: open directory %q for sync: %w", path, err)
-	}
-	defer func() {
-		if err := dir.Close(); err != nil {
-			returnErr = errors.Join(returnErr, fmt.Errorf("daemon: close directory %q after sync: %w", path, err))
-		}
-	}()
-
-	if err := dir.Sync(); err != nil {
-		return fmt.Errorf("daemon: sync directory %q: %w", path, err)
-	}
-	return nil
-}

--- a/internal/daemon/lock.go
+++ b/internal/daemon/lock.go
@@ -72,7 +72,7 @@ func acquireLock(path string, pid int, deps lockDeps) (*Lock, error) {
 		return nil, fmt.Errorf("daemon: create lock directory for %q: %w", cleanPath, err)
 	}
 
-	priorPID, err := readLockPID(cleanPath)
+	priorPID, err := readLockPID(lockPIDPath(cleanPath))
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func acquireLock(path string, pid int, deps lockDeps) (*Lock, error) {
 		stalePID = priorPID
 	}
 
-	if err := writeLockPID(cleanPath, pid); err != nil {
+	if err := writeLockPID(lockPIDPath(cleanPath), pid); err != nil {
 		unlockErr := fileLock.Unlock()
 		closeErr := fileLock.Close()
 		return nil, errors.Join(err, unlockErr, closeErr)
@@ -131,7 +131,7 @@ func (l *Lock) Release() error {
 	}
 
 	var errs []error
-	if err := writeLockPID(l.path, 0); err != nil {
+	if err := writeLockPID(lockPIDPath(l.path), 0); err != nil {
 		errs = append(errs, err)
 	}
 	if l.flock != nil {

--- a/internal/daemon/lock_pid_other.go
+++ b/internal/daemon/lock_pid_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package daemon
+
+// lockPIDPath returns the path used to persist the daemon PID.
+// On non-Windows platforms, advisory locks don't block writes from other file
+// descriptors, so the PID can be stored inside the lock file itself.
+func lockPIDPath(lockPath string) string {
+	return lockPath
+}

--- a/internal/daemon/lock_pid_windows.go
+++ b/internal/daemon/lock_pid_windows.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package daemon
+
+// lockPIDPath returns the path used to persist the daemon PID.
+// On Windows, flock's LockFileEx acquires a byte-range lock that prevents
+// other file handles — even within the same process — from writing to the
+// locked file. A separate .pid sidecar avoids that conflict.
+func lockPIDPath(lockPath string) string {
+	return lockPath + ".pid"
+}

--- a/internal/daemon/sync_dir_unix.go
+++ b/internal/daemon/sync_dir_unix.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// syncDir fsyncs the directory entry so an atomic rename becomes durable.
+// Non-Windows platforms allow opening a directory read-only and calling Sync;
+// the Windows sibling in sync_dir_windows.go is a no-op because
+// FlushFileBuffers requires a writable handle.
+func syncDir(path string) (returnErr error) {
+	dir, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("daemon: open directory %q for sync: %w", path, err)
+	}
+	defer func() {
+		if err := dir.Close(); err != nil {
+			returnErr = errors.Join(returnErr, fmt.Errorf("daemon: close directory %q after sync: %w", path, err))
+		}
+	}()
+
+	if err := dir.Sync(); err != nil {
+		return fmt.Errorf("daemon: sync directory %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/daemon/sync_dir_windows.go
+++ b/internal/daemon/sync_dir_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package daemon
+
+// syncDir is a no-op on Windows: FlushFileBuffers requires write access on
+// directory handles, but os.Open opens them read-only. Directory entry
+// durability after an atomic rename is handled by the NTFS journal.
+func syncDir(_ string) error {
+	return nil
+}

--- a/internal/procutil/detached_windows.go
+++ b/internal/procutil/detached_windows.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 func spawnDetachedLoggedProcess(
@@ -51,9 +52,15 @@ func spawnDetachedLoggedProcess(
 		return nil, errors.Join(err, closeDetachedLaunchHandles(stdinFile, logFile, req.LogPath))
 	}
 
+	// CREATE_NEW_PROCESS_GROUP detaches the daemon from the parent CLI's
+	// process group so Ctrl+C events sent to the CLI are not forwarded to
+	// the daemon. Unix uses Setpgid: true for the same effect.
 	process, err := startDetachedProcess(binary, launchArgv(binary, req.Args), &os.ProcAttr{
 		Env:   launchSandbox(req.Sandbox),
 		Files: []*os.File{stdinFile, logFile, logFile},
+		Sys: &syscall.SysProcAttr{
+			CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+		},
 	})
 	if err != nil {
 		return nil, errors.Join(

--- a/internal/procutil/process_started_at_windows.go
+++ b/internal/procutil/process_started_at_windows.go
@@ -19,10 +19,16 @@ func StartedAt(pid int) (time.Time, error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("procutil: open process %d: %w", pid, err)
 	}
+	if handle == 0 || handle == windows.InvalidHandle {
+		return time.Time{}, fmt.Errorf("procutil: open process %d: invalid handle", pid)
+	}
 	defer windows.CloseHandle(handle)
 
-	var createdAt windows.Filetime
-	if err := windows.GetProcessTimes(handle, &createdAt, nil, nil, nil); err != nil {
+	// GetProcessTimes crashes with ACCESS_VIOLATION when passed nil pointers
+	// for the exit/kernel/user time outputs on some Windows builds. Allocate
+	// discard buffers so the syscall receives four valid Filetime pointers.
+	var createdAt, exitAt, kernelTime, userTime windows.Filetime
+	if err := windows.GetProcessTimes(handle, &createdAt, &exitAt, &kernelTime, &userTime); err != nil {
 		return time.Time{}, fmt.Errorf("procutil: read process %d times: %w", pid, err)
 	}
 

--- a/internal/store/sessiondb/read_only.go
+++ b/internal/store/sessiondb/read_only.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -181,17 +180,9 @@ func openSessionDBReadOnlyOnce(ctx context.Context, sessionID string, path strin
 }
 
 func readOnlySessionSQLiteDSN(path string) string {
-	// Windows drive-letter normalization: absolute "C:\..." paths must be
-	// prefixed with "/" so url.URL serializes as "file:///C:/..." rather than
-	// "file://C:/..." (which SQLite parses as invalid uri authority "C:").
-	// See sqlite_config.go sqliteFilePath for full rationale.
-	slashPath := filepath.ToSlash(path)
-	if filepath.IsAbs(path) && !strings.HasPrefix(slashPath, "/") {
-		slashPath = "/" + slashPath
-	}
 	u := url.URL{
 		Scheme: "file",
-		Path:   slashPath,
+		Path:   store.SqliteFilePath(path),
 	}
 	query := u.Query()
 	query.Set("mode", "ro")

--- a/internal/store/sessiondb/read_only.go
+++ b/internal/store/sessiondb/read_only.go
@@ -181,9 +181,17 @@ func openSessionDBReadOnlyOnce(ctx context.Context, sessionID string, path strin
 }
 
 func readOnlySessionSQLiteDSN(path string) string {
+	// Windows drive-letter normalization: absolute "C:\..." paths must be
+	// prefixed with "/" so url.URL serializes as "file:///C:/..." rather than
+	// "file://C:/..." (which SQLite parses as invalid uri authority "C:").
+	// See sqlite_config.go sqliteFilePath for full rationale.
+	slashPath := filepath.ToSlash(path)
+	if filepath.IsAbs(path) && !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
 	u := url.URL{
 		Scheme: "file",
-		Path:   filepath.ToSlash(path),
+		Path:   slashPath,
 	}
 	query := u.Query()
 	query.Set("mode", "ro")

--- a/internal/store/sqlite_config.go
+++ b/internal/store/sqlite_config.go
@@ -28,10 +28,26 @@ func sqliteInitializationDSN(path string) string {
 	return sqliteDSNWithPragmas(path, false)
 }
 
+// sqliteFilePath normalizes a filesystem path for use as a file:// URL Path in a SQLite DSN.
+// url.URL requires an absolute path starting with "/" to produce the three-slash form
+// "file:///...". On Windows, filepath.IsAbs returns true for drive-letter paths (e.g.
+// "C:\..."), but filepath.ToSlash yields "C:/..." which url.URL serializes as "file://C:/..."
+// — the SQLite URI parser then interprets "C:" as the network authority rather than a drive
+// letter (failing with "invalid uri authority: C:"). Prepend "/" only for absolute paths
+// that lack one; relative paths are left unchanged so callers that pass relative paths are
+// unaffected.
+func sqliteFilePath(path string) string {
+	slashPath := filepath.ToSlash(path)
+	if filepath.IsAbs(path) && !strings.HasPrefix(slashPath, "/") {
+		slashPath = "/" + slashPath
+	}
+	return slashPath
+}
+
 func sqliteReadOnlyDSN(path string) string {
 	u := url.URL{
 		Scheme: sqliteFileScheme,
-		Path:   filepath.ToSlash(path),
+		Path:   sqliteFilePath(path),
 	}
 	query := u.Query()
 	query.Set("mode", "ro")
@@ -42,7 +58,7 @@ func sqliteReadOnlyDSN(path string) string {
 func sqliteDSNWithPragmas(path string, runtimePragmas bool, extraPragmas ...string) string {
 	u := url.URL{
 		Scheme: sqliteFileScheme,
-		Path:   filepath.ToSlash(path),
+		Path:   sqliteFilePath(path),
 	}
 	query := u.Query()
 	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", defaultBusyTimeoutMS))

--- a/internal/store/sqlite_config.go
+++ b/internal/store/sqlite_config.go
@@ -28,15 +28,16 @@ func sqliteInitializationDSN(path string) string {
 	return sqliteDSNWithPragmas(path, false)
 }
 
-// sqliteFilePath normalizes a filesystem path for use as a file:// URL Path in a SQLite DSN.
+// SqliteFilePath normalizes a filesystem path for use as a file:// URL Path in a SQLite DSN.
 // url.URL requires an absolute path starting with "/" to produce the three-slash form
 // "file:///...". On Windows, filepath.IsAbs returns true for drive-letter paths (e.g.
 // "C:\..."), but filepath.ToSlash yields "C:/..." which url.URL serializes as "file://C:/..."
 // — the SQLite URI parser then interprets "C:" as the network authority rather than a drive
 // letter (failing with "invalid uri authority: C:"). Prepend "/" only for absolute paths
 // that lack one; relative paths are left unchanged so callers that pass relative paths are
-// unaffected.
-func sqliteFilePath(path string) string {
+// unaffected. Exported so sibling packages (e.g. internal/store/sessiondb) build SQLite
+// DSNs through the same canonical normalization instead of duplicating the logic.
+func SqliteFilePath(path string) string {
 	slashPath := filepath.ToSlash(path)
 	if filepath.IsAbs(path) && !strings.HasPrefix(slashPath, "/") {
 		slashPath = "/" + slashPath
@@ -47,7 +48,7 @@ func sqliteFilePath(path string) string {
 func sqliteReadOnlyDSN(path string) string {
 	u := url.URL{
 		Scheme: sqliteFileScheme,
-		Path:   sqliteFilePath(path),
+		Path:   SqliteFilePath(path),
 	}
 	query := u.Query()
 	query.Set("mode", "ro")
@@ -58,7 +59,7 @@ func sqliteReadOnlyDSN(path string) string {
 func sqliteDSNWithPragmas(path string, runtimePragmas bool, extraPragmas ...string) string {
 	u := url.URL{
 		Scheme: sqliteFileScheme,
-		Path:   sqliteFilePath(path),
+		Path:   SqliteFilePath(path),
 	}
 	query := u.Query()
 	query.Add("_pragma", fmt.Sprintf("busy_timeout(%d)", defaultBusyTimeoutMS))


### PR DESCRIPTION
## Problem

The v0.3 refactor to CompozyOS silently lost the Windows platform-specific files merged in [PR #163](https://github.com/compozy/compozy/pull/163) (which itself closed issues #148, #157, #170). Reproducing on Windows 11 with the current beta binary:

```
$ compozy daemon start
error: cli: detached daemon exited before readiness: exit status 1: stderr=
  error: daemon: write daemon lock ".compozy/daemon.lock": another process
  has locked a portion of the file.
```

This is identical to the failure BrunoCanto reported in #148 on 2026-05-08, resolved in PR #163 on 2026-05-26, and then regressed sometime during the v0.3 refactor.

## Root causes

Working through the failures end-to-end on Windows 11 (build 26200) with `go 1.26.5` surfaced **six distinct bugs** — the four originally addressed by PR #163 plus two new Windows-only bugs that only became reachable once the daemon booted past the lock.

| # | Bug | Root cause | Original issue |
|---|---|---|---|
| 1 | `write daemon.lock: another process has locked a portion of the file` | `LockFileEx` byte-range lock blocks writes from every handle in the same process, including the daemon's own `writeLockPID`. | #148, #170 |
| 2 | `store: initialize sqlite database …: invalid uri authority: C:` | `sqliteDSN` calls `filepath.ToSlash` on an absolute drive-letter path and hands it to `url.URL`, which serialises as `file://C:/...` — SQLite parses `C:` as the network authority. | #157 |
| 3 | `sync directory "…": Access is denied` | `syncDir` in `info.go` calls `dir.Sync()` on a read-only handle; on Windows `FlushFileBuffers` requires a writable handle. | v0.3 regression |
| 4 | Daemon dies when parent CLI exits | `spawnDetachedLoggedProcess` on Windows does not set `CREATE_NEW_PROCESS_GROUP`, so the daemon inherits the parent's console group and receives the same signals. Unix uses `Setpgid: true` for the same effect (`detached_unix.go:58`). | **new** |
| 5 | `Exception 0xc0000005 (ACCESS_VIOLATION)` inside `windows.GetProcessTimes` | `procutil.StartedAt` passes `nil` for the exit/kernel/user time outputs. Depending on the Windows build, the kernel dereferences these pointers and segfaults. | **new** |
| 6 | `store.migrations.refused stream=global reason=sum_mismatch` (**not fixed by this PR**) | Git for Windows applies `core.autocrlf=true` to `.sql` files; the embedded `atlas.sum` was hashed with LF line endings on the Linux CI. Any local build on Windows fails migration validation. | **not in this PR** — needs `.gitattributes` policy discussion; documented under \"Follow-up\" |

## Changes

10 files, +106 / -25, all Windows-only or additive.

### New files (all guarded by build tags)

- `internal/daemon/lock_pid_other.go` — identity `lockPIDPath()` for non-Windows
- `internal/daemon/lock_pid_windows.go` — returns `lockPath + \".pid\"` so PID persists in a sidecar, avoiding the LockFileEx conflict
- `internal/daemon/sync_dir_unix.go` — extracted from `info.go`, preserves the existing `returnErr` pattern the v0.3 refactor added
- `internal/daemon/sync_dir_windows.go` — no-op; NTFS journal guarantees durability after atomic rename

### Modified files

- `internal/daemon/lock.go` — 3 call sites route through `lockPIDPath()`
- `internal/daemon/info.go` — drop the inline `syncDir` (moved to platform files)
- `internal/procutil/detached_windows.go` — `SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}`
- `internal/procutil/process_started_at_windows.go` — pass valid `Filetime` pointers for all four outputs; guard against invalid handle
- `internal/store/sqlite_config.go` — new `sqliteFilePath` helper that prefixes drive-letter absolute paths with `/`
- `internal/store/sessiondb/read_only.go` — same drive-letter normalisation inline (package boundary makes reuse awkward for two lines)

## Impact on Unix / Linux / macOS

**Zero behavioural change.**

- `lockPIDPath` on non-Windows is `return lockPath` (identity)
- `sqliteFilePath` prefix branch never fires on Unix because `filepath.ToSlash` already yields a leading `/`
- `sync_dir_unix.go` is the exact function that used to live in `info.go`, just relocated
- All new files are `//go:build windows` or `//go:build !windows`
- All Windows-specific behaviour changes sit inside the Windows-only files

Unix regression test coverage is unchanged.

## Validation

Manual end-to-end on Windows 11 (build 26200), `go 1.26.5`, `github.com/gofrs/flock v0.13.0`:

```
> compozy daemon start
Daemon
======
Status:                      running
PID:                         17980
Started:                     2026-07-29T13:39:11Z
Uptime:                      0s
Socket:                      C:\Users\Ailton\.compozy\daemon.sock
HTTP:                        localhost:2123
Active Sessions:             0
Total Sessions:              0
Version:                     dev
Network:                     ready
...

> compozy doctor -o json
{
  \"schema_version\": \"2026-07-16\",
  \"status\": \"error\",
  \"summary\": { \"total\": 36, ... }
}
```

`compozy daemon start` succeeds, the daemon accepts connections on the UDS socket, and `compozy doctor` reaches the daemon API. Diagnostics still return `status: error` in the summary because unrelated defaults are missing on a fresh install — that is expected for a bare `compozy install` and out of scope.

Cross-build `GOOS=windows GOARCH=amd64 go build ./cmd/compozy` compiles cleanly, and `go build ./internal/daemon/...` passes on Linux/macOS as well (no import churn on the Unix paths).

Full `make verify` was not run locally — the fork's `atlas.sum` mismatch (bug #6) blocks the pre-migration validate step until `.gitattributes` pins the SQL line endings or the sum policy is relaxed. CI on this PR will run the real Windows gate.

## Follow-up (not in this PR)

The `atlas.sum` mismatch when building on Windows is a real papercut for any Windows contributor — the checksum is computed against LF-encoded SQL but Git for Windows checks the files out as CRLF by default. The clean fix is:

```
# .gitattributes
*.sql text eol=lf
```

I did not include it in this PR because it touches every SQL file's canonical line ending and deserves its own review. Happy to open a separate PR for it if you want.

## Notes

- Commit message follows the repo convention (`fix: <description>`).
- No `chore:` / AI-attribution trailers.
- I ran into the same problem BrunoCanto reported in #148; the reproducibility on the current release binary suggests nobody is regularly exercising a Windows CI lane on the v0.3 branch — worth wiring one if you want to catch this class of regression automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon PID locking across platforms, using safer PID storage to avoid Windows lock conflicts.
  * Prevented Ctrl+C from reaching detached daemon processes on Windows.
  * Improved Windows process timing retrieval with added invalid-handle validation to reduce crashes.
  * Fixed SQLite `file://` DSN formatting for absolute Windows paths using consistent path normalization.
  * Enhanced persistence reliability by adding durable directory entry syncing on non-Windows platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->