### PR TITLE
fix: preserve Loop template manifests across hydration

### DIFF
--- a/docs/qa/charters/CH-loop-template-snapshot-round-trip.md
+++ b/docs/qa/charters/CH-loop-template-snapshot-round-trip.md
@@ -1,0 +1,25 @@
+# CH-loop-template-snapshot-round-trip: Start a templated parent Loop after preview
+
+```yaml
+charter:
+  id: CH-loop-template-snapshot-round-trip
+  mission: "As Ada, preview and start a parent Loop that passes values into two child Loops, then prove the created Run survives a fresh structured read."
+  mode: scenario-based
+  persona:
+    name: Ada
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-01
+  scenarios: [LP-loop-template-snapshot-round-trip]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Validate and dry-run a parent Loop whose two child Loops omit mode and receive templates from both the parent input and a prior agent output."
+      - "Confirm dry-run creates no Run, then submit the same inputs for real and capture the returned Run id."
+      - "Read that exact Run through a fresh structured surface and confirm the persisted status and definition digest."
+      - "Repeat the dry-run once to confirm the boundary is deterministic."
+    must_avoid:
+      - "Waiting for external agent work to finish; this charter ends when persistence and fresh public readback are proven."
+```

--- a/docs/qa/journeys/J-01-arrive-and-use-run.md
+++ b/docs/qa/journeys/J-01-arrive-and-use-run.md
@@ -57,7 +57,7 @@ journey:
       expected_observable: "6 numeric fields each show per-loop default / daemon ceiling and clamp at ceiling; NO Cost cap (USD) input; canonical defaults render (iteration cap 50, unbounded as ∞)"
     - step: 4
       verb: "Preview optional per-task runtime overrides"
-      expected_observable: "Dry-run reports the ordered effective runtime layers and input origins without creating a run or ACP session"
+      expected_observable: "Dry-run reports the ordered effective runtime layers and input origins, and proves the executed definition can be saved and loaded without creating a run or ACP session"
     - step: 5
       verb: "Run the Loop"
       expected_observable: "loop_run created (201); CLI/JSON/TOON identify the same persisted run and effective-port Web URL; the run page shows applied runtime provenance as read-only truth"
@@ -77,7 +77,7 @@ journey:
     - at_step: 4
       how: "Closes the browser tab while the run is still running."
       resume: "Run continues server-side; user re-finds it via global Runs (runs.html) and resumes observing — state and meters intact."
-  crosses: [catalog-projection, run-form-schema, runtime-resolver, daemon-binder, CLI, HTTP, UDS, native-tools, coordinator/task_runs, SQLite-provenance, generation-history, SSE-stream, web-run-inspect, global-runs-index]
+  crosses: [catalog-projection, run-form-schema, runtime-resolver, executed-definition-snapshot, daemon-binder, CLI, HTTP, UDS, native-tools, coordinator/task_runs, SQLite-provenance, generation-history, SSE-stream, web-run-inspect, global-runs-index]
 
 design_reference:
   screens:

--- a/docs/qa/reports/2026-08-05-issue-313-loop-manifest.md
+++ b/docs/qa/reports/2026-08-05-issue-313-loop-manifest.md
@@ -1,0 +1,70 @@
+# QA Run Report — 2026-08-05 — issue-313-loop-manifest
+
+- **Scope:** Issue #313 — Loop executed-definition template manifest round-trip from preview to persisted Run
+- **Cadence tier:** targeted
+- **Build:** `4cf544a4` + branch working tree · **Environment:** isolated local daemon at `http://127.0.0.1:52702`, CLI over `/var/folders/7x/xg204hnd04b81fczcxvjlhzr0000gn/T/compozyqa-bd990b9f3485/runtime/compozyd.sock`
+- **Started:** 2026-08-05T19:31:59Z · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | Power User | desktop / wifi-fast / en-US | CH-loop-template-snapshot-round-trip |
+
+## Flows in Scope
+
+- `J-01` — preview and start a Loop, then confirm the persisted Run (`../journeys/J-01-arrive-and-use-run.md`)
+- Adjacent canary: `J-02` — dry-run returns a plan with no persisted Run (`../journeys/J-02-dry-run-preview.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-loop-template-snapshot-round-trip | J-01 / LP-loop-template-snapshot-round-trip | Ada | Feature Tour | Pass | | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-loop-template-snapshot-round-trip — Ada
+
+- **Ran:** 2026-08-05T19:36:22Z → 2026-08-05T19:39:35Z (box respected: yes)
+- **Findings:** No issue #313 regression. Both Loop sources were visible, two dry-runs were deterministic and state-free, and the real submission persisted a Run whose executed definition loaded over CLI/UDS and HTTP.
+- **Bugs filed/updated:** None.
+- **Scenarios settled:** LP-loop-template-snapshot-round-trip → pass.
+- **Paper cuts:** None.
+- **Surprises:** The unconfigured provider made the draft node quarantine after submission. This happened after the Run and executed definition were persisted, so it did not affect the charter's true end state.
+- **Suggested next charter:** Exercise the same definition with a live provider only when child execution, rather than the submission boundary, changes.
+
+## What Was Fixed
+
+The issue #313 production fix and automated regression proofs predate this QA walk; no new finding has been fixed inside the session.
+
+## Paper Cuts
+
+None.
+
+## Runtime Errors Observed
+
+The draft agent reported the expected provider-bound action failure in this no-provider targeted lab. The persisted Run remained readable and its executed definition rehydrated through both public read paths.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- Journey and functional coverage use CLI, HTTP, UDS, and runtime persistence. Visual, mobile, and browser compatibility are out of scope because no rendered surface changed.
+- The adjacent canary is the no-state dry-run behavior from J-02.
+- Edge probes covered repeated dry-run and a post-preview real submission. Structured output remained clear and deterministic; accessibility, browser compatibility, and viewport lenses do not apply to this non-visual change.
+
+## Final Status
+
+- **Exit gate (full automated suite):** `make gate-full` evidence is recorded at `/Users/pedronauck/dev/qa-labs/compozy-issue-313-loop-manifest-20260805-193142-599093-lab/qa-artifacts/qa/issue-313/final-make-verify.log`; `make gate-status` confirms the record matches the final tree.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1 changed journey walked; J-02 no-state behavior exercised as the adjacent canary; no skips inside the structured surfaces in scope.
+- **Verdict:** PASS — the public Loop submission boundary and persisted readback passed, and `teardown.json` records `"clean": true` with no surviving processes.

--- a/docs/qa/scenarios/LP-loop-template-snapshot-round-trip.md
+++ b/docs/qa/scenarios/LP-loop-template-snapshot-round-trip.md
@@ -1,0 +1,32 @@
+---
+id: LP-loop-template-snapshot-round-trip
+area: LP
+title: Start a templated parent Loop after dry-run
+persona: Ada
+journey: J-01
+expected: A parent Loop with workspace and marketplace child Loops, templated child inputs, templated agent output references, and omitted child modes validates and dry-runs, then creates a persisted Run whose executed definition reloads through public status reads.
+entry_points: compozy loop validate; compozy loop run --dry-run; compozy loop run; compozy loop status over UDS; POST /api/workspaces/:workspace_id/loops/:name/run over HTTP
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-313-loop-manifest-20260805-193142-599093-lab/qa-artifacts/qa/issue-313/verification.json; /Users/pedronauck/dev/qa-labs/compozy-issue-313-loop-manifest-20260805-193142-599093-lab/qa-artifacts/qa/journey-log.jsonl
+last_report: docs/qa/reports/2026-08-05-issue-313-loop-manifest.md
+overlaps: LP-006; TA-068
+---
+
+QA impact 2026-08-05: added for issue #313. The walk must prove the dry-run leaves the Runs list
+unchanged, the real submission returns a Run id, and a fresh public read finds that same persisted
+Run. It must keep the default `await` child modes and template references intact; a successful
+preview followed by a manifest-integrity failure is a regression.
+
+Taxonomy: the CLI/HTTP/UDS walk owns journey, functional round-trip, error recovery, and structured
+surface consistency. Web responsiveness, mobile, and visual design are deliberate skips because this
+change adds no UI or rendered copy.
+
+QA result 2026-08-05: Ada validated the workspace parent and confirmed that `review-and-fix` came
+from the marketplace while `workspace-child` came from the workspace. Two identical dry-runs left
+the Runs list empty. The real UDS submission created `looprun-4b66e31d8f935186`; fresh CLI/UDS and
+HTTP reads agreed on digest `sha256:73a51e3b67426d74ce8a9749973e038819463c549e62f77a83353f42aa1eaf85`
+and exposed both child nodes with `mode: await` plus the authored input/output templates.

--- a/internal/loop/compiler.go
+++ b/internal/loop/compiler.go
@@ -97,34 +97,35 @@ func (c *Compiler) Compile(def dsl.Definition) (*ResolvedDefinition, error) {
 		return nil, fmt.Errorf("normalize Loop definition participation: %w", err)
 	}
 
-	ctx := newLintContext(def, &DefinitionLinter{tools: c.tools})
+	definition := foldDefinitionDefaults(def)
+	ctx := newLintContext(definition, &DefinitionLinter{tools: c.tools})
 	ctx.indexGraphTrusted()
 
 	resolved := &ResolvedDefinition{
-		Definition:  foldDefinitionDefaults(def),
+		Definition:  definition,
 		Templates:   map[string]*refs.Template{},
 		Conditions:  map[string]*refs.Condition{},
 		ToolSchemas: map[string]ToolSchemaSnapshot{},
 		WatchEventsContracts: referencedWatchEventsContracts(
-			def,
+			definition,
 			SupportedWatchEvents(),
 		),
 		Defaults: ResolvedDefaults{
 			FanOutBatchSize: 1,
 			RunLoopMode:     dsl.RunLoopAwait,
-			Concurrency:     def.Concurrency,
+			Concurrency:     definition.Concurrency,
 		},
 		compiled: true,
 	}
 	resolved.DefinitionVersion = resolved.Definition.Meta.Version
 
-	if err := compileContract(resolved, def, ctx, ctx.namespace(false, false)); err != nil {
+	if err := compileContract(resolved, definition, ctx, ctx.namespace(false, false)); err != nil {
 		return nil, err
 	}
-	if err := compileStarts(resolved, def, ctx); err != nil {
+	if err := compileStarts(resolved, definition, ctx); err != nil {
 		return nil, err
 	}
-	for _, node := range def.Graph.Nodes {
+	for _, node := range definition.Graph.Nodes {
 		namespace := ctx.namespace(ctx.inFanoutScope(node.ID), ctx.hasTriggerStart())
 		if err := compileNode(resolved, node, namespace, ctx); err != nil {
 			return nil, err
@@ -136,7 +137,7 @@ func (c *Compiler) Compile(def dsl.Definition) (*ResolvedDefinition, error) {
 			}
 		}
 	}
-	if err := compileSubLoopBodies(resolved, def, c.tools); err != nil {
+	if err := compileSubLoopBodies(resolved, definition, c.tools); err != nil {
 		return nil, err
 	}
 	return resolved, nil

--- a/internal/loop/coordinator_snapshot_test.go
+++ b/internal/loop/coordinator_snapshot_test.go
@@ -235,6 +235,80 @@ func TestCoordinatorRunnerShouldExecutePinnedDefinitionSnapshot(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Should round trip templated parent and child Loop actions", func(t *testing.T) {
+		t.Parallel()
+
+		definition, err := dsl.Parse([]byte(`apiVersion: compozy.loop/v1
+kind: Loop
+meta:
+  name: parent-loop
+  version: 1
+inputs:
+  slug: { type: string, required: true }
+contract:
+  goal: Deliver the requested change
+  definition_of_done: The child Loops complete
+  iteration_cap: 1
+  no_progress: { window: 1 }
+  budget: { on_exceeded: halt }
+graph:
+  nodes:
+    - id: draft
+      class: action
+      kind: run-agent
+      params:
+        agent: codex
+        prompt: Draft {{ .inputs.slug }}
+        output_schema:
+          summary: string
+    - id: workspace_child
+      class: action
+      kind: run-loop
+      params:
+        loop: workspace-child
+        inputs:
+          slug: "{{ .inputs.slug }}"
+          summary: "{{ .nodes.draft.output.summary }}"
+    - id: marketplace_child
+      class: action
+      kind: run-loop
+      params:
+        loop: review-and-fix
+        inputs:
+          slug: "{{ .inputs.slug }}"
+          summary: "{{ .nodes.draft.output.summary }}"
+  edges:
+    - { from: draft, to: workspace_child }
+    - { from: workspace_child, to: marketplace_child }
+start: [{ kind: manual }]
+`))
+		if err != nil {
+			t.Fatalf("Parse(parent and child Loops) error = %v", err)
+		}
+		resolved, err := NewCompiler().Compile(definition)
+		if err != nil {
+			t.Fatalf("Compile(parent and child Loops) error = %v", err)
+		}
+		raw, digest, err := BuildExecutedDefinitionSnapshot(resolved, snapshotEffectiveConfig())
+		if err != nil {
+			t.Fatalf("BuildExecutedDefinitionSnapshot() error = %v", err)
+		}
+		hydrated, err := LoadExecutedDefinitionSnapshot(raw, digest)
+		if err != nil {
+			t.Fatalf("LoadExecutedDefinitionSnapshot() error = %v", err)
+		}
+		for _, key := range []string{
+			"nodes.workspace_child.params.inputs.slug",
+			"nodes.workspace_child.params.inputs.summary",
+			"nodes.marketplace_child.params.inputs.slug",
+			"nodes.marketplace_child.params.inputs.summary",
+		} {
+			if hydrated.Templates[key] == nil {
+				t.Fatalf("hydrated template %q is nil", key)
+			}
+		}
+	})
 }
 
 func TestExecutedDefinitionSnapshotShouldCanonicalizeTypedNodeParams(t *testing.T) {

--- a/internal/loop/executed_definition_hydrate.go
+++ b/internal/loop/executed_definition_hydrate.go
@@ -45,29 +45,3 @@ func hydrateExecutedDefinitionSnapshot(
 	}
 	return resolved, nil
 }
-
-func resolvedTemplateSources(resolved *ResolvedDefinition) map[string]string {
-	sources := map[string]string{}
-	if resolved == nil {
-		return sources
-	}
-	for key, template := range resolved.Templates {
-		if template != nil {
-			sources[key] = template.Raw
-		}
-	}
-	return sources
-}
-
-func resolvedConditionSources(resolved *ResolvedDefinition) map[string]string {
-	sources := map[string]string{}
-	if resolved == nil {
-		return sources
-	}
-	for key, condition := range resolved.Conditions {
-		if condition != nil {
-			sources[key] = condition.Raw
-		}
-	}
-	return sources
-}

--- a/internal/loop/executed_definition_manifest.go
+++ b/internal/loop/executed_definition_manifest.go
@@ -1,0 +1,83 @@
+package loop
+
+import (
+	"fmt"
+	"slices"
+)
+
+func resolvedTemplateSources(resolved *ResolvedDefinition) map[string]string {
+	sources := map[string]string{}
+	if resolved == nil {
+		return sources
+	}
+	for key, template := range resolved.Templates {
+		if template != nil {
+			sources[key] = template.Raw
+		}
+	}
+	return sources
+}
+
+func resolvedConditionSources(resolved *ResolvedDefinition) map[string]string {
+	sources := map[string]string{}
+	if resolved == nil {
+		return sources
+	}
+	for key, condition := range resolved.Conditions {
+		if condition != nil {
+			sources[key] = condition.Raw
+		}
+	}
+	return sources
+}
+
+func validateExecutedManifestRoundTrip(
+	label string,
+	snapshot map[string]string,
+	hydrated map[string]string,
+) error {
+	keySet := make(map[string]struct{}, len(snapshot)+len(hydrated))
+	for key := range snapshot {
+		keySet[key] = struct{}{}
+	}
+	for key := range hydrated {
+		keySet[key] = struct{}{}
+	}
+	keys := make([]string, 0, len(keySet))
+	for key := range keySet {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	for _, key := range keys {
+		snapshotSource, inSnapshot := snapshot[key]
+		hydratedSource, inHydrated := hydrated[key]
+		switch {
+		case !inSnapshot:
+			return fmt.Errorf(
+				"%w: executed definition %s manifest key %q added during hydration with source %q",
+				ErrValidation,
+				label,
+				key,
+				hydratedSource,
+			)
+		case !inHydrated:
+			return fmt.Errorf(
+				"%w: executed definition %s manifest key %q missing after hydration; snapshot source %q",
+				ErrValidation,
+				label,
+				key,
+				snapshotSource,
+			)
+		case snapshotSource != hydratedSource:
+			return fmt.Errorf(
+				"%w: executed definition %s manifest key %q source changed during hydration from %q to %q",
+				ErrValidation,
+				label,
+				key,
+				snapshotSource,
+				hydratedSource,
+			)
+		}
+	}
+	return nil
+}

--- a/internal/loop/executed_definition_snapshot.go
+++ b/internal/loop/executed_definition_snapshot.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"strings"
 
 	"github.com/compozy/compozy/internal/hooks"
@@ -71,7 +70,12 @@ func BuildExecutedDefinitionSnapshot(
 	if err != nil {
 		return nil, "", err
 	}
-	return json.RawMessage(canonical), executedDefinitionDigest(canonical), nil
+	raw := json.RawMessage(canonical)
+	digest := executedDefinitionDigest(canonical)
+	if _, err := LoadExecutedDefinitionSnapshot(raw, digest); err != nil {
+		return nil, "", fmt.Errorf("loop: validate built executed definition snapshot: %w", err)
+	}
+	return raw, digest, nil
 }
 
 func canonicalExecutedDefinitionSnapshot(data []byte) ([]byte, error) {
@@ -134,11 +138,19 @@ func LoadExecutedDefinitionSnapshot(
 	if err != nil {
 		return nil, err
 	}
-	if !maps.Equal(resolvedTemplateSources(resolved), envelope.TemplateSources) {
-		return nil, fmt.Errorf("%w: executed definition template manifest changed", ErrValidation)
+	if err := validateExecutedManifestRoundTrip(
+		"template",
+		envelope.TemplateSources,
+		resolvedTemplateSources(resolved),
+	); err != nil {
+		return nil, err
 	}
-	if !maps.Equal(resolvedConditionSources(resolved), envelope.ConditionSources) {
-		return nil, fmt.Errorf("%w: executed definition condition manifest changed", ErrValidation)
+	if err := validateExecutedManifestRoundTrip(
+		"condition",
+		envelope.ConditionSources,
+		resolvedConditionSources(resolved),
+	); err != nil {
+		return nil, err
 	}
 	return resolved, nil
 }

--- a/internal/loop/service.go
+++ b/internal/loop/service.go
@@ -123,6 +123,9 @@ func (s *service) DryRun(
 	if err := validateLoopParticipation(resolved.Definition.Graph, networkSpec); err != nil {
 		return nil, err
 	}
+	if _, _, err := BuildExecutedDefinitionSnapshot(resolved, effective); err != nil {
+		return nil, err
+	}
 	return &PlanPreview{
 		LoopName:                     loopName,
 		ResolvedInputs:               resolvedInputs.Values,

--- a/internal/loop/service_integration_test.go
+++ b/internal/loop/service_integration_test.go
@@ -128,6 +128,91 @@ func TestServiceIntegrationDryRunShouldCreateNoState(t *testing.T) {
 	})
 }
 
+func TestServiceIntegrationExecutedDefinitionSnapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should persist and hydrate templated parent and child Loop actions", func(t *testing.T) {
+		t.Parallel()
+
+		definition := validDefinition()
+		definition.Inputs = map[string]dsl.Input{
+			"slug": {Type: dsl.InputTypeString, Required: true},
+		}
+		definition.Contract.NoProgress.HashFields = []string{"nodes.draft.output.summary"}
+		definition.Graph = dsl.Graph{
+			Nodes: []dsl.Node{
+				{
+					ID: "draft", Class: dsl.NodeClassAction, Kind: string(dsl.ActionRunAgent),
+					Params: dsl.NodeParams{
+						"agent": "codex", "prompt": "Draft {{ .inputs.slug }}",
+						"output_schema": map[string]any{"summary": "string"},
+					},
+				},
+				{
+					ID: "workspace_child", Class: dsl.NodeClassAction, Kind: string(dsl.ActionRunLoop),
+					Params: dsl.NodeParams{
+						"loop": "workspace-child",
+						"inputs": map[string]any{
+							"slug": "{{ .inputs.slug }}", "summary": "{{ .nodes.draft.output.summary }}",
+						},
+					},
+				},
+				{
+					ID: "marketplace_child", Class: dsl.NodeClassAction, Kind: string(dsl.ActionRunLoop),
+					Params: dsl.NodeParams{
+						"loop": "review-and-fix",
+						"inputs": map[string]any{
+							"slug": "{{ .inputs.slug }}", "summary": "{{ .nodes.draft.output.summary }}",
+						},
+					},
+				},
+			},
+			Edges: []dsl.Edge{
+				{From: "draft", To: "workspace_child"},
+				{From: "workspace_child", To: "marketplace_child"},
+			},
+		}
+		globalDB := openLoopServiceGlobalDB(t)
+		insertLoopServiceWorkspace(t, globalDB, "ws-1")
+		svc := newIntegrationService(t, globalDB, definition)
+		ctx := testutil.Context(t)
+
+		run, err := svc.Start(ctx, "ws-1", "valid-loop", loop.Inputs{
+			Values: map[string]any{"slug": "issue-313"},
+		}, humanActor(t))
+		if err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		stored, err := globalDB.GetLoopRun(ctx, "ws-1", run.ID)
+		if err != nil {
+			t.Fatalf("GetLoopRun() error = %v", err)
+		}
+		if stored.DefinitionDigest != run.DefinitionDigest || stored.Status != loop.StatusRunning {
+			t.Fatalf("stored Run = %#v, want running with digest %q", stored, run.DefinitionDigest)
+		}
+		snapshot, err := globalDB.GetLoopDefinitionSnapshot(ctx, "ws-1", run.DefinitionDigest)
+		if err != nil {
+			t.Fatalf("GetLoopDefinitionSnapshot() error = %v", err)
+		}
+		hydrated, err := loop.LoadExecutedDefinitionSnapshot(snapshot.Definition, snapshot.Digest)
+		if err != nil {
+			t.Fatalf("LoadExecutedDefinitionSnapshot() error = %v", err)
+		}
+		for _, key := range []string{
+			"nodes.workspace_child.params.inputs.slug",
+			"nodes.workspace_child.params.inputs.summary",
+			"nodes.marketplace_child.params.inputs.slug",
+			"nodes.marketplace_child.params.inputs.summary",
+			"nodes.workspace_child.params.mode",
+			"nodes.marketplace_child.params.mode",
+		} {
+			if hydrated.Templates[key] == nil {
+				t.Fatalf("hydrated template %q is nil", key)
+			}
+		}
+	})
+}
+
 func TestServiceIntegrationParticipationShouldPersistOneSnapshotPerLoopRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/loop/service_test.go
+++ b/internal/loop/service_test.go
@@ -1891,6 +1891,47 @@ func TestServiceDryRunShouldReturnPlanPreviewWithoutState(t *testing.T) {
 			t.Fatalf("CreateLoopRun calls = %d, want 0 after runtime validation", store.createCount())
 		}
 	})
+
+	t.Run("Should reject a definition snapshot that cannot round trip", func(t *testing.T) {
+		t.Parallel()
+
+		resolved := compileDefinition(t, validDefinition())
+		delete(resolved.Templates, "nodes.agent.params.prompt")
+		store := newFakeLoopStore()
+		svc, err := loop.NewService(
+			store,
+			loop.DefinitionResolverFunc(func(
+				context.Context,
+				loop.WorkspaceID,
+				string,
+			) (*loop.ResolvedDefinition, error) {
+				return resolved, nil
+			}),
+			testGoalRunPolicyResolver(0.8),
+			loop.WithClock(func() time.Time {
+				return time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+			}),
+			loop.WithRunIDFactory(func() (loop.RunID, error) {
+				return "looprun-preview", nil
+			}),
+		)
+		if err != nil {
+			t.Fatalf("NewService() error = %v", err)
+		}
+
+		_, err = svc.DryRun(context.Background(), "ws-1", "valid-loop", loop.Inputs{
+			Values: map[string]any{"tasks": "task-ref"},
+		})
+		if !errors.Is(err, loop.ErrValidation) || !strings.Contains(
+			err.Error(),
+			`template manifest key "nodes.agent.params.prompt" added during hydration`,
+		) {
+			t.Fatalf("DryRun() error = %v, want template key diagnostic", err)
+		}
+		if store.createCount() != 0 {
+			t.Fatalf("CreateLoopRun calls = %d, want 0 after snapshot validation", store.createCount())
+		}
+	})
 }
 
 func TestCostShouldBeDisplayOnly(t *testing.T) {

--- a/packages/site/content/docs/loops/authoring.mdx
+++ b/packages/site/content/docs/loops/authoring.mdx
@@ -24,7 +24,9 @@ is wrong before it ever costs anything.
     Resolve inputs and render the first generation's plan **without starting a run**. `compozy loop run
     --name <loop> --dry-run`, `POST /loops/:name/run?dry=true`, or `compozy__loop_run` with `dry: true`.
     It spends no budget, creates no run row, and returns a plan preview — resolved inputs, the
-    generation-1 nodes, the contract, and the effective config.
+    generation-1 nodes, the contract, and the effective config. Before returning the plan, the
+    daemon also checks that the compiled definition can be saved and loaded with the same template
+    and condition manifests. A mismatch names the exact key and source, and still creates no run.
   </WorkflowStep>
   <WorkflowStep title="Publish (compare-and-swap)">
     Persist the definition with `expected_version` set to the version you read in step one.

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -87,7 +87,9 @@ Follow **inspect → validate → dry-run → publish (with `expected_version`) 
    per-node codes (`unknown_reference`, `node_id_invalid`, `verdict_policy_requires_judge`,
    `fan_out_ceiling_exceeded`).
 3. **dry-run** — `compozy__loop_run` with `dry: true` resolves inputs and returns the first generation's
-   plan without creating a run or spending budget.
+   plan without creating a run or spending budget. It also builds and reloads the executed-definition
+   snapshot used by submission; a template or condition manifest mismatch reports the exact key and
+   source before any run is created.
 4. **publish** — `compozy__loop_create` with `expected_version` set to the version from step one (or
    HTTP `PATCH /loops/:name`). This is compare-and-swap: a stale version is rejected `409` with the
    current version. Native: `tool_conflict`/`loop_version_conflict` with


### PR DESCRIPTION
## Context and reproduction

Issue #313 exposed a mismatch between a Loop definition that could validate/dry-run and the executed-definition snapshot used when a real Run was submitted. A valid parent Loop with two `run-loop` children, templated child inputs, references to a prior node output, and omitted child `mode` values compiled successfully. Submission then failed while hydrating the persisted definition with `executed definition template manifest changed`.

The focused regression reproduced the exact drift:

- the snapshot built from the authored definition contained 8 template manifest entries;
- hydration recompiled the persisted, default-folded definition and produced 10 entries;
- the added entries were `nodes.workspace_child.params.mode` and `nodes.marketplace_child.params.mode`, both with source `await`.

This meant a definition accepted before submission could not cross the build → persistence → hydration boundary required to create and retain a Run.

## Proven root cause

`Compiler.Compile` stored `foldDefinitionDefaults(def)` in `ResolvedDefinition.Definition`, but linting and every template/condition compilation phase still consumed the original, unfolded `def`.

The snapshot therefore combined two different representations:

1. the persisted definition already contained default child Loop modes;
2. the template manifest was compiled from the pre-default definition and did not contain those mode keys.

On hydration, the daemon correctly recompiled the persisted definition. The default `await` strings were then discovered as template sources, so the integrity comparison rejected the snapshot. The integrity check was revealing a real compiler inconsistency; it was not the cause and has not been weakened.

## Solution design

- Fold defaults once at the start of compilation and use that single canonical definition for linting, contract/start/node compilation, watch-event contracts, graph metadata, and child Loop compilation.
- Make `BuildExecutedDefinitionSnapshot` validate its own canonical output through the production loader before returning bytes or a digest. A snapshot that cannot round-trip can no longer reach persistence.
- Exercise that same snapshot boundary during dry-run, after Loop participation resolution/validation and before returning a plan. This preserves the existing network-participation diagnostic precedence while ensuring preview cannot approve a definition that submission would reject.
- Replace the generic manifest mismatch with deterministic diagnostics that identify the manifest kind, exact key, and source for added, missing, or changed entries.
- Keep digest verification and manifest equality strict. No fallback, legacy alias, or integrity relaxation was added.

## Changes by surface

### Runtime and persistence

- Canonicalized compiler input in `internal/loop/compiler.go`.
- Added focused manifest comparison helpers in `internal/loop/executed_definition_manifest.go` and kept production files below the 500-line limit.
- Added build-time self-hydration and precise loader diagnostics.
- Added dry-run snapshot validation at the service boundary.
- Persisted Run and definition-snapshot storage formats remain unchanged; no schema migration is required.

### CLI, HTTP, UDS, native tools, and web

- `compozy loop run --dry-run` and `compozy__loop_run` with `dry: true` now exercise the same executed-definition snapshot boundary used by a real run.
- Real submission and fresh Run reads were exercised over CLI/UDS and HTTP.
- No request/response DTO, OpenAPI, CLI flag, UDS method, native-tool descriptor, schema digest, or web component changed. All public paths inherit the corrected service behavior.
- The web client needs no code change because it already uses the same HTTP service and no rendered behavior or copy changed.

### Documentation and agent operation

- Updated the Loop authoring docs to explain dry-run snapshot validation and exact manifest diagnostics.
- Updated the bundled official `compozy` skill so agents know that dry-run proves snapshot save/load before publication or token spend.
- Added and completed the content-addressed QA scenario, charter, journey impact, and dated report.

## Invariants and canonical test ownership

1. **Invariant:** an executed-definition snapshot built from templated parent/child Loops reloads with the identical template manifest, including folded child modes. **Owner:** Loop snapshot/hydration layer. **Canonical suite:** `internal/loop/coordinator_snapshot_test.go`.
2. **Invariant:** dry-run returns a plan only after the exact snapshot used by submission can build and load; failure creates no state and names the offending key. **Owner:** Loop service boundary. **Canonical suite:** `internal/loop/service_test.go`.
3. **Invariant:** Start persists a workspace-scoped Run and snapshot in SQLite, and the stored definition hydrates with parent input, prior-output, workspace-child, marketplace-child, and default-mode templates intact. **Owner:** Loop service + global store integration. **Canonical suite:** `internal/loop/service_integration_test.go`.

Focused evidence:

- `go test -race ./internal/loop -run 'TestCoordinator...|TestServiceDryRun...|TestServiceParticipation...' -count=1` — 8 tests passed.
- `go test -race -tags=integration ./internal/loop -run 'TestServiceIntegrationExecutedDefinitionSnapshot/...' -count=1` — 2 tests passed.
- `make gate-full` — PASS, fingerprint `d57067525fcf8439c110d219821c27aa3ff864fb`; 20,689 Go tests passed with 2 documented skips, plus codegen, installer, source-size, Bun lint/typecheck/test/build, Go format/lint/build, and package boundaries.

## Real-scenario QA and evidence

QA used a fresh isolated runtime with a unique `COMPOZY_HOME`, HTTP port `52702`, UDS path, and extension process envelope.

- Catalog inspection proved the parent and `workspace-child` came from the workspace and `review-and-fix` came from the marketplace.
- Validation returned `valid: true`.
- Two identical dry-runs returned the expected generation plan and left the Runs list empty.
- A real UDS submission created Run `looprun-4b66e31d8f935186` with digest `sha256:73a51e3b67426d74ce8a9749973e038819463c549e62f77a83353f42aa1eaf85`.
- Fresh CLI/UDS and HTTP reads returned that same persisted Run and digest.
- Hydration preserved both child nodes with `mode: await`, parent-input templates, and prior-node-output templates.
- The lab had no provider credentials, so the draft node later quarantined after persistence. That is outside this submission/hydration contract and did not affect the proven end state.
- Strict QA evidence audit: PASS, 0 blockers, 0 warnings.
- Mandatory teardown: `teardown.json` reports `"clean": true`, both registered processes were terminated, and survivors are empty.

Scenario: `docs/qa/scenarios/LP-loop-template-snapshot-round-trip.md`  
Report: `docs/qa/reports/2026-08-05-issue-313-loop-manifest.md`

## Compozy Impact Audit

- **Native tools:** Behavioral impact flows through existing `compozy__loop_run` dry-run/start paths. Checked `compozy__loop_validate`, `compozy__loop_run`, `compozy__loop_runs`, and their CLI/HTTP/UDS fallbacks. No tool IDs, toolsets, descriptors, I/O schemas, schema digests, risk flags, availability diagnostics, or capability gates changed.
- **Extensibility and hooks:** Workspace and marketplace child Loop resolution were exercised together. No extension contracts, hooks, capabilities, tool/resource registries, bridge SDKs, MCP sidecars, or `config.toml` keys/defaults/lifecycle changed; the compiler/service boundary is shared by those sources.
- **Workspace data isolation:** Executed definitions and Runs remain workspace-scoped existing data. Integration and QA used explicit workspace IDs for create, snapshot read, Run read, CLI/UDS, and HTTP paths; no global/session/agent datum or cache/SSE/event contract was introduced, and cross-workspace list/read behavior is unchanged.
- **Official Compozy skill:** Updated `skills/compozy/references/loops.md` to document the dry-run round-trip guarantee and exact key/source diagnostics.

## Compatibility, risks, and decisions

- This is a greenfield consistency fix with no legacy compatibility bridge. Existing inconsistent snapshots remain rejected; the rejection is now earlier and diagnostic rather than deferred until submission/hydration.
- Storage, OpenAPI, CLI, UDS, native-tool, web, and configuration contracts are unchanged.
- Participation validation still precedes snapshot validation, preserving the established `loop_requires_live` error contract.
- The remaining provider failure observed in QA occurs after successful Run persistence and is unrelated to issue #313. Live provider/child execution was deliberately not used as a substitute for the persistence boundary this issue owns.

Fixes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of default values when compiling loop definitions.
  * Preserved templated inputs and modes when saving and restoring loop execution snapshots.
  * Added validation to detect missing, unexpected, or modified template and condition data.
  * Dry runs now reject invalid execution snapshots before creating a run.

* **Reliability**
  * Snapshot generation now verifies that saved artifacts can be successfully reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->