### PR TITLE
feat: Domain core v3: types, invariants, persistence, config, reducers,…

### DIFF
--- a/.agents/skills/cy-loop-tasks/SKILL.md
+++ b/.agents/skills/cy-loop-tasks/SKILL.md
@@ -37,6 +37,11 @@ Stop→restart — restarts are a resume safety net, not the driver.
   and activates the herdr frontend lane for the whole loop. Captured once at
   bootstrap into `state.yaml.frontend_agent`; when absent, every task runs
   locally. Syntax examples in `references/goal-header-template.md`.
+- `--stacked` — optional, default off, tasks mode only. Publishes each Phase B
+  checkpoint as one layer of a GitHub stacked-PR chain (`gh stack`). Captured
+  once at bootstrap into `state.yaml.stacked`. When present, read
+  `references/stacked-prs.md` in full during bootstrap and verify its
+  prerequisites before the first Phase B iteration.
 - A pre-authored `.compozy/tasks/<slug>/_techspec.md`. Without it, bootstrap
   stops with a blocker.
 
@@ -107,9 +112,11 @@ the matching branch below is selected.
    `outcome=blocked`, and stop (`state.yaml` does not exist yet, so there is
    no update-state call).
 2. Run `python3 .agents/skills/cy-loop-tasks/scripts/init-state.py <slug> --goal "<goal_text>"`,
-   adding `--frontend <claude|cursor>` when the invocation text carries the
-   parameter. Mode auto-detects: `tasks` when `_tasks.md` plus at least one
-   `task_*.md` exist, else `free`.
+   adding `--frontend <claude|cursor>` and/or `--stacked` when the invocation
+   text carries the parameter (for `--stacked`, first read
+   `references/stacked-prs.md` in full and verify its prerequisites). Mode
+   auto-detects: `tasks` when `_tasks.md` plus at least one `task_*.md`
+   exist, else `free`.
 3. Activate `cy-spec-preflight` for the phase the next iteration enters
    (`tasks`, or `task-body` when a single concrete file is next).
 4. Scaffold `.compozy/tasks/<slug>/memory/MEMORY.md` with the canonical
@@ -146,9 +153,12 @@ sections.
    frontend lane, verify the worker's evidence instead of re-running verify.
 7. Run `python3 .agents/skills/cy-loop-tasks/scripts/update-state.py <slug> --phase B --task-completed <stem> --action "executed <stem>" --outcome completed --memory-written "memory/<stem>.md,memory/MEMORY.md" --verify-pass`.
 8. Run `python3 .agents/skills/cy-loop-tasks/scripts/commit-checkpoint.py <slug> --task <stem>`.
-   Stdout is a commit SHA or `SKIP: no changes`; copy it into the iteration
-   summary. On exit 1, enter the repair loop and retry the normal checkpoint
-   after its root cause is fixed. Never bypass the hook with `--no-verify`.
+   Stdout starts with a commit SHA or `SKIP: no changes`; copy it into the
+   iteration summary (in stacked mode a `stack: submitted` line follows —
+   the script owns the layer branch and PR submission, see
+   `references/stacked-prs.md`). On exit 1, enter the repair loop and retry
+   the normal checkpoint after its root cause is fixed. Never bypass the
+   hook with `--no-verify`.
 
 Done when: task frontmatter, memory, `state.yaml`, and the checkpoint result
 all reflect the same completed task.
@@ -322,7 +332,9 @@ The canonical `[[CODEX_LOOP ...]]` header, the manual invocation text, and
   `cy-execute-task` runs with auto-commit disabled, and every worker packet
   forbids committing. The checkpoint captures code, memory, task frontmatter,
   the master tasks file, and the advanced `state.yaml` in one atomic,
-  restorable snapshot.
+  restorable snapshot. When `state.stacked=true`, the checkpoint script also
+  owns the stack layer and PR submission (`references/stacked-prs.md`); the
+  loop never merges the stack.
 - Phase E requires `qa.report_done=true`, `qa.execution_done=true`,
   `review.ship=true`, and `verify.last_status=PASS`.
 - Do not regenerate the loop's input graph with `cy-create-tasks`,
@@ -347,6 +359,10 @@ The canonical `[[CODEX_LOOP ...]]` header, the manual invocation text, and
 - **`commit-checkpoint.py` exit 1** — repair the hook or commit failure and
   retry normally. If the repair changes tracked source after the last PASS,
   rerun `cy-final-verify` before retrying. `SKIP: no changes` is success.
+- **`commit-checkpoint.py` exit 2 in stacked mode** — resume drift: the
+  worktree is outside the stack while layer branches exist. Run
+  `gh stack checkout <slug>/task-NN` then `gh stack top` and retry
+  (`references/stacked-prs.md`); never re-init the stack.
 - **Worker launch or delegation failure** — the pane shows raw JSON instead
   of a TUI banner, `rtk herdr agent list` stays `unknown`, or the status wait
   times out with no progress: interrupt

--- a/.agents/skills/cy-loop-tasks/references/checklist.md
+++ b/.agents/skills/cy-loop-tasks/references/checklist.md
@@ -23,6 +23,7 @@ final iteration.
 - [ ] `mode` was decided by filesystem, not by guess (`tasks` if `_tasks.md` AND a `task_*.md` exist, else `free`).
 - [ ] `goal_signature` was copied verbatim from the user's prompt (CODEX_LOOP `goal=` value or manual reason).
 - [ ] `--frontend` was passed to `init-state.py` if and only if the invocation text carried it, and `state.frontend_agent` matches.
+- [ ] `--stacked` was passed to `init-state.py` if and only if the invocation text carried it; when set, `references/stacked-prs.md` was read in full and its prerequisites verified.
 
 ## Phase B mode=tasks only
 
@@ -31,7 +32,7 @@ final iteration.
 - [ ] Scoped validation ran, every failure was repaired in the same phase action, then `cy-final-verify` passed (or worker PASS evidence was verified for the frontend lane) before `update-state.py`.
 - [ ] No peer-review round (`deep-review`) ran in this iteration — per-task review instructions were deferred to Phase D.
 - [ ] Exactly ONE task was attempted in this iteration.
-- [ ] `commit-checkpoint.py <slug> --task <stem>` ran after `update-state.py` and printed a commit SHA or the literal `SKIP: no changes`, captured in the summary's checkpoint field.
+- [ ] `commit-checkpoint.py <slug> --task <stem>` ran after `update-state.py` and printed a commit SHA or the literal `SKIP: no changes` (plus a `stack: submitted` line when `state.stacked=true`), captured in the summary's checkpoint field.
 
 ## Phase B mode=free only
 

--- a/.agents/skills/cy-loop-tasks/references/goal-header-template.md
+++ b/.agents/skills/cy-loop-tasks/references/goal-header-template.md
@@ -41,6 +41,22 @@ Bootstrap passes the value to `init-state.py --frontend`; it lands in
 `state.yaml.frontend_agent` and holds for the whole loop. Omit the parameter
 to run every task locally.
 
+## Stacked PRs (`--stacked`)
+
+Opt-in, default off, tasks mode only. Append `--stacked` to the invocation
+line (combinable with `--frontend`):
+
+```text
+Use the cy-loop-tasks skill at .agents/skills/cy-loop-tasks/SKILL.md.
+The skill is a self-healing continue loop — repair command and gate failures inside the current phase action, then continue until Phase E or a proven external blocker. Slug: <slug>. --stacked
+```
+
+Bootstrap passes it to `init-state.py --stacked`; it lands in
+`state.yaml.stacked` and makes every Phase B checkpoint publish its task as
+one `gh stack` layer with a draft PR. Prerequisites and semantics:
+`references/stacked-prs.md`. Omit the parameter for the default single-branch
+checkpoint flow.
+
 ## Invoking without the plugin (manual run)
 
 ```

--- a/.agents/skills/cy-loop-tasks/references/stacked-prs.md
+++ b/.agents/skills/cy-loop-tasks/references/stacked-prs.md
@@ -1,0 +1,55 @@
+# Stacked-PR checkpoints (opt-in)
+
+Off by default. Active only when the invocation carried `--stacked` and
+bootstrap recorded `state.yaml.stacked: true` (tasks mode only —
+`init-state.py` refuses it in free mode). When active, every Phase B
+checkpoint publishes its task as one layer of a GitHub stacked-PR chain
+instead of piling commits on a single branch. The mechanics live entirely
+inside `commit-checkpoint.py`; the loop's phase machine does not change.
+
+## Prerequisites (verify at bootstrap, before the first Phase B iteration)
+
+1. `gh extension list` shows `github/gh-stack`. Missing → repair with
+   `gh extension install github/gh-stack`.
+2. The repository is enrolled in the stacked-PRs preview: `gh stack init --help`
+   exits 0 and a dry `gh stack view` on a stack branch does not report an
+   enrollment error. An un-enrolled repo is an **external blocker** for
+   stacked mode only — record it and rerun bootstrap without `--stacked`.
+3. The loop starts from the branch that will be the stack trunk (usually
+   `main`). The first checkpoint captures it as `--base`; do not pre-create a
+   feature branch for the loop — layer branches replace it.
+
+## Layer semantics
+
+- **One Phase B task = one layer.** The checkpoint creates
+  `<slug>/task-NN` on top of the previous layer and commits there. Stack
+  order = execution order emitted by `detect-phase.py`, which already
+  linearizes the task graph — fan-out siblings simply stack in the order
+  they execute. GitHub reviewers see one task's diff per PR.
+- **Phase C/D commits ride the current top layer.** QA fixes and
+  peer-review remediation are cross-cutting by nature; they never create
+  layers. `--review-round` requires the current branch to already belong to
+  the stack.
+- **Submission is part of the checkpoint.** After each commit the script runs
+  `gh stack submit --auto` (new PRs open as drafts). A clean tree inside a
+  stack still re-submits — that heals a commit-ok/submit-failed retry.
+- **The loop never merges the stack.** Phase E ends at the full gate +
+  done-signature as always; merging (`gh stack merge`, or per-layer) is the
+  operator's call afterwards. Merged lower layers auto-rebase the ones above
+  on GitHub's side.
+
+## Resume and drift
+
+On resume, land on the stack top before the next Phase B iteration:
+`gh stack checkout <slug>/task-NN` (any layer selects the stack), then
+`gh stack top`. The script guards drift: layer branches existing while the
+current branch is outside the stack is exit 2 — check out the stack and
+retry; never re-init.
+
+## Failure handling
+
+Same repair-loop contract as every checkpoint. `gh stack init/add` failures
+happen before the commit (nothing to restore); a `gh stack submit` failure
+after a successful commit prints the SHA path on retry via the clean-tree
+re-submit. Network/auth failures that survive the repair loop meet the
+external-blocker test — record and stop, the local stack is intact.

--- a/.agents/skills/cy-loop-tasks/references/state-schema.md
+++ b/.agents/skills/cy-loop-tasks/references/state-schema.md
@@ -20,6 +20,7 @@ No other writer is permitted. Hand-editing voids resume guarantees.
 | `iteration` | int ≥ 0 | Monotonic counter. `update-state.py` increments it once per call. |
 | `goal_signature` | string | Verbatim text from the user's `[[CODEX_LOOP goal="..."]]` header (or manual invocation reason). Read-only after bootstrap. |
 | `frontend_agent` | `claude` \| `cursor` \| null | Frontend worker selected via `init-state.py --frontend`. Non-null activates the herdr frontend lane for the whole loop. Read-only after bootstrap. |
+| `stacked` | bool | Stacked-PR checkpoints, opt-in via `init-state.py --stacked` (tasks mode only; default `false`). True makes `commit-checkpoint.py` publish each Phase B task as a `gh stack` layer (`references/stacked-prs.md`). Read-only after bootstrap. |
 | `tasks.total` | int | Total entries in `_tasks.md`. Populated only in `mode=tasks`. |
 | `tasks.completed` | list[string] | Stems (e.g., `task_01`) of completed entries, in completion order. |
 | `tasks.current` | string \| null | Stem of the task being worked on right now. Null between iterations. |
@@ -44,7 +45,8 @@ No other writer is permitted. Hand-editing voids resume guarantees.
    --reconcile-tasks` is used to rebuild `tasks.*` from task-file
    frontmatter after `_tasks.md` is authored later in the workflow. Do not
    hand-edit `mode`.
-3. `frontend_agent` is written once at bootstrap and never mutated.
+3. `frontend_agent` and `stacked` are written once at bootstrap and never
+   mutated.
 4. `progress.checklist[]` items move only forward
    (`pending → in_progress → completed`). Reverting requires a new entry.
 5. `review.rounds` only increments; `review.ship` only flips false → true

--- a/.agents/skills/cy-loop-tasks/scripts/_state_io.py
+++ b/.agents/skills/cy-loop-tasks/scripts/_state_io.py
@@ -63,6 +63,7 @@ def dump(state: dict, path: Path) -> None:
         "iteration",
         "goal_signature",
         "frontend_agent",
+        "stacked",
     ):
         out.append(f"{key}: {_scalar(state.get(key))}")
 

--- a/.agents/skills/cy-loop-tasks/scripts/commit-checkpoint.py
+++ b/.agents/skills/cy-loop-tasks/scripts/commit-checkpoint.py
@@ -16,7 +16,9 @@ Usage:
 
 Behavior:
     1. Verify state.yaml exists under <tasks-root>/<slug>/.
-    2. ``git status --porcelain``: empty tree -> print ``SKIP: no changes`` and exit 0.
+    2. ``git status --porcelain``: empty tree -> print ``SKIP: no changes`` and
+       exit 0 (stacked mode with an active stack still re-submits first; see
+       Stacked mode below).
     3. Build commit header:
          --task task_NN -> ``feat: <title from task_NN.md frontmatter> #<NN>``
          --slice "<txt>" -> ``feat: <txt>`` (whitespace collapsed)
@@ -32,15 +34,34 @@ Behavior:
        --no-verify, or --no-gpg-sign. Hook failures surface as exit 1.
     6. On success, print new commit SHA (``git rev-parse HEAD``) and exit 0.
 
+Stacked mode (``state.yaml`` has ``stacked: true``; set at bootstrap via
+``init-state.py --stacked``, tasks mode only):
+    - --task task_NN: before committing, ensure the layer branch
+      ``<slug>/task-NN`` is the checked-out stack top — first layer via
+      ``gh stack init <layer> --base <current branch>``, later layers via
+      ``gh stack add <layer>``. The commit lands on the layer branch.
+    - --review-round N: commit rides the current stack branch (no new layer);
+      the current branch must already belong to a stack.
+    - After every successful commit — and on a clean tree while inside a
+      stack — run ``gh stack submit --auto`` so every layer's PR is created
+      or refreshed. The SHA (or ``SKIP: no changes``) stays the first stdout
+      line; a ``stack: submitted`` line follows.
+    - Not in a stack but ``refs/heads/<slug>/task-*`` branches exist -> exit 2
+      (resume drift: run ``gh stack checkout`` + ``gh stack top`` first).
+    - --slice is incompatible with stacked mode -> exit 2.
+    - The gh binary honors the ``CY_LOOP_GH`` env override (tests use a stub).
+
 Exits:
     0 success (commit created OR ``SKIP: no changes``)
-    1 git command failure (commit, hook, rev-parse, ...)
-    2 argument or state error (missing slug dir, state.yaml, flag misuse)
+    1 git or gh command failure (commit, hook, rev-parse, stack submit, ...)
+    2 argument or state error (missing slug dir, state.yaml, flag misuse,
+      stacked-mode drift)
 """
 
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -124,6 +145,106 @@ def _tree_is_clean() -> bool:
     return status.stdout.strip() == ""
 
 
+def _run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    gh_bin = os.environ.get("CY_LOOP_GH", "gh")
+    return subprocess.run(
+        [gh_bin, *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _current_branch() -> str:
+    head = _run_git(["rev-parse", "--abbrev-ref", "HEAD"])
+    if head.returncode != 0:
+        print(
+            f"commit-checkpoint: git rev-parse HEAD failed: {head.stderr.strip()}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    branch = head.stdout.strip()
+    if branch == "HEAD":
+        print(
+            "commit-checkpoint: detached HEAD is incompatible with stacked "
+            "mode; check out a branch first",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return branch
+
+
+def _in_stack() -> bool:
+    return _run_gh(["stack", "view"]).returncode == 0
+
+
+def _layer_branches(slug: str) -> list[str]:
+    refs = _run_git(
+        [
+            "for-each-ref",
+            "--format=%(refname:short)",
+            f"refs/heads/{slug}/task-*",
+        ]
+    )
+    if refs.returncode != 0:
+        print(
+            f"commit-checkpoint: git for-each-ref failed: {refs.stderr.strip()}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return [line for line in refs.stdout.splitlines() if line.strip()]
+
+
+def _ensure_task_layer(slug: str, stem: str) -> str:
+    """Make ``<slug>/task-NN`` the checked-out stack layer; return its name."""
+    nn = _TASK_STEM.match(stem).group(1)  # stem validated by _build_task_header
+    layer = f"{slug}/task-{nn}"
+    if _current_branch() == layer:
+        return layer
+    if _in_stack():
+        add = _run_gh(["stack", "add", layer])
+        if add.returncode != 0:
+            print(
+                f"commit-checkpoint: gh stack add {layer} failed: "
+                f"{add.stderr.strip() or add.stdout.strip()}",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        return layer
+    if _layer_branches(slug):
+        print(
+            f"commit-checkpoint: layer branches for {slug!r} exist but the "
+            "current branch is not part of a stack; resume the stack first "
+            "(`gh stack checkout`, then `gh stack top`) and retry",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    base = _current_branch()
+    init = _run_gh(["stack", "init", layer, "--base", base])
+    if init.returncode != 0:
+        print(
+            f"commit-checkpoint: gh stack init {layer} --base {base} failed: "
+            f"{init.stderr.strip() or init.stdout.strip()}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return layer
+
+
+def _submit_stack() -> None:
+    submit = _run_gh(["stack", "submit", "--auto"])
+    if submit.returncode != 0:
+        print(
+            "commit-checkpoint: gh stack submit --auto failed: "
+            f"{submit.stderr.strip() or submit.stdout.strip()} "
+            "(any local commit is preserved; rerunning the checkpoint "
+            "re-submits)",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    print(f"stack: submitted ({_current_branch()})")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("slug")
@@ -180,10 +301,6 @@ def main() -> int:
         )
         return 2
 
-    if _tree_is_clean():
-        print("SKIP: no changes")
-        return 0
-
     try:
         state = load(state_path)
     except Exception as exc:  # noqa: BLE001
@@ -193,6 +310,22 @@ def main() -> int:
         )
         return 1
 
+    stacked = bool(state.get("stacked"))
+    if stacked and args.slice_text is not None:
+        print(
+            "commit-checkpoint: --slice is incompatible with stacked mode "
+            "(stack layers map to the authored task graph)",
+            file=sys.stderr,
+        )
+        return 2
+
+    if _tree_is_clean():
+        print("SKIP: no changes")
+        if stacked and _in_stack():
+            # Heal a prior commit-ok/submit-failed run: re-submit is idempotent.
+            _submit_stack()
+        return 0
+
     iteration = int(state.get("iteration", 0))
     mode = state.get("mode") or "?"
 
@@ -200,12 +333,22 @@ def main() -> int:
         task_md = slug_dir / f"{args.task}.md"
         header = _build_task_header(task_md, args.task)
         phase_label = f"phase B mode={mode}"
+        if stacked:
+            _ensure_task_layer(args.slug, args.task)
     elif args.slice_text is not None:
         header = _build_slice_header(args.slice_text)
         phase_label = f"phase B mode={mode}"
     else:
         header = _build_review_header(args.review_round)
         phase_label = f"phase D review round {args.review_round}"
+        if stacked and not _in_stack():
+            print(
+                "commit-checkpoint: stacked review-round checkpoint requires "
+                "the current branch to belong to a stack; resume it first "
+                "(`gh stack checkout`, then `gh stack top`)",
+                file=sys.stderr,
+            )
+            return 2
 
     body_parts = [
         f"Checkpoint via cy-loop-tasks (iteration {iteration}, {phase_label})."
@@ -237,6 +380,8 @@ def main() -> int:
         )
         return 1
     print(sha.stdout.strip())
+    if stacked:
+        _submit_stack()
     return 0
 
 

--- a/.agents/skills/cy-loop-tasks/scripts/init-state.py
+++ b/.agents/skills/cy-loop-tasks/scripts/init-state.py
@@ -8,14 +8,15 @@ an existing state.yaml. Read schema in ``references/state-schema.md``.
 
 Usage:
     init-state.py <slug> --goal "<text>" [--mode tasks|free]
-                  [--frontend claude|cursor] [--tasks-root <path>]
+                  [--frontend claude|cursor] [--stacked]
+                  [--tasks-root <path>]
 
 Exits:
     0 success
     1 generic error (stderr)
     2 state.yaml already exists
     3 _techspec.md missing
-    4 mode override conflicts with filesystem
+    4 mode override conflicts with filesystem, or --stacked outside tasks mode
 """
 
 from __future__ import annotations
@@ -44,6 +45,11 @@ def main() -> int:
         choices=["claude", "cursor"],
         default=None,
         help="frontend worker agent; non-null activates the herdr frontend lane",
+    )
+    ap.add_argument(
+        "--stacked",
+        action="store_true",
+        help="opt into stacked-PR checkpoints (gh stack); tasks mode only",
     )
     ap.add_argument(
         "--tasks-root",
@@ -81,6 +87,13 @@ def main() -> int:
             file=sys.stderr,
         )
         return 4
+    if args.stacked and chosen != "tasks":
+        print(
+            "init-state: --stacked requires tasks mode (stack layers map to "
+            "the authored task graph); author _tasks.md + task_*.md first",
+            file=sys.stderr,
+        )
+        return 4
 
     completed: list[str] = []
     pending: list[str] = []
@@ -101,6 +114,7 @@ def main() -> int:
         "iteration": 0,
         "goal_signature": args.goal,
         "frontend_agent": args.frontend,
+        "stacked": args.stacked,
         "tasks": {
             "total": total,
             "completed": completed,
@@ -119,7 +133,8 @@ def main() -> int:
     dump(state, state_path)
     print(
         f"init-state: wrote {state_path} (mode={chosen}, total_tasks={total}, "
-        f"frontend_agent={args.frontend or 'null'})"
+        f"frontend_agent={args.frontend or 'null'}, "
+        f"stacked={'true' if args.stacked else 'false'})"
     )
     return 0
 

--- a/.agents/skills/cy-loop-tasks/scripts/test_scripts.py
+++ b/.agents/skills/cy-loop-tasks/scripts/test_scripts.py
@@ -367,6 +367,26 @@ class CyLoopTasksScriptTests(unittest.TestCase):
             state = state_io.load(slug_dir / "state.yaml")
             self.assertEqual(state["goal_signature"], goal)
 
+    def test_update_state_normalizes_legacy_stacked_to_false(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tasks_root = Path(tmp) / "tasks"
+            slug = "legacy-stacked"
+            self.write_state(tasks_root, slug)  # helper predates the flag
+
+            updated = self.run_script(
+                "update-state.py",
+                slug,
+                "--tasks-root",
+                str(tasks_root),
+                "--phase",
+                "B",
+                "--action",
+                "advance",
+            )
+            self.assertEqual(updated.returncode, 0, updated.stderr)
+            state = state_io.load(tasks_root / slug / "state.yaml")
+            self.assertIs(state["stacked"], False)
+
     def test_init_state_defaults_frontend_agent_to_null(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tasks_root = Path(tmp) / "tasks"
@@ -387,6 +407,56 @@ class CyLoopTasksScriptTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             state = state_io.load(slug_dir / "state.yaml")
             self.assertIsNone(state["frontend_agent"])
+            self.assertFalse(state["stacked"])
+
+    def test_init_state_records_stacked_flag_in_tasks_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tasks_root = Path(tmp) / "tasks"
+            slug = "stacked-tasks"
+            slug_dir = tasks_root / slug
+            slug_dir.mkdir(parents=True)
+            (slug_dir / "_techspec.md").write_text("# spec\n", encoding="utf-8")
+            (slug_dir / "_tasks.md").write_text("# tasks\n", encoding="utf-8")
+            (slug_dir / "task_01.md").write_text(
+                "---\nstatus: pending\ntitle: first\n---\n", encoding="utf-8"
+            )
+
+            result = self.run_script(
+                "init-state.py",
+                slug,
+                "--tasks-root",
+                str(tasks_root),
+                "--goal",
+                "test goal",
+                "--stacked",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("stacked=true", result.stdout)
+            state = state_io.load(slug_dir / "state.yaml")
+            self.assertTrue(state["stacked"])
+
+    def test_init_state_rejects_stacked_in_free_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tasks_root = Path(tmp) / "tasks"
+            slug = "stacked-free"
+            slug_dir = tasks_root / slug
+            slug_dir.mkdir(parents=True)
+            (slug_dir / "_techspec.md").write_text("# spec\n", encoding="utf-8")
+
+            result = self.run_script(
+                "init-state.py",
+                slug,
+                "--tasks-root",
+                str(tasks_root),
+                "--goal",
+                "test goal",
+                "--stacked",
+            )
+
+            self.assertEqual(result.returncode, 4)
+            self.assertIn("--stacked requires tasks mode", result.stderr)
+            self.assertFalse((slug_dir / "state.yaml").exists())
 
     # ---- detect-phase.py -------------------------------------------------
 
@@ -626,17 +696,27 @@ class CyLoopTasksScriptTests(unittest.TestCase):
         first = _git(root, "commit", "-q", "-m", "anchor", env=env)
         self.assertEqual(first.returncode, 0, first.stderr)
 
-    def _setup_checkpoint_repo(self, root: Path, slug: str) -> Path:
+    def _setup_checkpoint_repo(self, root: Path, slug: str, **state_overrides: object) -> Path:
         self._init_git_repo(root)
         tasks_root = root / ".compozy" / "tasks"
-        self.write_state(tasks_root, slug, mode="tasks", iteration=4)
+        self.write_state(tasks_root, slug, mode="tasks", iteration=4, **state_overrides)
         # Track the state.yaml so subsequent checkpoint runs see a clean tree
         env = _git_env()
         _git(root, "add", "-A", env=env)
         _git(root, "commit", "-q", "-m", "state", env=env)
         return tasks_root
 
-    def _run_checkpoint(self, root: Path, tasks_root: Path, slug: str, *flags: str) -> subprocess.CompletedProcess[str]:
+    def _run_checkpoint(
+        self,
+        root: Path,
+        tasks_root: Path,
+        slug: str,
+        *flags: str,
+        extra_env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = _git_env()
+        if extra_env:
+            env.update(extra_env)
         return subprocess.run(
             [
                 sys.executable,
@@ -647,11 +727,48 @@ class CyLoopTasksScriptTests(unittest.TestCase):
                 str(tasks_root.relative_to(root)),
             ],
             cwd=root,
-            env=_git_env(),
+            env=env,
             check=False,
             text=True,
             capture_output=True,
         )
+
+    def _gh_stub(self, tmp: Path) -> tuple[Path, dict[str, str]]:
+        """Fake ``gh`` binary logging calls and mimicking stack init/add/view."""
+        stub_dir = tmp / "gh-stub"
+        stub_dir.mkdir(parents=True, exist_ok=True)
+        stub = stub_dir / "gh"
+        stub.write_text(
+            "#!/bin/sh\n"
+            'echo "$*" >> "$GH_STUB_LOG"\n'
+            'case "$1 $2" in\n'
+            '  "stack view")\n'
+            '    [ -f "$GH_STUB_STATE/in-stack" ] || exit 1\n'
+            "    ;;\n"
+            '  "stack init")\n'
+            '    git switch -q -c "$3" || exit 1\n'
+            '    touch "$GH_STUB_STATE/in-stack"\n'
+            "    ;;\n"
+            '  "stack add")\n'
+            '    git switch -q -c "$3" || exit 1\n'
+            "    ;;\n"
+            '  "stack submit")\n'
+            "    ;;\n"
+            "esac\n"
+            "exit 0\n",
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        env = {
+            "CY_LOOP_GH": str(stub),
+            "GH_STUB_LOG": str(stub_dir / "calls.log"),
+            "GH_STUB_STATE": str(stub_dir),
+        }
+        return stub_dir, env
+
+    def _stub_calls(self, stub_dir: Path) -> str:
+        log = stub_dir / "calls.log"
+        return log.read_text(encoding="utf-8") if log.exists() else ""
 
     def test_commit_checkpoint_skips_when_no_changes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -818,6 +935,157 @@ class CyLoopTasksScriptTests(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 2)
             self.assertIn("state.yaml", result.stderr)
+
+    # ---- commit-checkpoint.py stacked mode -------------------------------
+
+    def test_commit_checkpoint_stacked_inits_layer_commits_and_submits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            slug = "stacked-first"
+            tasks_root = self._setup_checkpoint_repo(root, slug, stacked=True)
+            stub_dir, gh_env = self._gh_stub(Path(tmp))
+            (tasks_root / slug / "task_07.md").write_text(
+                "---\nstatus: pending\ntitle: implement backend tests\n---\n",
+                encoding="utf-8",
+            )
+            (root / "feature.txt").write_text("change", encoding="utf-8")
+            env = _git_env()
+            _git(root, "add", "-A", env=env)
+            _git(root, "commit", "-q", "-m", "task file", env=env)
+            (root / "delta.txt").write_text("work", encoding="utf-8")
+
+            result = self._run_checkpoint(
+                root, tasks_root, slug, "--task", "task_07", extra_env=gh_env
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            lines = result.stdout.strip().splitlines()
+            self.assertEqual(len(lines[0]), 40)
+            self.assertEqual(lines[1], f"stack: submitted ({slug}/task-07)")
+
+            branch = _git(root, "rev-parse", "--abbrev-ref", "HEAD", env=env)
+            self.assertEqual(branch.stdout.strip(), f"{slug}/task-07")
+
+            calls = self._stub_calls(stub_dir)
+            self.assertIn(f"stack init {slug}/task-07 --base main", calls)
+            self.assertIn("stack submit --auto", calls)
+            self.assertNotIn("stack add", calls)
+
+            log = _git(root, "log", "-1", "--pretty=%B", env=env)
+            self.assertIn("feat: implement backend tests #07", log.stdout)
+
+    def test_commit_checkpoint_stacked_adds_layer_when_stack_active(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            slug = "stacked-next"
+            tasks_root = self._setup_checkpoint_repo(root, slug, stacked=True)
+            stub_dir, gh_env = self._gh_stub(Path(tmp))
+            (stub_dir / "in-stack").touch()
+            (tasks_root / slug / "task_02.md").write_text(
+                "---\nstatus: pending\ntitle: second layer\n---\n",
+                encoding="utf-8",
+            )
+            env = _git_env()
+            _git(root, "add", "-A", env=env)
+            _git(root, "commit", "-q", "-m", "task file", env=env)
+            (root / "delta.txt").write_text("work", encoding="utf-8")
+
+            result = self._run_checkpoint(
+                root, tasks_root, slug, "--task", "task_02", extra_env=gh_env
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            calls = self._stub_calls(stub_dir)
+            self.assertIn(f"stack add {slug}/task-02", calls)
+            self.assertNotIn("stack init", calls)
+            self.assertIn("stack submit --auto", calls)
+
+            branch = _git(root, "rev-parse", "--abbrev-ref", "HEAD", env=env)
+            self.assertEqual(branch.stdout.strip(), f"{slug}/task-02")
+
+    def test_commit_checkpoint_stacked_clean_tree_still_resubmits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            slug = "stacked-clean"
+            tasks_root = self._setup_checkpoint_repo(root, slug, stacked=True)
+            stub_dir, gh_env = self._gh_stub(Path(tmp))
+            (stub_dir / "in-stack").touch()
+
+            result = self._run_checkpoint(
+                root, tasks_root, slug, "--task", "task_01", extra_env=gh_env
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            lines = result.stdout.strip().splitlines()
+            self.assertEqual(lines[0], "SKIP: no changes")
+            self.assertTrue(lines[1].startswith("stack: submitted"))
+            self.assertIn("stack submit --auto", self._stub_calls(stub_dir))
+
+    def test_commit_checkpoint_stacked_rejects_slice(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            slug = "stacked-slice"
+            tasks_root = self._setup_checkpoint_repo(root, slug, stacked=True)
+            _, gh_env = self._gh_stub(Path(tmp))
+            (root / "delta.txt").write_text("work", encoding="utf-8")
+
+            result = self._run_checkpoint(
+                root, tasks_root, slug, "--slice", "some slice", extra_env=gh_env
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("incompatible with stacked mode", result.stderr)
+
+    def test_commit_checkpoint_stacked_guards_resume_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            slug = "stacked-drift"
+            tasks_root = self._setup_checkpoint_repo(root, slug, stacked=True)
+            stub_dir, gh_env = self._gh_stub(Path(tmp))
+            (tasks_root / slug / "task_02.md").write_text(
+                "---\nstatus: pending\ntitle: second layer\n---\n",
+                encoding="utf-8",
+            )
+            env = _git_env()
+            _git(root, "add", "-A", env=env)
+            _git(root, "commit", "-q", "-m", "task file", env=env)
+            # A prior layer branch exists but the stub reports no active stack.
+            _git(root, "branch", f"{slug}/task-01", env=env)
+            (root / "delta.txt").write_text("work", encoding="utf-8")
+
+            result = self._run_checkpoint(
+                root, tasks_root, slug, "--task", "task_02", extra_env=gh_env
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("resume the stack first", result.stderr)
+            self.assertNotIn("stack init", self._stub_calls(stub_dir))
+
+    def test_commit_checkpoint_stacked_review_round_requires_stack(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            slug = "stacked-review"
+            tasks_root = self._setup_checkpoint_repo(root, slug, stacked=True)
+            stub_dir, gh_env = self._gh_stub(Path(tmp))
+            (root / "remediation.txt").write_text("fix", encoding="utf-8")
+
+            outside = self._run_checkpoint(
+                root, tasks_root, slug, "--review-round", "1", extra_env=gh_env
+            )
+            self.assertEqual(outside.returncode, 2)
+            self.assertIn("belong to a stack", outside.stderr)
+
+            (stub_dir / "in-stack").touch()
+            inside = self._run_checkpoint(
+                root, tasks_root, slug, "--review-round", "1", extra_env=gh_env
+            )
+            self.assertEqual(inside.returncode, 0, inside.stderr)
+            lines = inside.stdout.strip().splitlines()
+            self.assertEqual(len(lines[0]), 40)
+            self.assertTrue(lines[1].startswith("stack: submitted"))
+            self.assertIn("stack submit --auto", self._stub_calls(stub_dir))
 
 
 if __name__ == "__main__":

--- a/.agents/skills/cy-loop-tasks/scripts/update-state.py
+++ b/.agents/skills/cy-loop-tasks/scripts/update-state.py
@@ -257,6 +257,9 @@ def main() -> int:
         print(f"update-state: failed to parse {state_path}: {exc}", file=sys.stderr)
         return 1
 
+    # Legacy states predate the stacked flag; normalize to the schema's bool.
+    state["stacked"] = bool(state.get("stacked"))
+
     record_iteration = _has_observation(args)
     try:
         _apply(state, args, slug_dir)

--- a/bun.lock
+++ b/bun.lock
@@ -187,6 +187,13 @@
       },
     },
   },
+  "overrides": {
+    "@assistant-ui/core": "0.3.0",
+    "@assistant-ui/react": "0.15.0",
+    "@assistant-ui/react-ai-sdk": "1.4.1",
+    "@assistant-ui/store": "0.3.0",
+    "lucide-react": "^1.28.0",
+  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
@@ -220,13 +227,13 @@
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
-    "@assistant-ui/core": ["@assistant-ui/core@0.3.2", "", { "dependencies": { "assistant-stream": "^0.3.31", "nanoid": "^6.0.0" }, "peerDependencies": { "@assistant-ui/store": "^0.3.0", "@assistant-ui/tap": "^0.9.0", "@types/react": "*", "assistant-cloud": "^0.1.31", "react": "^18 || ^19", "zustand": "^5.0.11" }, "optionalPeers": ["@types/react", "assistant-cloud", "react", "zustand"] }, "sha512-OXLoym/icUVPfgE3OrfNYkkL6sgscqZrQSoA/ru0ThIXPK69Yf6devhXzY6LAEcHFL4q/5TtZ/yI7YEy/W2D0w=="],
+    "@assistant-ui/core": ["@assistant-ui/core@0.3.0", "", { "dependencies": { "assistant-stream": "^0.3.29", "nanoid": "^6.0.0" }, "peerDependencies": { "@assistant-ui/store": "^0.3.0", "@assistant-ui/tap": "^0.9.0", "@types/react": "*", "assistant-cloud": "^0.1.31", "react": "^18 || ^19", "zustand": "^5.0.11" }, "optionalPeers": ["@types/react", "assistant-cloud", "react", "zustand"] }, "sha512-NnD9OryKzM8k74OTRznMOwhEUpWWdIFxX8yg3k6SSPEc2KqlID3WzaTMt/NvWPZMy+CFTfgFS6PpEmF80umyZg=="],
 
-    "@assistant-ui/react": ["@assistant-ui/react@0.15.1", "", { "dependencies": { "@assistant-ui/core": "^0.3.1", "@assistant-ui/store": "^0.3.1", "@assistant-ui/tap": "^0.9.7", "@radix-ui/primitive": "^1.1.7", "@radix-ui/react-collection": "^1.1.15", "@radix-ui/react-compose-refs": "^1.1.5", "@radix-ui/react-context": "^1.2.2", "@radix-ui/react-primitive": "^2.1.10", "@radix-ui/react-use-callback-ref": "^1.1.4", "@radix-ui/react-use-controllable-state": "^1.2.6", "@radix-ui/react-use-escape-keydown": "^1.1.5", "assistant-cloud": "^0.1.37", "assistant-stream": "^0.3.30", "nanoid": "^6.0.0", "radix-ui": "^1.6.7", "react-textarea-autosize": "^8.5.9", "safe-content-frame": "^0.0.25", "zod": "^4.4.3", "zustand": "^5.0.14" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-SZdhTCL7HdfsOs3K9pqDLpUPrsigvKjt2TawGaY0bU/Wt//U/dbNN9bRdTYYZ5wbAOPfpm8TNvZoLSXjZSkm8g=="],
+    "@assistant-ui/react": ["@assistant-ui/react@0.15.0", "", { "dependencies": { "@assistant-ui/core": "^0.3.0", "@assistant-ui/store": "^0.3.0", "@assistant-ui/tap": "^0.9.7", "@radix-ui/primitive": "^1.1.7", "@radix-ui/react-collection": "^1.1.15", "@radix-ui/react-compose-refs": "^1.1.5", "@radix-ui/react-context": "^1.2.2", "@radix-ui/react-primitive": "^2.1.10", "@radix-ui/react-use-callback-ref": "^1.1.4", "@radix-ui/react-use-controllable-state": "^1.2.6", "@radix-ui/react-use-escape-keydown": "^1.1.5", "assistant-cloud": "^0.1.37", "assistant-stream": "^0.3.29", "nanoid": "^6.0.0", "radix-ui": "^1.6.7", "react-textarea-autosize": "^8.5.9", "safe-content-frame": "^0.0.25", "zod": "^4.4.3", "zustand": "^5.0.14" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tTh81zhzPvo3nmcgD46RjXraOsu3INJjOMrwwFMRYOLnQbZi8GW+j42SrDoxIebN2WAS7/8EyWyCgNgTDsBdzQ=="],
 
-    "@assistant-ui/react-ai-sdk": ["@assistant-ui/react-ai-sdk@1.4.2", "", { "dependencies": { "@ai-sdk/mcp": "^2.0.16", "@ai-sdk/react": "^4.0.40", "@assistant-ui/core": "^0.3.2", "@assistant-ui/store": "^0.3.2", "ai": "^7.0.37", "assistant-cloud": "*", "assistant-stream": "^0.3.31" }, "peerDependencies": { "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-fXfVIE1cMmlv1vyVO7gU0HqazxlmuqfMa1rRNKi+01JLPf8VoTNh/37zmwn5ygLcM3pdlELTI6C4Ow4zyNFtcA=="],
+    "@assistant-ui/react-ai-sdk": ["@assistant-ui/react-ai-sdk@1.4.1", "", { "dependencies": { "@ai-sdk/mcp": "^2.0.16", "@ai-sdk/react": "^4.0.40", "@assistant-ui/core": "^0.3.0", "@assistant-ui/store": "^0.3.0", "ai": "^7.0.37", "assistant-cloud": "*", "assistant-stream": "^0.3.29" }, "peerDependencies": { "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-Ln1+JZW/AEt/AaYzSCTv5ZjXm8Nn0ECi5LawaHtNtf6Ng4Sn3eKufqJacubzUOp33n87NYlOlOiQjWzmfIIu2Q=="],
 
-    "@assistant-ui/store": ["@assistant-ui/store@0.3.2", "", { "peerDependencies": { "@assistant-ui/tap": "^0.9.0", "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-D6NgnYEifDcusQd6CbokNutqfHA2OEr1sz0/+ds+Bc7xsm8ghRxkvBubtttIYQKaajALPPJbWcr/zcvGv21g0g=="],
+    "@assistant-ui/store": ["@assistant-ui/store@0.3.0", "", { "dependencies": { "use-effect-event": "^2.0.3" }, "peerDependencies": { "@assistant-ui/tap": "^0.9.0", "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-t3UT7O4MzD/9EhklgYcaLpRTupKH2w5eQaYvwXBFIsmujB++t2bGgce8Z9MWQkt8vBTxX2ZRu0xAxVqt+LPxqA=="],
 
     "@assistant-ui/tap": ["@assistant-ui/tap@0.9.7", "", { "peerDependencies": { "@types/react": "*", "react": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-lIuADtloXINgKawy4cqGpf9JyfRQWgS2yP5VOCpBJOQuen1aCVcuXuDdxRBBn2gEYtLorRK9iLEQtx4VTNR/cw=="],
 
@@ -2786,6 +2793,8 @@
 
     "use-composed-ref": ["use-composed-ref@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w=="],
 
+    "use-effect-event": ["use-effect-event@2.0.3", "", { "peerDependencies": { "react": "^18.3 || ^19.0.0-0" } }, "sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ=="],
+
     "use-isomorphic-layout-effect": ["use-isomorphic-layout-effect@1.2.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA=="],
 
     "use-latest": ["use-latest@1.3.0", "", { "dependencies": { "use-isomorphic-layout-effect": "^1.1.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ=="],
@@ -2961,8 +2970,6 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/config-array/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
-    "@fumadocs/api-docs/lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
 
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.9.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw=="],
 
@@ -3413,10 +3420,6 @@
     "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "fumadocs-openapi/lucide-react": ["lucide-react@1.25.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw=="],
-
-    "fumadocs-ui/lucide-react": ["lucide-react@1.27.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-rJicGl/3Fly/E0rOH1YmPZ6e49JCnKknh1ox1vpHnkfjujAkKA6sqUZvH3MTAaXXjgexyUwgNwTJzTtYuAFYJw=="],
 
     "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 

--- a/internal/api/contract/settings_window_manager.go
+++ b/internal/api/contract/settings_window_manager.go
@@ -65,6 +65,8 @@ type SettingsWindowManagerConfigPayload struct {
 	GroupMoveModifier   SettingsWindowDragModifier          `json:"group_move_modifier"`
 	SwapModifier        SettingsWindowDragModifier          `json:"swap_modifier"`
 	HistoryLimit        int                                 `json:"history_limit"`
+	NavStackLimit       int                                 `json:"nav_stack_limit"`
+	ClosedEntryLimit    int                                 `json:"closed_entry_limit"`
 	DesktopTransition   SettingsWindowDesktopTransition     `json:"desktop_transition"`
 	Gaps                SettingsWindowManagerGapsPayload    `json:"gaps"`
 	Snap                SettingsWindowManagerSnapPayload    `json:"snap"`

--- a/internal/api/contract/windowmanager_conversions.go
+++ b/internal/api/contract/windowmanager_conversions.go
@@ -67,7 +67,7 @@ func WindowManagerClientFromDomain(client windowmanager.ClientView) (WindowManag
 }
 
 // WindowManagerResultFromDomain converts a semantic command result.
-func WindowManagerResultFromDomain(result windowmanager.Result) (WindowManagerResult, error) {
+func WindowManagerResultFromDomain(result *windowmanager.Result) (WindowManagerResult, error) {
 	snapshot, err := WindowManagerSnapshotFromDomain(result.Snapshot)
 	if err != nil {
 		return WindowManagerResult{}, err

--- a/internal/api/core/settings_test.go
+++ b/internal/api/core/settings_test.go
@@ -1219,6 +1219,8 @@ func TestSettingsSectionAndCollectionConversions(t *testing.T) {
 					GroupMoveModifier:   "control",
 					SwapModifier:        "meta",
 					HistoryLimit:        77,
+					NavStackLimit:       66,
+					ClosedEntryLimit:    18,
 					DesktopTransition:   compozyconfig.WindowDesktopTransitionCrossfade,
 					Gaps: compozyconfig.WindowManagerGapsConfig{
 						Inner: 12, Top: 18, Right: 14, Bottom: 16, Left: 20,
@@ -1357,6 +1359,8 @@ func TestSettingsSectionAndCollectionConversions(t *testing.T) {
 				GroupMoveModifier:   contract.SettingsWindowDragModifierControl,
 				SwapModifier:        contract.SettingsWindowDragModifierMeta,
 				HistoryLimit:        77,
+				NavStackLimit:       66,
+				ClosedEntryLimit:    18,
 				DesktopTransition:   contract.SettingsWindowDesktopTransitionCrossfade,
 				Gaps: contract.SettingsWindowManagerGapsPayload{
 					Inner: 12, Top: 18, Right: 14, Bottom: 16, Left: 20,
@@ -1936,6 +1940,8 @@ func TestUpdateSettingsSectionHandlersDelegateValidPayloads(t *testing.T) {
 				t.Helper()
 				if req.WindowManager == nil ||
 					req.WindowManager.HistoryLimit != 77 ||
+					req.WindowManager.NavStackLimit != 66 ||
+					req.WindowManager.ClosedEntryLimit != 18 ||
 					!reflect.DeepEqual(req.WindowManager.Snap.RepeatRatios, []float64{0.4, 0.7, 0.3}) ||
 					req.WindowManager.Shortcuts["desktop.switch.next"] != "Meta+ArrowRight" {
 					t.Fatalf("req.WindowManager = %#v, want complete window-manager config", req.WindowManager)
@@ -2042,6 +2048,8 @@ func validSettingsWindowManagerConfigPayload() contract.SettingsWindowManagerCon
 		GroupMoveModifier:   contract.SettingsWindowDragModifierControl,
 		SwapModifier:        contract.SettingsWindowDragModifierMeta,
 		HistoryLimit:        77,
+		NavStackLimit:       66,
+		ClosedEntryLimit:    18,
 		DesktopTransition:   contract.SettingsWindowDesktopTransitionCrossfade,
 		Gaps: contract.SettingsWindowManagerGapsPayload{
 			Inner:  12,

--- a/internal/api/core/settings_window_manager_payload.go
+++ b/internal/api/core/settings_window_manager_payload.go
@@ -38,6 +38,8 @@ func settingsWindowManagerConfigPayload(
 		GroupMoveModifier:   contract.SettingsWindowDragModifier(cfg.GroupMoveModifier),
 		SwapModifier:        contract.SettingsWindowDragModifier(cfg.SwapModifier),
 		HistoryLimit:        cfg.HistoryLimit,
+		NavStackLimit:       cfg.NavStackLimit,
+		ClosedEntryLimit:    cfg.ClosedEntryLimit,
 		DesktopTransition:   contract.SettingsWindowDesktopTransition(cfg.DesktopTransition),
 		Gaps: contract.SettingsWindowManagerGapsPayload{
 			Inner:  cfg.Gaps.Inner,
@@ -80,6 +82,8 @@ func windowManagerConfigFromPayload(
 		GroupMoveModifier:   strings.TrimSpace(string(payload.GroupMoveModifier)),
 		SwapModifier:        strings.TrimSpace(string(payload.SwapModifier)),
 		HistoryLimit:        payload.HistoryLimit,
+		NavStackLimit:       payload.NavStackLimit,
+		ClosedEntryLimit:    payload.ClosedEntryLimit,
 		DesktopTransition:   strings.TrimSpace(string(payload.DesktopTransition)),
 		Gaps: compozyconfig.WindowManagerGapsConfig{
 			Inner:  payload.Gaps.Inner,

--- a/internal/api/core/window_manager_handlers.go
+++ b/internal/api/core/window_manager_handlers.go
@@ -78,7 +78,7 @@ func (h *BaseHandlers) handleWindowManagerCommand(c *gin.Context, previewOnly bo
 		h.respondWindowManagerError(c, workspaceID, err)
 		return
 	}
-	payload, err := contract.WindowManagerResultFromDomain(result)
+	payload, err := contract.WindowManagerResultFromDomain(&result)
 	if err != nil {
 		h.respondWindowManagerError(c, workspaceID, fmt.Errorf("encode command result: %w", err))
 		return

--- a/internal/api/core/window_manager_layout.go
+++ b/internal/api/core/window_manager_layout.go
@@ -123,7 +123,7 @@ func (h *BaseHandlers) ReplaceWindowManagerLayout(c *gin.Context) {
 		h.respondWindowManagerError(c, workspaceID, err)
 		return
 	}
-	payload, err := contract.WindowManagerResultFromDomain(result)
+	payload, err := contract.WindowManagerResultFromDomain(&result)
 	if err != nil {
 		h.respondWindowManagerError(c, workspaceID, fmt.Errorf("encode layout replacement: %w", err))
 		return

--- a/internal/api/spec/settings_test.go
+++ b/internal/api/spec/settings_test.go
@@ -364,6 +364,8 @@ func TestSettingsRoutesAndSchemas(t *testing.T) {
 			"group_move_modifier",
 			"swap_modifier",
 			"history_limit",
+			"nav_stack_limit",
+			"closed_entry_limit",
 			"desktop_transition",
 			"gaps",
 			"snap",

--- a/internal/api/udsapi/handlers_test.go
+++ b/internal/api/udsapi/handlers_test.go
@@ -1091,6 +1091,8 @@ func validUDSWindowManagerSettingsPayload() contract.SettingsWindowManagerConfig
 		GroupMoveModifier:   contract.SettingsWindowDragModifierControl,
 		SwapModifier:        contract.SettingsWindowDragModifierMeta,
 		HistoryLimit:        77,
+		NavStackLimit:       66,
+		ClosedEntryLimit:    18,
 		DesktopTransition:   contract.SettingsWindowDesktopTransitionCrossfade,
 		Gaps: contract.SettingsWindowManagerGapsPayload{
 			Inner: 12, Top: 18, Right: 14, Bottom: 16, Left: 20,

--- a/internal/api/udsapi/transport_parity_integration_test.go
+++ b/internal/api/udsapi/transport_parity_integration_test.go
@@ -110,7 +110,12 @@ func TestUDSTransportSessionOwnerProjectionMatchesHTTP(t *testing.T) {
 		}
 		if owner.SessionID != sessionPayload.ID || owner.WorkspaceID != sessionPayload.WorkspaceID ||
 			strings.TrimSpace(owner.WorkspaceName) == "" {
-			t.Fatalf("owner = %#v, want session %q workspace %q and non-empty name", owner, sessionPayload.ID, sessionPayload.WorkspaceID)
+			t.Fatalf(
+				"owner = %#v, want session %q workspace %q and non-empty name",
+				owner,
+				sessionPayload.ID,
+				sessionPayload.WorkspaceID,
+			)
 		}
 	})
 }

--- a/internal/cli/bridge_control_integration_test.go
+++ b/internal/cli/bridge_control_integration_test.go
@@ -19,194 +19,202 @@ import (
 )
 
 func TestBridgeSetupVerifyAndSendIntegration(t *testing.T) {
-	t.Run("Should persist headless setup and round trip provider control without lifecycle mutation", func(t *testing.T) {
-		t.Parallel()
+	t.Run(
+		"Should persist headless setup and round trip provider control without lifecycle mutation",
+		func(t *testing.T) {
+			t.Parallel()
 
-		h := newIntegrationHarness(t)
-		h.runner.bridgeProviders = []bridgepkg.BridgeProvider{{
-			Platform:      "telegram",
-			ExtensionName: "telegram",
-			DisplayName:   "Telegram",
-		}}
-		mustExecuteRoot(t, h.deps, "daemon", "start", "-o", "json")
-		defer stopBridgeControlIntegrationDaemon(t, &h)
+			h := newIntegrationHarness(t)
+			h.runner.bridgeProviders = []bridgepkg.BridgeProvider{{
+				Platform:      "telegram",
+				ExtensionName: "telegram",
+				DisplayName:   "Telegram",
+			}}
+			mustExecuteRoot(t, h.deps, "daemon", "start", "-o", "json")
+			defer stopBridgeControlIntegrationDaemon(t, &h)
 
-		const botToken = "123456:abcdefghijklmnopqrstuvwxyzABCDE"
-		const webhookSecret = "telegram-webhook-secret-value"
-		setupInput := `{
+			const botToken = "123456:abcdefghijklmnopqrstuvwxyzABCDE"
+			const webhookSecret = "telegram-webhook-secret-value"
+			setupInput := `{
   "scope": "global",
   "webhook_public_url": "https://bridge.example.test/telegram/support",
   "webhook_path": "/telegram/support",
   "bot_token": "` + botToken + `",
   "webhook_secret": "` + webhookSecret + `"
 }`
-		setupOut, setupErr, err := executeRootCommandWithInput(
-			t,
-			h.deps,
-			setupInput,
-			"bridge", "setup", "telegram", "--json", "--print-only",
-		)
-		if err != nil {
-			t.Fatalf("bridge setup error = %v; stderr=%s", err, setupErr)
-		}
-		if strings.Contains(setupOut, botToken) || strings.Contains(setupOut, webhookSecret) {
-			t.Fatalf("bridge setup output leaked supplied secret: %s", setupOut)
-		}
-		var setup bridgeSetupResult
-		if err := json.Unmarshal([]byte(setupOut), &setup); err != nil {
-			t.Fatalf("json.Unmarshal(setup) error = %v; output=%s", err, setupOut)
-		}
-		if setup.Status != bridgepkg.BridgeStatusDisabled || setup.WebhookCommand == "" ||
-			setup.NextCommand != "compozy bridge verify "+setup.BridgeInstanceID {
-			t.Fatalf("setup result = %#v", setup)
-		}
-
-		getOut := mustExecuteRoot(t, h.deps, "bridge", "get", setup.BridgeInstanceID, "--json")
-		var before BridgeRecord
-		if err := json.Unmarshal([]byte(getOut), &before); err != nil {
-			t.Fatalf("json.Unmarshal(bridge get) error = %v", err)
-		}
-		if before.Enabled || before.Status != bridgepkg.BridgeStatusDisabled {
-			t.Fatalf("bridge before verify = %#v, want disabled", before)
-		}
-
-		bindingsOut := mustExecuteRoot(
-			t,
-			h.deps,
-			"bridge", "secret-bindings", "list", setup.BridgeInstanceID, "--json",
-		)
-		var bindings struct {
-			Bindings []BridgeSecretBindingRecord `json:"bindings"`
-		}
-		if err := json.Unmarshal([]byte(bindingsOut), &bindings); err != nil {
-			t.Fatalf("json.Unmarshal(bindings) error = %v", err)
-		}
-		if len(bindings.Bindings) != 2 {
-			t.Fatalf("bindings = %#v, want bot_token and webhook_secret", bindings.Bindings)
-		}
-
-		fakeTelegramCalls := 0
-		fakeTelegram := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
-			fakeTelegramCalls++
-			if request.Method != http.MethodPost || request.URL.Path != "/setWebhook" {
-				t.Errorf("fake Telegram request = %s %s", request.Method, request.URL.Path)
-			}
-			w.Header().Set("Content-Type", "application/json")
-			if _, err := io.WriteString(w, `{"ok":true,"result":true}`); err != nil {
-				t.Errorf("fake Telegram response write error = %v", err)
-			}
-		}))
-		defer fakeTelegram.Close()
-		h.runner.bridges.registerWebhookFn = func(
-			ctx context.Context,
-			extensionName string,
-			request bridgepkg.BridgeWebhookRegistrationRequest,
-		) (bridgepkg.BridgeWebhookRegistrationResponse, error) {
-			if extensionName != "telegram" || request.BridgeInstanceID != setup.BridgeInstanceID {
-				t.Fatalf("RegisterBridgeWebhook() extension=%q request=%#v", extensionName, request)
-			}
-			httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, fakeTelegram.URL+"/setWebhook", http.NoBody)
+			setupOut, setupErr, err := executeRootCommandWithInput(
+				t,
+				h.deps,
+				setupInput,
+				"bridge", "setup", "telegram", "--json", "--print-only",
+			)
 			if err != nil {
-				return bridgepkg.BridgeWebhookRegistrationResponse{}, err
+				t.Fatalf("bridge setup error = %v; stderr=%s", err, setupErr)
 			}
-			response, err := fakeTelegram.Client().Do(httpRequest)
+			if strings.Contains(setupOut, botToken) || strings.Contains(setupOut, webhookSecret) {
+				t.Fatalf("bridge setup output leaked supplied secret: %s", setupOut)
+			}
+			var setup bridgeSetupResult
+			if err := json.Unmarshal([]byte(setupOut), &setup); err != nil {
+				t.Fatalf("json.Unmarshal(setup) error = %v; output=%s", err, setupOut)
+			}
+			if setup.Status != bridgepkg.BridgeStatusDisabled || setup.WebhookCommand == "" ||
+				setup.NextCommand != "compozy bridge verify "+setup.BridgeInstanceID {
+				t.Fatalf("setup result = %#v", setup)
+			}
+
+			getOut := mustExecuteRoot(t, h.deps, "bridge", "get", setup.BridgeInstanceID, "--json")
+			var before BridgeRecord
+			if err := json.Unmarshal([]byte(getOut), &before); err != nil {
+				t.Fatalf("json.Unmarshal(bridge get) error = %v", err)
+			}
+			if before.Enabled || before.Status != bridgepkg.BridgeStatusDisabled {
+				t.Fatalf("bridge before verify = %#v, want disabled", before)
+			}
+
+			bindingsOut := mustExecuteRoot(
+				t,
+				h.deps,
+				"bridge", "secret-bindings", "list", setup.BridgeInstanceID, "--json",
+			)
+			var bindings struct {
+				Bindings []BridgeSecretBindingRecord `json:"bindings"`
+			}
+			if err := json.Unmarshal([]byte(bindingsOut), &bindings); err != nil {
+				t.Fatalf("json.Unmarshal(bindings) error = %v", err)
+			}
+			if len(bindings.Bindings) != 2 {
+				t.Fatalf("bindings = %#v, want bot_token and webhook_secret", bindings.Bindings)
+			}
+
+			fakeTelegramCalls := 0
+			fakeTelegram := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+				fakeTelegramCalls++
+				if request.Method != http.MethodPost || request.URL.Path != "/setWebhook" {
+					t.Errorf("fake Telegram request = %s %s", request.Method, request.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if _, err := io.WriteString(w, `{"ok":true,"result":true}`); err != nil {
+					t.Errorf("fake Telegram response write error = %v", err)
+				}
+			}))
+			defer fakeTelegram.Close()
+			h.runner.bridges.registerWebhookFn = func(
+				ctx context.Context,
+				extensionName string,
+				request bridgepkg.BridgeWebhookRegistrationRequest,
+			) (bridgepkg.BridgeWebhookRegistrationResponse, error) {
+				if extensionName != "telegram" || request.BridgeInstanceID != setup.BridgeInstanceID {
+					t.Fatalf("RegisterBridgeWebhook() extension=%q request=%#v", extensionName, request)
+				}
+				httpRequest, err := http.NewRequestWithContext(
+					ctx,
+					http.MethodPost,
+					fakeTelegram.URL+"/setWebhook",
+					http.NoBody,
+				)
+				if err != nil {
+					return bridgepkg.BridgeWebhookRegistrationResponse{}, err
+				}
+				response, err := fakeTelegram.Client().Do(httpRequest)
+				if err != nil {
+					return bridgepkg.BridgeWebhookRegistrationResponse{}, err
+				}
+				if closeErr := response.Body.Close(); closeErr != nil {
+					return bridgepkg.BridgeWebhookRegistrationResponse{}, closeErr
+				}
+				return bridgepkg.BridgeWebhookRegistrationResponse{Status: bridgepkg.BridgeCheckStatusPass}, nil
+			}
+			client, err := clientFromDeps(h.deps)
 			if err != nil {
-				return bridgepkg.BridgeWebhookRegistrationResponse{}, err
+				t.Fatalf("clientFromDeps() error = %v", err)
 			}
-			if closeErr := response.Body.Close(); closeErr != nil {
-				return bridgepkg.BridgeWebhookRegistrationResponse{}, closeErr
+			registrationClient, ok := client.(bridgeSetupClient)
+			if !ok {
+				t.Fatal("daemon client does not implement bridgeSetupClient")
 			}
-			return bridgepkg.BridgeWebhookRegistrationResponse{Status: bridgepkg.BridgeCheckStatusPass}, nil
-		}
-		client, err := clientFromDeps(h.deps)
-		if err != nil {
-			t.Fatalf("clientFromDeps() error = %v", err)
-		}
-		registrationClient, ok := client.(bridgeSetupClient)
-		if !ok {
-			t.Fatal("daemon client does not implement bridgeSetupClient")
-		}
-		registration, err := registrationClient.RegisterBridgeWebhook(t.Context(), setup.BridgeInstanceID)
-		if err != nil {
-			t.Fatalf("RegisterBridgeWebhook() error = %v", err)
-		}
-		if registration.Status != bridgepkg.BridgeCheckStatusPass || fakeTelegramCalls != 1 {
-			t.Fatalf("registration=%#v fake calls=%d, want pass/1", registration, fakeTelegramCalls)
-		}
+			registration, err := registrationClient.RegisterBridgeWebhook(t.Context(), setup.BridgeInstanceID)
+			if err != nil {
+				t.Fatalf("RegisterBridgeWebhook() error = %v", err)
+			}
+			if registration.Status != bridgepkg.BridgeCheckStatusPass || fakeTelegramCalls != 1 {
+				t.Fatalf("registration=%#v fake calls=%d, want pass/1", registration, fakeTelegramCalls)
+			}
 
-		h.runner.bridges.checkBridgeFn = func(
-			_ context.Context,
-			extensionName string,
-			request bridgepkg.BridgeCheckRequest,
-		) (bridgepkg.BridgeCheckResponse, error) {
-			if extensionName != "telegram" || request.BridgeInstanceID != setup.BridgeInstanceID {
-				t.Fatalf("CheckBridge() extension=%q request=%#v", extensionName, request)
+			h.runner.bridges.checkBridgeFn = func(
+				_ context.Context,
+				extensionName string,
+				request bridgepkg.BridgeCheckRequest,
+			) (bridgepkg.BridgeCheckResponse, error) {
+				if extensionName != "telegram" || request.BridgeInstanceID != setup.BridgeInstanceID {
+					t.Fatalf("CheckBridge() extension=%q request=%#v", extensionName, request)
+				}
+				return bridgepkg.BridgeCheckResponse{Checks: []bridgepkg.BridgeCheckRecord{
+					{Check: "provider.identity", Status: bridgepkg.BridgeCheckStatusPass},
+					{
+						Check: "webhook.reachability", Status: bridgepkg.BridgeCheckStatusSkipped,
+						Remediation: "Enable the bridge before testing reachability.",
+					},
+				}}, nil
 			}
-			return bridgepkg.BridgeCheckResponse{Checks: []bridgepkg.BridgeCheckRecord{
-				{Check: "provider.identity", Status: bridgepkg.BridgeCheckStatusPass},
-				{
-					Check: "webhook.reachability", Status: bridgepkg.BridgeCheckStatusSkipped,
-					Remediation: "Enable the bridge before testing reachability.",
-				},
-			}}, nil
-		}
-		verifyOut := mustExecuteRoot(
-			t,
-			h.deps,
-			"bridge", "verify", setup.BridgeInstanceID, "--json",
-		)
-		var verified BridgeVerifyRecord
-		if err := json.Unmarshal([]byte(verifyOut), &verified); err != nil {
-			t.Fatalf("json.Unmarshal(verify) error = %v", err)
-		}
-		if len(verified.Checks) != 2 || verified.Checks[1].Status != bridgepkg.BridgeCheckStatusSkipped {
-			t.Fatalf("verify response = %#v", verified)
-		}
-
-		afterOut := mustExecuteRoot(t, h.deps, "bridge", "get", setup.BridgeInstanceID, "--json")
-		var after BridgeRecord
-		if err := json.Unmarshal([]byte(afterOut), &after); err != nil {
-			t.Fatalf("json.Unmarshal(bridge after verify) error = %v", err)
-		}
-		if after.Enabled != before.Enabled || after.Status != before.Status {
-			t.Fatalf("verify changed lifecycle: before=%#v after=%#v", before, after)
-		}
-
-		platformSends := 0
-		h.runner.bridges.deliverBridgeFn = func(
-			_ context.Context,
-			extensionName string,
-			request bridgepkg.DeliveryRequest,
-		) (bridgepkg.DeliveryAck, error) {
-			platformSends++
-			if extensionName != "telegram" || request.Event.Content.Text != "Connection check" {
-				t.Fatalf("DeliverBridge() extension=%q request=%#v", extensionName, request)
+			verifyOut := mustExecuteRoot(
+				t,
+				h.deps,
+				"bridge", "verify", setup.BridgeInstanceID, "--json",
+			)
+			var verified BridgeVerifyRecord
+			if err := json.Unmarshal([]byte(verifyOut), &verified); err != nil {
+				t.Fatalf("json.Unmarshal(verify) error = %v", err)
 			}
-			return bridgepkg.DeliveryAck{
-				DeliveryID:      request.Event.DeliveryID,
-				Seq:             request.Event.Seq,
-				RemoteMessageID: "remote-integration",
-			}, nil
-		}
-		mustExecuteRoot(t, h.deps, "bridge", "enable", setup.BridgeInstanceID, "--json")
-		sendOut := mustExecuteRoot(
-			t,
-			h.deps,
-			"bridge", "send-test", setup.BridgeInstanceID,
-			"--message", "Connection check",
-			"--group-id", "-100123",
-			"--thread-id", "42",
-			"--mode", "direct-send",
-			"--json",
-		)
-		var sent BridgeSendTestRecord
-		if err := json.Unmarshal([]byte(sendOut), &sent); err != nil {
-			t.Fatalf("json.Unmarshal(send-test) error = %v", err)
-		}
-		if platformSends != 1 || sent.RemoteMessageID != "remote-integration" {
-			t.Fatalf("platform sends=%d response=%#v", platformSends, sent)
-		}
-	})
+			if len(verified.Checks) != 2 || verified.Checks[1].Status != bridgepkg.BridgeCheckStatusSkipped {
+				t.Fatalf("verify response = %#v", verified)
+			}
+
+			afterOut := mustExecuteRoot(t, h.deps, "bridge", "get", setup.BridgeInstanceID, "--json")
+			var after BridgeRecord
+			if err := json.Unmarshal([]byte(afterOut), &after); err != nil {
+				t.Fatalf("json.Unmarshal(bridge after verify) error = %v", err)
+			}
+			if after.Enabled != before.Enabled || after.Status != before.Status {
+				t.Fatalf("verify changed lifecycle: before=%#v after=%#v", before, after)
+			}
+
+			platformSends := 0
+			h.runner.bridges.deliverBridgeFn = func(
+				_ context.Context,
+				extensionName string,
+				request bridgepkg.DeliveryRequest,
+			) (bridgepkg.DeliveryAck, error) {
+				platformSends++
+				if extensionName != "telegram" || request.Event.Content.Text != "Connection check" {
+					t.Fatalf("DeliverBridge() extension=%q request=%#v", extensionName, request)
+				}
+				return bridgepkg.DeliveryAck{
+					DeliveryID:      request.Event.DeliveryID,
+					Seq:             request.Event.Seq,
+					RemoteMessageID: "remote-integration",
+				}, nil
+			}
+			mustExecuteRoot(t, h.deps, "bridge", "enable", setup.BridgeInstanceID, "--json")
+			sendOut := mustExecuteRoot(
+				t,
+				h.deps,
+				"bridge", "send-test", setup.BridgeInstanceID,
+				"--message", "Connection check",
+				"--group-id", "-100123",
+				"--thread-id", "42",
+				"--mode", "direct-send",
+				"--json",
+			)
+			var sent BridgeSendTestRecord
+			if err := json.Unmarshal([]byte(sendOut), &sent); err != nil {
+				t.Fatalf("json.Unmarshal(send-test) error = %v", err)
+			}
+			if platformSends != 1 || sent.RemoteMessageID != "remote-integration" {
+				t.Fatalf("platform sends=%d response=%#v", platformSends, sent)
+			}
+		},
+	)
 }
 
 func stopBridgeControlIntegrationDaemon(t *testing.T, h *integrationHarness) {

--- a/internal/cli/cli_historical_task_run_terminal_integration_test.go
+++ b/internal/cli/cli_historical_task_run_terminal_integration_test.go
@@ -187,7 +187,12 @@ func TestCLIHistoricalChannelTaskRunTerminalAfterDaemonRestartIntegration(t *tes
 				}
 				if terminalLease.Status != tt.wantRunStatus || terminalLease.RunID != enqueued.ID ||
 					terminalLease.SessionID != worker.ID {
-					t.Fatalf("terminal lease = %#v, want status %q for worker %q", terminalLease, tt.wantRunStatus, worker.ID)
+					t.Fatalf(
+						"terminal lease = %#v, want status %q for worker %q",
+						terminalLease,
+						tt.wantRunStatus,
+						worker.ID,
+					)
 				}
 				if resolvedParticipationChannelID(terminalLease.ResolvedNetworkParticipation) != tt.channel {
 					t.Fatalf("terminal lease = %#v, want preserved historical channel", terminalLease)
@@ -198,7 +203,12 @@ func TestCLIHistoricalChannelTaskRunTerminalAfterDaemonRestartIntegration(t *tes
 					t.Fatalf("json.Unmarshal(terminal run) error = %v", err)
 				}
 				if terminalRun.Status != tt.wantRunStatus || terminalRun.SessionID != worker.ID {
-					t.Fatalf("terminalRun = %#v, want status %q for worker %q", terminalRun, tt.wantRunStatus, worker.ID)
+					t.Fatalf(
+						"terminalRun = %#v, want status %q for worker %q",
+						terminalRun,
+						tt.wantRunStatus,
+						worker.ID,
+					)
 				}
 				if resolvedParticipationChannelID(terminalRun.ResolvedNetworkParticipation) != tt.channel {
 					t.Fatalf("terminalRun = %#v, want preserved historical channel", terminalRun)

--- a/internal/cli/extension_exec_integration_test.go
+++ b/internal/cli/extension_exec_integration_test.go
@@ -111,7 +111,8 @@ func TestExtensionExecInvokesCanonicalToolExactlyOnceAcrossOutputFormatsIntegrat
 			argv: []string{"-o", "toon"},
 			assert: func(t *testing.T, output string) {
 				t.Helper()
-				if !strings.Contains(output, "tool_invocation") || !strings.Contains(output, "ext__cmd_fixture__greet") {
+				if !strings.Contains(output, "tool_invocation") ||
+					!strings.Contains(output, "ext__cmd_fixture__greet") {
 					t.Fatalf("TOON output = %q", output)
 				}
 			},

--- a/internal/config/merge_window_manager.go
+++ b/internal/config/merge_window_manager.go
@@ -13,6 +13,8 @@ type windowManagerOverlay struct {
 	GroupMoveModifier   *string                     `toml:"group_move_modifier"`
 	SwapModifier        *string                     `toml:"swap_modifier"`
 	HistoryLimit        *int                        `toml:"history_limit"`
+	NavStackLimit       *int                        `toml:"nav_stack_limit"`
+	ClosedEntryLimit    *int                        `toml:"closed_entry_limit"`
 	DesktopTransition   *string                     `toml:"desktop_transition"`
 	Gaps                windowManagerGapsOverlay    `toml:"gaps"`
 	Snap                windowManagerSnapOverlay    `toml:"snap"`
@@ -51,6 +53,8 @@ func (o windowManagerOverlay) Apply(dst *WindowManagerConfig) {
 	applyStringPointer(o.GroupMoveModifier, &dst.GroupMoveModifier)
 	applyStringPointer(o.SwapModifier, &dst.SwapModifier)
 	applyIntPointer(o.HistoryLimit, &dst.HistoryLimit)
+	applyIntPointer(o.NavStackLimit, &dst.NavStackLimit)
+	applyIntPointer(o.ClosedEntryLimit, &dst.ClosedEntryLimit)
 	applyStringPointer(o.DesktopTransition, &dst.DesktopTransition)
 	o.Gaps.Apply(&dst.Gaps)
 	o.Snap.Apply(&dst.Snap)

--- a/internal/config/window_manager.go
+++ b/internal/config/window_manager.go
@@ -10,6 +10,9 @@ import (
 )
 
 const (
+	windowManagerNavStackLimitPath    = "window_manager.nav_stack_limit"
+	windowManagerClosedEntryLimitPath = "window_manager.closed_entry_limit"
+
 	WindowNewPolicyFloating    = "floating"
 	WindowNewPolicyBesideFocus = "beside_focus"
 
@@ -60,6 +63,8 @@ type WindowManagerConfig struct {
 	GroupMoveModifier   string                     `toml:"group_move_modifier"`
 	SwapModifier        string                     `toml:"swap_modifier"`
 	HistoryLimit        int                        `toml:"history_limit"`
+	NavStackLimit       int                        `toml:"nav_stack_limit"`
+	ClosedEntryLimit    int                        `toml:"closed_entry_limit"`
 	DesktopTransition   string                     `toml:"desktop_transition"`
 	Gaps                WindowManagerGapsConfig    `toml:"gaps"`
 	Snap                WindowManagerSnapConfig    `toml:"snap"`
@@ -104,6 +109,8 @@ func DefaultWindowManagerConfig() WindowManagerConfig {
 		GroupMoveModifier:   WindowDragModifierAlt,
 		SwapModifier:        WindowDragModifierShift,
 		HistoryLimit:        50,
+		NavStackLimit:       50,
+		ClosedEntryLimit:    20,
 		DesktopTransition:   WindowDesktopTransitionSlide,
 		Gaps: WindowManagerGapsConfig{
 			Inner: 8, Top: 8, Right: 10, Bottom: 8, Left: 10,
@@ -180,6 +187,12 @@ func (c WindowManagerConfig) Validate() error {
 		return ValidationError{
 			Path: "window_manager.history_limit", Message: "must be between 1 and 500",
 		}
+	}
+	if c.NavStackLimit < 1 || c.NavStackLimit > 200 {
+		return ValidationError{Path: windowManagerNavStackLimitPath, Message: "must be between 1 and 200"}
+	}
+	if c.ClosedEntryLimit < 1 || c.ClosedEntryLimit > 100 {
+		return ValidationError{Path: windowManagerClosedEntryLimitPath, Message: "must be between 1 and 100"}
 	}
 	if err := c.Gaps.Validate(); err != nil {
 		return err

--- a/internal/config/window_manager_test.go
+++ b/internal/config/window_manager_test.go
@@ -29,8 +29,8 @@ func TestWindowManagerConfig(t *testing.T) {
 		}
 		if got.NewWindowPolicy != WindowNewPolicyFloating ||
 			got.SmallViewportPolicy != WindowSmallViewportStack ||
-			got.HistoryLimit != 50 {
-			t.Fatalf("WindowManager = %#v, want floating/stack/history 50", got)
+			got.HistoryLimit != 50 || got.NavStackLimit != 50 || got.ClosedEntryLimit != 20 {
+			t.Fatalf("WindowManager = %#v, want floating/stack/history/nav/closed defaults", got)
 		}
 		wantRatios := []float64{0.5, 0.666667, 0.333333}
 		if !slices.Equal(got.Snap.RepeatRatios, wantRatios) {
@@ -49,6 +49,8 @@ func TestWindowManagerConfig(t *testing.T) {
 [window_manager]
 new_window_policy = "beside_focus"
 history_limit = 80
+nav_stack_limit = 120
+closed_entry_limit = 40
 
 [window_manager.gaps]
 inner = 12
@@ -59,6 +61,8 @@ repeat_ratios = [0.5, 0.75, 0.25]
 		writeFile(t, filepath.Join(workspaceRoot, DirName, ConfigName), `
 [window_manager]
 history_limit = 25
+nav_stack_limit = 75
+closed_entry_limit = 15
 desktop_transition = "crossfade"
 
 [window_manager.gaps]
@@ -75,6 +79,7 @@ top_center = "none"
 		windowManager := got.WindowManager
 		if windowManager.NewWindowPolicy != WindowNewPolicyBesideFocus ||
 			windowManager.HistoryLimit != 25 ||
+			windowManager.NavStackLimit != 75 || windowManager.ClosedEntryLimit != 15 ||
 			windowManager.DesktopTransition != WindowDesktopTransitionCrossfade {
 			t.Fatalf("WindowManager = %#v, want merged behavior", windowManager)
 		}
@@ -92,12 +97,16 @@ top_center = "none"
 		base := DefaultWindowManagerConfig()
 		base.NewWindowPolicy = WindowNewPolicyBesideFocus
 		base.HistoryLimit = 80
+		base.NavStackLimit = 90
+		base.ClosedEntryLimit = 30
 		base.Snap.RepeatRatios = []float64{0.5, 0.75, 0.25}
 		base.Shortcuts = map[string]string{"window.focus.left": "alt+KeyH"}
 		path := filepath.Join(t.TempDir(), ConfigName)
 		writeFile(t, path, `
 [window_manager]
 history_limit = 25
+nav_stack_limit = 70
+closed_entry_limit = 10
 
 [window_manager.gaps]
 right = 14
@@ -110,7 +119,8 @@ right = 14
 		if err != nil {
 			t.Fatalf("ApplyWindowManagerOverlayFile() error = %v", err)
 		}
-		if got.NewWindowPolicy != WindowNewPolicyBesideFocus || got.HistoryLimit != 25 {
+		if got.NewWindowPolicy != WindowNewPolicyBesideFocus || got.HistoryLimit != 25 ||
+			got.NavStackLimit != 70 || got.ClosedEntryLimit != 10 {
 			t.Fatalf("window manager overlay = %#v, want active policy and workspace history", got)
 		}
 		if got.Gaps.Right != 14 || got.Gaps.Left != base.Gaps.Left {
@@ -135,6 +145,28 @@ right = 14
 		_, err := ApplyWindowManagerOverlayFile(path, DefaultWindowManagerConfig())
 		assertWindowManagerValidationPath(t, err, "window_manager.history_limit")
 	})
+
+	t.Run(
+		"Should validate navigation and closed-entry ranges with exact paths [UT-140][UT-141][UT-142]",
+		func(t *testing.T) {
+			t.Parallel()
+			cases := []struct {
+				path    string
+				content string
+			}{
+				{path: windowManagerNavStackLimitPath, content: "[window_manager]\nnav_stack_limit = 0\n"},
+				{path: windowManagerNavStackLimitPath, content: "[window_manager]\nnav_stack_limit = 201\n"},
+				{path: windowManagerClosedEntryLimitPath, content: "[window_manager]\nclosed_entry_limit = 0\n"},
+				{path: windowManagerClosedEntryLimitPath, content: "[window_manager]\nclosed_entry_limit = 101\n"},
+			}
+			for _, testCase := range cases {
+				path := filepath.Join(t.TempDir(), ConfigName)
+				writeFile(t, path, testCase.content)
+				_, err := ApplyWindowManagerOverlayFile(path, DefaultWindowManagerConfig())
+				assertWindowManagerValidationPath(t, err, testCase.path)
+			}
+		},
+	)
 
 	t.Run("Should reject a duplicate shortcut chord", func(t *testing.T) {
 		t.Parallel()

--- a/internal/daemon/daemon_extension_agent_native_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_agent_native_e2e_integration_test.go
@@ -26,7 +26,10 @@ import (
 const agentNativeExtensionE2EName = "agent-native-e2e"
 
 func TestDaemonE2EAgentCompletesExtensionAuthoringThroughNativeTools(t *testing.T) {
-	t.Run("Should complete extension authoring through native tools", testDaemonE2EAgentCompletesExtensionAuthoringThroughNativeTools)
+	t.Run(
+		"Should complete extension authoring through native tools",
+		testDaemonE2EAgentCompletesExtensionAuthoringThroughNativeTools,
+	)
 }
 
 func testDaemonE2EAgentCompletesExtensionAuthoringThroughNativeTools(t *testing.T) {

--- a/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
@@ -26,7 +26,10 @@ import (
 const extensionAuthoringE2EName = "authoring-dev-e2e"
 
 func TestDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts(t *testing.T) {
-	t.Run("Should complete the development loop without trust prompts", testDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts)
+	t.Run(
+		"Should complete the development loop without trust prompts",
+		testDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts,
+	)
 }
 
 func testDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts(t *testing.T) {
@@ -139,7 +142,10 @@ const (
 )
 
 func TestDaemonE2EExtensionQuickstartReplayEndsWithAnInvocableExtension(t *testing.T) {
-	t.Run("Should replay the quickstart and invoke the installed extension", testDaemonE2EExtensionQuickstartReplayEndsWithAnInvocableExtension)
+	t.Run(
+		"Should replay the quickstart and invoke the installed extension",
+		testDaemonE2EExtensionQuickstartReplayEndsWithAnInvocableExtension,
+	)
 }
 
 func testDaemonE2EExtensionQuickstartReplayEndsWithAnInvocableExtension(t *testing.T) {

--- a/internal/daemon/daemon_extension_commands_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_commands_e2e_integration_test.go
@@ -23,7 +23,10 @@ import (
 const commandFixtureExtensionName = "cmd-fixture"
 
 func TestDaemonE2EExtensionContributedCommandsPreserveToolPolicy(t *testing.T) {
-	t.Run("Should preserve tool policy for contributed commands", testDaemonE2EExtensionContributedCommandsPreserveToolPolicy)
+	t.Run(
+		"Should preserve tool policy for contributed commands",
+		testDaemonE2EExtensionContributedCommandsPreserveToolPolicy,
+	)
 }
 
 func testDaemonE2EExtensionContributedCommandsPreserveToolPolicy(t *testing.T) {

--- a/internal/daemon/daemon_extension_distribution_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_distribution_e2e_integration_test.go
@@ -26,7 +26,10 @@ import (
 )
 
 func TestDaemonE2EExtensionDistributionAcrossIsolatedHomes(t *testing.T) {
-	t.Run("Should publish install update and remove across isolated homes", testDaemonE2EExtensionDistributionAcrossIsolatedHomes)
+	t.Run(
+		"Should publish install update and remove across isolated homes",
+		testDaemonE2EExtensionDistributionAcrossIsolatedHomes,
+	)
 }
 
 func testDaemonE2EExtensionDistributionAcrossIsolatedHomes(t *testing.T) {

--- a/internal/daemon/daemon_memory_e2e_integration_test.go
+++ b/internal/daemon/daemon_memory_e2e_integration_test.go
@@ -142,7 +142,12 @@ func TestDaemonE2EMemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation(t *test
 	if err := os.WriteFile(
 		noncanonicalPath,
 		[]byte(
-			memoryDocument("Noncanonical Decoy", "Noncanonical paths stay ignored", memcontract.TypeProject, "path decoy"),
+			memoryDocument(
+				"Noncanonical Decoy",
+				"Noncanonical paths stay ignored",
+				memcontract.TypeProject,
+				"path decoy",
+			),
 		),
 		0o644,
 	); err != nil {

--- a/internal/daemon/daemon_mock_agents_integration_test.go
+++ b/internal/daemon/daemon_mock_agents_integration_test.go
@@ -1723,7 +1723,12 @@ func assertWorkspaceAccessAgentCLIParity(
 	)
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) || exitErr.ExitCode() != agentidentity.ExitUnauthorized {
-		t.Fatalf("approve-reads CLI error = %v, want exit %d; stderr=%s", err, agentidentity.ExitUnauthorized, deniedStderr)
+		t.Fatalf(
+			"approve-reads CLI error = %v, want exit %d; stderr=%s",
+			err,
+			agentidentity.ExitUnauthorized,
+			deniedStderr,
+		)
 	}
 	if !strings.Contains(deniedStderr, workspaceaccess.DenialHint) {
 		t.Fatalf("approve-reads CLI stderr = %q, want denial hint", deniedStderr)

--- a/internal/daemon/daemon_review_and_fix_e2e_integration_test.go
+++ b/internal/daemon/daemon_review_and_fix_e2e_integration_test.go
@@ -239,7 +239,12 @@ func waitForReviewLoop(
 				return last
 			}
 			if loopRunStatusTerminal(last.Run.Status) {
-				t.Fatalf("wait review loop %s reached unexpected terminal status %q; last=%#v", want, last.Run.Status, last)
+				t.Fatalf(
+					"wait review loop %s reached unexpected terminal status %q; last=%#v",
+					want,
+					last.Run.Status,
+					last,
+				)
 			}
 		}
 		select {
@@ -325,7 +330,11 @@ func assertReviewAndFixRunContract(t testing.TB, detail contract.LoopRunResponse
 		"review", "has_issues", "write_artifacts", "fix_batches", "fix_batch", "collect_fixes", "finalize_round",
 	}
 	if len(detail.ExecutedDefinition.Graph.Nodes) != len(wantNodes) {
-		t.Fatalf("review-and-fix executed nodes = %#v, want exactly %#v", detail.ExecutedDefinition.Graph.Nodes, wantNodes)
+		t.Fatalf(
+			"review-and-fix executed nodes = %#v, want exactly %#v",
+			detail.ExecutedDefinition.Graph.Nodes,
+			wantNodes,
+		)
 	}
 	for index, wantNode := range wantNodes {
 		if got := detail.ExecutedDefinition.Graph.Nodes[index].ID; got != wantNode {
@@ -449,7 +458,11 @@ func assertReviewWriterContainment(
 		}
 		if strings.Contains(string(encoded), string(toolspkg.ErrorCodeNotFound)) ||
 			strings.Contains(string(encoded), "tool_not_found") {
-			t.Fatalf("writer containment task %q payload=%s, want boundary rejection instead of missing tool", taskName, encoded)
+			t.Fatalf(
+				"writer containment task %q payload=%s, want boundary rejection instead of missing tool",
+				taskName,
+				encoded,
+			)
 		}
 	}
 	entries, err := os.ReadDir(outside)
@@ -475,7 +488,16 @@ func reviewGoldenPath(t testing.TB, name string) string {
 	if !ok {
 		t.Fatal("runtime.Caller(0) failed")
 	}
-	return filepath.Join(filepath.Dir(file), "..", "..", "extensions", "dev-cycle", "testdata", "review_artifacts", name)
+	return filepath.Join(
+		filepath.Dir(file),
+		"..",
+		"..",
+		"extensions",
+		"dev-cycle",
+		"testdata",
+		"review_artifacts",
+		name,
+	)
 }
 
 func reviewFrontmatterValue(t testing.TB, content string, key string) string {

--- a/internal/daemon/daemon_software_delivery_e2e_integration_test.go
+++ b/internal/daemon/daemon_software_delivery_e2e_integration_test.go
@@ -229,6 +229,11 @@ func assertSoftwareDeliveryRuntimes(t testing.TB, detail contract.LoopRunRespons
 		t.Fatalf("software-delivery resolved runtimes = %#v, want three task rows", got)
 	}
 	for itemIndex, expected := range want {
-		loopRuntimeAssertJSONEqual(t, fmt.Sprintf("software-delivery item %d runtime", itemIndex), got[itemIndex], expected)
+		loopRuntimeAssertJSONEqual(
+			t,
+			fmt.Sprintf("software-delivery item %d runtime", itemIndex),
+			got[itemIndex],
+			expected,
+		)
 	}
 }

--- a/internal/daemon/loop_action_liveness_integration_helpers_test.go
+++ b/internal/daemon/loop_action_liveness_integration_helpers_test.go
@@ -483,7 +483,12 @@ func executeFailureBreakerGeneration(
 		executeErr := runtime.executeQueuedRun(ctx, taskRecord, run, loopActionRuntimeReasonEnqueued)
 		if metadata.NodeID == "failing" {
 			if !errors.Is(executeErr, errLoopFailureBreakerIntegration) {
-				t.Fatalf("executeQueuedRun(failing generation %d) error = %v, want %v", generation, executeErr, errLoopFailureBreakerIntegration)
+				t.Fatalf(
+					"executeQueuedRun(failing generation %d) error = %v, want %v",
+					generation,
+					executeErr,
+					errLoopFailureBreakerIntegration,
+				)
 			}
 			continue
 		}

--- a/internal/daemon/native_extension_tools_integration_test.go
+++ b/internal/daemon/native_extension_tools_integration_test.go
@@ -287,7 +287,12 @@ func TestNativeExtensionToolsIntegrationLifecycleParity(t *testing.T) {
 			t.Fatal("Registry.Call(global extensions_logs as agent) error = nil, want denial")
 		}
 		if reason, ok := toolspkg.ReasonOf(err); !ok || reason != toolspkg.ReasonExtensionSourceForbidden {
-			t.Fatalf("ReasonOf(global agent logs error) = %q/%t, want %q", reason, ok, toolspkg.ReasonExtensionSourceForbidden)
+			t.Fatalf(
+				"ReasonOf(global agent logs error) = %q/%t, want %q",
+				reason,
+				ok,
+				toolspkg.ReasonExtensionSourceForbidden,
+			)
 		}
 
 		_, err = registry.Call(t.Context(), scope, toolspkg.CallRequest{

--- a/internal/daemon/native_tool_window_manager_execute.go
+++ b/internal/daemon/native_tool_window_manager_execute.go
@@ -55,7 +55,7 @@ func (n *daemonNativeTools) executeWindowManagerCommand(
 	if err != nil {
 		return toolspkg.ToolResult{}, windowManagerToolError(req.ToolID, err)
 	}
-	payload := newWindowManagerCommandResult(command.CommandID(), result)
+	payload := newWindowManagerCommandResult(command.CommandID(), &result)
 	return structuredResult(payload, fmt.Sprintf("%s at revision %d", command.CommandID(), payload.Revision))
 }
 

--- a/internal/daemon/native_tool_window_manager_layout.go
+++ b/internal/daemon/native_tool_window_manager_layout.go
@@ -194,6 +194,6 @@ func (n *daemonNativeTools) layoutApply(
 	if err != nil {
 		return toolspkg.ToolResult{}, windowManagerToolError(req.ToolID, err)
 	}
-	payload := newWindowManagerCommandResult(windowmanager.CommandLayoutReplace, result)
+	payload := newWindowManagerCommandResult(windowmanager.CommandLayoutReplace, &result)
 	return structuredResult(payload, fmt.Sprintf("applied layout at revision %d", payload.Revision))
 }

--- a/internal/daemon/native_tool_window_manager_result.go
+++ b/internal/daemon/native_tool_window_manager_result.go
@@ -74,7 +74,7 @@ type windowManagerPreviewResult struct {
 
 func newWindowManagerCommandResult(
 	commandID windowmanager.CommandID,
-	result windowmanager.Result,
+	result *windowmanager.Result,
 ) windowManagerCommandResult {
 	return windowManagerCommandResult{
 		WorkspaceID: result.Snapshot.WorkspaceID,

--- a/internal/daemon/window_manager_boot.go
+++ b/internal/daemon/window_manager_boot.go
@@ -40,7 +40,7 @@ func (d *Daemon) bootDefaultWorkspaceAndWindowManager(
 		return fmt.Errorf("daemon: open window-manager store: %w", err)
 	}
 	cleanup.add(func(context.Context) error { return engine.Close() })
-	repository, err := newWindowManagerRepository(engine)
+	repository, err := newWindowManagerRepository(engine, withWindowManagerRepositoryLogger(state.logger))
 	if err != nil {
 		return err
 	}
@@ -52,6 +52,7 @@ func (d *Daemon) bootDefaultWorkspaceAndWindowManager(
 		windowManagerWorkspaceAuthorizer{resolver: resolver},
 		newWindowManagerLayoutRegistry(state.windowLayoutCatalog),
 		windowManagerDefaults(state.cfg.WindowManager),
+		windowmanager.WithLifecycleContext(ctx),
 		windowmanager.WithEventObserver(newWindowManagerHookObserver(state)),
 		windowmanager.WithWorkspaceConfigResolver(
 			windowManagerWorkspaceConfigResolver{resolver: state.workspaceResolver},
@@ -137,6 +138,8 @@ func windowManagerDefaults(cfg compozyconfig.WindowManagerConfig) windowmanager.
 		GroupMoveModifier:   cfg.GroupMoveModifier,
 		SwapModifier:        cfg.SwapModifier,
 		HistoryLimit:        cfg.HistoryLimit,
+		NavStackLimit:       cfg.NavStackLimit,
+		ClosedEntryLimit:    cfg.ClosedEntryLimit,
 		DesktopTransition:   windowmanager.DesktopTransition(cfg.DesktopTransition),
 		Gaps: windowmanager.GapsConfig{
 			Inner: float64(cfg.Gaps.Inner), Top: float64(cfg.Gaps.Top),
@@ -197,6 +200,8 @@ func windowManagerConfig(defaults windowmanager.Config) (compozyconfig.WindowMan
 		GroupMoveModifier:   defaults.GroupMoveModifier,
 		SwapModifier:        defaults.SwapModifier,
 		HistoryLimit:        defaults.HistoryLimit,
+		NavStackLimit:       defaults.NavStackLimit,
+		ClosedEntryLimit:    defaults.ClosedEntryLimit,
 		DesktopTransition:   string(defaults.DesktopTransition),
 		Gaps: compozyconfig.WindowManagerGapsConfig{
 			Inner: inner, Top: top, Right: right, Bottom: bottom, Left: left,

--- a/internal/daemon/window_manager_repository.go
+++ b/internal/daemon/window_manager_repository.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"sync"
 
 	"github.com/compozy/compozy/internal/clientstate"
@@ -21,27 +22,53 @@ const (
 // windowManagerRepository persists one typed aggregate per workspace.
 type windowManagerRepository struct {
 	service clientstate.Service
+	logger  *slog.Logger
 
 	mu    sync.Mutex
 	locks map[windowmanager.WorkspaceID]*sync.Mutex
 }
 
+var errWindowManagerSnapshotDiscardable = errors.New("daemon: discardable window-manager snapshot")
+
+type windowManagerRepositoryOption func(*windowManagerRepository)
+
+func withWindowManagerRepositoryLogger(logger *slog.Logger) windowManagerRepositoryOption {
+	return func(repository *windowManagerRepository) {
+		if logger != nil {
+			repository.logger = logger
+		}
+	}
+}
+
 var _ windowmanager.Repository = (*windowManagerRepository)(nil)
 
-func newWindowManagerRepository(service clientstate.Service) (*windowManagerRepository, error) {
+func newWindowManagerRepository(
+	service clientstate.Service,
+	options ...windowManagerRepositoryOption,
+) (*windowManagerRepository, error) {
 	if service == nil {
 		return nil, errors.New("daemon: window-manager client-state service is required")
 	}
-	return &windowManagerRepository{
+	repository := &windowManagerRepository{
 		service: service,
+		logger:  slog.Default(),
 		locks:   make(map[windowmanager.WorkspaceID]*sync.Mutex),
-	}, nil
+	}
+	for _, option := range options {
+		if option != nil {
+			option(repository)
+		}
+	}
+	return repository, nil
 }
 
 func (r *windowManagerRepository) Load(
 	ctx context.Context,
 	workspaceID windowmanager.WorkspaceID,
 ) (windowmanager.Snapshot, error) {
+	lock := r.lockFor(workspaceID)
+	lock.Lock()
+	defer lock.Unlock()
 	entry, err := r.service.Get(
 		ctx,
 		clientstate.WorkspaceID(workspaceID),
@@ -51,7 +78,27 @@ func (r *windowManagerRepository) Load(
 	if err != nil {
 		return windowmanager.Snapshot{}, mapWindowManagerStoreError("load snapshot", err)
 	}
-	return decodeWindowManagerSnapshot(entry.Value, workspaceID)
+	snapshot, err := decodeWindowManagerSnapshot(entry.Value, workspaceID)
+	if !errors.Is(err, errWindowManagerSnapshotDiscardable) {
+		return snapshot, err
+	}
+	r.logger.Warn(
+		"discarding incompatible window-manager snapshot",
+		"workspace_id", workspaceID,
+		"error", err,
+	)
+	if deleteErr := r.deleteSnapshotEntry(
+		ctx,
+		workspaceID,
+		entry.Rev,
+		"window-manager.snapshot.discard",
+	); deleteErr != nil {
+		return windowmanager.Snapshot{}, deleteErr
+	}
+	return windowmanager.Snapshot{}, fmt.Errorf(
+		"discarded window-manager snapshot: %w",
+		windowmanager.ErrSnapshotNotFound,
+	)
 }
 
 func (r *windowManagerRepository) Commit(ctx context.Context, commit *windowmanager.Commit) error {
@@ -128,14 +175,21 @@ func (r *windowManagerRepository) DeleteWorkspace(
 	if err != nil {
 		return mapWindowManagerStoreError("load snapshot for deletion", err)
 	}
-	_, err = r.service.Apply(
+	return r.deleteSnapshotEntry(ctx, workspaceID, entry.Rev, "window-manager.workspace.delete")
+}
+
+func (r *windowManagerRepository) deleteSnapshotEntry(
+	ctx context.Context,
+	workspaceID windowmanager.WorkspaceID,
+	revision uint64,
+	origin string,
+) error {
+	_, err := r.service.Apply(
 		ctx,
 		clientstate.WorkspaceID(workspaceID),
 		windowManagerStateDomain,
-		[]clientstate.Op{{
-			Kind: clientstate.OpDelete, Key: windowManagerSnapshotKey, IfRev: entry.Rev,
-		}},
-		clientstate.ApplyOptions{Origin: "window-manager.workspace.delete"},
+		[]clientstate.Op{{Kind: clientstate.OpDelete, Key: windowManagerSnapshotKey, IfRev: revision}},
+		clientstate.ApplyOptions{Origin: origin},
 	)
 	return mapWindowManagerStoreError("delete snapshot", err)
 }
@@ -219,7 +273,7 @@ func decodeWindowManagerSnapshot(
 	if err := decoder.Decode(&snapshot); err != nil {
 		return windowmanager.Snapshot{}, fmt.Errorf(
 			"daemon: decode window-manager snapshot: %w",
-			errors.Join(windowmanager.ErrInvalidTopology, err),
+			errors.Join(windowmanager.ErrInvalidTopology, errWindowManagerSnapshotDiscardable, err),
 		)
 	}
 	var trailing any
@@ -229,7 +283,14 @@ func decodeWindowManagerSnapshot(
 		}
 		return windowmanager.Snapshot{}, fmt.Errorf(
 			"daemon: decode trailing window-manager snapshot data: %w",
-			errors.Join(windowmanager.ErrInvalidTopology, err),
+			errors.Join(windowmanager.ErrInvalidTopology, errWindowManagerSnapshotDiscardable, err),
+		)
+	}
+	if snapshot.Version != windowmanager.SnapshotVersion {
+		return windowmanager.Snapshot{}, fmt.Errorf(
+			"daemon: window-manager snapshot version %d is unsupported: %w",
+			snapshot.Version,
+			errors.Join(windowmanager.ErrInvalidTopology, errWindowManagerSnapshotDiscardable),
 		)
 	}
 	if snapshot.WorkspaceID != workspaceID {

--- a/internal/daemon/window_manager_repository_test.go
+++ b/internal/daemon/window_manager_repository_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -25,12 +26,13 @@ func TestWindowManagerRepository(t *testing.T) {
 		}
 	})
 
-	t.Run("Should persist one typed snapshot exactly across store reopen", func(t *testing.T) {
+	t.Run("Should persist one full v3 snapshot exactly across store reopen [IT-001]", func(t *testing.T) {
 		t.Parallel()
 		fixture := newDaemonWindowManagerFixture(t)
 		ctx := testutil.Context(t)
 		workspaceID := windowmanager.WorkspaceID(fixture.workspace.ID)
 		want := daemonWindowManagerSnapshot(workspaceID, 1, "Primary")
+		decorateDaemonV3Snapshot(&want)
 		if err := fixture.repository.Commit(ctx, daemonWindowManagerCommit(want, 0)); err != nil {
 			t.Fatalf("Commit() error = %v", err)
 		}
@@ -107,7 +109,7 @@ func TestWindowManagerRepository(t *testing.T) {
 		}
 	})
 
-	t.Run("Should reject legacy unknown and malformed topology documents", func(t *testing.T) {
+	t.Run("Should discard legacy unknown and malformed snapshot documents", func(t *testing.T) {
 		t.Parallel()
 		cases := []struct {
 			name  string
@@ -132,7 +134,7 @@ func TestWindowManagerRepository(t *testing.T) {
 			},
 		}
 		for _, testCase := range cases {
-			t.Run("Should reject "+testCase.name, func(t *testing.T) {
+			t.Run("Should discard "+testCase.name, func(t *testing.T) {
 				t.Parallel()
 				fixture := newDaemonWindowManagerFixture(t)
 				ctx := testutil.Context(t)
@@ -154,12 +156,140 @@ func TestWindowManagerRepository(t *testing.T) {
 				if _, err := fixture.repository.Load(
 					ctx,
 					windowmanager.WorkspaceID(workspaceID),
-				); !errors.Is(err, windowmanager.ErrInvalidTopology) {
-					t.Fatalf("Load() error = %v, want ErrInvalidTopology", err)
+				); !errors.Is(err, windowmanager.ErrSnapshotNotFound) {
+					t.Fatalf("Load() error = %v, want ErrSnapshotNotFound", err)
+				}
+				if _, err := fixture.engine.Get(
+					ctx,
+					workspaceID,
+					windowManagerStateDomain,
+					windowManagerSnapshotKey,
+				); !errors.Is(err, clientstate.ErrNotFound) {
+					t.Fatalf("Get(after discard) error = %v, want ErrNotFound", err)
 				}
 			})
 		}
 	})
+
+	t.Run(
+		"Should reinitialize after a discard and commit the next command at revision one [UT-062]",
+		func(t *testing.T) {
+			t.Parallel()
+			fixture := newDaemonWindowManagerFixture(t)
+			ctx := testutil.Context(t)
+			workspaceID := clientstate.WorkspaceID(fixture.workspace.ID)
+			legacy := []byte(strings.ReplaceAll(
+				`{"version":2,"workspace_id":"WORKSPACE_ID","revision":7,"desktops":[],"windows":{},"history":{"undo":[],"redo":[]},"overrides":{},"updated_at":"2026-07-22T12:00:00Z"}`,
+				"WORKSPACE_ID",
+				fixture.workspace.ID,
+			))
+			if _, err := fixture.engine.Apply(
+				ctx,
+				workspaceID,
+				windowManagerStateDomain,
+				[]clientstate.Op{{Kind: clientstate.OpPut, Key: windowManagerSnapshotKey, Value: legacy}},
+				clientstate.ApplyOptions{},
+			); err != nil {
+				t.Fatalf("Apply(v2 snapshot) error = %v", err)
+			}
+			result, err := fixture.manager.Execute(ctx, windowmanager.CommandRequest{
+				WorkspaceID: windowmanager.WorkspaceID(workspaceID), ExpectedRevision: 0,
+				Payload: windowmanager.CreateDesktopCommand{DesktopID: "d2", Name: "Two"},
+			})
+			if err != nil || result.Snapshot.Revision != 1 || result.Snapshot.Version != 3 {
+				t.Fatalf("Execute(after discard) = %+v, error = %v", result, err)
+			}
+		},
+	)
+
+	t.Run(
+		"Should discard only decode and version classes while preserving forensic blobs [IT-002]",
+		func(t *testing.T) {
+			t.Parallel()
+			cases := []struct {
+				name        string
+				value       func(workspaceID string) []byte
+				wantError   error
+				wantDeleted bool
+			}{
+				{
+					name: "workspace mismatch is preserved",
+					value: func(string) []byte {
+						snapshot := daemonWindowManagerSnapshot("another-workspace", 1, "Mismatch")
+						encoded, err := json.Marshal(snapshot)
+						if err != nil {
+							t.Fatalf("json.Marshal(mismatch) error = %v", err)
+						}
+						return encoded
+					},
+					wantError: windowmanager.ErrInvalidTopology,
+				},
+				{
+					name: "invalid v3 topology is preserved",
+					value: func(workspaceID string) []byte {
+						snapshot := daemonWindowManagerSnapshot(windowmanager.WorkspaceID(workspaceID), 1, "Invalid")
+						snapshot.Desktops = nil
+						encoded, err := json.Marshal(snapshot)
+						if err != nil {
+							t.Fatalf("json.Marshal(invalid v3) error = %v", err)
+						}
+						return encoded
+					},
+					wantError: windowmanager.ErrInvalidTopology,
+				},
+				{
+					name: "unsupported version is deleted",
+					value: func(workspaceID string) []byte {
+						return fmt.Appendf(nil, `{"version":2,"workspace_id":%q}`, workspaceID)
+					},
+					wantError:   windowmanager.ErrSnapshotNotFound,
+					wantDeleted: true,
+				},
+				{
+					name: "unknown field is deleted",
+					value: func(workspaceID string) []byte {
+						return fmt.Appendf(nil, `{"version":3,"workspace_id":%q,"unknown":true}`, workspaceID)
+					},
+					wantError:   windowmanager.ErrSnapshotNotFound,
+					wantDeleted: true,
+				},
+			}
+			for _, testCase := range cases {
+				t.Run(testCase.name, func(t *testing.T) {
+					fixture := newDaemonWindowManagerFixture(t)
+					ctx := testutil.Context(t)
+					workspaceID := clientstate.WorkspaceID(fixture.workspace.ID)
+					value := testCase.value(fixture.workspace.ID)
+					if _, err := fixture.engine.Apply(
+						ctx,
+						workspaceID,
+						windowManagerStateDomain,
+						[]clientstate.Op{{Kind: clientstate.OpPut, Key: windowManagerSnapshotKey, Value: value}},
+						clientstate.ApplyOptions{},
+					); err != nil {
+						t.Fatalf("Apply(raw snapshot) error = %v", err)
+					}
+					_, loadErr := fixture.repository.Load(ctx, windowmanager.WorkspaceID(workspaceID))
+					if !errors.Is(loadErr, testCase.wantError) {
+						t.Fatalf("Load() error = %v, want %v", loadErr, testCase.wantError)
+					}
+					entry, getErr := fixture.engine.Get(
+						ctx,
+						workspaceID,
+						windowManagerStateDomain,
+						windowManagerSnapshotKey,
+					)
+					if testCase.wantDeleted {
+						if !errors.Is(getErr, clientstate.ErrNotFound) {
+							t.Fatalf("Get(after discard) error = %v", getErr)
+						}
+					} else if getErr != nil || !reflect.DeepEqual(entry.Value, value) {
+						t.Fatalf("preserved entry = %+v, error = %v, want bytes %s", entry, getErr, value)
+					}
+				})
+			}
+		},
+	)
 
 	t.Run("Should allow exactly one concurrent compare-and-swap writer", func(t *testing.T) {
 		t.Parallel()
@@ -198,4 +328,52 @@ func TestWindowManagerRepository(t *testing.T) {
 			t.Fatalf("concurrent results = successes %d conflicts %d, want 1/1", successes, conflicts)
 		}
 	})
+}
+
+func decorateDaemonV3Snapshot(snapshot *windowmanager.Snapshot) {
+	w1, w2, w3 := windowmanager.WindowID("w1"), windowmanager.WindowID("w2"), windowmanager.WindowID("w3")
+	active := w2
+	route := func(path string) windowmanager.RouteIntent {
+		return windowmanager.RouteIntent{Pathname: path, Search: windowmanager.RouteSearch{}}
+	}
+	snapshot.Windows = map[windowmanager.WindowID]windowmanager.Window{
+		w1: {
+			ID:           w1,
+			App:          "One",
+			Route:        route("/one"),
+			NavStack:     []windowmanager.RouteIntent{route("/root")},
+			Pinned:       true,
+			Placement:    windowmanager.WindowPlacementStacked,
+			DesktopID:    "desktop-default",
+			FloatingRect: windowmanager.NormalizedRect{Width: 1, Height: 1},
+		},
+		w2: {
+			ID:           w2,
+			App:          "Two",
+			Route:        route("/two"),
+			Placement:    windowmanager.WindowPlacementStacked,
+			DesktopID:    "desktop-default",
+			FloatingRect: windowmanager.NormalizedRect{Width: 1, Height: 1},
+		},
+	}
+	snapshot.Desktops[0].FloatingStacks = []windowmanager.FloatingStack{{
+		ID: "stack", WindowIDs: []windowmanager.WindowID{w1, w2}, ActiveID: &active,
+		Rect: windowmanager.NormalizedRect{X: 0.1, Y: 0.1, Width: 0.7, Height: 0.7},
+	}}
+	snapshot.ClosedEntries = []windowmanager.ClosedEntry{
+		{
+			Windows: []windowmanager.Window{
+				{
+					ID:           w3,
+					App:          "Three",
+					Route:        route("/three"),
+					DesktopID:    "desktop-default",
+					Placement:    windowmanager.WindowPlacementFloating,
+					FloatingRect: windowmanager.NormalizedRect{Width: 1, Height: 1},
+				},
+			},
+			DesktopID: "desktop-default",
+			Rect:      windowmanager.NormalizedRect{Width: 1, Height: 1},
+		},
+	}
 }

--- a/internal/daemon/workspace_access_integration_test.go
+++ b/internal/daemon/workspace_access_integration_test.go
@@ -134,7 +134,11 @@ func TestWorkspaceAccessIntegration(t *testing.T) {
 			t.Fatalf("Authorize(append failure) error = %v", err)
 		}
 		if !decision.Allowed || failingStore.writes != 1 {
-			t.Fatalf("append failure result = decision:%#v writes:%d, want allowed and one write", decision, failingStore.writes)
+			t.Fatalf(
+				"append failure result = decision:%#v writes:%d, want allowed and one write",
+				decision,
+				failingStore.writes,
+			)
 		}
 		if !bytes.Contains(logs.Bytes(), []byte("workspace access audit emission failed")) {
 			t.Fatalf("logs = %q, want audit failure warning", logs.String())
@@ -292,9 +296,11 @@ func newWorkspaceAccessIntegrationSession(
 		session.WithStore(func(ctx context.Context, sessionID string, path string) (session.EventRecorder, error) {
 			return sessiondb.OpenSessionDB(ctx, sessionID, path)
 		}),
-		session.WithQueryStore(func(ctx context.Context, sessionID string, path string) (session.EventReadCloser, error) {
-			return sessiondb.OpenSessionDBReadOnly(ctx, sessionID, path)
-		}),
+		session.WithQueryStore(
+			func(ctx context.Context, sessionID string, path string) (session.EventReadCloser, error) {
+				return sessiondb.OpenSessionDBReadOnly(ctx, sessionID, path)
+			},
+		),
 		session.WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))),
 		session.WithLifecycleContext(ctx),
 	}

--- a/internal/demoseed/seed_integration_test.go
+++ b/internal/demoseed/seed_integration_test.go
@@ -227,7 +227,13 @@ func assertLaunchTranscript(t *testing.T, ctx context.Context, paths config.Home
 
 func assertLoopDefinition(t *testing.T, workspaceRoot string) {
 	t.Helper()
-	path := filepath.Join(workspaceRoot, config.DirName, config.LoopsDirName, launchLoopName, looppkg.DefinitionFileName)
+	path := filepath.Join(
+		workspaceRoot,
+		config.DirName,
+		config.LoopsDirName,
+		launchLoopName,
+		looppkg.DefinitionFileName,
+	)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("ReadFile(Loop) error = %v", err)

--- a/internal/extension/dev_integration_test.go
+++ b/internal/extension/dev_integration_test.go
@@ -20,63 +20,66 @@ import (
 func TestManagerDevelopmentLifecycle(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should invoke the active subprocess generation and restore the published extension after unlink", func(t *testing.T) {
-		t.Parallel()
+	t.Run(
+		"Should invoke the active subprocess generation and restore the published extension after unlink",
+		func(t *testing.T) {
+			t.Parallel()
 
-		env := newRegistryTestEnv(t)
-		published := createManagerTestExtension(t, devManifest("dev-tool", "0.1.0", ""), nil)
-		installManagerFixture(t, env.registry, published, SourceUser, true)
+			env := newRegistryTestEnv(t)
+			published := createManagerTestExtension(t, devManifest("dev-tool", "0.1.0", ""), nil)
+			installManagerFixture(t, env.registry, published, SourceUser, true)
 
-		workspace := newDevTestWorkspace(t, "workspace-tool-runtime")
-		origin := filepath.Join(workspace.RootDir, "tool-extension")
-		firstHash := writeDevTestGenerationFiles(t, origin, map[string]string{
-			manifestJSONFileName: extensionToolManifestJSON(
-				"dev-tool",
-				helperCommand(t),
-				helperArgs(),
-				helperEnv("tool_call_generation_marker", "first"),
-				true,
-			),
-		})
-		secondHash := writeDevTestGenerationFiles(t, origin, map[string]string{
-			manifestJSONFileName: extensionToolManifestJSON(
-				"dev-tool",
-				helperCommand(t),
-				helperArgs(),
-				helperEnv("tool_call_generation_marker", "second"),
-				true,
-			),
-		})
-		manager := NewManager(
-			env.registry,
-			WithWorkspaceResolver(newHostAPIFakeWorkspaceResolver(workspace)),
-		)
-		startDevTestManager(t, manager)
+			workspace := newDevTestWorkspace(t, "workspace-tool-runtime")
+			origin := filepath.Join(workspace.RootDir, "tool-extension")
+			firstHash := writeDevTestGenerationFiles(t, origin, map[string]string{
+				manifestJSONFileName: extensionToolManifestJSON(
+					"dev-tool",
+					helperCommand(t),
+					helperArgs(),
+					helperEnv("tool_call_generation_marker", "first"),
+					true,
+				),
+			})
+			secondHash := writeDevTestGenerationFiles(t, origin, map[string]string{
+				manifestJSONFileName: extensionToolManifestJSON(
+					"dev-tool",
+					helperCommand(t),
+					helperArgs(),
+					helperEnv("tool_call_generation_marker", "second"),
+					true,
+				),
+			})
+			manager := NewManager(
+				env.registry,
+				WithWorkspaceResolver(newHostAPIFakeWorkspaceResolver(workspace)),
+			)
+			startDevTestManager(t, manager)
 
-		if _, err := manager.LinkDevelopmentFromOrigin(
-			testutil.Context(t), workspace.WorkspaceID, origin, firstHash,
-		); err != nil {
-			t.Fatalf("LinkDevelopmentFromOrigin() error = %v", err)
-		}
-		key := InstanceKey{Name: "dev-tool", WorkspaceID: workspace.WorkspaceID}
-		assertDevToolGeneration(t, manager, key, "first")
+			if _, err := manager.LinkDevelopmentFromOrigin(
+				testutil.Context(t), workspace.WorkspaceID, origin, firstHash,
+			); err != nil {
+				t.Fatalf("LinkDevelopmentFromOrigin() error = %v", err)
+			}
+			key := InstanceKey{Name: "dev-tool", WorkspaceID: workspace.WorkspaceID}
+			assertDevToolGeneration(t, manager, key, "first")
 
-		if _, err := manager.ReloadExtension(testutil.Context(t), key, secondHash); err != nil {
-			t.Fatalf("ReloadExtension() error = %v", err)
-		}
-		assertDevToolGeneration(t, manager, key, "second")
+			if _, err := manager.ReloadExtension(testutil.Context(t), key, secondHash); err != nil {
+				t.Fatalf("ReloadExtension() error = %v", err)
+			}
+			assertDevToolGeneration(t, manager, key, "second")
 
-		if err := manager.UnlinkDevelopment(testutil.Context(t), key); err != nil {
-			t.Fatalf("UnlinkDevelopment() error = %v", err)
-		}
-		active, err := env.registry.ResolveActive(key.Name, key.WorkspaceID)
-		if err != nil {
-			t.Fatalf("ResolveActive() error = %v", err)
-		}
-		if active.DevLink != nil || active.Published == nil || active.Published.Version != "0.1.0" {
-			t.Fatalf("ResolveActive() = %#v, want published fallback", active)
-		}
-	})
+			if err := manager.UnlinkDevelopment(testutil.Context(t), key); err != nil {
+				t.Fatalf("UnlinkDevelopment() error = %v", err)
+			}
+			active, err := env.registry.ResolveActive(key.Name, key.WorkspaceID)
+			if err != nil {
+				t.Fatalf("ResolveActive() error = %v", err)
+			}
+			if active.DevLink != nil || active.Published == nil || active.Published.Version != "0.1.0" {
+				t.Fatalf("ResolveActive() = %#v, want published fallback", active)
+			}
+		},
+	)
 
 	t.Run("Should override a published extension and restore it after unlink", func(t *testing.T) {
 		t.Parallel()
@@ -188,7 +191,13 @@ func TestManagerDevelopmentLifecycle(t *testing.T) {
 			t.Fatalf("GetForInstance(second) error = %v", err)
 		}
 		if first.Status.GenerationHash != firstHash || second.Status.GenerationHash != secondHash {
-			t.Fatalf("workspace generations = %q/%q, want %q/%q", first.Status.GenerationHash, second.Status.GenerationHash, firstHash, secondHash)
+			t.Fatalf(
+				"workspace generations = %q/%q, want %q/%q",
+				first.Status.GenerationHash,
+				second.Status.GenerationHash,
+				firstHash,
+				secondHash,
+			)
 		}
 		if first.RootDir == second.RootDir {
 			t.Fatalf("workspace roots both = %q, want isolated generations", first.RootDir)
@@ -240,7 +249,10 @@ func TestManagerDevelopmentLifecycle(t *testing.T) {
 }
 
 func TestManagerDevelopmentReloadConcurrency(t *testing.T) {
-	t.Run("Should serialize reloads per instance without blocking other workspaces", testManagerDevelopmentReloadConcurrency)
+	t.Run(
+		"Should serialize reloads per instance without blocking other workspaces",
+		testManagerDevelopmentReloadConcurrency,
+	)
 }
 
 func testManagerDevelopmentReloadConcurrency(t *testing.T) {
@@ -316,7 +328,10 @@ func testManagerDevelopmentReloadConcurrency(t *testing.T) {
 }
 
 func TestManagerDevelopmentCoordinatorBarrier(t *testing.T) {
-	t.Run("Should activate only generations published beyond the coordinator barrier", testManagerDevelopmentCoordinatorBarrier)
+	t.Run(
+		"Should activate only generations published beyond the coordinator barrier",
+		testManagerDevelopmentCoordinatorBarrier,
+	)
 }
 
 func testManagerDevelopmentCoordinatorBarrier(t *testing.T) {

--- a/internal/settings/config_apply_service_test.go
+++ b/internal/settings/config_apply_service_test.go
@@ -1147,8 +1147,14 @@ func TestReloadChangedPaths(t *testing.T) {
 		current := &compozyconfig.Config{WindowManager: compozyconfig.DefaultWindowManagerConfig()}
 		desired := *current
 		desired.WindowManager.HistoryLimit++
+		desired.WindowManager.NavStackLimit++
+		desired.WindowManager.ClosedEntryLimit++
 
-		want := []string{"window_manager.history_limit"}
+		want := []string{
+			"window_manager.history_limit",
+			"window_manager.nav_stack_limit",
+			"window_manager.closed_entry_limit",
+		}
 		if got := reloadChangedPaths(current, &desired); !slices.Equal(got, want) {
 			t.Fatalf("reloadChangedPaths() = %#v, want %#v", got, want)
 		}

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -5207,6 +5207,8 @@ func testWindowManagerConfig() compozyconfig.WindowManagerConfig {
 		GroupMoveModifier:   "control",
 		SwapModifier:        "meta",
 		HistoryLimit:        77,
+		NavStackLimit:       66,
+		ClosedEntryLimit:    18,
 		DesktopTransition:   compozyconfig.WindowDesktopTransitionCrossfade,
 		Gaps: compozyconfig.WindowManagerGapsConfig{
 			Inner:  12,

--- a/internal/settings/window_manager_section.go
+++ b/internal/settings/window_manager_section.go
@@ -17,7 +17,7 @@ func diffWindowManagerSettings(
 	current compozyconfig.WindowManagerConfig,
 	desired compozyconfig.WindowManagerConfig,
 ) []string {
-	changed := make([]string, 0, 23)
+	changed := make([]string, 0, 25)
 	appendChange := func(path string, differs bool) {
 		if differs {
 			changed = append(changed, path)
@@ -43,6 +43,8 @@ func diffWindowManagerSettings(
 	)
 	appendChange("window_manager.swap_modifier", current.SwapModifier != desired.SwapModifier)
 	appendChange("window_manager.history_limit", current.HistoryLimit != desired.HistoryLimit)
+	appendChange("window_manager.nav_stack_limit", current.NavStackLimit != desired.NavStackLimit)
+	appendChange("window_manager.closed_entry_limit", current.ClosedEntryLimit != desired.ClosedEntryLimit)
 	appendChange(
 		"window_manager.desktop_transition",
 		current.DesktopTransition != desired.DesktopTransition,
@@ -95,6 +97,8 @@ func applyWindowManagerSettings(
 		{path: root("group_move_modifier"), value: settings.GroupMoveModifier},
 		{path: root("swap_modifier"), value: settings.SwapModifier},
 		{path: root("history_limit"), value: settings.HistoryLimit},
+		{path: root("nav_stack_limit"), value: settings.NavStackLimit},
+		{path: root("closed_entry_limit"), value: settings.ClosedEntryLimit},
 		{path: root("desktop_transition"), value: settings.DesktopTransition},
 		{path: root("gaps", "inner"), value: settings.Gaps.Inner},
 		{path: root("gaps", "top"), value: settings.Gaps.Top},

--- a/internal/windowmanager/active_coalescer.go
+++ b/internal/windowmanager/active_coalescer.go
@@ -1,0 +1,248 @@
+package windowmanager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+)
+
+const stackActiveQuietPeriod = 2 * time.Second
+
+type activeCoalescer struct {
+	mu      sync.Mutex
+	pending map[WorkspaceID]map[NodeID]WindowID
+	timers  map[WorkspaceID]*time.Timer
+	cancels map[WorkspaceID]chan struct{}
+	locks   map[WorkspaceID]*sync.Mutex
+	closed  bool
+	wg      sync.WaitGroup
+	manager *Manager
+	ctx     context.Context
+}
+
+func newActiveCoalescer(ctx context.Context, manager *Manager) *activeCoalescer {
+	return &activeCoalescer{
+		pending: make(map[WorkspaceID]map[NodeID]WindowID),
+		timers:  make(map[WorkspaceID]*time.Timer),
+		cancels: make(map[WorkspaceID]chan struct{}),
+		locks:   make(map[WorkspaceID]*sync.Mutex),
+		manager: manager,
+		ctx:     ctx,
+	}
+}
+
+func (c *activeCoalescer) bindWorkspace(workspaceID WorkspaceID, lock *sync.Mutex) {
+	c.mu.Lock()
+	if !c.closed {
+		c.locks[workspaceID] = lock
+	}
+	c.mu.Unlock()
+}
+
+func (m *Manager) noteStackActive(workspaceID WorkspaceID, stackID NodeID, windowID WindowID) {
+	m.coalescer.note(workspaceID, stackID, windowID)
+}
+
+func (c *activeCoalescer) note(workspaceID WorkspaceID, stackID NodeID, windowID WindowID) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return
+	}
+	workspacePending := c.pending[workspaceID]
+	if workspacePending == nil {
+		workspacePending = make(map[NodeID]WindowID)
+		c.pending[workspaceID] = workspacePending
+	}
+	workspacePending[stackID] = windowID
+	c.stopTimerLocked(workspaceID)
+	lock := c.locks[workspaceID]
+	if lock == nil {
+		return
+	}
+	timer := time.NewTimer(stackActiveQuietPeriod)
+	cancel := make(chan struct{})
+	c.timers[workspaceID] = timer
+	c.cancels[workspaceID] = cancel
+	c.wg.Add(1)
+	go c.runTimer(workspaceID, lock, timer, cancel)
+}
+
+func (c *activeCoalescer) runTimer(
+	workspaceID WorkspaceID,
+	lock *sync.Mutex,
+	timer *time.Timer,
+	cancel <-chan struct{},
+) {
+	defer c.wg.Done()
+	triggered := false
+	select {
+	case <-timer.C:
+		triggered = true
+	case <-cancel:
+	}
+	if triggered {
+		lock.Lock()
+		err := c.manager.flushStackActiveLocked(c.ctx, workspaceID)
+		lock.Unlock()
+		if err != nil {
+			slog.Warn("window manager stack activation flush failed", "workspace_id", workspaceID, "error", err)
+		}
+	}
+	c.mu.Lock()
+	if c.timers[workspaceID] == timer {
+		delete(c.timers, workspaceID)
+		delete(c.cancels, workspaceID)
+	}
+	c.mu.Unlock()
+}
+
+func (c *activeCoalescer) stopTimerLocked(workspaceID WorkspaceID) {
+	if timer := c.timers[workspaceID]; timer != nil {
+		timer.Stop()
+		close(c.cancels[workspaceID])
+		delete(c.timers, workspaceID)
+		delete(c.cancels, workspaceID)
+	}
+}
+
+func (c *activeCoalescer) hasPending(workspaceID WorkspaceID) bool {
+	c.mu.Lock()
+	hasPending := len(c.pending[workspaceID]) > 0
+	c.mu.Unlock()
+	return hasPending
+}
+
+func (m *Manager) flushStackActiveLocked(ctx context.Context, workspaceID WorkspaceID) error {
+	return m.coalescer.flushLocked(ctx, workspaceID)
+}
+
+func (c *activeCoalescer) flushLocked(ctx context.Context, workspaceID WorkspaceID) error {
+	c.mu.Lock()
+	pending := clonePendingStackActive(c.pending[workspaceID])
+	c.mu.Unlock()
+	if len(pending) == 0 {
+		return nil
+	}
+	snapshot, err := c.manager.repository.Load(ctx, workspaceID)
+	if errors.Is(err, ErrSnapshotNotFound) {
+		c.clearMatching(workspaceID, pending)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("load stack activation snapshot: %w", err)
+	}
+	working := cloneSnapshot(snapshot)
+	changes := ChangeSet{}
+	for stackID, windowID := range pending {
+		location, found := findStackByID(&working, stackID)
+		if !found || !containsWindowID(location.members(), windowID) {
+			continue
+		}
+		if location.activeID() != nil && *location.activeID() == windowID {
+			continue
+		}
+		location.setActive(windowID)
+		changes.NodeIDs = append(changes.NodeIDs, stackID)
+		changes.WindowIDs = append(changes.WindowIDs, windowID)
+	}
+	if len(changes.NodeIDs) == 0 {
+		c.clearMatching(workspaceID, pending)
+		return nil
+	}
+	working = NormalizeSnapshot(working)
+	if err := ValidateSnapshot(working); err != nil {
+		return fmt.Errorf("validate stack activation snapshot: %w", err)
+	}
+	nextRevision, err := NextTopologyRevision(snapshot.Revision)
+	if err != nil {
+		return err
+	}
+	working.Revision = nextRevision
+	working.UpdatedAt = c.manager.now().UTC()
+	sortChangeSet(&changes)
+	request := CommandRequest{
+		WorkspaceID: workspaceID,
+		CommandID:   CommandWindowStackSetActive,
+		Actor:       Actor{Kind: "system", ID: "active_coalescer"},
+		Origin:      "active_coalescer",
+		Payload:     SetStackActiveCommand{},
+	}
+	event := newCommandEvent(working, request, CommandWindowStackSetActive, changes)
+	if err := c.manager.repository.Commit(ctx, &Commit{
+		WorkspaceID: workspaceID, ExpectedRevision: snapshot.Revision, Snapshot: working, Event: event,
+	}); err != nil {
+		return fmt.Errorf("commit stack activation: %w", err)
+	}
+	c.clearMatching(workspaceID, pending)
+	c.manager.publishEvent(event)
+	c.manager.observeCommittedEvent(ctx, event)
+	return nil
+}
+
+func clonePendingStackActive(source map[NodeID]WindowID) map[NodeID]WindowID {
+	cloned := make(map[NodeID]WindowID, len(source))
+	maps.Copy(cloned, source)
+	return cloned
+}
+
+func (c *activeCoalescer) clearMatching(workspaceID WorkspaceID, flushed map[NodeID]WindowID) {
+	c.mu.Lock()
+	current := c.pending[workspaceID]
+	for stackID, windowID := range flushed {
+		if current[stackID] == windowID {
+			delete(current, stackID)
+		}
+	}
+	if len(current) == 0 {
+		delete(c.pending, workspaceID)
+	}
+	c.mu.Unlock()
+}
+
+func (c *activeCoalescer) discardWorkspaceLocked(workspaceID WorkspaceID) {
+	c.mu.Lock()
+	c.stopTimerLocked(workspaceID)
+	delete(c.pending, workspaceID)
+	c.mu.Unlock()
+}
+
+func (c *activeCoalescer) close() error {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil
+	}
+	c.closed = true
+	workspaceIDs := make([]WorkspaceID, 0, len(c.pending))
+	for workspaceID := range c.pending {
+		workspaceIDs = append(workspaceIDs, workspaceID)
+	}
+	for workspaceID := range c.timers {
+		c.stopTimerLocked(workspaceID)
+	}
+	locks := make(map[WorkspaceID]*sync.Mutex, len(c.locks))
+	maps.Copy(locks, c.locks)
+	c.mu.Unlock()
+	slices.Sort(workspaceIDs)
+	var flushErrors []error
+	for _, workspaceID := range workspaceIDs {
+		lock := locks[workspaceID]
+		if lock == nil {
+			continue
+		}
+		lock.Lock()
+		err := c.flushLocked(c.ctx, workspaceID)
+		lock.Unlock()
+		if err != nil {
+			flushErrors = append(flushErrors, fmt.Errorf("flush workspace %q: %w", workspaceID, err))
+		}
+	}
+	c.wg.Wait()
+	return errors.Join(flushErrors...)
+}

--- a/internal/windowmanager/changes.go
+++ b/internal/windowmanager/changes.go
@@ -8,4 +8,6 @@ func sortChangeSet(changes *ChangeSet) {
 	slices.Sort(changes.GroupIDs)
 	slices.Sort(changes.NodeIDs)
 	slices.Sort(changes.ClientIDs)
+	slices.Sort(changes.StackGrouped)
+	slices.Sort(changes.StackUngrouped)
 }

--- a/internal/windowmanager/client_projection.go
+++ b/internal/windowmanager/client_projection.go
@@ -78,6 +78,13 @@ func projectDurableClientView(
 				view.FocusedWindowID = &command.WindowID
 				view.FocusOrder = prependFocus(view.FocusOrder, command.WindowID)
 			}
+		case SetStackActiveCommand:
+			if location, stacked := findStackByWindow(&snapshot, command.WindowID); stacked {
+				if view.StackActive == nil {
+					view.StackActive = make(map[NodeID]WindowID)
+				}
+				view.StackActive[location.id()] = command.WindowID
+			}
 		}
 	}
 	return repairClientView(view, snapshot)
@@ -145,6 +152,7 @@ func followDepartingZoomOwner(
 }
 
 func repairClientView(view ClientView, snapshot Snapshot) ClientView {
+	view.StackActive = repairStackActive(view.StackActive, &snapshot)
 	if _, exists := desktopIndexByID(&snapshot, view.ActiveDesktopID); !exists {
 		view.ActiveDesktopID = defaultDesktopID(snapshot)
 	}
@@ -173,6 +181,45 @@ func repairClientView(view ClientView, snapshot Snapshot) ClientView {
 	return view
 }
 
+func repairStackActive(current map[NodeID]WindowID, snapshot *Snapshot) map[NodeID]WindowID {
+	repaired := make(map[NodeID]WindowID)
+	for desktopIndex := range snapshot.Desktops {
+		desktop := &snapshot.Desktops[desktopIndex]
+		for stackIndex := range desktop.FloatingStacks {
+			stack := &desktop.FloatingStacks[stackIndex]
+			repaired[stack.ID] = repairedStackActive(current, stack.ID, stack.WindowIDs, stack.ActiveID)
+		}
+		for groupIndex := range desktop.Groups {
+			collectNodeStackActive(&desktop.Groups[groupIndex].Root, current, repaired)
+		}
+	}
+	return repaired
+}
+
+func collectNodeStackActive(node *LayoutNode, current map[NodeID]WindowID, repaired map[NodeID]WindowID) {
+	if node.Kind == NodeKindStack {
+		repaired[node.ID] = repairedStackActive(current, node.ID, node.WindowIDs, node.ActiveID)
+	}
+	for index := range node.Children {
+		collectNodeStackActive(&node.Children[index], current, repaired)
+	}
+}
+
+func repairedStackActive(
+	current map[NodeID]WindowID,
+	stackID NodeID,
+	members []WindowID,
+	durable *WindowID,
+) WindowID {
+	if active, exists := current[stackID]; exists && containsWindowID(members, active) {
+		return active
+	}
+	if durable != nil && containsWindowID(members, *durable) {
+		return *durable
+	}
+	return members[0]
+}
+
 func focusForDesktop(view ClientView, snapshot Snapshot) *WindowID {
 	for _, windowID := range view.FocusOrder {
 		if window, exists := snapshot.Windows[windowID]; exists &&
@@ -194,14 +241,32 @@ func firstVisibleWindow(snapshot Snapshot, desktopID DesktopID) WindowID {
 		return ""
 	}
 	for _, group := range snapshot.Desktops[desktopIndex].Groups {
-		for _, windowID := range nodeWindowIDs(group.Root) {
-			if !snapshot.Windows[windowID].Minimized {
-				return windowID
-			}
+		if windowID := firstVisibleNodeWindow(group.Root); windowID != "" {
+			return windowID
+		}
+	}
+	for _, stack := range snapshot.Desktops[desktopIndex].FloatingStacks {
+		if stack.ActiveID != nil && !snapshot.Windows[*stack.ActiveID].Minimized {
+			return *stack.ActiveID
 		}
 	}
 	for _, windowID := range snapshot.Desktops[desktopIndex].Floating {
 		if !snapshot.Windows[windowID].Minimized {
+			return windowID
+		}
+	}
+	return ""
+}
+
+func firstVisibleNodeWindow(node LayoutNode) WindowID {
+	if node.Kind == NodeKindStack && node.ActiveID != nil {
+		return *node.ActiveID
+	}
+	if node.Kind == NodeKindLeaf && node.WindowID != nil {
+		return *node.WindowID
+	}
+	for _, child := range node.Children {
+		if windowID := firstVisibleNodeWindow(child); windowID != "" {
 			return windowID
 		}
 	}
@@ -223,6 +288,14 @@ func clientViewsEqual(left, right ClientView) bool {
 		valueOrZero(left.FocusedWindowID) != valueOrZero(right.FocusedWindowID) ||
 		len(left.FocusOrder) != len(right.FocusOrder) {
 		return false
+	}
+	if len(left.StackActive) != len(right.StackActive) {
+		return false
+	}
+	for stackID, windowID := range left.StackActive {
+		if right.StackActive[stackID] != windowID {
+			return false
+		}
 	}
 	for index := range left.FocusOrder {
 		if left.FocusOrder[index] != right.FocusOrder[index] {

--- a/internal/windowmanager/clients.go
+++ b/internal/windowmanager/clients.go
@@ -53,6 +53,7 @@ func (m *Manager) RegisterClient(ctx context.Context, registration ClientRegistr
 			PresentationRevision: 1,
 			ConnectedAt:          m.now().UTC(),
 			FocusOrder:           []WindowID{},
+			StackActive:          map[NodeID]WindowID{},
 		}
 	} else {
 		before = cloneClientView(view)
@@ -95,6 +96,9 @@ func (m *Manager) UnregisterClient(ctx context.Context, workspaceID WorkspaceID,
 	}
 	lock.Lock()
 	defer lock.Unlock()
+	if err := m.flushStackActiveLocked(ctx, workspaceID); err != nil {
+		return fmt.Errorf("flush stack activation before unregister client %q: %w", clientID, err)
+	}
 	m.mu.Lock()
 	workspaceClients := m.clients[workspaceID]
 	if _, exists := workspaceClients[clientID]; !exists {
@@ -217,6 +221,15 @@ func (m *Manager) applyPresentation(
 			}
 			view.FocusedWindowID = &focused
 			view.FocusOrder = prependFocus(view.FocusOrder, focused)
+			if location, stacked := findStackByWindow(&snapshot, focused); stacked {
+				if view.StackActive == nil {
+					view.StackActive = make(map[NodeID]WindowID)
+				}
+				view.StackActive[location.id()] = focused
+				if persist {
+					m.noteStackActive(request.WorkspaceID, location.id(), focused)
+				}
+			}
 			view = repairClientView(view, snapshot)
 		}
 	default:

--- a/internal/windowmanager/clone.go
+++ b/internal/windowmanager/clone.go
@@ -5,6 +5,7 @@ import "maps"
 func cloneSnapshot(snapshot Snapshot) Snapshot {
 	snapshot.Desktops = cloneDesktops(snapshot.Desktops)
 	snapshot.Windows = cloneWindows(snapshot.Windows)
+	snapshot.ClosedEntries = cloneClosedEntries(snapshot.ClosedEntries)
 	snapshot.History = cloneHistory(snapshot.History)
 	snapshot.Overrides = cloneWorkspaceConfig(snapshot.Overrides)
 	return snapshot
@@ -26,6 +27,7 @@ func cloneDesktop(desktop Desktop) Desktop {
 		desktop.Groups[index] = cloneLayoutGroup(group)
 	}
 	desktop.Floating = append([]WindowID(nil), desktop.Floating...)
+	desktop.FloatingStacks = cloneFloatingStacks(desktop.FloatingStacks)
 	return desktop
 }
 
@@ -51,10 +53,47 @@ func cloneNode(node LayoutNode) LayoutNode {
 func cloneWindows(windows map[WindowID]Window) map[WindowID]Window {
 	cloned := make(map[WindowID]Window, len(windows))
 	for id, window := range windows {
-		window.InstanceKey = clonePointer(window.InstanceKey)
-		window.Route = cloneRouteIntent(window.Route)
-		window.ReturnAnchor = cloneReturnAnchor(window.ReturnAnchor)
-		cloned[id] = window
+		cloned[id] = cloneWindow(window)
+	}
+	return cloned
+}
+
+func cloneWindow(window Window) Window {
+	window.InstanceKey = clonePointer(window.InstanceKey)
+	window.Route = cloneRouteIntent(window.Route)
+	window.NavStack = cloneRouteIntents(window.NavStack)
+	window.ReturnAnchor = cloneReturnAnchor(window.ReturnAnchor)
+	return window
+}
+
+func cloneRouteIntents(routes []RouteIntent) []RouteIntent {
+	cloned := make([]RouteIntent, len(routes))
+	for index, route := range routes {
+		cloned[index] = cloneRouteIntent(route)
+	}
+	return cloned
+}
+
+func cloneFloatingStacks(stacks []FloatingStack) []FloatingStack {
+	cloned := make([]FloatingStack, len(stacks))
+	for index, stack := range stacks {
+		stack.WindowIDs = append([]WindowID(nil), stack.WindowIDs...)
+		stack.ActiveID = clonePointer(stack.ActiveID)
+		cloned[index] = stack
+	}
+	return cloned
+}
+
+func cloneClosedEntries(entries []ClosedEntry) []ClosedEntry {
+	cloned := make([]ClosedEntry, len(entries))
+	for index, entry := range entries {
+		entry.Windows = make([]Window, len(entries[index].Windows))
+		for windowIndex, window := range entries[index].Windows {
+			entry.Windows[windowIndex] = cloneWindow(window)
+		}
+		entry.ActiveID = clonePointer(entry.ActiveID)
+		entry.StackID = clonePointer(entry.StackID)
+		cloned[index] = entry
 	}
 	return cloned
 }
@@ -95,7 +134,17 @@ func cloneReturnAnchor(anchor *ReturnAnchor) *ReturnAnchor {
 func cloneClientView(view ClientView) ClientView {
 	view.FocusedWindowID = clonePointer(view.FocusedWindowID)
 	view.FocusOrder = append([]WindowID(nil), view.FocusOrder...)
+	view.StackActive = cloneStackActive(view.StackActive)
 	return view
+}
+
+func cloneStackActive(values map[NodeID]WindowID) map[NodeID]WindowID {
+	if values == nil {
+		return nil
+	}
+	cloned := make(map[NodeID]WindowID, len(values))
+	maps.Copy(cloned, values)
+	return cloned
 }
 
 func cloneHistory(history History) History {
@@ -136,6 +185,8 @@ func cloneWorkspaceConfig(config WorkspaceConfig) WorkspaceConfig {
 	config.GroupMoveModifier = clonePointer(config.GroupMoveModifier)
 	config.SwapModifier = clonePointer(config.SwapModifier)
 	config.HistoryLimit = clonePointer(config.HistoryLimit)
+	config.NavStackLimit = clonePointer(config.NavStackLimit)
+	config.ClosedEntryLimit = clonePointer(config.ClosedEntryLimit)
 	config.DesktopTransition = clonePointer(config.DesktopTransition)
 	config.Gaps = clonePointer(config.Gaps)
 	if config.Snap != nil {
@@ -173,6 +224,8 @@ func cloneChangeSet(changes ChangeSet) ChangeSet {
 	changes.GroupIDs = append([]GroupID(nil), changes.GroupIDs...)
 	changes.NodeIDs = append([]NodeID(nil), changes.NodeIDs...)
 	changes.ClientIDs = append([]ClientID(nil), changes.ClientIDs...)
+	changes.StackGrouped = append([]NodeID(nil), changes.StackGrouped...)
+	changes.StackUngrouped = append([]NodeID(nil), changes.StackUngrouped...)
 	return changes
 }
 

--- a/internal/windowmanager/closed_entries.go
+++ b/internal/windowmanager/closed_entries.go
@@ -1,0 +1,36 @@
+package windowmanager
+
+func reservedWindowID(snapshot *Snapshot, windowID WindowID) bool {
+	if _, exists := snapshot.Windows[windowID]; exists {
+		return true
+	}
+	for _, entry := range snapshot.ClosedEntries {
+		for _, window := range entry.Windows {
+			if window.ID == windowID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pushClosedEntry(snapshot *Snapshot, entry ClosedEntry, limit int) {
+	entry.Windows = cloneClosedEntries([]ClosedEntry{entry})[0].Windows
+	entry.ActiveID = clonePointer(entry.ActiveID)
+	entry.StackID = clonePointer(entry.StackID)
+	snapshot.ClosedEntries = append(snapshot.ClosedEntries, entry)
+	if len(snapshot.ClosedEntries) > limit {
+		snapshot.ClosedEntries = append(
+			[]ClosedEntry(nil),
+			snapshot.ClosedEntries[len(snapshot.ClosedEntries)-limit:]...,
+		)
+	}
+}
+
+func closedEntryWindowIDs(entry ClosedEntry) []WindowID {
+	windowIDs := make([]WindowID, 0, len(entry.Windows))
+	for _, window := range entry.Windows {
+		windowIDs = append(windowIDs, window.ID)
+	}
+	return windowIDs
+}

--- a/internal/windowmanager/commands.go
+++ b/internal/windowmanager/commands.go
@@ -16,6 +16,11 @@ const (
 	CommandWindowSwap           CommandID = "window.swap"
 	CommandWindowToggleFloating CommandID = "window.toggle_floating"
 	CommandWindowZoom           CommandID = "window.zoom"
+	CommandWindowStackGroup     CommandID = "window.stack.group"
+	CommandWindowStackReorder   CommandID = "window.stack.reorder"
+	CommandWindowStackSetActive CommandID = "window.stack.set_active"
+	CommandWindowPin            CommandID = "window.pin"
+	CommandWindowReopen         CommandID = "window.reopen"
 	CommandLayoutArrange        CommandID = "layout.arrange"
 	CommandLayoutResize         CommandID = "layout.resize"
 	CommandLayoutBalance        CommandID = "layout.balance"
@@ -87,13 +92,14 @@ type DeleteDesktopCommand struct {
 func (DeleteDesktopCommand) CommandID() CommandID { return CommandDesktopDelete }
 
 type WindowSpec struct {
-	ID           WindowID
-	App          string
-	InstanceKey  *string
-	Route        RouteIntent
-	DesktopID    DesktopID
-	FloatingRect NormalizedRect
-	InsertTiled  bool
+	ID                  WindowID       `json:"id,omitempty"`
+	App                 string         `json:"app"`
+	InstanceKey         *string        `json:"instance_key,omitempty"`
+	Route               RouteIntent    `json:"route"`
+	DesktopID           DesktopID      `json:"desktop_id"`
+	FloatingRect        NormalizedRect `json:"floating_rect"`
+	InsertTiled         bool           `json:"insert_tiled,omitempty"`
+	StackTargetWindowID *WindowID      `json:"stack_target_window_id,omitempty"`
 }
 
 type OpenWindowCommand struct {
@@ -104,19 +110,70 @@ type OpenWindowCommand struct {
 func (OpenWindowCommand) CommandID() CommandID { return CommandWindowOpen }
 
 type NavigateWindowCommand struct {
-	WindowID WindowID
-	Route    RouteIntent
+	WindowID WindowID     `json:"window_id"`
+	Route    RouteIntent  `json:"route,omitzero"`
+	Mode     NavigateMode `json:"mode,omitempty"`
 }
 
 func (NavigateWindowCommand) CommandID() CommandID { return CommandWindowNavigate }
 
 // CloseWindowCommand minimizes instead of deleting when Minimize is true.
 type CloseWindowCommand struct {
-	WindowID WindowID
-	Minimize bool
+	WindowID WindowID   `json:"window_id"`
+	Minimize bool       `json:"minimize,omitempty"`
+	Scope    CloseScope `json:"scope,omitempty"`
 }
 
 func (CloseWindowCommand) CommandID() CommandID { return CommandWindowClose }
+
+type NavigateMode string
+
+const (
+	NavigateReplace NavigateMode = ""
+	NavigatePush    NavigateMode = "push"
+	NavigatePop     NavigateMode = "pop"
+)
+
+type CloseScope string
+
+const (
+	CloseScopeTab    CloseScope = ""
+	CloseScopeGroup  CloseScope = "group"
+	CloseScopeOthers CloseScope = "others"
+	CloseScopeRight  CloseScope = "right"
+)
+
+type GroupWindowsCommand struct {
+	TargetWindowID WindowID   `json:"target_window_id"`
+	WindowIDs      []WindowID `json:"window_ids"`
+	InsertIndex    *int       `json:"insert_index,omitempty"`
+}
+
+func (GroupWindowsCommand) CommandID() CommandID { return CommandWindowStackGroup }
+
+type ReorderStackCommand struct {
+	WindowID WindowID `json:"window_id"`
+	Index    int      `json:"index"`
+}
+
+func (ReorderStackCommand) CommandID() CommandID { return CommandWindowStackReorder }
+
+type SetStackActiveCommand struct {
+	WindowID WindowID `json:"window_id"`
+}
+
+func (SetStackActiveCommand) CommandID() CommandID { return CommandWindowStackSetActive }
+
+type PinWindowCommand struct {
+	WindowID WindowID `json:"window_id"`
+	Pinned   bool     `json:"pinned"`
+}
+
+func (PinWindowCommand) CommandID() CommandID { return CommandWindowPin }
+
+type ReopenCommand struct{}
+
+func (ReopenCommand) CommandID() CommandID { return CommandWindowReopen }
 
 type FocusDirection string
 
@@ -225,11 +282,13 @@ func (ReplaceLayoutCommand) CommandID() CommandID { return CommandLayoutReplace 
 
 // ChangeSet names the entities affected by one command.
 type ChangeSet struct {
-	DesktopIDs []DesktopID `json:"desktop_ids,omitempty"`
-	WindowIDs  []WindowID  `json:"window_ids,omitempty"`
-	GroupIDs   []GroupID   `json:"group_ids,omitempty"`
-	NodeIDs    []NodeID    `json:"node_ids,omitempty"`
-	ClientIDs  []ClientID  `json:"client_ids,omitempty"`
+	DesktopIDs     []DesktopID `json:"desktop_ids,omitempty"`
+	WindowIDs      []WindowID  `json:"window_ids,omitempty"`
+	GroupIDs       []GroupID   `json:"group_ids,omitempty"`
+	NodeIDs        []NodeID    `json:"node_ids,omitempty"`
+	ClientIDs      []ClientID  `json:"client_ids,omitempty"`
+	StackGrouped   []NodeID    `json:"stack_grouped,omitempty"`
+	StackUngrouped []NodeID    `json:"stack_ungrouped,omitempty"`
 }
 
 // Result reports one applied or no-op command.

--- a/internal/windowmanager/config.go
+++ b/internal/windowmanager/config.go
@@ -75,6 +75,8 @@ type Config struct {
 	GroupMoveModifier   string              `json:"group_move_modifier"`
 	SwapModifier        string              `json:"swap_modifier"`
 	HistoryLimit        int                 `json:"history_limit"`
+	NavStackLimit       int                 `json:"nav_stack_limit"`
+	ClosedEntryLimit    int                 `json:"closed_entry_limit"`
 	DesktopTransition   DesktopTransition   `json:"desktop_transition"`
 	Gaps                GapsConfig          `json:"gaps"`
 	Snap                SnapConfig          `json:"snap"`
@@ -94,6 +96,8 @@ type WorkspaceConfig struct {
 	GroupMoveModifier   *string              `json:"group_move_modifier,omitempty"`
 	SwapModifier        *string              `json:"swap_modifier,omitempty"`
 	HistoryLimit        *int                 `json:"history_limit,omitempty"`
+	NavStackLimit       *int                 `json:"nav_stack_limit,omitempty"`
+	ClosedEntryLimit    *int                 `json:"closed_entry_limit,omitempty"`
 	DesktopTransition   *DesktopTransition   `json:"desktop_transition,omitempty"`
 	Gaps                *GapsConfig          `json:"gaps,omitempty"`
 	Snap                *SnapConfig          `json:"snap,omitempty"`
@@ -112,6 +116,8 @@ func DefaultConfig() Config {
 		GroupMoveModifier:   dragModifierAlt,
 		SwapModifier:        dragModifierShift,
 		HistoryLimit:        50,
+		NavStackLimit:       50,
+		ClosedEntryLimit:    20,
 		DesktopTransition:   DesktopTransitionSlide,
 		Gaps:                GapsConfig{Inner: 8, Top: 8, Right: 10, Bottom: 8, Left: 10},
 		Snap: SnapConfig{
@@ -150,6 +156,22 @@ func validateBehaviorConfig(config Config) error {
 	}
 	if config.HistoryLimit <= 0 || config.HistoryLimit > 500 {
 		return fmt.Errorf("history limit %d must be between 1 and 500: %w", config.HistoryLimit, ErrInvalidCommand)
+	}
+	if config.NavStackLimit <= 0 || config.NavStackLimit > absoluteNavStackLimit {
+		return fmt.Errorf(
+			"nav stack limit %d must be between 1 and %d: %w",
+			config.NavStackLimit,
+			absoluteNavStackLimit,
+			ErrInvalidCommand,
+		)
+	}
+	if config.ClosedEntryLimit <= 0 || config.ClosedEntryLimit > absoluteClosedEntryLimit {
+		return fmt.Errorf(
+			"closed entry limit %d must be between 1 and %d: %w",
+			config.ClosedEntryLimit,
+			absoluteClosedEntryLimit,
+			ErrInvalidCommand,
+		)
 	}
 	if config.DesktopTransition != DesktopTransitionSlide && config.DesktopTransition != DesktopTransitionCrossfade &&
 		config.DesktopTransition != DesktopTransitionInstant {
@@ -261,6 +283,12 @@ func effectiveConfig(defaults Config, overrides WorkspaceConfig) (Config, error)
 	}
 	if overrides.HistoryLimit != nil {
 		result.HistoryLimit = *overrides.HistoryLimit
+	}
+	if overrides.NavStackLimit != nil {
+		result.NavStackLimit = *overrides.NavStackLimit
+	}
+	if overrides.ClosedEntryLimit != nil {
+		result.ClosedEntryLimit = *overrides.ClosedEntryLimit
 	}
 	if overrides.DesktopTransition != nil {
 		result.DesktopTransition = *overrides.DesktopTransition

--- a/internal/windowmanager/config_test.go
+++ b/internal/windowmanager/config_test.go
@@ -26,6 +26,8 @@ func TestEffectiveConfig(t *testing.T) {
 		groupMoveModifier := dragModifierMeta
 		swapModifier := dragModifierControl
 		historyLimit := 7
+		navStackLimit := 8
+		closedEntryLimit := 9
 		desktopTransition := DesktopTransitionInstant
 		gaps := GapsConfig{Inner: 1, Top: 2, Right: 3, Bottom: 4, Left: 5}
 		snap := SnapConfig{EdgeBand: 24, CornerReach: 120, ExitSlack: 12, RepeatRatios: []float64{0.4, 0.6}}
@@ -38,8 +40,9 @@ func TestEffectiveConfig(t *testing.T) {
 			FocusFollowsPointer: &focusFollowsPointer, RaiseOnFocus: &raiseOnFocus,
 			DragAwayPolicy: &dragAwayPolicy, GroupMoveModifier: &groupMoveModifier,
 			SwapModifier: &swapModifier,
-			HistoryLimit: &historyLimit, DesktopTransition: &desktopTransition,
-			Gaps: &gaps, Snap: &snap,
+			HistoryLimit: &historyLimit, NavStackLimit: &navStackLimit, ClosedEntryLimit: &closedEntryLimit,
+			DesktopTransition: &desktopTransition,
+			Gaps:              &gaps, Snap: &snap,
 			Bindings: &bindings, Shortcuts: shortcuts,
 		})
 		if err != nil {
@@ -52,7 +55,8 @@ func TestEffectiveConfig(t *testing.T) {
 			effective.DragAwayPolicy != DragAwayGroup ||
 			effective.GroupMoveModifier != dragModifierMeta ||
 			effective.SwapModifier != dragModifierControl ||
-			effective.HistoryLimit != 7 || effective.DesktopTransition != DesktopTransitionInstant {
+			effective.HistoryLimit != 7 || effective.NavStackLimit != 8 || effective.ClosedEntryLimit != 9 ||
+			effective.DesktopTransition != DesktopTransitionInstant {
 			t.Fatalf("effective behavioral config = %+v", effective)
 		}
 		if effective.Gaps != gaps || effective.Bindings != bindings || len(effective.Snap.RepeatRatios) != 2 ||
@@ -72,6 +76,70 @@ func TestEffectiveConfig(t *testing.T) {
 }
 
 func TestCanonicalShortcuts(t *testing.T) {
+	t.Run(
+		"Should accept tab actions through jump eight and reject jump nine or collisions [UT-143]",
+		func(t *testing.T) {
+			t.Parallel()
+			actions := []string{
+				shortcutWindowTabNewAction,
+				"window.tab.next",
+				"window.tab.previous",
+				"window.tab.last",
+				shortcutWindowTabReopenAction,
+				"window.tab.jump.1",
+				"window.tab.jump.2",
+				"window.tab.jump.3",
+				"window.tab.jump.4",
+				"window.tab.jump.5",
+				"window.tab.jump.6",
+				"window.tab.jump.7",
+				"window.tab.jump.8",
+			}
+			shortcuts := make(map[string]string, len(actions))
+			codes := []string{
+				"KeyA",
+				"KeyB",
+				"KeyC",
+				"KeyD",
+				"KeyE",
+				"Digit1",
+				"Digit2",
+				"Digit3",
+				"Digit4",
+				"Digit5",
+				"Digit6",
+				"Digit7",
+				"Digit8",
+			}
+			for index, action := range actions {
+				shortcuts[action] = "meta+" + codes[index]
+			}
+			canonical, err := CanonicalShortcuts(shortcuts)
+			if err != nil || len(canonical) != len(actions) {
+				t.Fatalf("CanonicalShortcuts(tab actions) = %#v, error = %v", canonical, err)
+			}
+			if _, err := CanonicalShortcuts(
+				map[string]string{"window.tab.jump.9": "meta+Digit9"},
+			); !errors.Is(
+				err,
+				ErrInvalidCommand,
+			) {
+				t.Fatalf("CanonicalShortcuts(jump.9) error = %v", err)
+			}
+			if _, err := CanonicalShortcuts(
+				map[string]string{
+					shortcutWindowTabNewAction:    "meta+KeyT",
+					shortcutWindowTabReopenAction: "META + KeyT",
+				},
+			); !errors.Is(
+				err,
+				ErrInvalidCommand,
+			) {
+				t.Fatalf("CanonicalShortcuts(tab collision) error = %v", err)
+			}
+		},
+	)
+
 	t.Run("Should accept every action and canonicalize modifier order before conflict checks", func(t *testing.T) {
 		t.Parallel()
 		actions := []string{

--- a/internal/windowmanager/errors.go
+++ b/internal/windowmanager/errors.go
@@ -22,6 +22,8 @@ var (
 	ErrPresentationRevisionExhausted = errors.New("window manager presentation revision exhausted")
 	ErrTopologyRevisionExhausted     = errors.New("window manager topology revision exhausted")
 	ErrClosed                        = errors.New("window manager closed")
+	ErrNotStacked                    = errors.New("window manager window not stacked")
+	ErrWindowPinned                  = errors.New("window manager window pinned")
 )
 
 // Diagnostic identifies one stable validation failure.

--- a/internal/windowmanager/floating_stack.go
+++ b/internal/windowmanager/floating_stack.go
@@ -1,0 +1,160 @@
+package windowmanager
+
+type stackLocation struct {
+	desktopIndex       int
+	groupIndex         int
+	floatingStackIndex int
+	node               *LayoutNode
+	floating           *FloatingStack
+}
+
+func findStackByWindow(snapshot *Snapshot, windowID WindowID) (stackLocation, bool) {
+	window, exists := snapshot.Windows[windowID]
+	if !exists {
+		return stackLocation{}, false
+	}
+	desktopIndex, exists := desktopIndexByID(snapshot, window.DesktopID)
+	if !exists {
+		return stackLocation{}, false
+	}
+	desktop := &snapshot.Desktops[desktopIndex]
+	for index := range desktop.FloatingStacks {
+		stack := &desktop.FloatingStacks[index]
+		if containsWindowID(stack.WindowIDs, windowID) {
+			return stackLocation{
+				desktopIndex:       desktopIndex,
+				groupIndex:         -1,
+				floatingStackIndex: index,
+				floating:           stack,
+			}, true
+		}
+	}
+	for groupIndex := range desktop.Groups {
+		if node, found := findStackNodeByWindow(&desktop.Groups[groupIndex].Root, windowID); found {
+			return stackLocation{
+				desktopIndex:       desktopIndex,
+				groupIndex:         groupIndex,
+				floatingStackIndex: -1,
+				node:               node,
+			}, true
+		}
+	}
+	return stackLocation{}, false
+}
+
+func findStackByID(snapshot *Snapshot, stackID NodeID) (stackLocation, bool) {
+	for desktopIndex := range snapshot.Desktops {
+		desktop := &snapshot.Desktops[desktopIndex]
+		for index := range desktop.FloatingStacks {
+			if desktop.FloatingStacks[index].ID == stackID {
+				return stackLocation{
+					desktopIndex:       desktopIndex,
+					groupIndex:         -1,
+					floatingStackIndex: index,
+					floating:           &desktop.FloatingStacks[index],
+				}, true
+			}
+		}
+		for groupIndex := range desktop.Groups {
+			node, found := findNode(&desktop.Groups[groupIndex].Root, stackID)
+			if found && node.Kind == NodeKindStack {
+				return stackLocation{
+					desktopIndex:       desktopIndex,
+					groupIndex:         groupIndex,
+					floatingStackIndex: -1,
+					node:               node,
+				}, true
+			}
+		}
+	}
+	return stackLocation{}, false
+}
+
+func findStackNodeByWindow(node *LayoutNode, windowID WindowID) (*LayoutNode, bool) {
+	if node.Kind == NodeKindStack && containsWindowID(node.WindowIDs, windowID) {
+		return node, true
+	}
+	for index := range node.Children {
+		if found, exists := findStackNodeByWindow(&node.Children[index], windowID); exists {
+			return found, true
+		}
+	}
+	return nil, false
+}
+
+func (location stackLocation) id() NodeID {
+	if location.floating != nil {
+		return location.floating.ID
+	}
+	return location.node.ID
+}
+
+func (location stackLocation) members() []WindowID {
+	if location.floating != nil {
+		return location.floating.WindowIDs
+	}
+	return location.node.WindowIDs
+}
+
+func (location stackLocation) activeID() *WindowID {
+	if location.floating != nil {
+		return location.floating.ActiveID
+	}
+	return location.node.ActiveID
+}
+
+func (location stackLocation) setMembers(windowIDs []WindowID) {
+	if location.floating != nil {
+		location.floating.WindowIDs = windowIDs
+		return
+	}
+	location.node.WindowIDs = windowIDs
+}
+
+func (location stackLocation) setActive(windowID WindowID) {
+	if location.floating != nil {
+		location.floating.ActiveID = &windowID
+		return
+	}
+	location.node.ActiveID = &windowID
+}
+
+func (location stackLocation) rect(snapshot *Snapshot) NormalizedRect {
+	if location.floating != nil {
+		return location.floating.Rect
+	}
+	return snapshot.Desktops[location.desktopIndex].Groups[location.groupIndex].Frame
+}
+
+func collatePinned(windowIDs []WindowID, windows map[WindowID]Window) []WindowID {
+	pinned := make([]WindowID, 0, len(windowIDs))
+	unpinned := make([]WindowID, 0, len(windowIDs))
+	for _, windowID := range windowIDs {
+		if windows[windowID].Pinned {
+			pinned = append(pinned, windowID)
+		} else {
+			unpinned = append(unpinned, windowID)
+		}
+	}
+	return append(pinned, unpinned...)
+}
+
+func pinnedPrefixLength(windowIDs []WindowID, windows map[WindowID]Window) int {
+	count := 0
+	for _, windowID := range windowIDs {
+		if !windows[windowID].Pinned {
+			break
+		}
+		count++
+	}
+	return count
+}
+
+func nextActiveAfterRemoval(members []WindowID, removedIndex int) *WindowID {
+	if len(members) == 0 {
+		return nil
+	}
+	index := min(removedIndex, len(members)-1)
+	active := members[index]
+	return &active
+}

--- a/internal/windowmanager/history.go
+++ b/internal/windowmanager/history.go
@@ -40,17 +40,25 @@ func restoreState(snapshot *Snapshot, state State) {
 }
 
 func restoreStatePreservingRoutes(snapshot *Snapshot, state State) {
-	routes := make(map[WindowID]RouteIntent, len(snapshot.Windows))
+	type navigationState struct {
+		route    RouteIntent
+		navStack []RouteIntent
+	}
+	navigation := make(map[WindowID]navigationState, len(snapshot.Windows))
 	for windowID, window := range snapshot.Windows {
-		routes[windowID] = cloneRouteIntent(window.Route)
+		navigation[windowID] = navigationState{
+			route:    cloneRouteIntent(window.Route),
+			navStack: cloneRouteIntents(window.NavStack),
+		}
 	}
 	restoreState(snapshot, state)
-	for windowID, route := range routes {
+	for windowID, current := range navigation {
 		window, exists := snapshot.Windows[windowID]
 		if !exists {
 			continue
 		}
-		window.Route = route
+		window.Route = current.route
+		window.NavStack = current.navStack
 		snapshot.Windows[windowID] = window
 	}
 }

--- a/internal/windowmanager/lifecycle_test.go
+++ b/internal/windowmanager/lifecycle_test.go
@@ -7,9 +7,12 @@ package windowmanager
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -98,6 +101,919 @@ func TestWindowLifecycleReflow(t *testing.T) {
 			t.Fatalf("minimizeWindow() error = %v, want ErrInvalidTopology", err)
 		}
 	})
+}
+
+func TestWindowTabGroupingV3(t *testing.T) {
+	t.Run("Should group floating windows and activate the newly added member [UT-010]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w2", "desktop-default")
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, GroupWindowsCommand{
+			TargetWindowID: "w1", WindowIDs: []WindowID{"w2"},
+		})
+		stack := result.Snapshot.Desktops[0].FloatingStacks[0]
+		if !slices.Equal(stack.WindowIDs, []WindowID{"w1", "w2"}) || valueOrZero(stack.ActiveID) != "w2" {
+			t.Fatalf("floating stack = %+v", stack)
+		}
+		requireValidSnapshot(t, result.Snapshot)
+	})
+
+	t.Run("Should reject empty duplicate self and missing group members atomically [UT-011]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w2", "desktop-default")
+		cases := []GroupWindowsCommand{
+			{TargetWindowID: "w1"},
+			{TargetWindowID: "w1", WindowIDs: []WindowID{"w1"}},
+			{TargetWindowID: "w1", WindowIDs: []WindowID{"w2", "w2"}},
+			{TargetWindowID: "missing", WindowIDs: []WindowID{"w2"}},
+			{TargetWindowID: "w1", WindowIDs: []WindowID{"missing"}},
+		}
+		before, err := environment.manager.Snapshot(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("Snapshot() error = %v", err)
+		}
+		for _, command := range cases {
+			_, err := environment.manager.Execute(t.Context(), CommandRequest{
+				WorkspaceID: "workspace-a", ExpectedRevision: before.Revision, Payload: command,
+			})
+			if err == nil {
+				t.Fatalf("Execute(%+v) error = nil", command)
+			}
+		}
+		after, err := environment.manager.Snapshot(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("Snapshot(after errors) error = %v", err)
+		}
+		if after.Revision != before.Revision {
+			t.Fatalf("revision after rejected groups = %d, want %d", after.Revision, before.Revision)
+		}
+	})
+
+	t.Run("Should grow a tiled leaf stack and restore a minimized member [UT-012]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w2", "desktop-default")
+		executeTestCommand(t, environment.manager, "workspace-a", nil, ToggleFloatingCommand{WindowID: "w1"})
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			CloseWindowCommand{WindowID: "w2", Minimize: true},
+		)
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, GroupWindowsCommand{
+			TargetWindowID: "w1", WindowIDs: []WindowID{"w2"},
+		})
+		root := result.Snapshot.Desktops[0].Groups[0].Root
+		if root.Kind != NodeKindStack || !slices.Equal(root.WindowIDs, []WindowID{"w1", "w2"}) ||
+			result.Snapshot.Windows["w2"].Minimized {
+			t.Fatalf("grouped root = %+v, w2 = %+v", root, result.Snapshot.Windows["w2"])
+		}
+	})
+
+	t.Run(
+		"Should fold all requested source-stack members into the target in payload order [UT-013]",
+		func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			for _, windowID := range []WindowID{"w1", "w2", "w3"} {
+				openTestWindow(t, environment.manager, "workspace-a", nil, windowID, "desktop-default")
+			}
+			source := executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				GroupWindowsCommand{TargetWindowID: "w2", WindowIDs: []WindowID{"w3"}},
+			)
+			sourceLocation, found := findStackByWindow(&source.Snapshot, "w2")
+			if !found {
+				t.Fatal("source stack not found")
+			}
+			result := executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				GroupWindowsCommand{TargetWindowID: "w1", WindowIDs: []WindowID{"w2", "w3"}},
+			)
+			members := stackMembersForWindow(t, result.Snapshot, "w1")
+			if !slices.Equal(members, []WindowID{"w1", "w2", "w3"}) {
+				t.Fatalf("grouped members = %v", members)
+			}
+			if !slices.Contains(result.Changes.StackUngrouped, sourceLocation.id()) {
+				t.Fatalf("group changes = %+v, want source stack %q ungrouped", result.Changes, sourceLocation.id())
+			}
+		},
+	)
+
+	t.Run("Should migrate grouped members to the targets desktop [UT-014]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			CreateDesktopCommand{DesktopID: "d2", Name: "Two"},
+		)
+		openTestWindow(t, environment.manager, "workspace-a", nil, "target", "desktop-default")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "member", "d2")
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			GroupWindowsCommand{TargetWindowID: "target", WindowIDs: []WindowID{"member"}},
+		)
+		if result.Snapshot.Windows["member"].DesktopID != "desktop-default" ||
+			len(result.Snapshot.Desktops[1].Floating) != 0 {
+			t.Fatalf("cross-desktop result = %+v", result.Snapshot)
+		}
+	})
+
+	t.Run("Should reorder DropCenter within one stack without duplicate membership [UT-015]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		created := createFloatingStack(t, environment.manager, []WindowID{"w1", "w2"})
+		before, found := findStackByWindow(&created.Snapshot, "w1")
+		if !found {
+			t.Fatal("stack before DropCenter not found")
+		}
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, MoveWindowCommand{
+			WindowID:             "w1",
+			DestinationDesktopID: "desktop-default",
+			TargetWindowID:       new(WindowID("w2")),
+			Placement:            DropCenter,
+		})
+		members := stackMembersForWindow(t, result.Snapshot, "w1")
+		if !slices.Equal(members, []WindowID{"w2", "w1"}) {
+			t.Fatalf("DropCenter members = %v", members)
+		}
+		after, found := findStackByWindow(&result.Snapshot, "w1")
+		if !found {
+			t.Fatal("stack after DropCenter not found")
+		}
+		if after.id() != before.id() {
+			t.Fatalf("DropCenter stack ID = %q, want %q", after.id(), before.id())
+		}
+		requireValidSnapshot(t, result.Snapshot)
+	})
+
+	t.Run("Should merge pinned and unpinned regions with stable relative order [UT-016]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		for _, windowID := range []WindowID{"p1", "u1", "u2", "p2"} {
+			openTestWindow(t, environment.manager, "workspace-a", nil, windowID, "desktop-default")
+		}
+		executeTestCommand(t, environment.manager, "workspace-a", nil, PinWindowCommand{WindowID: "p1", Pinned: true})
+		executeTestCommand(t, environment.manager, "workspace-a", nil, PinWindowCommand{WindowID: "p2", Pinned: true})
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			GroupWindowsCommand{TargetWindowID: "p1", WindowIDs: []WindowID{"u1"}},
+		)
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			GroupWindowsCommand{TargetWindowID: "p1", WindowIDs: []WindowID{"u2", "p2"}},
+		)
+		members := stackMembersForWindow(t, result.Snapshot, "p1")
+		if !slices.Equal(members, []WindowID{"p1", "p2", "u1", "u2"}) {
+			t.Fatalf("merged members = %v", members)
+		}
+	})
+
+	t.Run("Should place an unpinned member at the start of the unpinned region [UT-017]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"w1", "w2", "w3"})
+		executeTestCommand(t, environment.manager, "workspace-a", nil, PinWindowCommand{WindowID: "w2", Pinned: true})
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			PinWindowCommand{WindowID: "w2", Pinned: false},
+		)
+		if members := stackMembersForWindow(
+			t,
+			result.Snapshot,
+			"w2",
+		); !slices.Equal(
+			members,
+			[]WindowID{"w2", "w1", "w3"},
+		) {
+			t.Fatalf("members after unpin = %v", members)
+		}
+	})
+
+	t.Run("Should ungroup a pinned member without clearing the pin [UT-018]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"w1", "w2"})
+		executeTestCommand(t, environment.manager, "workspace-a", nil, PinWindowCommand{WindowID: "w1", Pinned: true})
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, ToggleFloatingCommand{WindowID: "w1"})
+		if !result.Snapshot.Windows["w1"].Pinned || result.Snapshot.Windows["w1"].Placement != WindowPlacementFloating {
+			t.Fatalf("ungrouped pinned window = %+v", result.Snapshot.Windows["w1"])
+		}
+	})
+
+	t.Run("Should clamp reorder within the pin region and reject non-stacked windows [UT-019]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"p1", "p2", "u1", "u2"})
+		for _, windowID := range []WindowID{"p1", "p2"} {
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				PinWindowCommand{WindowID: windowID, Pinned: true},
+			)
+		}
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			ReorderStackCommand{WindowID: "u2", Index: 0},
+		)
+		if members := stackMembersForWindow(
+			t,
+			result.Snapshot,
+			"u2",
+		); !slices.Equal(
+			members,
+			[]WindowID{"p1", "p2", "u2", "u1"},
+		) {
+			t.Fatalf("clamped members = %v", members)
+		}
+		openTestWindow(t, environment.manager, "workspace-a", nil, "solo", "desktop-default")
+		snapshot, err := environment.manager.Snapshot(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("Snapshot() error = %v", err)
+		}
+		_, err = environment.manager.Execute(
+			t.Context(),
+			CommandRequest{
+				WorkspaceID:      "workspace-a",
+				ExpectedRevision: snapshot.Revision,
+				Payload:          ReorderStackCommand{WindowID: "solo", Index: 0},
+			},
+		)
+		if !errors.Is(err, ErrNotStacked) {
+			t.Fatalf("ReorderStack(solo) error = %v, want ErrNotStacked", err)
+		}
+	})
+
+	t.Run("Should splice and clamp group InsertIndex within legal pin regions [UT-179]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"p1", "u1"})
+		executeTestCommand(t, environment.manager, "workspace-a", nil, PinWindowCommand{WindowID: "p1", Pinned: true})
+		for _, windowID := range []WindowID{"p2", "u2", "u3"} {
+			openTestWindow(t, environment.manager, "workspace-a", nil, windowID, "desktop-default")
+		}
+		executeTestCommand(t, environment.manager, "workspace-a", nil, PinWindowCommand{WindowID: "p2", Pinned: true})
+		zero := 0
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			GroupWindowsCommand{TargetWindowID: "p1", WindowIDs: []WindowID{"u2", "p2"}, InsertIndex: &zero},
+		)
+		if members := stackMembersForWindow(
+			t,
+			result.Snapshot,
+			"p1",
+		); !slices.Equal(
+			members,
+			[]WindowID{"p2", "p1", "u2", "u1"},
+		) {
+			t.Fatalf("indexed members = %v", members)
+		}
+		result = executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			GroupWindowsCommand{TargetWindowID: "p1", WindowIDs: []WindowID{"u3"}},
+		)
+		if members := stackMembersForWindow(
+			t,
+			result.Snapshot,
+			"p1",
+		); !slices.Equal(
+			members,
+			[]WindowID{"p2", "p1", "u2", "u1", "u3"},
+		) {
+			t.Fatalf("nil-index members = %v", members)
+		}
+	})
+}
+
+func createFloatingStack(t *testing.T, manager *Manager, windowIDs []WindowID) Result {
+	t.Helper()
+	for _, windowID := range windowIDs {
+		openTestWindow(t, manager, "workspace-a", nil, windowID, "desktop-default")
+	}
+	return executeTestCommand(t, manager, "workspace-a", nil, GroupWindowsCommand{
+		TargetWindowID: windowIDs[0], WindowIDs: append([]WindowID(nil), windowIDs[1:]...),
+	})
+}
+
+func stackMembersForWindow(t *testing.T, snapshot Snapshot, windowID WindowID) []WindowID {
+	t.Helper()
+	location, found := findStackByWindow(&snapshot, windowID)
+	if !found {
+		t.Fatalf("window %q is not stacked in %+v", windowID, snapshot)
+	}
+	return append([]WindowID(nil), location.members()...)
+}
+
+func TestWindowTabCloseAndReopenV3(t *testing.T) {
+	t.Run("Should close one tab into a complete entry and activate the right neighbor [UT-020]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"w1", "w2", "w3"})
+		executeTestCommand(t, environment.manager, "workspace-a", nil, SetStackActiveCommand{WindowID: "w2"})
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w2"})
+		if len(result.Snapshot.ClosedEntries) != 1 {
+			t.Fatalf("closed entries = %+v", result.Snapshot.ClosedEntries)
+		}
+		entry := result.Snapshot.ClosedEntries[0]
+		if !slices.Equal(closedEntryWindowIDs(entry), []WindowID{"w2"}) || entry.StackID == nil ||
+			valueOrZero(entry.ActiveID) != "w2" {
+			t.Fatalf("closed entry = %+v", entry)
+		}
+		location, found := findStackByWindow(&result.Snapshot, "w1")
+		if !found || valueOrZero(location.activeID()) != "w3" {
+			t.Fatalf("surviving stack = %+v, found = %v", location, found)
+		}
+	})
+
+	t.Run("Should close a whole frame as one ordered entry [UT-021]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		stacked := createFloatingStack(t, environment.manager, []WindowID{"w1", "w2", "w3"})
+		stack := stacked.Snapshot.Desktops[0].FloatingStacks[0]
+		executeTestCommand(t, environment.manager, "workspace-a", nil, SetStackActiveCommand{WindowID: "w2"})
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			CloseWindowCommand{WindowID: "w1", Scope: CloseScopeGroup},
+		)
+		entry := result.Snapshot.ClosedEntries[0]
+		if !slices.Equal(closedEntryWindowIDs(entry), []WindowID{"w1", "w2", "w3"}) ||
+			valueOrZero(entry.ActiveID) != "w2" || valueOrZero(entry.StackID) != stack.ID || entry.Rect != stack.Rect {
+			t.Fatalf("group closed entry = %+v", entry)
+		}
+		if len(result.Snapshot.Windows) != 0 || result.Snapshot.Revision != stacked.Snapshot.Revision+2 {
+			t.Fatalf("group close result = %+v", result)
+		}
+	})
+
+	t.Run("Should leave a valid empty desktop after closing the last window [UT-022]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "solo", "desktop-default")
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "solo"})
+		if len(result.Snapshot.Windows) != 0 || len(result.Snapshot.Desktops[0].Floating) != 0 {
+			t.Fatalf("empty desktop result = %+v", result.Snapshot)
+		}
+		requireValidSnapshot(t, result.Snapshot)
+	})
+
+	t.Run(
+		"Should protect a pinned tab but allow scoped frame close and reject scoped minimize [UT-023]",
+		func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			createFloatingStack(t, environment.manager, []WindowID{"pinned", "other"})
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				PinWindowCommand{WindowID: "pinned", Pinned: true},
+			)
+			snapshot, err := environment.manager.Snapshot(t.Context(), "workspace-a")
+			if err != nil {
+				t.Fatalf("Snapshot() error = %v", err)
+			}
+			for _, command := range []CloseWindowCommand{
+				{WindowID: "pinned"},
+				{WindowID: "pinned", Minimize: true, Scope: CloseScopeGroup},
+			} {
+				_, executeErr := environment.manager.Execute(
+					t.Context(),
+					CommandRequest{WorkspaceID: "workspace-a", ExpectedRevision: snapshot.Revision, Payload: command},
+				)
+				if executeErr == nil {
+					t.Fatalf("Execute(%+v) error = nil", command)
+				}
+			}
+			result := executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				CloseWindowCommand{WindowID: "pinned", Scope: CloseScopeGroup},
+			)
+			if len(result.Snapshot.Windows) != 0 || len(result.Snapshot.ClosedEntries) != 1 {
+				t.Fatalf("pinned group close = %+v", result.Snapshot)
+			}
+		},
+	)
+
+	t.Run("Should open directly into floating and tiled target stacks [UT-024]", func(t *testing.T) {
+		for _, tiled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("Should join a tiled target equal %v", tiled), func(t *testing.T) {
+				t.Parallel()
+				environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+				openTestWindow(t, environment.manager, "workspace-a", nil, "target", "desktop-default")
+				if tiled {
+					executeTestCommand(
+						t,
+						environment.manager,
+						"workspace-a",
+						nil,
+						ToggleFloatingCommand{WindowID: "target"},
+					)
+				}
+				targetID := WindowID("target")
+				result := executeTestCommand(
+					t,
+					environment.manager,
+					"workspace-a",
+					nil,
+					OpenWindowCommand{Window: WindowSpec{
+						ID:                  "new",
+						App:                 "New",
+						Route:               testRoute("/new"),
+						FloatingRect:        fullRect(),
+						StackTargetWindowID: &targetID,
+					}},
+				)
+				if members := stackMembersForWindow(
+					t,
+					result.Snapshot,
+					"new",
+				); !slices.Equal(
+					members,
+					[]WindowID{"target", "new"},
+				) {
+					t.Fatalf("open-as-tab members = %v", members)
+				}
+			})
+		}
+	})
+
+	t.Run("Should reopen into a living stack with route nav and pin state preserved [UT-025]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"w1", "w2", "w3"})
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			NavigateWindowCommand{WindowID: "w3", Route: testRoute("/next"), Mode: NavigatePush},
+		)
+		executeTestCommand(t, environment.manager, "workspace-a", nil, SetStackActiveCommand{WindowID: "w3"})
+		closed := executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w3"})
+		want := closed.Snapshot.ClosedEntries[0].Windows[0]
+		reopened := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		got := reopened.Snapshot.Windows["w3"]
+		if got.Pinned != want.Pinned || !routeIntentsEqual(got.Route, want.Route) ||
+			len(got.NavStack) != len(want.NavStack) {
+			t.Fatalf("reopened window = %+v, want state = %+v", got, want)
+		}
+		location, found := findStackByWindow(&reopened.Snapshot, "w3")
+		if !found || valueOrZero(location.activeID()) != "w3" || len(reopened.Snapshot.ClosedEntries) != 0 {
+			t.Fatalf("reopened stack = %+v found=%v", location, found)
+		}
+	})
+
+	t.Run("Should rebuild a dead frame or degrade a singleton to floating [UT-026]", func(t *testing.T) {
+		t.Run("Should rebuild a multi-window frame", func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			createFloatingStack(t, environment.manager, []WindowID{"w1", "w2"})
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				CloseWindowCommand{WindowID: "w1", Scope: CloseScopeGroup},
+			)
+			result := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+			if len(result.Snapshot.Desktops[0].FloatingStacks) != 1 ||
+				!slices.Equal(stackMembersForWindow(t, result.Snapshot, "w1"), []WindowID{"w1", "w2"}) {
+				t.Fatalf("rebuilt frame = %+v", result.Snapshot.Desktops[0])
+			}
+		})
+		t.Run("Should reopen one window as floating", func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			openTestWindow(t, environment.manager, "workspace-a", nil, "solo", "desktop-default")
+			executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "solo"})
+			result := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+			if result.Snapshot.Windows["solo"].Placement != WindowPlacementFloating ||
+				!slices.Contains(result.Snapshot.Desktops[0].Floating, WindowID("solo")) {
+				t.Fatalf("reopened singleton = %+v", result.Snapshot)
+			}
+		})
+		t.Run("Should fall back to the requesting client's active desktop", func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				CreateDesktopCommand{DesktopID: "d2", Name: "Two"},
+			)
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				CreateDesktopCommand{DesktopID: "d3", Name: "Three"},
+			)
+			openTestWindow(t, environment.manager, "workspace-a", nil, "solo", "d2")
+			executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "solo"})
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				DeleteDesktopCommand{DesktopID: "d2", DestinationID: new(DesktopID("d3"))},
+			)
+			clientID := ClientID("client-a")
+			if _, err := environment.manager.RegisterClient(t.Context(), ClientRegistration{
+				WorkspaceID: "workspace-a", ClientID: clientID, ActiveDesktopID: "d3",
+			}); err != nil {
+				t.Fatalf("RegisterClient() error = %v", err)
+			}
+			result := executeTestCommand(t, environment.manager, "workspace-a", &clientID, ReopenCommand{})
+			if result.Snapshot.Windows["solo"].DesktopID != "d3" {
+				t.Fatalf("reopened desktop = %q, want d3", result.Snapshot.Windows["solo"].DesktopID)
+			}
+		})
+	})
+
+	t.Run("Should treat reopen with empty history as a no-op without revision [UT-027]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		before, err := environment.manager.Snapshot(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("Snapshot() error = %v", err)
+		}
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		if result.Applied || result.Snapshot.Revision != before.Revision {
+			t.Fatalf("empty reopen result = %+v", result)
+		}
+	})
+
+	t.Run("Should reopen a fully pinned frame with every pin intact [UT-028]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"p1", "p2"})
+		for _, windowID := range []WindowID{"p1", "p2"} {
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				PinWindowCommand{WindowID: windowID, Pinned: true},
+			)
+		}
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			CloseWindowCommand{WindowID: "p1", Scope: CloseScopeGroup},
+		)
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		if !result.Snapshot.Windows["p1"].Pinned || !result.Snapshot.Windows["p2"].Pinned {
+			t.Fatalf("reopened pins = %+v", result.Snapshot.Windows)
+		}
+	})
+
+	t.Run("Should consume closed entries newest-first then become a no-op [UT-029]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		for _, windowID := range []WindowID{"w1", "w2"} {
+			openTestWindow(t, environment.manager, "workspace-a", nil, windowID, "desktop-default")
+			executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: windowID})
+		}
+		first := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		if _, exists := first.Snapshot.Windows["w2"]; !exists {
+			t.Fatalf("first reopen windows = %+v", first.Snapshot.Windows)
+		}
+		second := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		if _, exists := second.Snapshot.Windows["w1"]; !exists {
+			t.Fatalf("second reopen windows = %+v", second.Snapshot.Windows)
+		}
+		third := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		if third.Applied {
+			t.Fatalf("third reopen = %+v", third)
+		}
+	})
+
+	t.Run("Should close others and right as one unpinned batch [UT-172]", func(t *testing.T) {
+		for _, scope := range []CloseScope{CloseScopeOthers, CloseScopeRight} {
+			t.Run("Should apply scope "+string(scope), func(t *testing.T) {
+				t.Parallel()
+				environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+				created := createFloatingStack(t, environment.manager, []WindowID{"p", "w1", "w2", "w3"})
+				executeTestCommand(
+					t,
+					environment.manager,
+					"workspace-a",
+					nil,
+					PinWindowCommand{WindowID: "p", Pinned: true},
+				)
+				before, err := environment.manager.Snapshot(t.Context(), "workspace-a")
+				if err != nil {
+					t.Fatalf("Snapshot() error = %v", err)
+				}
+				result := executeTestCommand(
+					t,
+					environment.manager,
+					"workspace-a",
+					nil,
+					CloseWindowCommand{WindowID: "w1", Scope: scope},
+				)
+				if result.Snapshot.Revision != before.Revision+1 || len(result.Snapshot.ClosedEntries) != 1 ||
+					!slices.Equal(closedEntryWindowIDs(result.Snapshot.ClosedEntries[0]), []WindowID{"w2", "w3"}) {
+					t.Fatalf("scoped close result = %+v, created revision = %d", result, created.Snapshot.Revision)
+				}
+				if _, pinnedLives := result.Snapshot.Windows["p"]; !pinnedLives {
+					t.Fatal("pinned peer was closed")
+				}
+			})
+		}
+	})
+
+	t.Run("Should reserve closed IDs through generation and release them on eviction [UT-173]", func(t *testing.T) {
+		t.Parallel()
+		windowID, err := randomID("window")
+		if err != nil {
+			t.Fatalf("randomID(window) error = %v", err)
+		}
+		if !strings.HasPrefix(windowID, "w-") || len(windowID) != 28 {
+			t.Fatalf("randomID(window) = %q, want w-<26-char-random>", windowID)
+		}
+		if _, err := hex.DecodeString(strings.TrimPrefix(windowID, "w-")); err != nil {
+			t.Fatalf("randomID(window) random suffix is not hexadecimal: %v", err)
+		}
+		config := DefaultConfig()
+		config.ClosedEntryLimit = 1
+		var generated atomic.Int64
+		environment := newTestEnvironmentWithOptions(
+			t,
+			config,
+			[]WorkspaceID{"workspace-a"},
+			WithIDGenerator(func(kind string) (string, error) {
+				if kind == "window" {
+					if generated.Add(1) == 1 {
+						return "w1", nil
+					}
+					return "w-new", nil
+				}
+				return kind + "-generated", nil
+			}),
+		)
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+		executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w1"})
+		snapshot, err := environment.manager.Snapshot(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("Snapshot() error = %v", err)
+		}
+		_, err = environment.manager.Execute(
+			t.Context(),
+			CommandRequest{
+				WorkspaceID:      "workspace-a",
+				ExpectedRevision: snapshot.Revision,
+				Payload: OpenWindowCommand{
+					Window: WindowSpec{
+						ID:           "w1",
+						App:          "Reserved",
+						Route:        testRoute("/reserved"),
+						FloatingRect: fullRect(),
+					},
+				},
+			},
+		)
+		if err == nil {
+			t.Fatal("OpenWindow(reserved caller ID) error = nil")
+		}
+		generatedResult := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			OpenWindowCommand{
+				Window: WindowSpec{App: "Generated", Route: testRoute("/generated"), FloatingRect: fullRect()},
+			},
+		)
+		if _, exists := generatedResult.Snapshot.Windows["w-new"]; !exists {
+			t.Fatalf("generated windows = %+v", generatedResult.Snapshot.Windows)
+		}
+		executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w-new"})
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			OpenWindowCommand{
+				Window: WindowSpec{ID: "w1", App: "Released", Route: testRoute("/released"), FloatingRect: fullRect()},
+			},
+		)
+		if _, exists := result.Snapshot.Windows["w1"]; !exists {
+			t.Fatalf("released ID windows = %+v", result.Snapshot.Windows)
+		}
+	})
+}
+
+func TestWindowTabNavigationV3(t *testing.T) {
+	t.Run(
+		"Should cap navigation at the effective limit while retaining newest ancestors [UT-008][UT-031]",
+		func(t *testing.T) {
+			t.Parallel()
+			config := DefaultConfig()
+			config.NavStackLimit = 2
+			environment := newTestEnvironment(t, config, "workspace-a")
+			openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+			for _, path := range []string{"/one", "/two", "/three"} {
+				executeTestCommand(
+					t,
+					environment.manager,
+					"workspace-a",
+					nil,
+					NavigateWindowCommand{WindowID: "w1", Route: testRoute(path), Mode: NavigatePush},
+				)
+			}
+			window := mustSnapshot(t, environment.manager, "workspace-a").Windows["w1"]
+			if len(window.NavStack) != 2 || window.NavStack[0].Pathname != "/one" ||
+				window.NavStack[1].Pathname != "/two" {
+				t.Fatalf("capped navigation = %+v", window)
+			}
+		},
+	)
+
+	t.Run("Should apply a lowered closed-entry limit only on the next close [UT-009]", func(t *testing.T) {
+		t.Parallel()
+		config := DefaultConfig()
+		config.ClosedEntryLimit = 2
+		environment := newTestEnvironment(t, config, "workspace-a")
+		for _, windowID := range []WindowID{"w1", "w2"} {
+			openTestWindow(t, environment.manager, "workspace-a", nil, windowID, "desktop-default")
+			executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: windowID})
+		}
+		if got := len(mustSnapshot(t, environment.manager, "workspace-a").ClosedEntries); got != 2 {
+			t.Fatalf("closed entries before lowering = %d", got)
+		}
+		config.ClosedEntryLimit = 1
+		if err := environment.manager.UpdateDefaults(config); err != nil {
+			t.Fatalf("UpdateDefaults() error = %v", err)
+		}
+		if got := len(mustSnapshot(t, environment.manager, "workspace-a").ClosedEntries); got != 2 {
+			t.Fatalf("closed entries changed retroactively = %d", got)
+		}
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w3", "desktop-default")
+		executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w3"})
+		if got := len(mustSnapshot(t, environment.manager, "workspace-a").ClosedEntries); got != 1 {
+			t.Fatalf("closed entries after next close = %d", got)
+		}
+	})
+
+	t.Run("Should push the prior route and pop it back [UT-030]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+		pushed := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/child"), Mode: NavigatePush},
+		)
+		if pushed.Snapshot.Windows["w1"].Route.Pathname != "/child" ||
+			len(pushed.Snapshot.Windows["w1"].NavStack) != 1 {
+			t.Fatalf("pushed window = %+v", pushed.Snapshot.Windows["w1"])
+		}
+		popped := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			NavigateWindowCommand{WindowID: "w1", Mode: NavigatePop},
+		)
+		if popped.Snapshot.Windows["w1"].Route.Pathname != "/test" || len(popped.Snapshot.Windows["w1"].NavStack) != 0 {
+			t.Fatalf("popped window = %+v", popped.Snapshot.Windows["w1"])
+		}
+	})
+
+	t.Run("Should treat pop at the root as a successful no-op [UT-032]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+		before := mustSnapshot(t, environment.manager, "workspace-a")
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			NavigateWindowCommand{WindowID: "w1", Mode: NavigatePop},
+		)
+		if result.Applied || result.Snapshot.Revision != before.Revision {
+			t.Fatalf("root pop = %+v", result)
+		}
+	})
+
+	t.Run("Should preserve navigation while dragging a tab out and collapsing two to one [UT-033]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		for _, windowID := range []WindowID{"w1", "w2"} {
+			openTestWindow(t, environment.manager, "workspace-a", nil, windowID, "desktop-default")
+		}
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			ArrangeLayoutCommand{
+				DesktopID:   "desktop-default",
+				WindowIDs:   []WindowID{"w1", "w2"},
+				Arrangement: ArrangementStack,
+				Frame:       fullRect(),
+				GroupID:     "group",
+			},
+		)
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/child"), Mode: NavigatePush},
+		)
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, ToggleFloatingCommand{WindowID: "w1"})
+		root := result.Snapshot.Desktops[0].Groups[0].Root
+		if root.Kind != NodeKindLeaf || valueOrZero(root.WindowID) != "w2" ||
+			len(result.Snapshot.Windows["w1"].NavStack) != 1 {
+			t.Fatalf("drag-out result = %+v", result.Snapshot)
+		}
+	})
+
+	t.Run("Should keep arrange stack producing one three-member node stack [UT-035]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		for _, windowID := range []WindowID{"w1", "w2", "w3"} {
+			openTestWindow(t, environment.manager, "workspace-a", nil, windowID, "desktop-default")
+		}
+		result := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			ArrangeLayoutCommand{
+				DesktopID:   "desktop-default",
+				WindowIDs:   []WindowID{"w1", "w2", "w3"},
+				Arrangement: ArrangementStack,
+				Frame:       fullRect(),
+				GroupID:     "group",
+			},
+		)
+		root := result.Snapshot.Desktops[0].Groups[0].Root
+		if root.Kind != NodeKindStack || !slices.Equal(root.WindowIDs, []WindowID{"w1", "w2", "w3"}) {
+			t.Fatalf("arranged stack = %+v", root)
+		}
+	})
+}
+
+func mustSnapshot(t *testing.T, manager *Manager, workspaceID WorkspaceID) Snapshot {
+	t.Helper()
+	snapshot, err := manager.Snapshot(t.Context(), workspaceID)
+	if err != nil {
+		t.Fatalf("Snapshot() error = %v", err)
+	}
+	return snapshot
 }
 
 func TestWindowNavigation(t *testing.T) {
@@ -845,6 +1761,8 @@ func TestFocusAndZoom(t *testing.T) {
 				},
 			)
 			sourceGroup := arranged.Snapshot.Desktops[0].Groups[0]
+			activeAfterFocus := WindowID("settings")
+			sourceGroup.Root.ActiveID = &activeAfterFocus
 			clientID := ClientID("client-a")
 			registerTestClient(t, environment.manager, "workspace-a", clientID)
 			executeTestCommand(

--- a/internal/windowmanager/normalize.go
+++ b/internal/windowmanager/normalize.go
@@ -24,32 +24,7 @@ func NormalizeSnapshot(snapshot Snapshot) Snapshot {
 	}
 	seen := make(map[WindowID]struct{}, len(normalized.Windows))
 	for desktopIndex := range normalized.Desktops {
-		desktop := &normalized.Desktops[desktopIndex]
-		groups := make([]LayoutGroup, 0, len(desktop.Groups))
-		for _, group := range desktop.Groups {
-			root, present := normalizeNode(group.Root, desktop.ID, normalized.Windows, seen)
-			if !present {
-				continue
-			}
-			group.Root = root
-			groups = append(groups, group)
-		}
-		desktop.Groups = groups
-		floating := make([]WindowID, 0, len(desktop.Floating))
-		for _, windowID := range desktop.Floating {
-			window, exists := normalized.Windows[windowID]
-			if !exists || window.DesktopID != desktop.ID {
-				continue
-			}
-			if _, duplicate := seen[windowID]; duplicate {
-				continue
-			}
-			seen[windowID] = struct{}{}
-			window.Placement = WindowPlacementFloating
-			normalized.Windows[windowID] = window
-			floating = append(floating, windowID)
-		}
-		desktop.Floating = floating
+		normalizeDesktop(&normalized.Desktops[desktopIndex], normalized.Windows, seen)
 	}
 	windowIDs := make([]WindowID, 0, len(normalized.Windows))
 	for windowID := range normalized.Windows {
@@ -73,6 +48,86 @@ func NormalizeSnapshot(snapshot Snapshot) Snapshot {
 	return normalized
 }
 
+func normalizeDesktop(desktop *Desktop, windows map[WindowID]Window, seen map[WindowID]struct{}) {
+	groups := make([]LayoutGroup, 0, len(desktop.Groups))
+	for _, group := range desktop.Groups {
+		root, present := normalizeNode(group.Root, desktop.ID, windows, seen)
+		if !present {
+			continue
+		}
+		group.Root = root
+		groups = append(groups, group)
+	}
+	desktop.Groups = groups
+	dissolved := normalizeFloatingStacks(desktop, windows, seen)
+	normalizeFloatingWindows(desktop, dissolved, windows, seen)
+}
+
+func normalizeFloatingStacks(
+	desktop *Desktop,
+	windows map[WindowID]Window,
+	seen map[WindowID]struct{},
+) []WindowID {
+	floatingStacks := make([]FloatingStack, 0, len(desktop.FloatingStacks))
+	dissolved := make([]WindowID, 0)
+	for _, stack := range desktop.FloatingStacks {
+		windowIDs := make([]WindowID, 0, len(stack.WindowIDs))
+		for _, windowID := range stack.WindowIDs {
+			if claimNodeWindow(windowID, desktop.ID, WindowPlacementStacked, windows, seen) {
+				window := windows[windowID]
+				window.Minimized = false
+				windows[windowID] = window
+				windowIDs = append(windowIDs, windowID)
+			}
+		}
+		windowIDs = collatePinned(windowIDs, windows)
+		switch len(windowIDs) {
+		case 0:
+			continue
+		case 1:
+			windowID := windowIDs[0]
+			window := windows[windowID]
+			window.Placement = WindowPlacementFloating
+			window.FloatingRect = clampRect(stack.Rect)
+			windows[windowID] = window
+			dissolved = append(dissolved, windowID)
+			continue
+		}
+		stack.WindowIDs = windowIDs
+		if stack.ActiveID == nil || !containsWindowID(windowIDs, *stack.ActiveID) {
+			activeID := windowIDs[0]
+			stack.ActiveID = &activeID
+		}
+		floatingStacks = append(floatingStacks, stack)
+	}
+	desktop.FloatingStacks = floatingStacks
+	return dissolved
+}
+
+func normalizeFloatingWindows(
+	desktop *Desktop,
+	dissolved []WindowID,
+	windows map[WindowID]Window,
+	seen map[WindowID]struct{},
+) {
+	source := desktop.Floating
+	floating := append(make([]WindowID, 0, len(dissolved)+len(source)), dissolved...)
+	for _, windowID := range source {
+		window, exists := windows[windowID]
+		if !exists || window.DesktopID != desktop.ID {
+			continue
+		}
+		if _, duplicate := seen[windowID]; duplicate {
+			continue
+		}
+		seen[windowID] = struct{}{}
+		window.Placement = WindowPlacementFloating
+		windows[windowID] = window
+		floating = append(floating, windowID)
+	}
+	desktop.Floating = floating
+}
+
 func normalizeNode(
 	node LayoutNode,
 	desktopID DesktopID,
@@ -92,6 +147,7 @@ func normalizeNode(
 				windowIDs = append(windowIDs, windowID)
 			}
 		}
+		windowIDs = collatePinned(windowIDs, windows)
 		if len(windowIDs) == 0 {
 			return LayoutNode{}, false
 		}

--- a/internal/windowmanager/options.go
+++ b/internal/windowmanager/options.go
@@ -17,6 +17,7 @@ type managerOptions struct {
 	subscriptionBuffer int
 	eventObserver      EventObserver
 	workspaceConfig    WorkspaceConfigResolver
+	lifecycleContext   context.Context
 }
 
 // Option customizes the manager without introducing operational globals.
@@ -85,8 +86,24 @@ func WithWorkspaceConfigResolver(resolver WorkspaceConfigResolver) Option {
 	}
 }
 
+// WithLifecycleContext preserves boot-scoped values for detached background work.
+func WithLifecycleContext(ctx context.Context) Option {
+	return func(options *managerOptions) error {
+		if ctx == nil {
+			return errors.New("window manager lifecycle context is required")
+		}
+		options.lifecycleContext = context.WithoutCancel(ctx)
+		return nil
+	}
+}
+
 func resolveOptions(options []Option) (managerOptions, error) {
-	resolved := managerOptions{now: time.Now, generate: randomID, subscriptionBuffer: defaultSubscriptionBuffer}
+	resolved := managerOptions{
+		now:                time.Now,
+		generate:           randomID,
+		subscriptionBuffer: defaultSubscriptionBuffer,
+		lifecycleContext:   context.Background(),
+	}
 	for _, option := range options {
 		if option == nil {
 			continue
@@ -99,9 +116,15 @@ func resolveOptions(options []Option) (managerOptions, error) {
 }
 
 func randomID(kind string) (string, error) {
-	bytes := make([]byte, 16)
+	prefix := kind + "-"
+	randomBytes := 16
+	if kind == "window" {
+		prefix = "w-"
+		randomBytes = 13
+	}
+	bytes := make([]byte, randomBytes)
 	if _, err := rand.Read(bytes); err != nil {
 		return "", fmt.Errorf("read random ID: %w", err)
 	}
-	return kind + "-" + hex.EncodeToString(bytes), nil
+	return prefix + hex.EncodeToString(bytes), nil
 }

--- a/internal/windowmanager/reducer.go
+++ b/internal/windowmanager/reducer.go
@@ -1,22 +1,50 @@
 package windowmanager
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type reducer struct {
 	generate      idGenerator
 	config        Config
 	focusedWindow *WindowID
+	activeDesktop *DesktopID
+	now           func() time.Time
 	changes       changeBuilder
 }
 
 type reduction struct {
 	changed bool
+	applied bool
 	changes ChangeSet
 }
 
 func (r *reducer) reduce(snapshot *Snapshot, command Command) (reduction, error) {
-	var changed bool
-	var err error
+	changed, reportsApplied, handled, err := r.reduceTopologyCommand(snapshot, command)
+	if !handled {
+		changed, handled, err = r.reduceLayoutCommand(snapshot, command)
+		reportsApplied = true
+	}
+	if err != nil {
+		return reduction{}, err
+	}
+	if !handled {
+		switch command.(type) {
+		case SwitchDesktopCommand, FocusWindowCommand:
+			return reduction{}, fmt.Errorf("presentation command reached durable reducer: %w", ErrInvalidCommand)
+		default:
+			return reduction{}, fmt.Errorf("unsupported command %T: %w", command, ErrInvalidCommand)
+		}
+	}
+	return r.completeReduction(snapshot, changed, changed && reportsApplied), nil
+}
+
+func (r *reducer) reduceTopologyCommand(
+	snapshot *Snapshot,
+	command Command,
+) (changed bool, reportsApplied bool, handled bool, err error) {
+	reportsApplied = true
 	switch payload := command.(type) {
 	case CreateDesktopCommand:
 		changed, err = r.createDesktop(snapshot, payload)
@@ -38,8 +66,30 @@ func (r *reducer) reduce(snapshot *Snapshot, command Command) (reduction, error)
 		changed, err = r.swapWindows(snapshot, payload)
 	case ToggleFloatingCommand:
 		changed, err = r.toggleFloating(snapshot, payload)
+	case GroupWindowsCommand:
+		changed, err = r.groupWindows(snapshot, payload)
+	case ReorderStackCommand:
+		changed, err = r.reorderStack(snapshot, payload)
+	case SetStackActiveCommand:
+		changed, err = r.setStackActive(snapshot, payload)
+	case PinWindowCommand:
+		changed, err = r.pinWindow(snapshot, payload)
+	case ReopenCommand:
+		changed = r.reopenWindow(snapshot)
+		reportsApplied = len(r.changes.windows) > 0
 	case ZoomWindowCommand:
 		changed, err = r.zoomWindow(snapshot, payload)
+	default:
+		return false, true, false, nil
+	}
+	return changed, reportsApplied, true, err
+}
+
+func (r *reducer) reduceLayoutCommand(
+	snapshot *Snapshot,
+	command Command,
+) (changed bool, handled bool, err error) {
+	switch payload := command.(type) {
 	case ArrangeLayoutCommand:
 		changed, err = r.arrange(snapshot, payload)
 	case ResizeLayoutCommand:
@@ -52,29 +102,26 @@ func (r *reducer) reduce(snapshot *Snapshot, command Command) (reduction, error)
 		changed, err = r.redo(snapshot)
 	case ReplaceLayoutCommand:
 		changed, err = r.replace(snapshot, payload)
-	case SwitchDesktopCommand, FocusWindowCommand:
-		return reduction{}, fmt.Errorf("presentation command reached durable reducer: %w", ErrInvalidCommand)
 	default:
-		return reduction{}, fmt.Errorf("unsupported command %T: %w", command, ErrInvalidCommand)
+		return false, false, nil
 	}
-	if err != nil {
-		return reduction{}, err
-	}
-	return r.completeReduction(snapshot, changed), nil
+	return changed, true, err
 }
 
-func (r *reducer) completeReduction(snapshot *Snapshot, changed bool) reduction {
+func (r *reducer) completeReduction(snapshot *Snapshot, changed bool, applied bool) reduction {
 	if changed {
 		r.releaseDetachedFocusDesktops(snapshot)
 	}
-	return reduction{changed: changed, changes: r.changes.result()}
+	return reduction{changed: changed, applied: applied, changes: r.changes.result()}
 }
 
 type changeBuilder struct {
-	desktops map[DesktopID]struct{}
-	windows  map[WindowID]struct{}
-	groups   map[GroupID]struct{}
-	nodes    map[NodeID]struct{}
+	desktops        map[DesktopID]struct{}
+	windows         map[WindowID]struct{}
+	groups          map[GroupID]struct{}
+	nodes           map[NodeID]struct{}
+	groupedStacks   map[NodeID]struct{}
+	ungroupedStacks map[NodeID]struct{}
 }
 
 func (b *changeBuilder) desktop(id DesktopID) {
@@ -101,6 +148,18 @@ func (b *changeBuilder) node(id NodeID) {
 	}
 	b.nodes[id] = struct{}{}
 }
+func (b *changeBuilder) stackGrouped(id NodeID) {
+	if b.groupedStacks == nil {
+		b.groupedStacks = make(map[NodeID]struct{})
+	}
+	b.groupedStacks[id] = struct{}{}
+}
+func (b *changeBuilder) stackUngrouped(id NodeID) {
+	if b.ungroupedStacks == nil {
+		b.ungroupedStacks = make(map[NodeID]struct{})
+	}
+	b.ungroupedStacks[id] = struct{}{}
+}
 func (b *changeBuilder) result() ChangeSet {
 	result := ChangeSet{}
 	for id := range b.desktops {
@@ -114,6 +173,12 @@ func (b *changeBuilder) result() ChangeSet {
 	}
 	for id := range b.nodes {
 		result.NodeIDs = append(result.NodeIDs, id)
+	}
+	for id := range b.groupedStacks {
+		result.StackGrouped = append(result.StackGrouped, id)
+	}
+	for id := range b.ungroupedStacks {
+		result.StackUngrouped = append(result.StackUngrouped, id)
 	}
 	sortChangeSet(&result)
 	return result

--- a/internal/windowmanager/reducer_stack_active.go
+++ b/internal/windowmanager/reducer_stack_active.go
@@ -1,0 +1,20 @@
+package windowmanager
+
+import "fmt"
+
+func (r *reducer) setStackActive(snapshot *Snapshot, command SetStackActiveCommand) (bool, error) {
+	location, found := findStackByWindow(snapshot, command.WindowID)
+	if !found {
+		if _, exists := snapshot.Windows[command.WindowID]; !exists {
+			return false, fmt.Errorf("window %q: %w", command.WindowID, ErrWindowNotFound)
+		}
+		return false, fmt.Errorf("window %q: %w", command.WindowID, ErrNotStacked)
+	}
+	if location.activeID() != nil && *location.activeID() == command.WindowID {
+		return false, nil
+	}
+	location.setActive(command.WindowID)
+	r.changes.window(command.WindowID)
+	r.changes.node(location.id())
+	return true, nil
+}

--- a/internal/windowmanager/reducer_stack_group.go
+++ b/internal/windowmanager/reducer_stack_group.go
@@ -1,0 +1,171 @@
+package windowmanager
+
+import "fmt"
+
+func (r *reducer) groupWindows(snapshot *Snapshot, command GroupWindowsCommand) (bool, error) {
+	if len(command.WindowIDs) == 0 {
+		return false, fmt.Errorf("windows to group are required: %w", ErrInvalidCommand)
+	}
+	target, exists := snapshot.Windows[command.TargetWindowID]
+	if !exists {
+		return false, fmt.Errorf("target window %q: %w", command.TargetWindowID, ErrWindowNotFound)
+	}
+	seen := make(map[WindowID]struct{}, len(command.WindowIDs))
+	for _, windowID := range command.WindowIDs {
+		if windowID == command.TargetWindowID {
+			return false, fmt.Errorf("window cannot group with itself: %w", ErrInvalidCommand)
+		}
+		if _, duplicate := seen[windowID]; duplicate {
+			return false, fmt.Errorf("window %q is duplicated: %w", windowID, ErrInvalidCommand)
+		}
+		seen[windowID] = struct{}{}
+		if _, exists := snapshot.Windows[windowID]; !exists {
+			return false, fmt.Errorf("window %q: %w", windowID, ErrWindowNotFound)
+		}
+	}
+	targetStackID := NodeID("")
+	if location, stacked := findStackByWindow(snapshot, command.TargetWindowID); stacked {
+		targetStackID = location.id()
+	}
+
+	for _, windowID := range command.WindowIDs {
+		sourceStackID := NodeID("")
+		if location, stacked := findStackByWindow(snapshot, windowID); stacked {
+			sourceStackID = location.id()
+		}
+		window := snapshot.Windows[windowID]
+		if sourceStackID != targetStackID || targetStackID == "" {
+			if !removeWindow(snapshot, windowID) {
+				return false, fmt.Errorf("window %q has no placement: %w", windowID, ErrInvalidTopology)
+			}
+			if sourceStackID != "" {
+				if _, stillStacked := findStackByID(snapshot, sourceStackID); !stillStacked {
+					r.changes.stackUngrouped(sourceStackID)
+				}
+			}
+		}
+		window.DesktopID = target.DesktopID
+		window.Placement = WindowPlacementStacked
+		window.Minimized = false
+		window.ReturnAnchor = nil
+		snapshot.Windows[windowID] = window
+		r.changes.window(windowID)
+	}
+
+	location, err := r.ensureTargetStack(snapshot, command.TargetWindowID)
+	if err != nil {
+		return false, err
+	}
+	existing := make([]WindowID, 0, len(location.members()))
+	for _, windowID := range location.members() {
+		if _, joining := seen[windowID]; !joining {
+			existing = append(existing, windowID)
+		}
+	}
+	members := spliceStackMembers(existing, command.WindowIDs, command.InsertIndex, snapshot.Windows)
+	location.setMembers(members)
+	location.setActive(command.WindowIDs[len(command.WindowIDs)-1])
+	for _, memberID := range members {
+		member := snapshot.Windows[memberID]
+		member.DesktopID = target.DesktopID
+		member.Placement = WindowPlacementStacked
+		member.Minimized = false
+		snapshot.Windows[memberID] = member
+		r.changes.window(memberID)
+	}
+	r.changes.desktop(target.DesktopID)
+	r.changes.stackGrouped(location.id())
+	return true, nil
+}
+
+func (r *reducer) ensureTargetStack(snapshot *Snapshot, targetID WindowID) (stackLocation, error) {
+	if location, found := findStackByWindow(snapshot, targetID); found {
+		return location, nil
+	}
+	placement, found := findWindowPlacement(snapshot, targetID)
+	if !found {
+		return stackLocation{}, fmt.Errorf("target window %q has no placement: %w", targetID, ErrInvalidTopology)
+	}
+	stackIDRaw, err := r.generate("node")
+	if err != nil {
+		return stackLocation{}, fmt.Errorf("generate stack ID: %w", err)
+	}
+	stackID := NodeID(stackIDRaw)
+	target := snapshot.Windows[targetID]
+	if placement.floatingIndex >= 0 {
+		desktop := &snapshot.Desktops[placement.desktopIndex]
+		desktop.Floating = append(
+			desktop.Floating[:placement.floatingIndex],
+			desktop.Floating[placement.floatingIndex+1:]...)
+		target.Placement = WindowPlacementStacked
+		target.Minimized = false
+		snapshot.Windows[targetID] = target
+		desktop.FloatingStacks = append(desktop.FloatingStacks, FloatingStack{
+			ID: stackID, WindowIDs: []WindowID{targetID}, ActiveID: &targetID, Rect: target.FloatingRect,
+		})
+		index := len(desktop.FloatingStacks) - 1
+		return stackLocation{
+			desktopIndex:       placement.desktopIndex,
+			groupIndex:         -1,
+			floatingStackIndex: index,
+			floating:           &desktop.FloatingStacks[index],
+		}, nil
+	}
+	if placement.groupIndex < 0 {
+		return stackLocation{}, fmt.Errorf("target window %q placement: %w", targetID, ErrInvalidTopology)
+	}
+	node, found := findNodeInSnapshot(snapshot, placement.nodeID)
+	if !found || node.Kind != NodeKindLeaf {
+		return stackLocation{}, fmt.Errorf("target window %q node: %w", targetID, ErrInvalidTopology)
+	}
+	*node = LayoutNode{ID: stackID, Kind: NodeKindStack, WindowIDs: []WindowID{targetID}, ActiveID: &targetID}
+	target.Placement = WindowPlacementStacked
+	snapshot.Windows[targetID] = target
+	return stackLocation{
+		desktopIndex:       placement.desktopIndex,
+		groupIndex:         placement.groupIndex,
+		floatingStackIndex: -1,
+		node:               node,
+	}, nil
+}
+
+func spliceStackMembers(
+	existing []WindowID,
+	joiners []WindowID,
+	requested *int,
+	windows map[WindowID]Window,
+) []WindowID {
+	pinnedJoiners := make([]WindowID, 0, len(joiners))
+	unpinnedJoiners := make([]WindowID, 0, len(joiners))
+	for _, windowID := range joiners {
+		if windows[windowID].Pinned {
+			pinnedJoiners = append(pinnedJoiners, windowID)
+		} else {
+			unpinnedJoiners = append(unpinnedJoiners, windowID)
+		}
+	}
+	base := len(existing)
+	if requested != nil {
+		base = min(max(*requested, 0), len(existing))
+	}
+	pinnedCount := pinnedPrefixLength(existing, windows)
+	pinnedIndex := min(base, pinnedCount)
+	result := spliceWindowIDs(existing, pinnedIndex, pinnedJoiners)
+	unpinnedBase := base
+	if pinnedIndex <= base {
+		unpinnedBase += len(pinnedJoiners)
+	}
+	unpinnedIndex := min(max(unpinnedBase, pinnedCount+len(pinnedJoiners)), len(result))
+	return spliceWindowIDs(result, unpinnedIndex, unpinnedJoiners)
+}
+
+func spliceWindowIDs(values []WindowID, index int, inserted []WindowID) []WindowID {
+	if len(inserted) == 0 {
+		return append([]WindowID(nil), values...)
+	}
+	result := make([]WindowID, 0, len(values)+len(inserted))
+	result = append(result, values[:index]...)
+	result = append(result, inserted...)
+	result = append(result, values[index:]...)
+	return result
+}

--- a/internal/windowmanager/reducer_stack_reorder.go
+++ b/internal/windowmanager/reducer_stack_reorder.go
@@ -1,0 +1,37 @@
+package windowmanager
+
+import "fmt"
+
+func (r *reducer) reorderStack(snapshot *Snapshot, command ReorderStackCommand) (bool, error) {
+	location, found := findStackByWindow(snapshot, command.WindowID)
+	if !found {
+		if _, exists := snapshot.Windows[command.WindowID]; !exists {
+			return false, fmt.Errorf("window %q: %w", command.WindowID, ErrWindowNotFound)
+		}
+		return false, fmt.Errorf("window %q: %w", command.WindowID, ErrNotStacked)
+	}
+	members := append([]WindowID(nil), location.members()...)
+	current := -1
+	for index, windowID := range members {
+		if windowID == command.WindowID {
+			current = index
+			members = append(members[:index], members[index+1:]...)
+			break
+		}
+	}
+	pinnedCount := pinnedPrefixLength(members, snapshot.Windows)
+	index := command.Index
+	if snapshot.Windows[command.WindowID].Pinned {
+		index = min(max(index, 0), pinnedCount)
+	} else {
+		index = min(max(index, pinnedCount), len(members))
+	}
+	if current == index {
+		return false, nil
+	}
+	members = spliceWindowIDs(members, index, []WindowID{command.WindowID})
+	location.setMembers(members)
+	r.changes.window(command.WindowID)
+	r.changes.node(location.id())
+	return true, nil
+}

--- a/internal/windowmanager/reducer_window_close.go
+++ b/internal/windowmanager/reducer_window_close.go
@@ -1,29 +1,133 @@
 package windowmanager
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 func (r *reducer) closeWindow(snapshot *Snapshot, command CloseWindowCommand) (bool, error) {
 	window, exists := snapshot.Windows[command.WindowID]
 	if !exists {
 		return false, fmt.Errorf("window %q: %w", command.WindowID, ErrWindowNotFound)
 	}
-	if command.Minimize && window.Minimized {
-		return false, nil
-	}
 	if command.Minimize {
+		if command.Scope != CloseScopeTab {
+			return false, fmt.Errorf("minimize cannot include a close scope: %w", ErrInvalidCommand)
+		}
+		if window.Minimized {
+			return false, nil
+		}
 		return r.minimizeWindow(snapshot, command.WindowID)
 	}
-	if !removeWindow(snapshot, command.WindowID) {
-		return false, fmt.Errorf("window %q has no placement: %w", command.WindowID, ErrInvalidTopology)
+	if !validCloseScope(command.Scope) {
+		return false, fmt.Errorf("close scope %q: %w", command.Scope, ErrInvalidCommand)
 	}
-	delete(snapshot.Windows, command.WindowID)
-	r.changes.window(command.WindowID)
-	r.changes.desktop(window.DesktopID)
+	if command.Scope == CloseScopeTab && window.Pinned {
+		return false, fmt.Errorf("window %q: %w", command.WindowID, ErrWindowPinned)
+	}
+	entry, closeIDs, err := r.closedEntryForCommand(snapshot, command)
+	if err != nil || len(closeIDs) == 0 {
+		return false, err
+	}
+	for _, windowID := range closeIDs {
+		closedWindow := snapshot.Windows[windowID]
+		if !removeWindow(snapshot, windowID) {
+			return false, fmt.Errorf("window %q has no placement: %w", windowID, ErrInvalidTopology)
+		}
+		delete(snapshot.Windows, windowID)
+		r.changes.window(windowID)
+		r.changes.desktop(closedWindow.DesktopID)
+	}
+	if entry.StackID != nil {
+		if _, stillStacked := findStackByID(snapshot, *entry.StackID); !stillStacked {
+			r.changes.stackUngrouped(*entry.StackID)
+		}
+	}
+	pushClosedEntry(snapshot, entry, r.config.ClosedEntryLimit)
 	return true, nil
 }
 
+func validCloseScope(scope CloseScope) bool {
+	switch scope {
+	case CloseScopeTab, CloseScopeGroup, CloseScopeOthers, CloseScopeRight:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *reducer) closedEntryForCommand(
+	snapshot *Snapshot,
+	command CloseWindowCommand,
+) (ClosedEntry, []WindowID, error) {
+	window := snapshot.Windows[command.WindowID]
+	placement, found := findWindowPlacement(snapshot, command.WindowID)
+	if !found {
+		return ClosedEntry{}, nil, fmt.Errorf("window %q has no placement: %w", command.WindowID, ErrInvalidTopology)
+	}
+	closeIDs := []WindowID{command.WindowID}
+	entry := ClosedEntry{DesktopID: window.DesktopID, Rect: window.FloatingRect, ClosedAt: r.nowUTC()}
+	if placement.groupIndex >= 0 {
+		entry.Rect = snapshot.Desktops[placement.desktopIndex].Groups[placement.groupIndex].Frame
+	}
+	if location, stacked := findStackByWindow(snapshot, command.WindowID); stacked {
+		stackID := location.id()
+		entry.StackID = &stackID
+		entry.ActiveID = clonePointer(location.activeID())
+		entry.Rect = location.rect(snapshot)
+		members := append([]WindowID(nil), location.members()...)
+		switch command.Scope {
+		case CloseScopeGroup:
+			closeIDs = members
+		case CloseScopeOthers:
+			closeIDs = closeStackMembers(snapshot, members, command.WindowID, false)
+		case CloseScopeRight:
+			closeIDs = closeStackMembers(snapshot, members, command.WindowID, true)
+		}
+	} else {
+		switch command.Scope {
+		case CloseScopeOthers, CloseScopeRight:
+			return ClosedEntry{}, nil, nil
+		case CloseScopeGroup, CloseScopeTab:
+		}
+		activeID := command.WindowID
+		entry.ActiveID = &activeID
+	}
+	entry.Windows = make([]Window, 0, len(closeIDs))
+	for _, windowID := range closeIDs {
+		closedWindow := snapshot.Windows[windowID]
+		closedWindow.ReturnAnchor = captureReturnAnchor(snapshot, windowID)
+		entry.Windows = append(entry.Windows, closedWindow)
+	}
+	return entry, closeIDs, nil
+}
+
+func closeStackMembers(snapshot *Snapshot, members []WindowID, selected WindowID, rightOnly bool) []WindowID {
+	selectedIndex := 0
+	for index, windowID := range members {
+		if windowID == selected {
+			selectedIndex = index
+			break
+		}
+	}
+	closeIDs := make([]WindowID, 0, len(members))
+	for index, windowID := range members {
+		if windowID == selected || snapshot.Windows[windowID].Pinned || (rightOnly && index <= selectedIndex) {
+			continue
+		}
+		closeIDs = append(closeIDs, windowID)
+	}
+	return closeIDs
+}
+
+func (r *reducer) nowUTC() time.Time {
+	if r.now == nil {
+		return time.Now().UTC()
+	}
+	return r.now().UTC()
+}
+
 func (r *reducer) minimizeWindow(snapshot *Snapshot, windowID WindowID) (bool, error) {
-	// A zoomed window returns to its source before minimizing so its anchor is the real placement.
 	if ownsFocusDesktop(snapshot, windowID) {
 		if _, err := r.restoreZoomedWindow(snapshot, windowID); err != nil {
 			return false, err
@@ -41,12 +145,7 @@ func (r *reducer) minimizeWindow(snapshot *Snapshot, windowID WindowID) (bool, e
 	snapshot.Windows[windowID] = window
 	desktopIndex, exists := desktopIndexByID(snapshot, window.DesktopID)
 	if !exists {
-		return false, fmt.Errorf(
-			"window %q desktop %q: %w",
-			windowID,
-			window.DesktopID,
-			ErrInvalidTopology,
-		)
+		return false, fmt.Errorf("window %q desktop %q: %w", windowID, window.DesktopID, ErrInvalidTopology)
 	}
 	snapshot.Desktops[desktopIndex].Floating = append(snapshot.Desktops[desktopIndex].Floating, windowID)
 	r.changes.window(windowID)
@@ -64,8 +163,5 @@ func ownsFocusDesktop(snapshot *Snapshot, windowID WindowID) bool {
 		return false
 	}
 	desktop := snapshot.Desktops[index]
-	if desktop.Purpose != DesktopPurposeFocus || desktop.FocusOwner == nil || *desktop.FocusOwner != windowID {
-		return false
-	}
-	return true
+	return desktop.Purpose == DesktopPurposeFocus && desktop.FocusOwner != nil && *desktop.FocusOwner == windowID
 }

--- a/internal/windowmanager/reducer_window_move.go
+++ b/internal/windowmanager/reducer_window_move.go
@@ -28,6 +28,12 @@ func (r *reducer) moveWindow(snapshot *Snapshot, command MoveWindowCommand) (boo
 			return false, fmt.Errorf("target window belongs to another desktop: %w", ErrInvalidCommand)
 		}
 	}
+	if command.Placement == DropCenter && command.TargetWindowID != nil {
+		return r.groupWindows(snapshot, GroupWindowsCommand{
+			TargetWindowID: *command.TargetWindowID,
+			WindowIDs:      []WindowID{command.WindowID},
+		})
+	}
 	anchor := captureReturnAnchor(snapshot, command.WindowID)
 	if !removeWindow(snapshot, command.WindowID) {
 		return false, fmt.Errorf("window %q has no placement: %w", command.WindowID, ErrInvalidTopology)

--- a/internal/windowmanager/reducer_window_navigate.go
+++ b/internal/windowmanager/reducer_window_navigate.go
@@ -7,14 +7,36 @@ func (r *reducer) navigateWindow(snapshot *Snapshot, command NavigateWindowComma
 	if !exists {
 		return false, fmt.Errorf("window %q: %w", command.WindowID, ErrWindowNotFound)
 	}
-	route, err := CanonicalRouteIntent(command.Route)
-	if err != nil {
-		return false, fmt.Errorf("window %q route: %w: %w", command.WindowID, err, ErrInvalidCommand)
+	if command.Mode == NavigatePop {
+		if command.Route.Pathname != "" || command.Route.Search != nil {
+			return false, fmt.Errorf("pop navigation cannot include a route: %w", ErrInvalidCommand)
+		}
+		if len(window.NavStack) == 0 {
+			return false, nil
+		}
+		window.Route = cloneRouteIntent(window.NavStack[len(window.NavStack)-1])
+		window.NavStack = window.NavStack[:len(window.NavStack)-1]
+	} else {
+		if command.Mode != NavigateReplace && command.Mode != NavigatePush {
+			return false, fmt.Errorf("navigation mode %q: %w", command.Mode, ErrInvalidCommand)
+		}
+		route, err := CanonicalRouteIntent(command.Route)
+		if err != nil {
+			return false, fmt.Errorf("window %q route: %w: %w", command.WindowID, err, ErrInvalidCommand)
+		}
+		if routeIntentsEqual(window.Route, route) {
+			return false, nil
+		}
+		if command.Mode == NavigatePush {
+			window.NavStack = append(window.NavStack, cloneRouteIntent(window.Route))
+			if len(window.NavStack) > r.config.NavStackLimit {
+				window.NavStack = append(
+					[]RouteIntent(nil),
+					window.NavStack[len(window.NavStack)-r.config.NavStackLimit:]...)
+			}
+		}
+		window.Route = route
 	}
-	if routeIntentsEqual(window.Route, route) {
-		return false, nil
-	}
-	window.Route = route
 	snapshot.Windows[command.WindowID] = window
 	r.changes.window(command.WindowID)
 	return true, nil

--- a/internal/windowmanager/reducer_window_open.go
+++ b/internal/windowmanager/reducer_window_open.go
@@ -16,6 +16,18 @@ func (r *reducer) openWindow(snapshot *Snapshot, command OpenWindowCommand) (boo
 	windowID := window.ID
 	desktopID := window.DesktopID
 	snapshot.Windows[windowID] = window
+	if command.Window.StackTargetWindowID != nil {
+		desktopIndex, _ := desktopIndexByID(snapshot, desktopID)
+		snapshot.Desktops[desktopIndex].Floating = append(snapshot.Desktops[desktopIndex].Floating, windowID)
+		changed, groupErr := r.groupWindows(snapshot, GroupWindowsCommand{
+			TargetWindowID: *command.Window.StackTargetWindowID,
+			WindowIDs:      []WindowID{windowID},
+		})
+		if groupErr != nil {
+			return false, groupErr
+		}
+		return changed, nil
+	}
 	insertTiled := command.Window.InsertTiled || r.config.NewWindowPolicy == NewWindowInsert
 	if insertTiled && r.focusedWindow != nil {
 		focused, exists := snapshot.Windows[*r.focusedWindow]
@@ -67,14 +79,33 @@ func (r *reducer) openWindow(snapshot *Snapshot, command OpenWindowCommand) (boo
 func (r *reducer) newOpenWindow(snapshot *Snapshot, spec WindowSpec) (Window, error) {
 	windowID := spec.ID
 	if windowID == "" {
-		generated, err := r.generate("window")
-		if err != nil {
-			return Window{}, fmt.Errorf("generate window ID: %w", err)
+		for range 128 {
+			generated, err := r.generate("window")
+			if err != nil {
+				return Window{}, fmt.Errorf("generate window ID: %w", err)
+			}
+			candidate := WindowID(generated)
+			if !reservedWindowID(snapshot, candidate) {
+				windowID = candidate
+				break
+			}
 		}
-		windowID = WindowID(generated)
+		if windowID == "" {
+			return Window{}, fmt.Errorf("generate unique window ID: %w", ErrInvalidCommand)
+		}
 	}
-	if _, exists := snapshot.Windows[windowID]; exists {
+	if reservedWindowID(snapshot, windowID) {
 		return Window{}, fmt.Errorf("window %q already exists: %w", windowID, ErrInvalidCommand)
+	}
+	if spec.StackTargetWindowID != nil {
+		target, exists := snapshot.Windows[*spec.StackTargetWindowID]
+		if !exists {
+			return Window{}, fmt.Errorf("stack target window %q: %w", *spec.StackTargetWindowID, ErrWindowNotFound)
+		}
+		if spec.DesktopID != "" && spec.DesktopID != target.DesktopID {
+			return Window{}, fmt.Errorf("stack target belongs to another desktop: %w", ErrInvalidCommand)
+		}
+		spec.DesktopID = target.DesktopID
 	}
 	app := strings.TrimSpace(spec.App)
 	if app == "" {

--- a/internal/windowmanager/reducer_window_pin.go
+++ b/internal/windowmanager/reducer_window_pin.go
@@ -1,0 +1,21 @@
+package windowmanager
+
+import "fmt"
+
+func (r *reducer) pinWindow(snapshot *Snapshot, command PinWindowCommand) (bool, error) {
+	window, exists := snapshot.Windows[command.WindowID]
+	if !exists {
+		return false, fmt.Errorf("window %q: %w", command.WindowID, ErrWindowNotFound)
+	}
+	if window.Pinned == command.Pinned {
+		return false, nil
+	}
+	window.Pinned = command.Pinned
+	snapshot.Windows[command.WindowID] = window
+	if location, found := findStackByWindow(snapshot, command.WindowID); found {
+		location.setMembers(collatePinned(location.members(), snapshot.Windows))
+		r.changes.node(location.id())
+	}
+	r.changes.window(command.WindowID)
+	return true, nil
+}

--- a/internal/windowmanager/reducer_window_reopen.go
+++ b/internal/windowmanager/reducer_window_reopen.go
@@ -1,0 +1,109 @@
+package windowmanager
+
+func (r *reducer) reopenWindow(snapshot *Snapshot) bool {
+	if len(snapshot.ClosedEntries) == 0 {
+		return false
+	}
+	entry := snapshot.ClosedEntries[len(snapshot.ClosedEntries)-1]
+	snapshot.ClosedEntries = snapshot.ClosedEntries[:len(snapshot.ClosedEntries)-1]
+	reopen := make([]Window, 0, len(entry.Windows))
+	for _, window := range entry.Windows {
+		if _, live := snapshot.Windows[window.ID]; !live {
+			reopen = append(reopen, window)
+		}
+	}
+	if len(reopen) == 0 {
+		return true
+	}
+	desktopID := r.reopenDesktop(snapshot, entry.DesktopID)
+	for _, window := range reopen {
+		window.DesktopID = desktopID
+		window.Minimized = false
+		window.ReturnAnchor = nil
+		snapshot.Windows[window.ID] = window
+		r.changes.window(window.ID)
+	}
+
+	if entry.StackID != nil {
+		if location, found := findStackByID(snapshot, *entry.StackID); found {
+			r.rejoinClosedWindows(snapshot, location, reopen, entry.ActiveID)
+			r.changes.desktop(snapshot.Desktops[location.desktopIndex].ID)
+			return true
+		}
+	}
+	if len(reopen) >= 2 && entry.StackID != nil {
+		windowIDs := make([]WindowID, 0, len(reopen))
+		for _, window := range reopen {
+			windowIDs = append(windowIDs, window.ID)
+		}
+		windowIDs = collatePinned(windowIDs, snapshot.Windows)
+		activeID := windowIDs[0]
+		if entry.ActiveID != nil && containsWindowID(windowIDs, *entry.ActiveID) {
+			activeID = *entry.ActiveID
+		}
+		desktopIndex, _ := desktopIndexByID(snapshot, desktopID)
+		stackID := *entry.StackID
+		snapshot.Desktops[desktopIndex].FloatingStacks = append(
+			snapshot.Desktops[desktopIndex].FloatingStacks,
+			FloatingStack{ID: stackID, WindowIDs: windowIDs, ActiveID: &activeID, Rect: entry.Rect},
+		)
+		for _, windowID := range windowIDs {
+			window := snapshot.Windows[windowID]
+			window.Placement = WindowPlacementStacked
+			window.FloatingRect = entry.Rect
+			snapshot.Windows[windowID] = window
+		}
+		r.changes.stackGrouped(stackID)
+	} else {
+		desktopIndex, _ := desktopIndexByID(snapshot, desktopID)
+		for _, reopened := range reopen {
+			window := snapshot.Windows[reopened.ID]
+			window.Placement = WindowPlacementFloating
+			window.FloatingRect = entry.Rect
+			snapshot.Windows[reopened.ID] = window
+			snapshot.Desktops[desktopIndex].Floating = append(snapshot.Desktops[desktopIndex].Floating, reopened.ID)
+		}
+	}
+	r.changes.desktop(desktopID)
+	return true
+}
+
+func (r *reducer) reopenDesktop(snapshot *Snapshot, requested DesktopID) DesktopID {
+	if _, exists := desktopIndexByID(snapshot, requested); exists {
+		return requested
+	}
+	if r.activeDesktop != nil {
+		if _, exists := desktopIndexByID(snapshot, *r.activeDesktop); exists {
+			return *r.activeDesktop
+		}
+	}
+	for _, desktop := range snapshot.Desktops {
+		if desktop.Purpose == DesktopPurposeStandard {
+			return desktop.ID
+		}
+	}
+	return snapshot.Desktops[0].ID
+}
+
+func (r *reducer) rejoinClosedWindows(
+	snapshot *Snapshot,
+	location stackLocation,
+	windows []Window,
+	activeID *WindowID,
+) {
+	members := append([]WindowID(nil), location.members()...)
+	for _, reopened := range windows {
+		window := snapshot.Windows[reopened.ID]
+		window.DesktopID = snapshot.Desktops[location.desktopIndex].ID
+		window.Placement = WindowPlacementStacked
+		snapshot.Windows[reopened.ID] = window
+		members = append(members, reopened.ID)
+	}
+	members = collatePinned(members, snapshot.Windows)
+	location.setMembers(members)
+	if activeID != nil && containsWindowID(members, *activeID) {
+		location.setActive(*activeID)
+	} else if location.activeID() == nil || !containsWindowID(members, *location.activeID()) {
+		location.setActive(members[0])
+	}
+}

--- a/internal/windowmanager/reducer_window_toggle_floating.go
+++ b/internal/windowmanager/reducer_window_toggle_floating.go
@@ -31,6 +31,13 @@ func (r *reducer) toggleFloating(snapshot *Snapshot, command ToggleFloatingComma
 		window.ReturnAnchor = nil
 		snapshot.Windows[command.WindowID] = window
 	} else {
+		floatingRect := window.FloatingRect
+		if location, stacked := findStackByWindow(snapshot, command.WindowID); stacked {
+			floatingRect = cascadeRect(location.rect(snapshot))
+			if len(location.members()) == 2 {
+				r.changes.stackUngrouped(location.id())
+			}
+		}
 		anchor := captureReturnAnchor(snapshot, command.WindowID)
 		removeWindow(snapshot, command.WindowID)
 		window.Placement = WindowPlacementFloating
@@ -39,7 +46,7 @@ func (r *reducer) toggleFloating(snapshot *Snapshot, command ToggleFloatingComma
 		if command.FloatingRect != nil {
 			window.FloatingRect = clampRect(*command.FloatingRect)
 		} else {
-			window.FloatingRect = clampRect(window.FloatingRect)
+			window.FloatingRect = clampRect(floatingRect)
 		}
 		snapshot.Windows[command.WindowID] = window
 		desktopIndex, _ := desktopIndexByID(snapshot, window.DesktopID)
@@ -48,6 +55,12 @@ func (r *reducer) toggleFloating(snapshot *Snapshot, command ToggleFloatingComma
 	r.changes.window(command.WindowID)
 	r.changes.desktop(window.DesktopID)
 	return true, nil
+}
+
+func cascadeRect(rect NormalizedRect) NormalizedRect {
+	rect.X += 0.02
+	rect.Y += 0.02
+	return clampRect(rect)
 }
 
 func (r *reducer) tileWindowFallback(snapshot *Snapshot, windowID WindowID) error {

--- a/internal/windowmanager/service.go
+++ b/internal/windowmanager/service.go
@@ -28,6 +28,7 @@ type Manager struct {
 	workspaceLocks map[WorkspaceID]*sync.Mutex
 	clients        map[WorkspaceID]map[ClientID]ClientView
 	hubs           map[WorkspaceID]*subscriptionHub
+	coalescer      *activeCoalescer
 }
 
 // UpdateDefaults atomically replaces validated runtime defaults for future commands.
@@ -80,7 +81,7 @@ func NewService(
 	if err != nil {
 		return nil, err
 	}
-	return &Manager{
+	manager := &Manager{
 		repository:         repository,
 		workspaces:         workspaces,
 		layouts:            layouts,
@@ -93,7 +94,9 @@ func NewService(
 		workspaceLocks:     make(map[WorkspaceID]*sync.Mutex),
 		clients:            make(map[WorkspaceID]map[ClientID]ClientView),
 		hubs:               make(map[WorkspaceID]*subscriptionHub),
-	}, nil
+	}
+	manager.coalescer = newActiveCoalescer(resolved.lifecycleContext, manager)
+	return manager, nil
 }
 
 // Snapshot returns a validated workspace aggregate.
@@ -125,9 +128,20 @@ func (m *Manager) Execute(ctx context.Context, request CommandRequest) (Result, 
 	}
 	lock.Lock()
 	result, executeErr := func() (Result, error) {
+		hadPending := commandID != CommandDesktopSwitch && commandID != CommandWindowFocus &&
+			m.coalescer.hasPending(request.WorkspaceID)
+		if hadPending {
+			if flushErr := m.flushStackActiveLocked(ctx, request.WorkspaceID); flushErr != nil {
+				return Result{}, fmt.Errorf("flush stack activation before %q: %w", commandID, flushErr)
+			}
+		}
 		snapshot, loadErr := m.loadSnapshot(ctx, request.WorkspaceID)
 		if loadErr != nil {
 			return Result{}, loadErr
+		}
+		if hadPending && request.ExpectedRevision < Revision(^uint64(0)) &&
+			snapshot.Revision == request.ExpectedRevision+1 {
+			request.ExpectedRevision = snapshot.Revision
 		}
 		rebasedFrom, revisionErr := resolveExpectedRevision(&snapshot, request)
 		if revisionErr != nil {
@@ -199,10 +213,14 @@ func (m *Manager) Preview(ctx context.Context, request CommandRequest) (Preview,
 	}
 	working := cloneSnapshot(snapshot)
 	var focused *WindowID
+	var activeDesktop *DesktopID
 	if client != nil {
 		focused = clonePointer(client.FocusedWindowID)
+		activeDesktop = new(client.ActiveDesktopID)
 	}
-	reduced, err := (&reducer{generate: m.generate, config: config, focusedWindow: focused}).reduce(
+	reduced, err := (&reducer{
+		generate: m.generate, config: config, focusedWindow: focused, activeDesktop: activeDesktop, now: m.now,
+	}).reduce(
 		&working,
 		payload,
 	)

--- a/internal/windowmanager/service_contract_test.go
+++ b/internal/windowmanager/service_contract_test.go
@@ -7,7 +7,9 @@ package windowmanager
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -294,6 +296,103 @@ func TestLayoutDocumentContract(t *testing.T) {
 		afterFailure, err := manager.Snapshot(t.Context(), "workspace-a")
 		if err != nil || afterFailure.Revision != 1 || len(afterFailure.History.Undo) != 1 {
 			t.Fatalf("Snapshot(after invalid resources) = %+v, error = %v", afterFailure, err)
+		}
+	})
+}
+
+func TestWindowTabLayoutDocumentV3(t *testing.T) {
+	t.Run("Should export v3 tab state without closed entries or history [UT-037]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		createFloatingStack(t, environment.manager, []WindowID{"w1", "w2", "w3"})
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/child"), Mode: NavigatePush},
+		)
+		executeTestCommand(t, environment.manager, "workspace-a", nil, PinWindowCommand{WindowID: "w1", Pinned: true})
+		executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w3"})
+		document, err := environment.manager.ExportLayout(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("ExportLayout() error = %v", err)
+		}
+		if document.Version != 3 || len(document.Desktops[0].FloatingStacks) != 1 || !document.Windows["w1"].Pinned ||
+			len(document.Windows["w1"].NavStack) != 1 {
+			t.Fatalf("exported document = %+v", document)
+		}
+		encoded, err := json.Marshal(document)
+		if err != nil {
+			t.Fatalf("json.Marshal(document) error = %v", err)
+		}
+		if strings.Contains(string(encoded), "closed_entries") || strings.Contains(string(encoded), "history") {
+			t.Fatalf("exported JSON leaked runtime-only state: %s", encoded)
+		}
+	})
+
+	t.Run("Should replace a v3 document with floating stacks and live navigation [UT-038]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		created := createFloatingStack(t, environment.manager, []WindowID{"w1", "w2"})
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/child"), Mode: NavigatePush},
+		)
+		document, err := environment.manager.ExportLayout(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("ExportLayout() error = %v", err)
+		}
+		document.Desktops[0].Name = "Replaced"
+		result, err := environment.manager.ReplaceLayout(
+			t.Context(),
+			ReplaceLayoutRequest{
+				WorkspaceID:      "workspace-a",
+				ExpectedRevision: created.Snapshot.Revision + 1,
+				Document:         document,
+			},
+		)
+		if err != nil {
+			t.Fatalf("ReplaceLayout() error = %v", err)
+		}
+		if result.Snapshot.Desktops[0].Name != "Replaced" || len(result.Snapshot.Desktops[0].FloatingStacks) != 1 ||
+			len(result.Snapshot.Windows["w1"].NavStack) != 1 {
+			t.Fatalf("replaced snapshot = %+v", result.Snapshot)
+		}
+		requireValidSnapshot(t, result.Snapshot)
+	})
+
+	t.Run("Should reject v2 replace and profile documents with a version diagnostic [UT-039]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		document, err := environment.manager.ExportLayout(t.Context(), "workspace-a")
+		if err != nil {
+			t.Fatalf("ExportLayout() error = %v", err)
+		}
+		document.Version = 2
+		validation, err := environment.manager.ValidateLayout(t.Context(), "workspace-a", document)
+		if err != nil || validation.Valid || len(validation.Diagnostics) == 0 ||
+			validation.Diagnostics[0].Code != "topology.unsupported_version" {
+			t.Fatalf("ValidateLayout(v2) = %+v, error = %v", validation, err)
+		}
+		_, err = environment.manager.ReplaceLayout(
+			t.Context(),
+			ReplaceLayoutRequest{WorkspaceID: "workspace-a", Document: document},
+		)
+		if !errors.Is(err, ErrInvalidTopology) {
+			t.Fatalf("ReplaceLayout(v2) error = %v", err)
+		}
+		registry := &testLayoutRegistry{resources: []LayoutResource{{ID: "v2", Document: document}}}
+		manager := newTestManagerWithRegistry(t, registry)
+		_, err = manager.Execute(
+			t.Context(),
+			CommandRequest{WorkspaceID: "workspace-a", Payload: ArrangeLayoutCommand{ResourceID: "v2"}},
+		)
+		if !errors.Is(err, ErrInvalidTopology) {
+			t.Fatalf("Execute(v2 profile) error = %v", err)
 		}
 	})
 }

--- a/internal/windowmanager/service_execute.go
+++ b/internal/windowmanager/service_execute.go
@@ -34,8 +34,10 @@ func (m *Manager) executeDurable(
 	}
 	working.Revision = nextRevision
 	working.UpdatedAt = m.now().UTC()
-	if err := m.recordCommandHistory(&working, snapshot, request, commandID, workspaceDefaults); err != nil {
-		return Result{}, err
+	if reduced.applied {
+		if err := m.recordCommandHistory(&working, snapshot, request, commandID, workspaceDefaults); err != nil {
+			return Result{}, err
+		}
 	}
 	projection, err := m.projectClientViews(request.WorkspaceID, snapshot, working, request)
 	if err != nil {
@@ -51,7 +53,7 @@ func (m *Manager) executeDurable(
 		m.publishClient(view)
 	}
 	return Result{
-		Snapshot: cloneSnapshot(working), Applied: true, Changes: reduced.changes,
+		Snapshot: cloneSnapshot(working), Applied: reduced.applied, Changes: reduced.changes,
 		Client: client, RebasedFrom: rebasedFrom,
 	}, nil
 }
@@ -105,11 +107,13 @@ func (m *Manager) reduceDurable(
 	}
 	working := cloneSnapshot(snapshot)
 	var focused *WindowID
+	var activeDesktop *DesktopID
 	if client != nil {
 		focused = clonePointer(client.FocusedWindowID)
+		activeDesktop = new(client.ActiveDesktopID)
 	}
 	reduced, err := (&reducer{
-		generate: m.generate, config: config, focusedWindow: focused,
+		generate: m.generate, config: config, focusedWindow: focused, activeDesktop: activeDesktop, now: m.now,
 	}).reduce(&working, payload)
 	if err != nil {
 		return Snapshot{}, reduction{}, Config{}, err
@@ -124,7 +128,8 @@ func (m *Manager) recordCommandHistory(
 	commandID CommandID,
 	workspaceDefaults Config,
 ) error {
-	if commandID == CommandLayoutUndo || commandID == CommandLayoutRedo || commandID == CommandWindowNavigate {
+	if commandID == CommandLayoutUndo || commandID == CommandLayoutRedo || commandID == CommandWindowNavigate ||
+		commandID == CommandWindowStackSetActive {
 		return nil
 	}
 	config, err := effectiveConfig(workspaceDefaults, working.Overrides)

--- a/internal/windowmanager/service_helpers.go
+++ b/internal/windowmanager/service_helpers.go
@@ -28,8 +28,8 @@ func (m *Manager) resolveWorkspace(ctx context.Context, workspaceID WorkspaceID)
 
 func (m *Manager) lockFor(workspaceID WorkspaceID) (*sync.Mutex, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	if m.closed {
+		m.mu.Unlock()
 		return nil, ErrClosed
 	}
 	lock := m.workspaceLocks[workspaceID]
@@ -37,6 +37,8 @@ func (m *Manager) lockFor(workspaceID WorkspaceID) (*sync.Mutex, error) {
 		lock = &sync.Mutex{}
 		m.workspaceLocks[workspaceID] = lock
 	}
+	m.mu.Unlock()
+	m.coalescer.bindWorkspace(workspaceID, lock)
 	return lock, nil
 }
 
@@ -53,10 +55,11 @@ func (m *Manager) Close() error {
 		hubs = append(hubs, hub)
 	}
 	m.mu.Unlock()
+	coalescerErr := m.coalescer.close()
 	for _, hub := range hubs {
 		hub.closeAll(nil)
 	}
-	return nil
+	return coalescerErr
 }
 
 func validateCommandRequest(request CommandRequest) (CommandID, error) {

--- a/internal/windowmanager/service_subscription.go
+++ b/internal/windowmanager/service_subscription.go
@@ -97,6 +97,7 @@ func (m *Manager) DeleteWorkspace(ctx context.Context, workspaceID WorkspaceID) 
 	}
 	lock.Lock()
 	defer lock.Unlock()
+	m.coalescer.discardWorkspaceLocked(workspaceID)
 	if err := m.repository.DeleteWorkspace(ctx, workspaceID); err != nil {
 		return fmt.Errorf("delete window workspace: %w", err)
 	}
@@ -113,9 +114,13 @@ func (m *Manager) DeleteWorkspace(ctx context.Context, workspaceID WorkspaceID) 
 
 // ForgetWorkspace tears down transient state after the workspace owner commits deletion.
 func (m *Manager) ForgetWorkspace(workspaceID WorkspaceID) {
+	if lock, err := m.lockFor(workspaceID); err == nil {
+		lock.Lock()
+		m.coalescer.discardWorkspaceLocked(workspaceID)
+		lock.Unlock()
+	}
 	m.mu.Lock()
 	delete(m.clients, workspaceID)
-	delete(m.workspaceLocks, workspaceID)
 	hub := m.hubs[workspaceID]
 	delete(m.hubs, workspaceID)
 	m.mu.Unlock()

--- a/internal/windowmanager/service_test.go
+++ b/internal/windowmanager/service_test.go
@@ -8,7 +8,10 @@ package windowmanager
 import (
 	"context"
 	"errors"
+	"fmt"
+	"reflect"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -474,7 +477,7 @@ func TestHistory(t *testing.T) {
 		},
 	)
 
-	t.Run("Should preserve current routes across undo and redo without changing redo history", func(t *testing.T) {
+	t.Run("Should preserve current routes and navigation stacks across undo and redo [UT-034]", func(t *testing.T) {
 		t.Parallel()
 		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
 		openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
@@ -494,7 +497,7 @@ func TestHistory(t *testing.T) {
 			environment.manager,
 			"workspace-a",
 			nil,
-			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/after-arrange")},
+			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/after-arrange"), Mode: NavigatePush},
 		)
 		if len(navigated.Snapshot.History.Undo) != len(arranged.Snapshot.History.Undo) ||
 			len(navigated.Snapshot.History.Redo) != len(arranged.Snapshot.History.Redo) {
@@ -502,6 +505,7 @@ func TestHistory(t *testing.T) {
 		}
 		undone := executeTestCommand(t, environment.manager, "workspace-a", nil, UndoLayoutCommand{})
 		if undone.Snapshot.Windows["w1"].Route.Pathname != "/after-arrange" ||
+			len(undone.Snapshot.Windows["w1"].NavStack) != 1 ||
 			len(undone.Snapshot.History.Redo) != 1 {
 			t.Fatalf("undo route/history = %+v / %+v", undone.Snapshot.Windows["w1"].Route, undone.Snapshot.History)
 		}
@@ -510,17 +514,460 @@ func TestHistory(t *testing.T) {
 			environment.manager,
 			"workspace-a",
 			nil,
-			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/before-redo")},
+			NavigateWindowCommand{WindowID: "w1", Route: testRoute("/before-redo"), Mode: NavigatePush},
 		)
 		if len(renavigated.Snapshot.History.Redo) != 1 {
 			t.Fatalf("navigation cleared redo = %+v", renavigated.Snapshot.History)
 		}
 		redone := executeTestCommand(t, environment.manager, "workspace-a", nil, RedoLayoutCommand{})
-		if redone.Snapshot.Windows["w1"].Route.Pathname != "/before-redo" {
+		if redone.Snapshot.Windows["w1"].Route.Pathname != "/before-redo" ||
+			len(redone.Snapshot.Windows["w1"].NavStack) != 2 {
 			t.Fatalf("redo route = %+v", redone.Snapshot.Windows["w1"].Route)
 		}
 	})
 }
+
+func TestWindowTabHistoryV3(t *testing.T) {
+	t.Run("Should undo and redo grouping while set-active stays outside history [UT-036]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		grouped := createFloatingStack(t, environment.manager, []WindowID{"w1", "w2"})
+		historyLength := len(grouped.Snapshot.History.Undo)
+		activated := executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			nil,
+			SetStackActiveCommand{WindowID: "w1"},
+		)
+		if len(activated.Snapshot.History.Undo) != historyLength {
+			t.Fatalf("set-active history = %+v", activated.Snapshot.History)
+		}
+		undone := executeTestCommand(t, environment.manager, "workspace-a", nil, UndoLayoutCommand{})
+		if _, stacked := findStackByWindow(&undone.Snapshot, "w1"); stacked {
+			t.Fatalf("undo retained stack = %+v", undone.Snapshot)
+		}
+		redone := executeTestCommand(t, environment.manager, "workspace-a", nil, RedoLayoutCommand{})
+		if members := stackMembersForWindow(
+			t,
+			redone.Snapshot,
+			"w1",
+		); !reflect.DeepEqual(
+			members,
+			[]WindowID{"w1", "w2"},
+		) {
+			t.Fatalf("redo members = %v", members)
+		}
+	})
+
+	t.Run("Should reopen only dead members from an entry containing a live ID [UT-174]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		snapshot := initialSnapshot("workspace-a")
+		w1 := Window{
+			ID:           "w1",
+			App:          "One",
+			Route:        testRoute("/one"),
+			DesktopID:    "desktop-default",
+			Placement:    WindowPlacementFloating,
+			FloatingRect: fullRect(),
+		}
+		w2 := Window{
+			ID:           "w2",
+			App:          "Two",
+			Route:        testRoute("/two"),
+			DesktopID:    "desktop-default",
+			Placement:    WindowPlacementFloating,
+			FloatingRect: fullRect(),
+		}
+		snapshot.Windows["w1"] = w1
+		snapshot.Desktops[0].Floating = []WindowID{"w1"}
+		snapshot.ClosedEntries = []ClosedEntry{
+			{Windows: []Window{w1, w2}, DesktopID: "desktop-default", Rect: fullRect()},
+		}
+		environment.repository.mu.Lock()
+		environment.repository.snapshots["workspace-a"] = cloneSnapshot(snapshot)
+		environment.repository.mu.Unlock()
+		result := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		if len(result.Snapshot.Windows) != 2 || result.Snapshot.Windows["w1"].App != "One" ||
+			result.Snapshot.Windows["w2"].App != "Two" ||
+			len(result.Snapshot.ClosedEntries) != 0 {
+			t.Fatalf("mixed reopen = %+v", result.Snapshot)
+		}
+		liveSnapshot := cloneSnapshot(result.Snapshot)
+		liveSnapshot.ClosedEntries = []ClosedEntry{
+			{Windows: []Window{w1, w2}, DesktopID: "desktop-default", Rect: fullRect()},
+		}
+		historyLength := len(liveSnapshot.History.Undo)
+		environment.repository.mu.Lock()
+		environment.repository.snapshots["workspace-a"] = liveSnapshot
+		environment.repository.mu.Unlock()
+		allLive := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+		if allLive.Applied || len(allLive.Snapshot.ClosedEntries) != 0 {
+			t.Fatalf("all-live reopen = %+v", allLive)
+		}
+		if len(allLive.Snapshot.History.Undo) != historyLength {
+			t.Fatalf("all-live reopen history = %+v", allLive.Snapshot.History)
+		}
+	})
+
+	t.Run(
+		"Should preserve entries through close undo redo and keep reopen consumption outside history [UT-175]",
+		func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			openTestWindow(t, environment.manager, "workspace-a", nil, "w1", "desktop-default")
+			closed := executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w1"})
+			wantEntries := cloneClosedEntries(closed.Snapshot.ClosedEntries)
+			undone := executeTestCommand(t, environment.manager, "workspace-a", nil, UndoLayoutCommand{})
+			if _, live := undone.Snapshot.Windows["w1"]; !live ||
+				!reflect.DeepEqual(undone.Snapshot.ClosedEntries, wantEntries) {
+				t.Fatalf("undo close = %+v", undone.Snapshot)
+			}
+			redone := executeTestCommand(t, environment.manager, "workspace-a", nil, RedoLayoutCommand{})
+			if _, live := redone.Snapshot.Windows["w1"]; live ||
+				!reflect.DeepEqual(redone.Snapshot.ClosedEntries, wantEntries) {
+				t.Fatalf("redo close = %+v", redone.Snapshot)
+			}
+			reopened := executeTestCommand(t, environment.manager, "workspace-a", nil, ReopenCommand{})
+			if len(reopened.Snapshot.ClosedEntries) != 0 {
+				t.Fatalf("reopen did not consume entry = %+v", reopened.Snapshot.ClosedEntries)
+			}
+			undoReopen := executeTestCommand(t, environment.manager, "workspace-a", nil, UndoLayoutCommand{})
+			if len(undoReopen.Snapshot.ClosedEntries) != 0 {
+				t.Fatalf("undo reopen resurrected entries = %+v", undoReopen.Snapshot.ClosedEntries)
+			}
+		},
+	)
+}
+
+func TestWindowTabCASAndRestartV3(t *testing.T) {
+	t.Run("Should serialize same-revision groups and allow an explicitly guarded rebase [UT-060]", func(t *testing.T) {
+		t.Parallel()
+		repository := NewMemoryRepository()
+		resolver := NewMemoryWorkspaceResolver("workspace-a")
+		managerA := newWindowTabTestManager(t, repository, resolver)
+		managerB := newWindowTabTestManager(t, repository, resolver)
+		for _, windowID := range []WindowID{"w1", "w2", "w3", "w4"} {
+			openTestWindow(t, managerA, "workspace-a", nil, windowID, "desktop-default")
+		}
+		base := mustSnapshot(t, managerA, "workspace-a")
+		first, err := managerA.Execute(
+			t.Context(),
+			CommandRequest{
+				WorkspaceID:      "workspace-a",
+				ExpectedRevision: base.Revision,
+				Payload:          GroupWindowsCommand{TargetWindowID: "w1", WindowIDs: []WindowID{"w2"}},
+			},
+		)
+		if err != nil {
+			t.Fatalf("Execute(first group) error = %v", err)
+		}
+		_, err = managerB.Execute(
+			t.Context(),
+			CommandRequest{
+				WorkspaceID:      "workspace-a",
+				ExpectedRevision: base.Revision,
+				Payload:          GroupWindowsCommand{TargetWindowID: "w1", WindowIDs: []WindowID{"w2"}},
+			},
+		)
+		if !errors.Is(err, ErrRevisionConflict) {
+			t.Fatalf("Execute(conflicting group) error = %v", err)
+		}
+		w3 := WindowID("w3")
+		rebased, err := managerB.Execute(
+			t.Context(),
+			CommandRequest{
+				WorkspaceID:      "workspace-a",
+				ExpectedRevision: base.Revision,
+				Rebase:           &RebaseGuard{WindowID: &w3},
+				Payload:          GroupWindowsCommand{TargetWindowID: "w3", WindowIDs: []WindowID{"w4"}},
+			},
+		)
+		if err != nil || rebased.RebasedFrom == nil || *rebased.RebasedFrom != base.Revision ||
+			rebased.Snapshot.Revision != first.Snapshot.Revision+1 {
+			t.Fatalf("rebased group = %+v, error = %v", rebased, err)
+		}
+	})
+
+	t.Run("Should restore v3 topology and seed a new client from durable active state [UT-061]", func(t *testing.T) {
+		t.Parallel()
+		repository := NewMemoryRepository()
+		resolver := NewMemoryWorkspaceResolver("workspace-a")
+		managerA := newWindowTabTestManager(t, repository, resolver)
+		createFloatingStack(t, managerA, []WindowID{"w1", "w2"})
+		executeTestCommand(t, managerA, "workspace-a", nil, SetStackActiveCommand{WindowID: "w1"})
+		persisted := mustSnapshot(t, managerA, "workspace-a")
+		location, found := findStackByWindow(&persisted, "w1")
+		if !found {
+			t.Fatal("persisted stack not found")
+		}
+		managerB := newWindowTabTestManager(t, repository, resolver)
+		view, err := managerB.RegisterClient(
+			t.Context(),
+			ClientRegistration{WorkspaceID: "workspace-a", ClientID: "client-b"},
+		)
+		if err != nil || view.StackActive[location.id()] != "w1" {
+			t.Fatalf("RegisterClient(restart) = %+v, error = %v", view, err)
+		}
+	})
+}
+
+func TestWindowTabClientActivationV3(t *testing.T) {
+	t.Run(
+		"Should isolate client active tabs repair peers and seed re-registrations [UT-063][UT-064][IT-007]",
+		func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			created := createFloatingStack(t, environment.manager, []WindowID{"w1", "w2", "w3"})
+			location, found := findStackByWindow(&created.Snapshot, "w1")
+			if !found {
+				t.Fatal("created stack not found")
+			}
+			clientA, clientB := ClientID("client-a"), ClientID("client-b")
+			registerTestClient(t, environment.manager, "workspace-a", clientA)
+			registerTestClient(t, environment.manager, "workspace-a", clientB)
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				&clientA,
+				FocusWindowCommand{WindowID: new(WindowID("w1"))},
+			)
+			views, err := environment.manager.Clients(t.Context(), "workspace-a")
+			if err != nil {
+				t.Fatalf("Clients() error = %v", err)
+			}
+			activeByClient := make(map[ClientID]WindowID)
+			for _, view := range views {
+				activeByClient[view.ClientID] = view.StackActive[location.id()]
+			}
+			if activeByClient[clientA] != "w1" || activeByClient[clientB] != "w3" {
+				t.Fatalf("client active tabs = %v", activeByClient)
+			}
+			closed := executeTestCommand(t, environment.manager, "workspace-a", nil, CloseWindowCommand{WindowID: "w3"})
+			views, err = environment.manager.Clients(t.Context(), "workspace-a")
+			if err != nil {
+				t.Fatalf("Clients(after close) error = %v", err)
+			}
+			for _, view := range views {
+				if view.StackActive[location.id()] != "w1" {
+					t.Fatalf("repaired view = %+v, close = %+v", view, closed)
+				}
+			}
+			if err := environment.manager.UnregisterClient(t.Context(), "workspace-a", clientB); err != nil {
+				t.Fatalf("UnregisterClient() error = %v", err)
+			}
+			reregistered, err := environment.manager.RegisterClient(
+				t.Context(),
+				ClientRegistration{WorkspaceID: "workspace-a", ClientID: clientB},
+			)
+			if err != nil || reregistered.StackActive[location.id()] != "w1" {
+				t.Fatalf("RegisterClient(after close) = %+v, error = %v", reregistered, err)
+			}
+		},
+	)
+}
+
+func TestActiveCoalescerV3(t *testing.T) {
+	t.Run(
+		"Should flush before a structural reducer without deadlock or stale active state [UT-065]",
+		func(t *testing.T) {
+			t.Parallel()
+			environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+			created := createFloatingStack(t, environment.manager, []WindowID{"w1", "w2"})
+			clientID := ClientID("client-a")
+			registerTestClient(t, environment.manager, "workspace-a", clientID)
+			executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				&clientID,
+				FocusWindowCommand{WindowID: new(WindowID("w1"))},
+			)
+			result := executeTestCommand(
+				t,
+				environment.manager,
+				"workspace-a",
+				nil,
+				PinWindowCommand{WindowID: "w2", Pinned: true},
+			)
+			location, found := findStackByWindow(&result.Snapshot, "w1")
+			if !found || valueOrZero(location.activeID()) != "w1" {
+				t.Fatalf("post-flush stack = %+v, found = %v", location, found)
+			}
+			commits := environment.repository.Commits("workspace-a")
+			if len(commits) < 2 || commits[len(commits)-2].Event.CommandID != CommandWindowStackSetActive ||
+				commits[len(commits)-1].Event.CommandID != CommandWindowPin ||
+				result.Snapshot.Revision != created.Snapshot.Revision+2 {
+				t.Fatalf("coalesced commits = %+v", commits)
+			}
+		},
+	)
+
+	t.Run("Should flush once on unregister and shutdown without history [UT-066]", func(t *testing.T) {
+		t.Parallel()
+		environment := newTestEnvironment(t, DefaultConfig(), "workspace-a")
+		created := createFloatingStack(t, environment.manager, []WindowID{"w1", "w2"})
+		clientID := ClientID("client-a")
+		registerTestClient(t, environment.manager, "workspace-a", clientID)
+		executeTestCommand(
+			t,
+			environment.manager,
+			"workspace-a",
+			&clientID,
+			FocusWindowCommand{WindowID: new(WindowID("w1"))},
+		)
+		if err := environment.manager.UnregisterClient(t.Context(), "workspace-a", clientID); err != nil {
+			t.Fatalf("UnregisterClient() error = %v", err)
+		}
+		commits := environment.repository.Commits("workspace-a")
+		if len(commits) == 0 || commits[len(commits)-1].Event.CommandID != CommandWindowStackSetActive ||
+			len(commits[len(commits)-1].Snapshot.History.Undo) != len(created.Snapshot.History.Undo) {
+			t.Fatalf("unregister flush commits = %+v", commits)
+		}
+		count := len(commits)
+		if err := environment.manager.Close(); err != nil {
+			t.Fatalf("Manager.Close() error = %v", err)
+		}
+		if got := len(environment.repository.Commits("workspace-a")); got != count {
+			t.Fatalf("shutdown duplicate commits = %d, want %d", got, count)
+		}
+	})
+
+	t.Run("Should retain failed pending values and isolate concurrent workspace retries [UT-176]", func(t *testing.T) {
+		t.Parallel()
+		base := NewMemoryRepository()
+		repository := &failingWindowManagerRepository{MemoryRepository: base}
+		resolver := NewMemoryWorkspaceResolver("workspace-a", "workspace-b")
+		manager, err := NewService(
+			repository,
+			resolver,
+			nil,
+			DefaultConfig(),
+			WithIDGenerator(func(kind string) (string, error) {
+				return fmt.Sprintf(
+					"%s-%d",
+					kind,
+					len(base.Commits("workspace-a"))+len(base.Commits("workspace-b"))+1,
+				), nil
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewService() error = %v", err)
+		}
+		for _, workspaceID := range []WorkspaceID{"workspace-a", "workspace-b"} {
+			openTestWindow(t, manager, workspaceID, nil, WindowID(workspaceID+"-1"), "desktop-default")
+			openTestWindow(t, manager, workspaceID, nil, WindowID(workspaceID+"-2"), "desktop-default")
+			executeTestCommand(
+				t,
+				manager,
+				workspaceID,
+				nil,
+				GroupWindowsCommand{
+					TargetWindowID: WindowID(workspaceID + "-1"),
+					WindowIDs:      []WindowID{WindowID(workspaceID + "-2")},
+				},
+			)
+			clientID := ClientID(workspaceID + "-client")
+			registerTestClient(t, manager, workspaceID, clientID)
+			executeTestCommand(
+				t,
+				manager,
+				workspaceID,
+				&clientID,
+				FocusWindowCommand{WindowID: new(WindowID(workspaceID + "-1"))},
+			)
+		}
+		repository.failNext.Store(true)
+		lockA, lockErr := manager.lockFor("workspace-a")
+		if lockErr != nil {
+			t.Fatalf("lockFor(A) error = %v", lockErr)
+		}
+		lockA.Lock()
+		flushErr := manager.flushStackActiveLocked(t.Context(), "workspace-a")
+		lockA.Unlock()
+		if flushErr == nil || !manager.coalescer.hasPending("workspace-a") {
+			t.Fatalf("failed flush error = %v pending = %v", flushErr, manager.coalescer.hasPending("workspace-a"))
+		}
+		var wait sync.WaitGroup
+		errorsByWorkspace := make(chan error, 2)
+		for _, workspaceID := range []WorkspaceID{"workspace-a", "workspace-b"} {
+			wait.Go(func() {
+				lock, lockErr := manager.lockFor(workspaceID)
+				if lockErr != nil {
+					errorsByWorkspace <- lockErr
+					return
+				}
+				lock.Lock()
+				err := manager.flushStackActiveLocked(t.Context(), workspaceID)
+				lock.Unlock()
+				errorsByWorkspace <- err
+			})
+		}
+		wait.Wait()
+		close(errorsByWorkspace)
+		for flushErr := range errorsByWorkspace {
+			if flushErr != nil {
+				t.Fatalf("retry flush error = %v", flushErr)
+			}
+		}
+		for _, workspaceID := range []WorkspaceID{"workspace-a", "workspace-b"} {
+			snapshot, loadErr := base.Load(t.Context(), workspaceID)
+			if loadErr != nil {
+				t.Fatalf("Load(%s) error = %v", workspaceID, loadErr)
+			}
+			windowID := WindowID(workspaceID + "-1")
+			location, found := findStackByWindow(&snapshot, windowID)
+			if !found || valueOrZero(location.activeID()) != windowID {
+				t.Fatalf("workspace %s active = %+v", workspaceID, location)
+			}
+		}
+		if err := manager.Close(); err != nil {
+			t.Fatalf("Manager.Close() error = %v", err)
+		}
+	})
+}
+
+type failingWindowManagerRepository struct {
+	*MemoryRepository
+	failNext atomic.Bool
+}
+
+func (r *failingWindowManagerRepository) Commit(ctx context.Context, commit *Commit) error {
+	if r.failNext.Swap(false) {
+		return errors.New("injected commit failure")
+	}
+	return r.MemoryRepository.Commit(ctx, commit)
+}
+
+func newWindowTabTestManager(
+	t *testing.T,
+	repository Repository,
+	resolver WorkspaceResolver,
+) *Manager {
+	t.Helper()
+	manager, err := NewService(
+		repository,
+		resolver,
+		nil,
+		DefaultConfig(),
+		WithIDGenerator(func(kind string) (string, error) {
+			return fmt.Sprintf("%s-%d", kind, windowTabManagerIDSequence.Add(1)), nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if closeErr := manager.Close(); closeErr != nil {
+			t.Errorf("Manager.Close() error = %v", closeErr)
+		}
+	})
+	return manager
+}
+
+var windowTabManagerIDSequence atomic.Int64
 
 func TestRevisionRebase(t *testing.T) {
 	t.Run(

--- a/internal/windowmanager/shortcuts.go
+++ b/internal/windowmanager/shortcuts.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-const shortcutWindowMinimizeAction = "window.minimize"
+const (
+	shortcutWindowMinimizeAction  = "window.minimize"
+	shortcutWindowTabNewAction    = "window.tab.new"
+	shortcutWindowTabReopenAction = "window.tab.reopen"
+)
 
 var shortcutModifierOrder = []string{
 	dragModifierMeta,
@@ -102,6 +106,9 @@ func isShortcutModifier(token string) bool {
 }
 
 func validShortcutAction(action string) bool {
+	if strings.HasPrefix(action, "window.tab.jump.") {
+		return len(action) == len("window.tab.jump.1") && action[len(action)-1] >= '1' && action[len(action)-1] <= '8'
+	}
 	switch action {
 	case string(CommandWindowClose),
 		shortcutWindowMinimizeAction,
@@ -127,6 +134,12 @@ func validShortcutAction(action string) bool {
 		string(CommandLayoutBalance),
 		string(CommandLayoutUndo),
 		string(CommandLayoutRedo):
+		return true
+	case shortcutWindowTabNewAction,
+		"window.tab.next",
+		"window.tab.previous",
+		"window.tab.last",
+		shortcutWindowTabReopenAction:
 		return true
 	default:
 		return false

--- a/internal/windowmanager/topology_test.go
+++ b/internal/windowmanager/topology_test.go
@@ -391,6 +391,217 @@ func TestValidateSnapshot(t *testing.T) {
 	})
 }
 
+func TestWindowTabTopologyV3(t *testing.T) {
+	t.Run("Should accept a valid floating stack with two members [UT-001]", func(t *testing.T) {
+		t.Parallel()
+		requireValidSnapshot(t, validFloatingStackSnapshot())
+	})
+
+	t.Run("Should diagnose floating stack size active and placement independently [UT-002]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		w1, w2 := WindowID("w1"), WindowID("w2")
+		snapshot.Desktops[0].FloatingStacks[0].WindowIDs = []WindowID{w1}
+		snapshot.Desktops[0].FloatingStacks[0].ActiveID = &w2
+		window := snapshot.Windows[w1]
+		window.Placement = WindowPlacementFloating
+		snapshot.Windows[w1] = window
+		codes := topologyDiagnosticCodes(t, ValidateSnapshot(snapshot))
+		for _, code := range []string{"topology.stack_size", "topology.stack_active", "topology.window_placement"} {
+			if !slices.Contains(codes, code) {
+				t.Fatalf("diagnostic codes = %v, want %q", codes, code)
+			}
+		}
+	})
+
+	t.Run("Should reject a window in both a floating stack and the floating list [UT-003]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		snapshot.Desktops[0].Floating = []WindowID{"w1"}
+		codes := topologyDiagnosticCodes(t, ValidateSnapshot(snapshot))
+		if !slices.Contains(codes, "topology.window_membership") {
+			t.Fatalf("diagnostic codes = %v, want topology.window_membership", codes)
+		}
+	})
+
+	t.Run("Should dissolve a singleton floating stack at its frame rectangle [UT-004]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		delete(snapshot.Windows, "w2")
+		stack := snapshot.Desktops[0].FloatingStacks[0]
+		stack.WindowIDs = []WindowID{"w1"}
+		stack.ActiveID = new(WindowID("w1"))
+		snapshot.Desktops[0].FloatingStacks[0] = stack
+		normalized := NormalizeSnapshot(snapshot)
+		if len(normalized.Desktops[0].FloatingStacks) != 0 ||
+			!slices.Equal(normalized.Desktops[0].Floating, []WindowID{"w1"}) {
+			t.Fatalf("normalized desktop = %+v", normalized.Desktops[0])
+		}
+		window := normalized.Windows["w1"]
+		if window.Placement != WindowPlacementFloating || window.FloatingRect != stack.Rect {
+			t.Fatalf("normalized window = %+v, frame = %+v", window, stack.Rect)
+		}
+		requireValidSnapshot(t, normalized)
+	})
+
+	t.Run("Should repair stale active members in floating and tiled stacks [UT-005]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		w3, w4, missing := WindowID("w3"), WindowID("w4"), WindowID("missing")
+		for _, windowID := range []WindowID{w3, w4} {
+			snapshot.Windows[windowID] = Window{
+				ID: windowID, App: "Tiled", Route: testRoute("/tiled"), DesktopID: "desktop-default",
+				Placement: WindowPlacementStacked, FloatingRect: fullRect(),
+			}
+		}
+		snapshot.Desktops[0].Groups = []LayoutGroup{{
+			ID: "group", Frame: fullRect(),
+			Root: LayoutNode{ID: "tiled-stack", Kind: NodeKindStack, WindowIDs: []WindowID{w3, w4}, ActiveID: &missing},
+		}}
+		snapshot.Desktops[0].FloatingStacks[0].ActiveID = &missing
+		normalized := NormalizeSnapshot(snapshot)
+		if valueOrZero(normalized.Desktops[0].FloatingStacks[0].ActiveID) != "w1" ||
+			valueOrZero(normalized.Desktops[0].Groups[0].Root.ActiveID) != w3 {
+			t.Fatalf(
+				"normalized active members = floating:%v tiled:%v",
+				normalized.Desktops[0].FloatingStacks[0].ActiveID,
+				normalized.Desktops[0].Groups[0].Root.ActiveID,
+			)
+		}
+		requireValidSnapshot(t, normalized)
+	})
+
+	t.Run("Should collate a stable pinned prefix in both stack representations [UT-006]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		w3, w4 := WindowID("w3"), WindowID("w4")
+		for _, windowID := range []WindowID{w3, w4} {
+			snapshot.Windows[windowID] = Window{
+				ID: windowID, App: "Tiled", Route: testRoute("/tiled"), DesktopID: "desktop-default",
+				Placement: WindowPlacementStacked, FloatingRect: fullRect(), Pinned: windowID == w4,
+			}
+		}
+		window := snapshot.Windows["w1"]
+		window.Pinned = false
+		snapshot.Windows["w1"] = window
+		window = snapshot.Windows["w2"]
+		window.Pinned = true
+		snapshot.Windows["w2"] = window
+		snapshot.Desktops[0].Groups = []LayoutGroup{{
+			ID: "group", Frame: fullRect(),
+			Root: LayoutNode{ID: "tiled-stack", Kind: NodeKindStack, WindowIDs: []WindowID{w3, w4}, ActiveID: &w3},
+		}}
+		normalized := NormalizeSnapshot(snapshot)
+		if !slices.Equal(normalized.Desktops[0].FloatingStacks[0].WindowIDs, []WindowID{"w2", "w1"}) ||
+			!slices.Equal(normalized.Desktops[0].Groups[0].Root.WindowIDs, []WindowID{w4, w3}) {
+			t.Fatalf(
+				"normalized stacks = floating:%v tiled:%v",
+				normalized.Desktops[0].FloatingStacks[0].WindowIDs,
+				normalized.Desktops[0].Groups[0].Root.WindowIDs,
+			)
+		}
+		requireValidSnapshot(t, normalized)
+	})
+
+	t.Run("Should reject every snapshot version except v3 [UT-007]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		snapshot.Version = 2
+		codes := topologyDiagnosticCodes(t, ValidateSnapshot(snapshot))
+		if !slices.Contains(codes, "topology.unsupported_version") {
+			t.Fatalf("diagnostic codes = %v", codes)
+		}
+	})
+
+	t.Run("Should enforce only the absolute navigation maximum without normalizing it [UT-008]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		window := snapshot.Windows["w1"]
+		window.NavStack = make([]RouteIntent, absoluteNavStackLimit+1)
+		for index := range window.NavStack {
+			window.NavStack[index] = testRoute("/history")
+		}
+		snapshot.Windows["w1"] = window
+		if got := len(NormalizeSnapshot(snapshot).Windows["w1"].NavStack); got != absoluteNavStackLimit+1 {
+			t.Fatalf("NormalizeSnapshot() nav stack length = %d", got)
+		}
+		codes := topologyDiagnosticCodes(t, ValidateSnapshot(snapshot))
+		if !slices.Contains(codes, "topology.nav_stack_limit") {
+			t.Fatalf("diagnostic codes = %v", codes)
+		}
+	})
+
+	t.Run("Should enforce only the absolute closed-entry maximum without normalizing it [UT-009]", func(t *testing.T) {
+		t.Parallel()
+		snapshot := validFloatingStackSnapshot()
+		closedWindow := snapshot.Windows["w1"]
+		snapshot.ClosedEntries = make([]ClosedEntry, absoluteClosedEntryLimit+1)
+		for index := range snapshot.ClosedEntries {
+			snapshot.ClosedEntries[index] = ClosedEntry{
+				Windows:   []Window{closedWindow},
+				DesktopID: "desktop-default",
+				Rect:      fullRect(),
+			}
+		}
+		if got := len(NormalizeSnapshot(snapshot).ClosedEntries); got != absoluteClosedEntryLimit+1 {
+			t.Fatalf("NormalizeSnapshot() closed-entry length = %d", got)
+		}
+		codes := topologyDiagnosticCodes(t, ValidateSnapshot(snapshot))
+		if !slices.Contains(codes, "topology.closed_entry_limit") {
+			t.Fatalf("diagnostic codes = %v", codes)
+		}
+	})
+}
+
+func validFloatingStackSnapshot() Snapshot {
+	w1, w2 := WindowID("w1"), WindowID("w2")
+	active := w2
+	return Snapshot{
+		Version: SnapshotVersion, WorkspaceID: "workspace-a",
+		Desktops: []Desktop{{
+			ID: "desktop-default", Name: defaultDesktopName, Purpose: DesktopPurposeStandard,
+			Groups: []LayoutGroup{}, Floating: []WindowID{},
+			FloatingStacks: []FloatingStack{{
+				ID: "floating-stack", WindowIDs: []WindowID{w1, w2}, ActiveID: &active,
+				Rect: NormalizedRect{X: 0.1, Y: 0.1, Width: 0.6, Height: 0.6},
+			}},
+		}},
+		Windows: map[WindowID]Window{
+			w1: {
+				ID:           w1,
+				App:          "One",
+				Route:        testRoute("/one"),
+				DesktopID:    "desktop-default",
+				Placement:    WindowPlacementStacked,
+				FloatingRect: fullRect(),
+				Pinned:       true,
+			},
+			w2: {
+				ID:           w2,
+				App:          "Two",
+				Route:        testRoute("/two"),
+				DesktopID:    "desktop-default",
+				Placement:    WindowPlacementStacked,
+				FloatingRect: fullRect(),
+			},
+		},
+		History: History{Undo: []HistoryEntry{}, Redo: []HistoryEntry{}},
+	}
+}
+
+func topologyDiagnosticCodes(t *testing.T, err error) []string {
+	t.Helper()
+	var topologyErr *TopologyError
+	if !errors.As(err, &topologyErr) {
+		t.Fatalf("error = %v, want TopologyError", err)
+	}
+	codes := make([]string, 0, len(topologyErr.Diagnostics))
+	for _, diagnostic := range topologyErr.Diagnostics {
+		codes = append(codes, diagnostic.Code)
+	}
+	return codes
+}
+
 func TestSharedBoundaryResize(t *testing.T) {
 	t.Run("Should resize one-to-many descendants through one split boundary", func(t *testing.T) {
 		t.Parallel()

--- a/internal/windowmanager/tree_mutation.go
+++ b/internal/windowmanager/tree_mutation.go
@@ -10,6 +10,44 @@ func removeWindow(snapshot *Snapshot, windowID WindowID) bool {
 		return false
 	}
 	desktop := &snapshot.Desktops[placement.desktopIndex]
+	if placement.floatingStackIndex >= 0 {
+		stack := desktop.FloatingStacks[placement.floatingStackIndex]
+		removedIndex := -1
+		for index, memberID := range stack.WindowIDs {
+			if memberID == windowID {
+				removedIndex = index
+				stack.WindowIDs = append(stack.WindowIDs[:index], stack.WindowIDs[index+1:]...)
+				break
+			}
+		}
+		if removedIndex < 0 {
+			return false
+		}
+		if stack.ActiveID == nil || *stack.ActiveID == windowID {
+			stack.ActiveID = nextActiveAfterRemoval(stack.WindowIDs, removedIndex)
+		}
+		switch len(stack.WindowIDs) {
+		case 1:
+			survivorID := stack.WindowIDs[0]
+			survivor := snapshot.Windows[survivorID]
+			survivor.Placement = WindowPlacementFloating
+			survivor.FloatingRect = stack.Rect
+			snapshot.Windows[survivorID] = survivor
+			desktop.Floating = append(desktop.Floating, survivorID)
+			desktop.FloatingStacks = append(
+				desktop.FloatingStacks[:placement.floatingStackIndex],
+				desktop.FloatingStacks[placement.floatingStackIndex+1:]...,
+			)
+		case 0:
+			desktop.FloatingStacks = append(
+				desktop.FloatingStacks[:placement.floatingStackIndex],
+				desktop.FloatingStacks[placement.floatingStackIndex+1:]...,
+			)
+		default:
+			desktop.FloatingStacks[placement.floatingStackIndex] = stack
+		}
+		return true
+	}
 	if placement.floatingIndex >= 0 {
 		desktop.Floating = append(
 			desktop.Floating[:placement.floatingIndex],
@@ -45,8 +83,11 @@ func removeWindowFromNode(node LayoutNode, windowID WindowID) (LayoutNode, bool)
 				return LayoutNode{}, true
 			}
 			if node.ActiveID == nil || *node.ActiveID == windowID {
-				active := node.WindowIDs[0]
-				node.ActiveID = &active
+				node.ActiveID = nextActiveAfterRemoval(node.WindowIDs, index)
+			}
+			if len(node.WindowIDs) == 1 {
+				survivor := node.WindowIDs[0]
+				return LayoutNode{ID: node.ID, Kind: NodeKindLeaf, WindowID: &survivor}, true
 			}
 			return node, true
 		}

--- a/internal/windowmanager/tree_query.go
+++ b/internal/windowmanager/tree_query.go
@@ -1,15 +1,16 @@
 package windowmanager
 
 type windowPlacement struct {
-	desktopIndex  int
-	groupIndex    int
-	floatingIndex int
-	nodeID        NodeID
-	parentSplitID *NodeID
-	childIndex    *int
-	weight        *float64
-	placement     WindowPlacement
-	neighbors     []WindowID
+	desktopIndex       int
+	groupIndex         int
+	floatingIndex      int
+	floatingStackIndex int
+	nodeID             NodeID
+	parentSplitID      *NodeID
+	childIndex         *int
+	weight             *float64
+	placement          WindowPlacement
+	neighbors          []WindowID
 }
 
 func desktopIndexByID(snapshot *Snapshot, desktopID DesktopID) (int, bool) {
@@ -31,13 +32,30 @@ func findWindowPlacement(snapshot *Snapshot, windowID WindowID) (windowPlacement
 		return windowPlacement{}, false
 	}
 	desktop := &snapshot.Desktops[desktopIndex]
+	for index := range desktop.FloatingStacks {
+		stack := &desktop.FloatingStacks[index]
+		if containsWindowID(stack.WindowIDs, windowID) {
+			neighbors := make([]WindowID, 0, len(stack.WindowIDs)-1)
+			for _, memberID := range stack.WindowIDs {
+				if memberID != windowID {
+					neighbors = append(neighbors, memberID)
+				}
+			}
+			return windowPlacement{
+				desktopIndex: desktopIndex, groupIndex: -1, floatingIndex: -1,
+				floatingStackIndex: index, nodeID: stack.ID,
+				placement: WindowPlacementStacked, neighbors: neighbors,
+			}, true
+		}
+	}
 	for index, candidate := range desktop.Floating {
 		if candidate == windowID {
 			return windowPlacement{
-				desktopIndex:  desktopIndex,
-				groupIndex:    -1,
-				floatingIndex: index,
-				placement:     WindowPlacementFloating,
+				desktopIndex:       desktopIndex,
+				groupIndex:         -1,
+				floatingIndex:      index,
+				floatingStackIndex: -1,
+				placement:          WindowPlacementFloating,
 			}, true
 		}
 	}
@@ -46,6 +64,7 @@ func findWindowPlacement(snapshot *Snapshot, windowID WindowID) (windowPlacement
 			placement.desktopIndex = desktopIndex
 			placement.groupIndex = groupIndex
 			placement.floatingIndex = -1
+			placement.floatingStackIndex = -1
 			return placement, true
 		}
 	}

--- a/internal/windowmanager/types.go
+++ b/internal/windowmanager/types.go
@@ -6,7 +6,12 @@ import (
 	"time"
 )
 
-const SnapshotVersion uint32 = 2
+const SnapshotVersion uint32 = 3
+
+const (
+	absoluteNavStackLimit    = 200
+	absoluteClosedEntryLimit = 100
+)
 
 type WorkspaceID string
 type DesktopID string
@@ -65,25 +70,36 @@ type NormalizedRect struct {
 
 // Snapshot is the complete durable workspace aggregate.
 type Snapshot struct {
-	Version     uint32              `json:"version"`
-	WorkspaceID WorkspaceID         `json:"workspace_id"`
-	Revision    Revision            `json:"revision"`
-	Desktops    []Desktop           `json:"desktops"`
-	Windows     map[WindowID]Window `json:"windows"`
-	History     History             `json:"history"`
-	Overrides   WorkspaceConfig     `json:"overrides"`
-	UpdatedAt   time.Time           `json:"updated_at"`
+	Version       uint32              `json:"version"`
+	WorkspaceID   WorkspaceID         `json:"workspace_id"`
+	Revision      Revision            `json:"revision"`
+	Desktops      []Desktop           `json:"desktops"`
+	Windows       map[WindowID]Window `json:"windows"`
+	ClosedEntries []ClosedEntry       `json:"closed_entries,omitempty"`
+	History       History             `json:"history"`
+	Overrides     WorkspaceConfig     `json:"overrides"`
+	UpdatedAt     time.Time           `json:"updated_at"`
 }
 
 // Desktop owns tiled groups and floating order.
 type Desktop struct {
-	ID         DesktopID      `json:"id"`
-	Name       string         `json:"name"`
-	Order      int            `json:"order"`
-	Purpose    DesktopPurpose `json:"purpose"`
-	FocusOwner *WindowID      `json:"focus_owner,omitempty"`
-	Groups     []LayoutGroup  `json:"groups"`
-	Floating   []WindowID     `json:"floating"`
+	ID             DesktopID       `json:"id"`
+	Name           string          `json:"name"`
+	Order          int             `json:"order"`
+	Purpose        DesktopPurpose  `json:"purpose"`
+	FocusOwner     *WindowID       `json:"focus_owner,omitempty"`
+	Groups         []LayoutGroup   `json:"groups"`
+	Floating       []WindowID      `json:"floating"`
+	FloatingStacks []FloatingStack `json:"floating_stacks"`
+}
+
+// FloatingStack is one floating frame containing an ordered tab deck.
+type FloatingStack struct {
+	ID        NodeID         `json:"id"`
+	WindowIDs []WindowID     `json:"window_ids"`
+	ActiveID  *WindowID      `json:"active_id,omitempty"`
+	Rect      NormalizedRect `json:"rect"`
+	Minimized bool           `json:"minimized,omitempty"`
 }
 
 // LayoutGroup is one independent tiled island.
@@ -111,11 +127,23 @@ type Window struct {
 	App          string          `json:"app"`
 	InstanceKey  *string         `json:"instance_key,omitempty"`
 	Route        RouteIntent     `json:"route"`
+	NavStack     []RouteIntent   `json:"nav_stack"`
+	Pinned       bool            `json:"pinned,omitempty"`
 	Placement    WindowPlacement `json:"placement"`
 	DesktopID    DesktopID       `json:"desktop_id"`
 	FloatingRect NormalizedRect  `json:"floating_rect"`
 	Minimized    bool            `json:"minimized"`
 	ReturnAnchor *ReturnAnchor   `json:"return_anchor,omitempty"`
+}
+
+// ClosedEntry is one reopenable close operation, newest last in Snapshot.ClosedEntries.
+type ClosedEntry struct {
+	Windows   []Window       `json:"windows"`
+	ActiveID  *WindowID      `json:"active_id,omitempty"`
+	StackID   *NodeID        `json:"stack_id,omitempty"`
+	DesktopID DesktopID      `json:"desktop_id"`
+	Rect      NormalizedRect `json:"rect"`
+	ClosedAt  time.Time      `json:"closed_at"`
 }
 
 // ReturnAnchor describes a window's prior structural slot.
@@ -132,13 +160,14 @@ type ReturnAnchor struct {
 
 // ClientView is transient presentation state for one connected client.
 type ClientView struct {
-	WorkspaceID          WorkspaceID `json:"workspace_id"`
-	ClientID             ClientID    `json:"client_id"`
-	PresentationRevision uint64      `json:"presentation_revision"`
-	ActiveDesktopID      DesktopID   `json:"active_desktop_id"`
-	FocusedWindowID      *WindowID   `json:"focused_window_id,omitempty"`
-	FocusOrder           []WindowID  `json:"focus_order"`
-	ConnectedAt          time.Time   `json:"connected_at"`
+	WorkspaceID          WorkspaceID         `json:"workspace_id"`
+	ClientID             ClientID            `json:"client_id"`
+	PresentationRevision uint64              `json:"presentation_revision"`
+	ActiveDesktopID      DesktopID           `json:"active_desktop_id"`
+	FocusedWindowID      *WindowID           `json:"focused_window_id,omitempty"`
+	FocusOrder           []WindowID          `json:"focus_order"`
+	StackActive          map[NodeID]WindowID `json:"stack_active,omitempty"`
+	ConnectedAt          time.Time           `json:"connected_at"`
 }
 
 // ClientRegistration requests a live client view.

--- a/internal/windowmanager/validate.go
+++ b/internal/windowmanager/validate.go
@@ -42,6 +42,7 @@ func (v *snapshotValidator) validate() {
 	v.validateHeader()
 	v.validateDesktopIdentities()
 	v.validateWindowRecords()
+	v.validateClosedEntries()
 	for index := range v.snapshot.Desktops {
 		v.validateDesktop(index)
 	}
@@ -50,7 +51,7 @@ func (v *snapshotValidator) validate() {
 
 func (v *snapshotValidator) validateHeader() {
 	if v.snapshot.Version != SnapshotVersion {
-		v.add("topology.unsupported_version", "version", "document version must be 2")
+		v.add("topology.unsupported_version", "version", "document version must be 3")
 	}
 	if strings.TrimSpace(string(v.snapshot.WorkspaceID)) == "" {
 		v.add("topology.workspace_required", "workspace_id", "workspace ID is required")
@@ -94,6 +95,7 @@ func (v *snapshotValidator) validateWindowRecords() {
 		} else if !routeIntentsEqual(window.Route, canonicalRoute) {
 			v.add("topology.window_route_canonical", path+".route", "window route must be canonical")
 		}
+		v.validateNavStack(window.NavStack, path+".nav_stack")
 		if _, exists := v.desktops[window.DesktopID]; !exists {
 			v.add("topology.window_desktop_unknown", path+".desktop_id", "window desktop does not exist")
 		}
@@ -123,6 +125,13 @@ func (v *snapshotValidator) validateMembershipCompleteness() {
 func (v *snapshotValidator) validateDesktop(index int) {
 	desktop := v.snapshot.Desktops[index]
 	path := fmt.Sprintf("desktops[%d]", index)
+	v.validateDesktopGroups(desktop, path)
+	v.validateDesktopFloatingStacks(desktop, path)
+	v.validateDesktopFloatingWindows(desktop, path)
+	v.validateDesktopFocusOwner(desktop, path)
+}
+
+func (v *snapshotValidator) validateDesktopGroups(desktop Desktop, path string) {
 	for left := range desktop.Groups {
 		group := desktop.Groups[left]
 		groupPath := fmt.Sprintf("%s.groups[%d]", path, left)
@@ -142,6 +151,34 @@ func (v *snapshotValidator) validateDesktop(index int) {
 		}
 		v.validateNode(group.Root, desktop.ID, groupPath+".root")
 	}
+}
+
+func (v *snapshotValidator) validateDesktopFloatingStacks(desktop Desktop, path string) {
+	for stackIndex, stack := range desktop.FloatingStacks {
+		stackPath := fmt.Sprintf("%s.floating_stacks[%d]", path, stackIndex)
+		v.validateNodeIdentity(LayoutNode{ID: stack.ID}, stackPath)
+		if !validRect(stack.Rect) {
+			v.add("topology.floating_stack_rect", stackPath+".rect", "floating stack rectangle must be normalized")
+		}
+		if len(stack.WindowIDs) < 2 {
+			v.add("topology.stack_size", stackPath+".window_ids", "stack requires at least two windows")
+		}
+		for memberIndex, windowID := range stack.WindowIDs {
+			v.validateNodeWindow(
+				windowID,
+				desktop.ID,
+				WindowPlacementStacked,
+				fmt.Sprintf("%s.window_ids[%d]", stackPath, memberIndex),
+			)
+		}
+		if stack.ActiveID == nil || !containsWindowID(stack.WindowIDs, valueOrZero(stack.ActiveID)) {
+			v.add("topology.stack_active", stackPath+".active_id", "stack active window must be a member")
+		}
+		v.validatePinnedPrefix(stack.WindowIDs, stackPath+".window_ids")
+	}
+}
+
+func (v *snapshotValidator) validateDesktopFloatingWindows(desktop Desktop, path string) {
 	for floatingIndex, windowID := range desktop.Floating {
 		memberPath := fmt.Sprintf("%s.floating[%d]", path, floatingIndex)
 		window, exists := v.snapshot.Windows[windowID]
@@ -157,6 +194,9 @@ func (v *snapshotValidator) validateDesktop(index int) {
 			v.add("topology.window_placement", memberPath, "floating membership and placement disagree")
 		}
 	}
+}
+
+func (v *snapshotValidator) validateDesktopFocusOwner(desktop Desktop, path string) {
 	if desktop.Purpose == DesktopPurposeFocus {
 		if desktop.FocusOwner == nil {
 			v.add("topology.focus_owner_required", path+".focus_owner", "focus desktop requires an owner")
@@ -224,6 +264,71 @@ func (v *snapshotValidator) validateStackNode(node LayoutNode, desktopID Desktop
 	}
 	if node.ActiveID == nil || !containsWindowID(node.WindowIDs, valueOrZero(node.ActiveID)) {
 		v.add("topology.stack_active", path+".active_id", "stack active window must be a member")
+	}
+	v.validatePinnedPrefix(node.WindowIDs, path+".window_ids")
+}
+
+func (v *snapshotValidator) validatePinnedPrefix(windowIDs []WindowID, path string) {
+	seenUnpinned := false
+	for index, windowID := range windowIDs {
+		window, exists := v.snapshot.Windows[windowID]
+		if !exists {
+			continue
+		}
+		if !window.Pinned {
+			seenUnpinned = true
+			continue
+		}
+		if seenUnpinned {
+			v.add(
+				"topology.stack_pinned_prefix",
+				fmt.Sprintf("%s[%d]", path, index),
+				"pinned windows must form a contiguous prefix",
+			)
+		}
+	}
+}
+
+func (v *snapshotValidator) validateNavStack(routes []RouteIntent, path string) {
+	if len(routes) > absoluteNavStackLimit {
+		v.add("topology.nav_stack_limit", path, "navigation stack exceeds the absolute maximum")
+	}
+	for index, route := range routes {
+		canonical, err := CanonicalRouteIntent(route)
+		routePath := fmt.Sprintf("%s[%d]", path, index)
+		if err != nil {
+			v.add("topology.window_route", routePath, err.Error())
+		} else if !routeIntentsEqual(route, canonical) {
+			v.add("topology.window_route_canonical", routePath, "navigation route must be canonical")
+		}
+	}
+}
+
+func (v *snapshotValidator) validateClosedEntries() {
+	if len(v.snapshot.ClosedEntries) > absoluteClosedEntryLimit {
+		v.add("topology.closed_entry_limit", "closed_entries", "closed entries exceed the absolute maximum")
+	}
+	for entryIndex, entry := range v.snapshot.ClosedEntries {
+		path := fmt.Sprintf("closed_entries[%d]", entryIndex)
+		if len(entry.Windows) == 0 {
+			v.add("topology.closed_entry_empty", path+".windows", "closed entry requires at least one window")
+		}
+		if !validRect(entry.Rect) {
+			v.add("topology.closed_entry_rect", path+".rect", "closed entry rectangle must be normalized")
+		}
+		for windowIndex, window := range entry.Windows {
+			windowPath := fmt.Sprintf("%s.windows[%d]", path, windowIndex)
+			if strings.TrimSpace(string(window.ID)) == "" || strings.TrimSpace(window.App) == "" {
+				v.add("topology.closed_window_identity", windowPath, "closed window identity and app are required")
+			}
+			canonical, err := CanonicalRouteIntent(window.Route)
+			if err != nil {
+				v.add("topology.window_route", windowPath+".route", err.Error())
+			} else if !routeIntentsEqual(window.Route, canonical) {
+				v.add("topology.window_route_canonical", windowPath+".route", "window route must be canonical")
+			}
+			v.validateNavStack(window.NavStack, windowPath+".nav_stack")
+		}
 	}
 }
 

--- a/magefiles/gotest_lane_test.go
+++ b/magefiles/gotest_lane_test.go
@@ -88,7 +88,13 @@ func TestParseGoTestShard(t *testing.T) {
 			got, enabled, err := parseGoTestShard(tt.indexRaw, tt.totalRaw)
 			if tt.wantError != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantError) {
-					t.Fatalf("parseGoTestShard(%q, %q) error = %v, want containing %q", tt.indexRaw, tt.totalRaw, err, tt.wantError)
+					t.Fatalf(
+						"parseGoTestShard(%q, %q) error = %v, want containing %q",
+						tt.indexRaw,
+						tt.totalRaw,
+						err,
+						tt.wantError,
+					)
 				}
 				return
 			}

--- a/magefiles/magefile_test.go
+++ b/magefiles/magefile_test.go
@@ -90,7 +90,12 @@ func TestFilesImporting(t *testing.T) {
 		t.Parallel()
 
 		root := t.TempDir()
-		writeTestFile(t, root, "exact.go", "package fixture\nimport _ \"github.com/compozy/compozy/internal/session\"\n")
+		writeTestFile(
+			t,
+			root,
+			"exact.go",
+			"package fixture\nimport _ \"github.com/compozy/compozy/internal/session\"\n",
+		)
 		writeTestFile(
 			t,
 			root,
@@ -210,7 +215,11 @@ func TestProductionSourceLineLimit(t *testing.T) {
 			{name: "Should include Storybook source", path: "web/src/system.stories.tsx", want: true},
 			{name: "Should exclude Go tests", path: "internal/store/sqlite_test.go", want: false},
 			{name: "Should exclude Web tests", path: "web/src/__tests__/view.test.tsx", want: false},
-			{name: "Should exclude generated contracts", path: "sdk/typescript/src/generated/contracts.ts", want: false},
+			{
+				name: "Should exclude generated contracts",
+				path: "sdk/typescript/src/generated/contracts.ts",
+				want: false,
+			},
 			{name: "Should exclude sqlc output", path: "internal/store/sqlcgen/query.sql.go", want: false},
 			{name: "Should exclude fixtures", path: "web/src/system/fixtures/data.ts", want: false},
 			{name: "Should exclude reference slides", path: "packages/slides/slides/demo/index.tsx", want: false},
@@ -234,7 +243,12 @@ func TestProductionSourceLineLimit(t *testing.T) {
 		root := t.TempDir()
 		oversized := strings.Repeat("package fixture\n", maxProductionSourceLines+1)
 		writeTestFile(t, root, "internal/runtime/oversized.go", oversized)
-		writeTestFile(t, root, "packages/site/app/oversized.css", strings.Repeat(".fixture {}\n", maxProductionSourceLines+1))
+		writeTestFile(
+			t,
+			root,
+			"packages/site/app/oversized.css",
+			strings.Repeat(".fixture {}\n", maxProductionSourceLines+1),
+		)
 		writeTestFile(
 			t,
 			root,

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -2518,6 +2518,18 @@
                     },
                     "type": "array"
                   },
+                  "stack_grouped": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "stack_ungrouped": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
                   "window_ids": {
                     "items": {
                       "type": "string"
@@ -2781,6 +2793,10 @@
                 ],
                 "type": "object"
               },
+              "closed_entry_limit": {
+                "nullable": true,
+                "type": "integer"
+              },
               "desktop_transition": {
                 "nullable": true,
                 "type": "string"
@@ -2839,6 +2855,10 @@
                 "type": "string"
               },
               "history_limit": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "nav_stack_limit": {
                 "nullable": true,
                 "type": "integer"
               },
@@ -3470,6 +3490,10 @@
                     ],
                     "type": "object"
                   },
+                  "closed_entry_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "desktop_transition": {
                     "nullable": true,
                     "type": "string"
@@ -3528,6 +3552,10 @@
                     "type": "string"
                   },
                   "history_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "nav_stack_limit": {
                     "nullable": true,
                     "type": "integer"
                   },
@@ -4012,6 +4040,10 @@
                     ],
                     "type": "object"
                   },
+                  "closed_entry_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "desktop_transition": {
                     "nullable": true,
                     "type": "string"
@@ -4070,6 +4102,10 @@
                     "type": "string"
                   },
                   "history_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "nav_stack_limit": {
                     "nullable": true,
                     "type": "integer"
                   },
@@ -4629,6 +4665,18 @@
                 },
                 "type": "array"
               },
+              "stack_grouped": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "stack_ungrouped": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "window_ids": {
                 "items": {
                   "type": "string"
@@ -5021,6 +5069,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -5079,6 +5131,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -5529,6 +5585,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -5587,6 +5647,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -6094,6 +6158,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -6152,6 +6220,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -6602,6 +6674,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -6660,6 +6736,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -7017,6 +7097,10 @@
                     ],
                     "type": "object"
                   },
+                  "closed_entry_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "desktop_transition": {
                     "nullable": true,
                     "type": "string"
@@ -7075,6 +7159,10 @@
                     "type": "string"
                   },
                   "history_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "nav_stack_limit": {
                     "nullable": true,
                     "type": "integer"
                   },
@@ -7577,6 +7665,10 @@
                     ],
                     "type": "object"
                   },
+                  "closed_entry_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "desktop_transition": {
                     "nullable": true,
                     "type": "string"
@@ -7635,6 +7727,10 @@
                     "type": "string"
                   },
                   "history_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "nav_stack_limit": {
                     "nullable": true,
                     "type": "integer"
                   },
@@ -7988,6 +8084,18 @@
                 "type": "array"
               },
               "node_ids": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "stack_grouped": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "stack_ungrouped": {
                 "items": {
                   "type": "string"
                 },
@@ -8390,6 +8498,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -8448,6 +8560,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -8898,6 +9014,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -8956,6 +9076,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -9463,6 +9587,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -9521,6 +9649,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -9971,6 +10103,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -10029,6 +10165,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -10386,6 +10526,10 @@
                     ],
                     "type": "object"
                   },
+                  "closed_entry_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "desktop_transition": {
                     "nullable": true,
                     "type": "string"
@@ -10444,6 +10588,10 @@
                     "type": "string"
                   },
                   "history_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "nav_stack_limit": {
                     "nullable": true,
                     "type": "integer"
                   },
@@ -11084,6 +11232,10 @@
                               ],
                               "type": "object"
                             },
+                            "closed_entry_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
                             "desktop_transition": {
                               "nullable": true,
                               "type": "string"
@@ -11142,6 +11294,10 @@
                               "type": "string"
                             },
                             "history_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
+                            "nav_stack_limit": {
                               "nullable": true,
                               "type": "integer"
                             },
@@ -11592,6 +11748,10 @@
                               ],
                               "type": "object"
                             },
+                            "closed_entry_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
                             "desktop_transition": {
                               "nullable": true,
                               "type": "string"
@@ -11650,6 +11810,10 @@
                               "type": "string"
                             },
                             "history_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
+                            "nav_stack_limit": {
                               "nullable": true,
                               "type": "integer"
                             },
@@ -12157,6 +12321,10 @@
                               ],
                               "type": "object"
                             },
+                            "closed_entry_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
                             "desktop_transition": {
                               "nullable": true,
                               "type": "string"
@@ -12215,6 +12383,10 @@
                               "type": "string"
                             },
                             "history_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
+                            "nav_stack_limit": {
                               "nullable": true,
                               "type": "integer"
                             },
@@ -12665,6 +12837,10 @@
                               ],
                               "type": "object"
                             },
+                            "closed_entry_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
                             "desktop_transition": {
                               "nullable": true,
                               "type": "string"
@@ -12723,6 +12899,10 @@
                               "type": "string"
                             },
                             "history_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
+                            "nav_stack_limit": {
                               "nullable": true,
                               "type": "integer"
                             },
@@ -13080,6 +13260,10 @@
                 ],
                 "type": "object"
               },
+              "closed_entry_limit": {
+                "nullable": true,
+                "type": "integer"
+              },
               "desktop_transition": {
                 "nullable": true,
                 "type": "string"
@@ -13138,6 +13322,10 @@
                 "type": "string"
               },
               "history_limit": {
+                "nullable": true,
+                "type": "integer"
+              },
+              "nav_stack_limit": {
                 "nullable": true,
                 "type": "integer"
               },
@@ -13819,6 +14007,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -13877,6 +14069,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -14327,6 +14523,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -14385,6 +14585,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -14892,6 +15096,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -14950,6 +15158,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -15400,6 +15612,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -15458,6 +15674,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -15815,6 +16035,10 @@
                     ],
                     "type": "object"
                   },
+                  "closed_entry_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
                   "desktop_transition": {
                     "nullable": true,
                     "type": "string"
@@ -15873,6 +16097,10 @@
                     "type": "string"
                   },
                   "history_limit": {
+                    "nullable": true,
+                    "type": "integer"
+                  },
+                  "nav_stack_limit": {
                     "nullable": true,
                     "type": "integer"
                   },
@@ -139942,6 +140170,9 @@
                           ],
                           "type": "object"
                         },
+                        "closed_entry_limit": {
+                          "type": "integer"
+                        },
                         "desktop_transition": {
                           "enum": [
                             "slide",
@@ -140011,6 +140242,9 @@
                         "history_limit": {
                           "type": "integer"
                         },
+                        "nav_stack_limit": {
+                          "type": "integer"
+                        },
                         "new_window_policy": {
                           "enum": [
                             "floating",
@@ -140075,6 +140309,7 @@
                       },
                       "required": [
                         "bindings",
+                        "closed_entry_limit",
                         "desktop_transition",
                         "drag_away_policy",
                         "focus_follows_pointer",
@@ -140083,6 +140318,7 @@
                         "gaps",
                         "group_move_modifier",
                         "history_limit",
+                        "nav_stack_limit",
                         "new_window_policy",
                         "raise_on_focus",
                         "shortcuts",
@@ -140236,6 +140472,9 @@
                         ],
                         "type": "object"
                       },
+                      "closed_entry_limit": {
+                        "type": "integer"
+                      },
                       "desktop_transition": {
                         "enum": [
                           "slide",
@@ -140305,6 +140544,9 @@
                       "history_limit": {
                         "type": "integer"
                       },
+                      "nav_stack_limit": {
+                        "type": "integer"
+                      },
                       "new_window_policy": {
                         "enum": [
                           "floating",
@@ -140369,6 +140611,7 @@
                     },
                     "required": [
                       "bindings",
+                      "closed_entry_limit",
                       "desktop_transition",
                       "drag_away_policy",
                       "focus_follows_pointer",
@@ -140377,6 +140620,7 @@
                       "gaps",
                       "group_move_modifier",
                       "history_limit",
+                      "nav_stack_limit",
                       "new_window_policy",
                       "raise_on_focus",
                       "shortcuts",
@@ -261679,6 +261923,10 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "closed_entry_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
                                       "desktop_transition": {
                                         "nullable": true,
                                         "type": "string"
@@ -261737,6 +261985,10 @@
                                         "type": "string"
                                       },
                                       "history_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
+                                      "nav_stack_limit": {
                                         "nullable": true,
                                         "type": "integer"
                                       },
@@ -262187,6 +262439,10 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "closed_entry_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
                                       "desktop_transition": {
                                         "nullable": true,
                                         "type": "string"
@@ -262245,6 +262501,10 @@
                                         "type": "string"
                                       },
                                       "history_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
+                                      "nav_stack_limit": {
                                         "nullable": true,
                                         "type": "integer"
                                       },
@@ -262752,6 +263012,10 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "closed_entry_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
                                       "desktop_transition": {
                                         "nullable": true,
                                         "type": "string"
@@ -262810,6 +263074,10 @@
                                         "type": "string"
                                       },
                                       "history_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
+                                      "nav_stack_limit": {
                                         "nullable": true,
                                         "type": "integer"
                                       },
@@ -263260,6 +263528,10 @@
                                         ],
                                         "type": "object"
                                       },
+                                      "closed_entry_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
                                       "desktop_transition": {
                                         "nullable": true,
                                         "type": "string"
@@ -263318,6 +263590,10 @@
                                         "type": "string"
                                       },
                                       "history_limit": {
+                                        "nullable": true,
+                                        "type": "integer"
+                                      },
+                                      "nav_stack_limit": {
                                         "nullable": true,
                                         "type": "integer"
                                       },
@@ -263675,6 +263951,10 @@
                           ],
                           "type": "object"
                         },
+                        "closed_entry_limit": {
+                          "nullable": true,
+                          "type": "integer"
+                        },
                         "desktop_transition": {
                           "nullable": true,
                           "type": "string"
@@ -263733,6 +264013,10 @@
                           "type": "string"
                         },
                         "history_limit": {
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "nav_stack_limit": {
                           "nullable": true,
                           "type": "integer"
                         },
@@ -265474,6 +265758,18 @@
                           },
                           "type": "array"
                         },
+                        "stack_grouped": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "stack_ungrouped": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "window_ids": {
                           "items": {
                             "type": "string"
@@ -265871,6 +266167,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -265929,6 +266229,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -266379,6 +266683,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -266437,6 +266745,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -266944,6 +267256,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -267002,6 +267318,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -267452,6 +267772,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -267510,6 +267834,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -267867,6 +268195,10 @@
                               ],
                               "type": "object"
                             },
+                            "closed_entry_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
                             "desktop_transition": {
                               "nullable": true,
                               "type": "string"
@@ -267925,6 +268257,10 @@
                               "type": "string"
                             },
                             "history_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
+                            "nav_stack_limit": {
                               "nullable": true,
                               "type": "integer"
                             },
@@ -268786,6 +269122,10 @@
                           ],
                           "type": "object"
                         },
+                        "closed_entry_limit": {
+                          "nullable": true,
+                          "type": "integer"
+                        },
                         "desktop_transition": {
                           "nullable": true,
                           "type": "string"
@@ -268844,6 +269184,10 @@
                           "type": "string"
                         },
                         "history_limit": {
+                          "nullable": true,
+                          "type": "integer"
+                        },
+                        "nav_stack_limit": {
                           "nullable": true,
                           "type": "integer"
                         },
@@ -269525,6 +269869,10 @@
                             ],
                             "type": "object"
                           },
+                          "closed_entry_limit": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
                           "desktop_transition": {
                             "nullable": true,
                             "type": "string"
@@ -269583,6 +269931,10 @@
                             "type": "string"
                           },
                           "history_limit": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "nav_stack_limit": {
                             "nullable": true,
                             "type": "integer"
                           },
@@ -269938,6 +270290,18 @@
                           "type": "array"
                         },
                         "node_ids": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "stack_grouped": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "stack_ungrouped": {
                           "items": {
                             "type": "string"
                           },
@@ -270340,6 +270704,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -270398,6 +270766,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -270848,6 +271220,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -270906,6 +271282,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -271413,6 +271793,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -271471,6 +271855,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -271921,6 +272309,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -271979,6 +272371,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -272336,6 +272732,10 @@
                               ],
                               "type": "object"
                             },
+                            "closed_entry_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
                             "desktop_transition": {
                               "nullable": true,
                               "type": "string"
@@ -272394,6 +272794,10 @@
                               "type": "string"
                             },
                             "history_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
+                            "nav_stack_limit": {
                               "nullable": true,
                               "type": "integer"
                             },
@@ -275494,6 +275898,10 @@
                             ],
                             "type": "object"
                           },
+                          "closed_entry_limit": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
                           "desktop_transition": {
                             "nullable": true,
                             "type": "string"
@@ -275552,6 +275960,10 @@
                             "type": "string"
                           },
                           "history_limit": {
+                            "nullable": true,
+                            "type": "integer"
+                          },
+                          "nav_stack_limit": {
                             "nullable": true,
                             "type": "integer"
                           },
@@ -276416,6 +276828,18 @@
                           },
                           "type": "array"
                         },
+                        "stack_grouped": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "stack_ungrouped": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
                         "window_ids": {
                           "items": {
                             "type": "string"
@@ -276808,6 +277232,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -276866,6 +277294,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -277316,6 +277748,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -277374,6 +277810,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -277881,6 +278321,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -277939,6 +278383,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -278389,6 +278837,10 @@
                                             ],
                                             "type": "object"
                                           },
+                                          "closed_entry_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
                                           "desktop_transition": {
                                             "nullable": true,
                                             "type": "string"
@@ -278447,6 +278899,10 @@
                                             "type": "string"
                                           },
                                           "history_limit": {
+                                            "nullable": true,
+                                            "type": "integer"
+                                          },
+                                          "nav_stack_limit": {
                                             "nullable": true,
                                             "type": "integer"
                                           },
@@ -278804,6 +279260,10 @@
                               ],
                               "type": "object"
                             },
+                            "closed_entry_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
                             "desktop_transition": {
                               "nullable": true,
                               "type": "string"
@@ -278862,6 +279322,10 @@
                               "type": "string"
                             },
                             "history_limit": {
+                              "nullable": true,
+                              "type": "integer"
+                            },
+                            "nav_stack_limit": {
                               "nullable": true,
                               "type": "integer"
                             },
@@ -279951,6 +280415,10 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "closed_entry_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
                                               "desktop_transition": {
                                                 "nullable": true,
                                                 "type": "string"
@@ -280009,6 +280477,10 @@
                                                 "type": "string"
                                               },
                                               "history_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
+                                              "nav_stack_limit": {
                                                 "nullable": true,
                                                 "type": "integer"
                                               },
@@ -280459,6 +280931,10 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "closed_entry_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
                                               "desktop_transition": {
                                                 "nullable": true,
                                                 "type": "string"
@@ -280517,6 +280993,10 @@
                                                 "type": "string"
                                               },
                                               "history_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
+                                              "nav_stack_limit": {
                                                 "nullable": true,
                                                 "type": "integer"
                                               },
@@ -281024,6 +281504,10 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "closed_entry_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
                                               "desktop_transition": {
                                                 "nullable": true,
                                                 "type": "string"
@@ -281082,6 +281566,10 @@
                                                 "type": "string"
                                               },
                                               "history_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
+                                              "nav_stack_limit": {
                                                 "nullable": true,
                                                 "type": "integer"
                                               },
@@ -281532,6 +282020,10 @@
                                                 ],
                                                 "type": "object"
                                               },
+                                              "closed_entry_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
                                               "desktop_transition": {
                                                 "nullable": true,
                                                 "type": "string"
@@ -281590,6 +282082,10 @@
                                                 "type": "string"
                                               },
                                               "history_limit": {
+                                                "nullable": true,
+                                                "type": "integer"
+                                              },
+                                              "nav_stack_limit": {
                                                 "nullable": true,
                                                 "type": "integer"
                                               },
@@ -281947,6 +282443,10 @@
                                   ],
                                   "type": "object"
                                 },
+                                "closed_entry_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
                                 "desktop_transition": {
                                   "nullable": true,
                                   "type": "string"
@@ -282005,6 +282505,10 @@
                                   "type": "string"
                                 },
                                 "history_limit": {
+                                  "nullable": true,
+                                  "type": "integer"
+                                },
+                                "nav_stack_limit": {
                                   "nullable": true,
                                   "type": "integer"
                                 },
@@ -282370,6 +282874,18 @@
                                   "type": "array"
                                 },
                                 "node_ids": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "stack_grouped": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "stack_ungrouped": {
                                   "items": {
                                     "type": "string"
                                   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,13 @@
         "vite": "^8.2.0",
         "vitest": "^4.1.10"
     },
+    "overrides": {
+        "@assistant-ui/core": "0.3.0",
+        "@assistant-ui/react": "0.15.0",
+        "@assistant-ui/react-ai-sdk": "1.4.1",
+        "@assistant-ui/store": "0.3.0",
+        "lucide-react": "^1.28.0"
+    },
     "lint-staged": {
         "*.go": "sh -c 'make fmt'",
         "*.{css,html,json,jsonc,yaml,yml,md}": [

--- a/packages/ui/src/components/context-menu.tsx
+++ b/packages/ui/src/components/context-menu.tsx
@@ -1,0 +1,243 @@
+import * as React from "react";
+import { ContextMenu as ContextMenuPrimitive } from "@base-ui/react/context-menu";
+
+import { cn } from "@compozy/ui/lib/utils";
+import { ChevronRightIcon, CheckIcon } from "lucide-react";
+
+function ContextMenu({ ...props }: ContextMenuPrimitive.Root.Props) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />;
+}
+
+function ContextMenuPortal({ ...props }: ContextMenuPrimitive.Portal.Props) {
+  return <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />;
+}
+
+function ContextMenuTrigger({ className, ...props }: ContextMenuPrimitive.Trigger.Props) {
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      className={cn("select-none", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuContent({
+  className,
+  align = "start",
+  alignOffset = 4,
+  side = "right",
+  sideOffset = 0,
+  ...props
+}: ContextMenuPrimitive.Popup.Props &
+  Pick<ContextMenuPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <ContextMenuPrimitive.Popup
+          data-slot="context-menu-content"
+          className={cn(
+            "z-50 max-h-(--available-height) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </ContextMenuPrimitive.Positioner>
+    </ContextMenuPrimitive.Portal>
+  );
+}
+
+function ContextMenuGroup({ ...props }: ContextMenuPrimitive.Group.Props) {
+  return <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />;
+}
+
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: ContextMenuPrimitive.GroupLabel.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.GroupLabel
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: ContextMenuPrimitive.Item.Props & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <ContextMenuPrimitive.Item
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/context-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuSub({ ...props }: ContextMenuPrimitive.SubmenuRoot.Props) {
+  return <ContextMenuPrimitive.SubmenuRoot data-slot="context-menu-sub" {...props} />;
+}
+
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: ContextMenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.SubmenuTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </ContextMenuPrimitive.SubmenuTrigger>
+  );
+}
+
+function ContextMenuSubContent({ ...props }: React.ComponentProps<typeof ContextMenuContent>) {
+  return (
+    <ContextMenuContent
+      data-slot="context-menu-sub-content"
+      className="shadow-lg"
+      side="right"
+      {...props}
+    />
+  );
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: ContextMenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.CheckboxItem
+      data-slot="context-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon />
+        </ContextMenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.CheckboxItem>
+  );
+}
+
+function ContextMenuRadioGroup({ ...props }: ContextMenuPrimitive.RadioGroup.Props) {
+  return <ContextMenuPrimitive.RadioGroup data-slot="context-menu-radio-group" {...props} />;
+}
+
+function ContextMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: ContextMenuPrimitive.RadioItem.Props & {
+  inset?: boolean;
+}) {
+  return (
+    <ContextMenuPrimitive.RadioItem
+      data-slot="context-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.RadioItemIndicator>
+          <CheckIcon />
+        </ContextMenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </ContextMenuPrimitive.RadioItem>
+  );
+}
+
+function ContextMenuSeparator({ className, ...props }: ContextMenuPrimitive.Separator.Props) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function ContextMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+};

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -6362,6 +6362,8 @@ export interface components {
           desktop_ids?: string[];
           group_ids?: string[];
           node_ids?: string[];
+          stack_grouped?: string[];
+          stack_ungrouped?: string[];
           window_ids?: string[];
         };
         /** @enum {string} */
@@ -6441,6 +6443,7 @@ export interface components {
           bottom_center: string;
           top_center: string;
         } | null;
+        closed_entry_limit?: number | null;
         desktop_transition?: string | null;
         drag_away_policy?: string | null;
         focus_follows_pointer?: boolean | null;
@@ -6460,6 +6463,7 @@ export interface components {
         } | null;
         group_move_modifier?: string | null;
         history_limit?: number | null;
+        nav_stack_limit?: number | null;
         new_window_policy?: string | null;
         raise_on_focus?: boolean | null;
         shortcuts?: {
@@ -6625,6 +6629,7 @@ export interface components {
             bottom_center: string;
             top_center: string;
           } | null;
+          closed_entry_limit?: number | null;
           desktop_transition?: string | null;
           drag_away_policy?: string | null;
           focus_follows_pointer?: boolean | null;
@@ -6644,6 +6649,7 @@ export interface components {
           } | null;
           group_move_modifier?: string | null;
           history_limit?: number | null;
+          nav_stack_limit?: number | null;
           new_window_policy?: string | null;
           raise_on_focus?: boolean | null;
           shortcuts?: {
@@ -6771,6 +6777,7 @@ export interface components {
             bottom_center: string;
             top_center: string;
           } | null;
+          closed_entry_limit?: number | null;
           desktop_transition?: string | null;
           drag_away_policy?: string | null;
           focus_follows_pointer?: boolean | null;
@@ -6790,6 +6797,7 @@ export interface components {
           } | null;
           group_move_modifier?: string | null;
           history_limit?: number | null;
+          nav_stack_limit?: number | null;
           new_window_policy?: string | null;
           raise_on_focus?: boolean | null;
           shortcuts?: {
@@ -6943,6 +6951,8 @@ export interface components {
         desktop_ids?: string[];
         group_ids?: string[];
         node_ids?: string[];
+        stack_grouped?: string[];
+        stack_ungrouped?: string[];
         window_ids?: string[];
       };
       client?: {
@@ -7041,6 +7051,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -7060,6 +7071,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -7180,6 +7192,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -7199,6 +7212,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -7349,6 +7363,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -7368,6 +7383,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -7488,6 +7504,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -7507,6 +7524,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -7618,6 +7636,7 @@ export interface components {
             bottom_center: string;
             top_center: string;
           } | null;
+          closed_entry_limit?: number | null;
           desktop_transition?: string | null;
           drag_away_policy?: string | null;
           focus_follows_pointer?: boolean | null;
@@ -7637,6 +7656,7 @@ export interface components {
           } | null;
           group_move_modifier?: string | null;
           history_limit?: number | null;
+          nav_stack_limit?: number | null;
           new_window_policy?: string | null;
           raise_on_focus?: boolean | null;
           shortcuts?: {
@@ -7769,6 +7789,7 @@ export interface components {
             bottom_center: string;
             top_center: string;
           } | null;
+          closed_entry_limit?: number | null;
           desktop_transition?: string | null;
           drag_away_policy?: string | null;
           focus_follows_pointer?: boolean | null;
@@ -7788,6 +7809,7 @@ export interface components {
           } | null;
           group_move_modifier?: string | null;
           history_limit?: number | null;
+          nav_stack_limit?: number | null;
           new_window_policy?: string | null;
           raise_on_focus?: boolean | null;
           shortcuts?: {
@@ -7884,6 +7906,8 @@ export interface components {
         desktop_ids?: string[];
         group_ids?: string[];
         node_ids?: string[];
+        stack_grouped?: string[];
+        stack_ungrouped?: string[];
         window_ids?: string[];
       };
       client?: {
@@ -7983,6 +8007,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -8002,6 +8027,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -8122,6 +8148,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -8141,6 +8168,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -8291,6 +8319,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -8310,6 +8339,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -8430,6 +8460,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -8449,6 +8480,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -8560,6 +8592,7 @@ export interface components {
             bottom_center: string;
             top_center: string;
           } | null;
+          closed_entry_limit?: number | null;
           desktop_transition?: string | null;
           drag_away_policy?: string | null;
           focus_follows_pointer?: boolean | null;
@@ -8579,6 +8612,7 @@ export interface components {
           } | null;
           group_move_modifier?: string | null;
           history_limit?: number | null;
+          nav_stack_limit?: number | null;
           new_window_policy?: string | null;
           raise_on_focus?: boolean | null;
           shortcuts?: {
@@ -8746,6 +8780,7 @@ export interface components {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -8765,6 +8800,7 @@ export interface components {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -8885,6 +8921,7 @@ export interface components {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -8904,6 +8941,7 @@ export interface components {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -9054,6 +9092,7 @@ export interface components {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -9073,6 +9112,7 @@ export interface components {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -9193,6 +9233,7 @@ export interface components {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -9212,6 +9253,7 @@ export interface components {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -9323,6 +9365,7 @@ export interface components {
           bottom_center: string;
           top_center: string;
         } | null;
+        closed_entry_limit?: number | null;
         desktop_transition?: string | null;
         drag_away_policy?: string | null;
         focus_follows_pointer?: boolean | null;
@@ -9342,6 +9385,7 @@ export interface components {
         } | null;
         group_move_modifier?: string | null;
         history_limit?: number | null;
+        nav_stack_limit?: number | null;
         new_window_policy?: string | null;
         raise_on_focus?: boolean | null;
         shortcuts?: {
@@ -9520,6 +9564,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -9539,6 +9584,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -9659,6 +9705,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -9678,6 +9725,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -9828,6 +9876,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -9847,6 +9896,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -9967,6 +10017,7 @@ export interface components {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -9986,6 +10037,7 @@ export interface components {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -10097,6 +10149,7 @@ export interface components {
             bottom_center: string;
             top_center: string;
           } | null;
+          closed_entry_limit?: number | null;
           desktop_transition?: string | null;
           drag_away_policy?: string | null;
           focus_follows_pointer?: boolean | null;
@@ -10116,6 +10169,7 @@ export interface components {
           } | null;
           group_move_modifier?: string | null;
           history_limit?: number | null;
+          nav_stack_limit?: number | null;
           new_window_policy?: string | null;
           raise_on_focus?: boolean | null;
           shortcuts?: {
@@ -55860,6 +55914,7 @@ export interface operations {
                 /** @enum {string} */
                 top_center: "none" | "reserved" | "zoom";
               };
+              closed_entry_limit: number;
               /** @enum {string} */
               desktop_transition: "slide" | "crossfade" | "instant";
               /** @enum {string} */
@@ -55878,6 +55933,7 @@ export interface operations {
               /** @enum {string} */
               group_move_modifier: "alt" | "control" | "meta" | "shift" | "none";
               history_limit: number;
+              nav_stack_limit: number;
               /** @enum {string} */
               new_window_policy: "floating" | "beside_focus";
               raise_on_focus: boolean;
@@ -55956,6 +56012,7 @@ export interface operations {
               /** @enum {string} */
               top_center: "none" | "reserved" | "zoom";
             };
+            closed_entry_limit: number;
             /** @enum {string} */
             desktop_transition: "slide" | "crossfade" | "instant";
             /** @enum {string} */
@@ -55974,6 +56031,7 @@ export interface operations {
             /** @enum {string} */
             group_move_modifier: "alt" | "control" | "meta" | "shift" | "none";
             history_limit: number;
+            nav_stack_limit: number;
             /** @enum {string} */
             new_window_policy: "floating" | "beside_focus";
             raise_on_focus: boolean;
@@ -104120,6 +104178,7 @@ export interface operations {
                       bottom_center: string;
                       top_center: string;
                     } | null;
+                    closed_entry_limit?: number | null;
                     desktop_transition?: string | null;
                     drag_away_policy?: string | null;
                     focus_follows_pointer?: boolean | null;
@@ -104139,6 +104198,7 @@ export interface operations {
                     } | null;
                     group_move_modifier?: string | null;
                     history_limit?: number | null;
+                    nav_stack_limit?: number | null;
                     new_window_policy?: string | null;
                     raise_on_focus?: boolean | null;
                     shortcuts?: {
@@ -104259,6 +104319,7 @@ export interface operations {
                       bottom_center: string;
                       top_center: string;
                     } | null;
+                    closed_entry_limit?: number | null;
                     desktop_transition?: string | null;
                     drag_away_policy?: string | null;
                     focus_follows_pointer?: boolean | null;
@@ -104278,6 +104339,7 @@ export interface operations {
                     } | null;
                     group_move_modifier?: string | null;
                     history_limit?: number | null;
+                    nav_stack_limit?: number | null;
                     new_window_policy?: string | null;
                     raise_on_focus?: boolean | null;
                     shortcuts?: {
@@ -104428,6 +104490,7 @@ export interface operations {
                       bottom_center: string;
                       top_center: string;
                     } | null;
+                    closed_entry_limit?: number | null;
                     desktop_transition?: string | null;
                     drag_away_policy?: string | null;
                     focus_follows_pointer?: boolean | null;
@@ -104447,6 +104510,7 @@ export interface operations {
                     } | null;
                     group_move_modifier?: string | null;
                     history_limit?: number | null;
+                    nav_stack_limit?: number | null;
                     new_window_policy?: string | null;
                     raise_on_focus?: boolean | null;
                     shortcuts?: {
@@ -104567,6 +104631,7 @@ export interface operations {
                       bottom_center: string;
                       top_center: string;
                     } | null;
+                    closed_entry_limit?: number | null;
                     desktop_transition?: string | null;
                     drag_away_policy?: string | null;
                     focus_follows_pointer?: boolean | null;
@@ -104586,6 +104651,7 @@ export interface operations {
                     } | null;
                     group_move_modifier?: string | null;
                     history_limit?: number | null;
+                    nav_stack_limit?: number | null;
                     new_window_policy?: string | null;
                     raise_on_focus?: boolean | null;
                     shortcuts?: {
@@ -104697,6 +104763,7 @@ export interface operations {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -104716,6 +104783,7 @@ export interface operations {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -105428,6 +105496,8 @@ export interface operations {
               desktop_ids?: string[];
               group_ids?: string[];
               node_ids?: string[];
+              stack_grouped?: string[];
+              stack_ungrouped?: string[];
               window_ids?: string[];
             };
             client?: {
@@ -105527,6 +105597,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -105546,6 +105617,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -105666,6 +105738,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -105685,6 +105758,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -105835,6 +105909,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -105854,6 +105929,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -105974,6 +106050,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -105993,6 +106070,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -106104,6 +106182,7 @@ export interface operations {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -106123,6 +106202,7 @@ export interface operations {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -106423,6 +106503,7 @@ export interface operations {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -106442,6 +106523,7 @@ export interface operations {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -106663,6 +106745,7 @@ export interface operations {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -106682,6 +106765,7 @@ export interface operations {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -106784,6 +106868,8 @@ export interface operations {
               desktop_ids?: string[];
               group_ids?: string[];
               node_ids?: string[];
+              stack_grouped?: string[];
+              stack_ungrouped?: string[];
               window_ids?: string[];
             };
             client?: {
@@ -106883,6 +106969,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -106902,6 +106989,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -107022,6 +107110,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -107041,6 +107130,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -107191,6 +107281,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -107210,6 +107301,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -107330,6 +107422,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -107349,6 +107442,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -107460,6 +107554,7 @@ export interface operations {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -107479,6 +107574,7 @@ export interface operations {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -108638,6 +108734,7 @@ export interface operations {
                 bottom_center: string;
                 top_center: string;
               } | null;
+              closed_entry_limit?: number | null;
               desktop_transition?: string | null;
               drag_away_policy?: string | null;
               focus_follows_pointer?: boolean | null;
@@ -108657,6 +108754,7 @@ export interface operations {
               } | null;
               group_move_modifier?: string | null;
               history_limit?: number | null;
+              nav_stack_limit?: number | null;
               new_window_policy?: string | null;
               raise_on_focus?: boolean | null;
               shortcuts?: {
@@ -108983,6 +109081,8 @@ export interface operations {
               desktop_ids?: string[];
               group_ids?: string[];
               node_ids?: string[];
+              stack_grouped?: string[];
+              stack_ungrouped?: string[];
               window_ids?: string[];
             };
             client?: {
@@ -109081,6 +109181,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -109100,6 +109201,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -109220,6 +109322,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -109239,6 +109342,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -109389,6 +109493,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -109408,6 +109513,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -109528,6 +109634,7 @@ export interface operations {
                         bottom_center: string;
                         top_center: string;
                       } | null;
+                      closed_entry_limit?: number | null;
                       desktop_transition?: string | null;
                       drag_away_policy?: string | null;
                       focus_follows_pointer?: boolean | null;
@@ -109547,6 +109654,7 @@ export interface operations {
                       } | null;
                       group_move_modifier?: string | null;
                       history_limit?: number | null;
+                      nav_stack_limit?: number | null;
                       new_window_policy?: string | null;
                       raise_on_focus?: boolean | null;
                       shortcuts?: {
@@ -109658,6 +109766,7 @@ export interface operations {
                   bottom_center: string;
                   top_center: string;
                 } | null;
+                closed_entry_limit?: number | null;
                 desktop_transition?: string | null;
                 drag_away_policy?: string | null;
                 focus_follows_pointer?: boolean | null;
@@ -109677,6 +109786,7 @@ export interface operations {
                 } | null;
                 group_move_modifier?: string | null;
                 history_limit?: number | null;
+                nav_stack_limit?: number | null;
                 new_window_policy?: string | null;
                 raise_on_focus?: boolean | null;
                 shortcuts?: {
@@ -110036,6 +110146,7 @@ export interface operations {
                             bottom_center: string;
                             top_center: string;
                           } | null;
+                          closed_entry_limit?: number | null;
                           desktop_transition?: string | null;
                           drag_away_policy?: string | null;
                           focus_follows_pointer?: boolean | null;
@@ -110055,6 +110166,7 @@ export interface operations {
                           } | null;
                           group_move_modifier?: string | null;
                           history_limit?: number | null;
+                          nav_stack_limit?: number | null;
                           new_window_policy?: string | null;
                           raise_on_focus?: boolean | null;
                           shortcuts?: {
@@ -110175,6 +110287,7 @@ export interface operations {
                             bottom_center: string;
                             top_center: string;
                           } | null;
+                          closed_entry_limit?: number | null;
                           desktop_transition?: string | null;
                           drag_away_policy?: string | null;
                           focus_follows_pointer?: boolean | null;
@@ -110194,6 +110307,7 @@ export interface operations {
                           } | null;
                           group_move_modifier?: string | null;
                           history_limit?: number | null;
+                          nav_stack_limit?: number | null;
                           new_window_policy?: string | null;
                           raise_on_focus?: boolean | null;
                           shortcuts?: {
@@ -110344,6 +110458,7 @@ export interface operations {
                             bottom_center: string;
                             top_center: string;
                           } | null;
+                          closed_entry_limit?: number | null;
                           desktop_transition?: string | null;
                           drag_away_policy?: string | null;
                           focus_follows_pointer?: boolean | null;
@@ -110363,6 +110478,7 @@ export interface operations {
                           } | null;
                           group_move_modifier?: string | null;
                           history_limit?: number | null;
+                          nav_stack_limit?: number | null;
                           new_window_policy?: string | null;
                           raise_on_focus?: boolean | null;
                           shortcuts?: {
@@ -110483,6 +110599,7 @@ export interface operations {
                             bottom_center: string;
                             top_center: string;
                           } | null;
+                          closed_entry_limit?: number | null;
                           desktop_transition?: string | null;
                           drag_away_policy?: string | null;
                           focus_follows_pointer?: boolean | null;
@@ -110502,6 +110619,7 @@ export interface operations {
                           } | null;
                           group_move_modifier?: string | null;
                           history_limit?: number | null;
+                          nav_stack_limit?: number | null;
                           new_window_policy?: string | null;
                           raise_on_focus?: boolean | null;
                           shortcuts?: {
@@ -110613,6 +110731,7 @@ export interface operations {
                       bottom_center: string;
                       top_center: string;
                     } | null;
+                    closed_entry_limit?: number | null;
                     desktop_transition?: string | null;
                     drag_away_policy?: string | null;
                     focus_follows_pointer?: boolean | null;
@@ -110632,6 +110751,7 @@ export interface operations {
                     } | null;
                     group_move_modifier?: string | null;
                     history_limit?: number | null;
+                    nav_stack_limit?: number | null;
                     new_window_policy?: string | null;
                     raise_on_focus?: boolean | null;
                     shortcuts?: {
@@ -110732,6 +110852,8 @@ export interface operations {
                     desktop_ids?: string[];
                     group_ids?: string[];
                     node_ids?: string[];
+                    stack_grouped?: string[];
+                    stack_ungrouped?: string[];
                     window_ids?: string[];
                   };
                   /** @enum {string} */

--- a/web/src/systems/settings/mocks/window-manager-fixtures.ts
+++ b/web/src/systems/settings/mocks/window-manager-fixtures.ts
@@ -52,6 +52,8 @@ export const settingsWindowManagerSectionFixture: SettingsWindowManagerSection =
     group_move_modifier: "alt",
     swap_modifier: "shift",
     history_limit: 100,
+    nav_stack_limit: 50,
+    closed_entry_limit: 20,
     desktop_transition: "slide",
     gaps: { inner: 8, top: 8, right: 10, bottom: 8, left: 10 },
     snap: {


### PR DESCRIPTION
Checkpoint via cy-loop-tasks (iteration 2, phase B mode=tasks).

Implements the Window Manager v3 domain foundation, tab and stack reducers, bounded navigation and closed-entry state, settings contract persistence, generated types, and race-tested repository/coalescer behavior. Full gate fingerprint 99d7040882996e5be214f2376e834576ea023e4d passed.

Co-Authored-By: Codex <noreply@openai.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added window tab grouping, reordering, pinning, and active-tab controls.
  - Added scoped tab closing and reopening with preserved navigation and layout state.
  - Added push, replace, and pop navigation modes with configurable history limits.
  - Added configurable navigation-stack and closed-entry limits, including validation.
  - Added a reusable context-menu component suite for consistent menu interactions.

- **Bug Fixes**
  - Improved recovery from incompatible saved window layouts.
  - Improved client active-tab tracking and synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->