### PR TITLE
build: enable CodeRabbit reviews for stacked PRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,9 @@ reviews:
   collapse_walkthrough: false
   sequence_diagrams: true
   profile: "chill"
+  auto_review:
+    base_branches:
+      - "stack/.*"
   path_filters:
     - "!docs/design/**/*"
     - "!**/*.md"


### PR DESCRIPTION
Allow automatic CodeRabbit review when a pull request targets a `stack/*` branch. The default `main` target remains included automatically; the regex only extends review eligibility to native stacked PR layers.