### PR TITLE
fix(loop): hydrate externalized node outputs before namespace construction

### DIFF
--- a/internal/loop/coordinator.go
+++ b/internal/loop/coordinator.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -45,6 +46,9 @@ type GenerationOutputReader interface {
 		runID RunID,
 		generation int,
 	) ([]GenerationOutput, error)
+	// GetGenerationOutputPayload resolves one content-addressed output ref into the payload
+	// the producing node returned.
+	GetGenerationOutputPayload(ctx context.Context, outputRef string) (json.RawMessage, error)
 }
 
 // GateDecisionReader reads persisted human decisions for coordinator gate re-evaluation.
@@ -196,6 +200,9 @@ func (r *CoordinatorRunner) buildCoordinatorPlan(
 	if run.Generation > 0 {
 		outputs, err := r.outputs.ListGenerationOutputs(ctx, run.WorkspaceID, run.ID, run.Generation)
 		if err != nil {
+			return task.CoordinatorCompletionPlan{}, err
+		}
+		if err := hydrateGenerationOutputs(ctx, r.outputs, outputs); err != nil {
 			return task.CoordinatorCompletionPlan{}, err
 		}
 		if len(outputs) > 0 {

--- a/internal/loop/coordinator_action.go
+++ b/internal/loop/coordinator_action.go
@@ -67,6 +67,9 @@ func (r *CoordinatorRunner) ExecuteActionRun(
 	if err != nil {
 		return task.RunResult{}, err
 	}
+	if err := hydrateGenerationOutputs(ctx, r.outputs, outputs); err != nil {
+		return task.RunResult{}, err
+	}
 	input, err := actionExecutionInput(
 		taskRun,
 		actor,

--- a/internal/loop/coordinator_test.go
+++ b/internal/loop/coordinator_test.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -2433,7 +2434,8 @@ func (r *coordinatorRunnerTaskRunReader) GetTaskRun(
 }
 
 type coordinatorRunnerOutputs struct {
-	outputs map[int][]GenerationOutput
+	outputs  map[int][]GenerationOutput
+	payloads map[string]json.RawMessage
 }
 
 func (r coordinatorRunnerOutputs) ListGenerationOutputs(
@@ -2446,6 +2448,17 @@ func (r coordinatorRunnerOutputs) ListGenerationOutputs(
 		return nil, nil
 	}
 	return append([]GenerationOutput(nil), r.outputs[generation]...), nil
+}
+
+func (r coordinatorRunnerOutputs) GetGenerationOutputPayload(
+	_ context.Context,
+	outputRef string,
+) (json.RawMessage, error) {
+	payload, ok := r.payloads[outputRef]
+	if !ok {
+		return nil, ErrOutputRefNotFound
+	}
+	return payload, nil
 }
 
 type coordinatorRunnerLoopStore struct {

--- a/internal/loop/generation_output_hydration.go
+++ b/internal/loop/generation_output_hydration.go
@@ -1,0 +1,47 @@
+package loop
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// hydrateGenerationOutputs replaces content-addressed output refs with the payloads they
+// stand for, in place.
+//
+// Outputs at or below LoopOutputInlineLimitBytes are persisted inline, so OutputRef already
+// carries the value; larger ones are externalized to the output blob store and OutputRef
+// carries a "sha256:…" ref instead. Everything downstream — runtimeNamespace, fan-out
+// materialization, gate criteria, action params — reads OutputRef as the value, so an
+// unresolved ref silently degrades a node's output to a hash string. Resolving refs here
+// keeps externalization a storage detail rather than something every consumer must know
+// about.
+func hydrateGenerationOutputs(
+	ctx context.Context,
+	reader GenerationOutputReader,
+	outputs []GenerationOutput,
+) error {
+	if reader == nil {
+		return nil
+	}
+	// One blob can back several outputs (a fan-out branch reusing its producer's payload,
+	// a reattempted generation), so resolve each ref once.
+	resolved := make(map[string]string)
+	for idx := range outputs {
+		ref := strings.TrimSpace(outputs[idx].OutputRef)
+		if !OutputRefLooksContentAddressed(ref) {
+			continue
+		}
+		payload, seen := resolved[ref]
+		if !seen {
+			raw, err := reader.GetGenerationOutputPayload(ctx, ref)
+			if err != nil {
+				return fmt.Errorf("loop: hydrate generation output %q: %w", ref, err)
+			}
+			payload = string(raw)
+			resolved[ref] = payload
+		}
+		outputs[idx].OutputRef = payload
+	}
+	return nil
+}

--- a/internal/loop/generation_output_hydration_test.go
+++ b/internal/loop/generation_output_hydration_test.go
@@ -1,0 +1,160 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type stubOutputPayloadReader struct {
+	payloads map[string]json.RawMessage
+	calls    map[string]int
+}
+
+func (r *stubOutputPayloadReader) ListGenerationOutputs(
+	_ context.Context,
+	_ WorkspaceID,
+	_ RunID,
+	_ int,
+) ([]GenerationOutput, error) {
+	return nil, nil
+}
+
+func (r *stubOutputPayloadReader) GetGenerationOutputPayload(
+	_ context.Context,
+	outputRef string,
+) (json.RawMessage, error) {
+	if r.calls == nil {
+		r.calls = map[string]int{}
+	}
+	r.calls[outputRef]++
+	payload, ok := r.payloads[outputRef]
+	if !ok {
+		return nil, ErrOutputRefNotFound
+	}
+	return payload, nil
+}
+
+func TestHydrateGenerationOutputsShouldResolveExternalizedPayloads(t *testing.T) {
+	t.Parallel()
+
+	// A node output above LoopOutputInlineLimitBytes is stored as a content-addressed ref.
+	// Left unresolved, every template reading that node sees the hash instead of the value.
+	largeRef := OutputRefForPayload(json.RawMessage(`{"tasks":[{"id":"task_02"}]}`))
+
+	t.Run("Should replace content-addressed refs with their payload", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &stubOutputPayloadReader{payloads: map[string]json.RawMessage{
+			largeRef: json.RawMessage(`{"tasks":[{"id":"task_02"}]}`),
+		}}
+		outputs := []GenerationOutput{{NodeID: "load_tasks", Status: "succeeded", OutputRef: largeRef}}
+
+		if err := hydrateGenerationOutputs(context.Background(), reader, outputs); err != nil {
+			t.Fatalf("hydrateGenerationOutputs() error = %v", err)
+		}
+		if got, want := outputs[0].OutputRef, `{"tasks":[{"id":"task_02"}]}`; got != want {
+			t.Fatalf("output ref = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Should leave inline outputs untouched", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &stubOutputPayloadReader{}
+		outputs := []GenerationOutput{
+			{NodeID: "slug_input", Status: "succeeded", OutputRef: `"marketplace-ops-board"`},
+			{NodeID: "pending", Status: "pending"},
+		}
+
+		if err := hydrateGenerationOutputs(context.Background(), reader, outputs); err != nil {
+			t.Fatalf("hydrateGenerationOutputs() error = %v", err)
+		}
+		if got, want := outputs[0].OutputRef, `"marketplace-ops-board"`; got != want {
+			t.Fatalf("inline ref = %q, want %q", got, want)
+		}
+		if got := len(reader.calls); got != 0 {
+			t.Fatalf("payload lookups = %d, want 0", got)
+		}
+	})
+
+	t.Run("Should resolve each ref once when outputs share a payload", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &stubOutputPayloadReader{payloads: map[string]json.RawMessage{
+			largeRef: json.RawMessage(`{"tasks":[]}`),
+		}}
+		outputs := []GenerationOutput{
+			{NodeID: "load_tasks", ItemIndex: 0, OutputRef: largeRef},
+			{NodeID: "load_tasks", ItemIndex: 1, OutputRef: largeRef},
+		}
+
+		if err := hydrateGenerationOutputs(context.Background(), reader, outputs); err != nil {
+			t.Fatalf("hydrateGenerationOutputs() error = %v", err)
+		}
+		if got, want := reader.calls[largeRef], 1; got != want {
+			t.Fatalf("payload lookups = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("Should surface a missing payload instead of degrading to the ref", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &stubOutputPayloadReader{}
+		outputs := []GenerationOutput{{NodeID: "load_tasks", OutputRef: largeRef}}
+
+		err := hydrateGenerationOutputs(context.Background(), reader, outputs)
+		if !errors.Is(err, ErrOutputRefNotFound) {
+			t.Fatalf("hydrateGenerationOutputs() error = %v, want %v", err, ErrOutputRefNotFound)
+		}
+	})
+}
+
+func TestHydratedOutputsShouldResolveFanOutCollections(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the reported failure: before hydration the fan-out collection reference
+	// resolved against the literal "sha256:…" string and the coordinator aborted the run.
+	payload := json.RawMessage(`{"tasks":[{"id":"task_02"},{"id":"task_04"}]}`)
+	ref := OutputRefForPayload(payload)
+	reader := &stubOutputPayloadReader{payloads: map[string]json.RawMessage{ref: payload}}
+	outputs := []GenerationOutput{{NodeID: "load_tasks", Status: "succeeded", OutputRef: ref}}
+
+	t.Run("Should expose node output fields after hydration", func(t *testing.T) {
+		t.Parallel()
+
+		if _, ok := valueAtPath(namespaceForOutputs(outputs), []string{
+			"nodes", "load_tasks", "output", "tasks",
+		}); ok {
+			t.Fatal("collection resolved before hydration, want unavailable")
+		}
+		if err := hydrateGenerationOutputs(context.Background(), reader, outputs); err != nil {
+			t.Fatalf("hydrateGenerationOutputs() error = %v", err)
+		}
+		value, ok := valueAtPath(namespaceForOutputs(outputs), []string{
+			"nodes", "load_tasks", "output", "tasks",
+		})
+		if !ok {
+			t.Fatal("collection reference unavailable after hydration")
+		}
+		items, err := collectionItems(value)
+		if err != nil {
+			t.Fatalf("collectionItems() error = %v", err)
+		}
+		if got, want := len(items), 2; got != want {
+			t.Fatalf("items len = %d, want %d", got, want)
+		}
+	})
+}
+
+func namespaceForOutputs(outputs []GenerationOutput) map[string]any {
+	nodes := map[string]any{}
+	for _, output := range outputs {
+		nodes[output.NodeID] = map[string]any{
+			"status": output.Status,
+			"output": outputValue(output.OutputRef),
+		}
+	}
+	return map[string]any{"nodes": nodes}
+}

--- a/internal/store/globaldb/global_db_loop_outputs.go
+++ b/internal/store/globaldb/global_db_loop_outputs.go
@@ -172,6 +172,22 @@ func (g *LoopRepo) LookupLoopGenerationOutputStatus(
 	return strings.TrimSpace(status), true, nil
 }
 
+// GetGenerationOutputPayload loads one externalized loop output payload by its
+// content-addressed ref.
+func (g *LoopRepo) GetGenerationOutputPayload(
+	ctx context.Context,
+	outputRef string,
+) (json.RawMessage, error) {
+	if err := g.checkReady(ctx, "get loop generation output payload"); err != nil {
+		return nil, err
+	}
+	outputRef = strings.TrimSpace(outputRef)
+	if !looppkg.OutputRefLooksContentAddressed(outputRef) {
+		return nil, fmt.Errorf("%w: output_ref is invalid: %q", looppkg.ErrValidation, outputRef)
+	}
+	return getLoopOutputByRefWithExecutor(ctx, g.db, outputRef)
+}
+
 func getLoopOutputByRefWithExecutor(
 	ctx context.Context,
 	exec taskSQLExecutor,


### PR DESCRIPTION
Fixes #285.

## Problem

Loop node results larger than `LoopOutputInlineLimitBytes` (16 KB) are externalized to
`loop_output_blobs`, and `GenerationOutput.OutputRef` then holds a `sha256:…` ref rather than the
payload. Nothing read that blob back. `runtimeNamespace` builds each node entry straight from the
ref:

```go
entry["output"] = outputValue(output.OutputRef)
```

`outputValue` tries to parse the ref as JSON, fails, and returns the raw `"sha256:…"` string. Every
template reaching into that node's output then resolves against a hash.

Fan-out is where it fails loudly — `resolveFanOutCollection` cannot walk `.output.tasks` inside a
string, so the run dies with `fan-out collection reference … is unavailable` right after its producer
succeeded. Gate criteria, action params and prompt templates degrade silently through the same path.

This breaks the first-party `dev-cycle` `software-delivery` Loop for realistic inputs: `load_tasks`
inlines each task's full markdown body, so four ordinary task files produced a 41 KB output and the
fan-out driving the whole delivery could not resolve.

## Change

Resolve content-addressed refs into their payloads immediately after the coordinator loads generation
outputs, so externalization stays a storage detail instead of something every consumer must know
about.

The read side already existed and was simply never wired — `getLoopOutputByRefWithExecutor` had no
production caller, and `ErrOutputRefNotFound` was already defined for exactly this. This exposes it
as `LoopRepo.GetGenerationOutputPayload`, adds it to `GenerationOutputReader`, and calls it from
`hydrateGenerationOutputs`.

Two properties worth calling out:

- **Fan-out materializations are covered too.** A materialization carrying large items exceeds the
  limit itself and becomes a blob, which would break `fanOutItem` serving `.item` to the fan-out
  body. Hydrating at the load site fixes the collection and `.item` in one place; fixing only
  `resolveFanOutCollection` would have failed at the next step.
- **The HTTP surface is unchanged.** Hydration is scoped to the two coordinator load sites rather
  than to `LoopRepo.ListGenerationOutputs`, so `GET /loop-runs/:id` keeps returning refs instead of
  inlining full payloads into API responses.

`output_ref` already holds *either* inline JSON *or* a ref depending on size, so replacing a ref with
its payload restores the invariant `outputValue` has always assumed rather than introducing new
semantics.

## Scope

Read-path only. The write path (`OutputPayloadRequiresRef`, `writeGenerationOutputBlob`) and the
16 KB limit itself are untouched — the limit is a reasonable inline cap that was just missing its
matching read.

## Tests

`internal/loop/generation_output_hydration_test.go` covers:

- a content-addressed ref replaced by its payload
- inline outputs passing through with no blob lookup
- one lookup per distinct ref when several outputs share a payload
- a missing blob surfacing `ErrOutputRefNotFound` instead of degrading to the ref
- a regression asserting the fan-out collection reference is unavailable before hydration and
  resolves to its items after

```
go test ./internal/loop/...
ok  github.com/compozy/compozy/internal/loop
ok  github.com/compozy/compozy/internal/loop/dsl
ok  github.com/compozy/compozy/internal/loop/dsl/refs
ok  github.com/compozy/compozy/internal/loop/gate
ok  github.com/compozy/compozy/internal/loop/goal
ok  github.com/compozy/compozy/internal/loop/watch
```

`go vet ./internal/loop/... ./internal/store/globaldb/... ./internal/daemon/...` is clean, as is
`gofmt`.

## Verification against the reported failure

The 16 KB boundary was measured by running `software-delivery` in a throwaway workspace against a
synthetic task file of increasing size and reading back `loop_generation_outputs.output_ref`: outputs
of 2 713 B / 9 789 B / 15 822 B stayed inline and ran, while 18 142 B / 19 302 B became blobs and
failed. Details in #285.

I have not been able to run the full repository suite locally (the sandbox only has the Go packages
checked out), so CI is the real signal for anything outside `internal/loop`.
