### PR TITLE
fix: preserve ACP stream disconnect recovery

### DIFF
--- a/docs/qa/charters/CH-acp-stream-disconnect-recovery.md
+++ b/docs/qa/charters/CH-acp-stream-disconnect-recovery.md
@@ -1,0 +1,29 @@
+# CH-acp-stream-disconnect-recovery: Keep partial work and recover after an ACP disconnect
+
+```yaml
+charter:
+  id: CH-acp-stream-disconnect-recovery
+  mission: "As Ada, drive one session through a provider-process disconnect and prove every structured surface reports the failure without losing delivered output or replaying the failed prompt."
+  mode: scenario-based
+  persona:
+    name: Ada
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-15
+  scenarios: [RT-acp-stream-disconnect-recovery]
+  tour: Network Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Send a prompt through HTTP to a deterministic ACP subprocess that emits one assistant chunk and then exits; read the terminal stream frame, transcript, session detail, and crash diagnostics."
+      - "Repeat through the UDS-backed CLI in JSONL mode; preserve stdout and confirm the process exits nonzero after printing both the partial chunk and terminal error frame."
+      - "Invoke `compozy__session_prompt` through the native-tool HTTP surface and confirm it returns `tool_backend_failed` with `backend_dead` rather than a successful result."
+      - "Send one different explicit prompt to the same Compozy session and confirm it completes without replaying the failed prompt or duplicating the partial chunk."
+      - "Compare HTTP, UDS, CLI, native-tool, persisted transcript, and runtime diagnostics for the same failure classification."
+    must_avoid:
+      - "Do not automatically retry the failed prompt; its provider-side effects are unknown."
+      - "Do not treat a client-only network disconnect as a provider-process disconnect; J-15 owns that separate reconnect path."
+```
+
+<!-- Immutable charter: write each run's outcome only in that run report. -->

--- a/docs/qa/journeys/J-15-operate-session-via-cli-api.md
+++ b/docs/qa/journeys/J-15-operate-session-via-cli-api.md
@@ -9,6 +9,10 @@ flowchart TD
     E3[Entry: UDS client] --> C
     C --> REST[Read bounded transcript tail + older pages via before_sequence]
     C --> STRM[Subscribe SSE: frames=transcript + after_sequence + epoch + generation]
+    C -->|ACP process disconnects mid-response| PFAIL[Persist delivered chunks + emit terminal error]
+    PFAIL --> DIAG[Read process_exit diagnostics + preserved transcript]
+    DIAG -->|new explicit prompt| RECOVER[Restart provider process without replaying the failed prompt]
+    RECOVER --> C
     STRM -->|no cursor| SNAP[Bounded snapshot, reset=false]
     STRM -->|missing/stale fence or reset cursor| RESET[Reset snapshot + explicit reason]
     STRM -->|empty delta with newer cursor| ADV[Advance safe cursor without adding an entry]
@@ -44,15 +48,18 @@ journey:
       verb: "Subscribe to the stream and read bounded history"
       expected_observable: "Transcript REST returns a bounded tail and older pages via `before_sequence`; transcript SSE reconnects with `after_sequence`, `epoch`, and `generation`, emits bounded deltas for matching fences, emits an explicit reset snapshot for `fence_missing`, `epoch_mismatch`, `generation_mismatch`, or `sequence_reset`, and may advance the cursor with an empty delta; idle streams emit keep-alive comments ≤ heartbeat"
     - step: 3
+      verb: "Handle an ACP process disconnect during a prompt"
+      expected_observable: "Already delivered chunks remain persisted; HTTP and UDS emit a terminal error, CLI JSONL prints the partial frames and exits nonzero, `compozy__session_prompt` returns `tool_backend_failed` with `backend_dead`, session diagnostics classify `process_exit`, and no automatic replay occurs"
+    - step: 4
       verb: "Stop the session and read during finalize"
       expected_observable: "Reads racing the stop return the persisted transcript, never a recorder-unavailable error; recap is byte-identical to the streamed payload"
-    - step: 4
+    - step: 5
       verb: "Compare list, detail, and status across surfaces"
       expected_observable: "State is identical across `list`, `detail`, and `status` through spawn → background → stop (and after a daemon restart); HTTP and UDS agree byte-for-byte on the same inputs"
   goal:
     observable: "The agent reads a complete, gap-free transcript and drives the session to a terminal outcome deterministically, with lifecycle state consistent across every surface"
-    side_effects: [session-created, prompt-streamed, session-stopped]
-  true_end_state: "Older REST pages remain loaded; reconnect after killing the client resumes from `after_sequence` with matching `epoch`/`generation`, or replaces the bounded tail only on an explicit reset; empty deltas still advance the cursor; list/detail/status agree after a daemon restart; HTTP and UDS return identical structured output."
+    side_effects: [session-created, prompt-streamed, partial-output-persisted, session-stopped]
+  true_end_state: "Older REST pages remain loaded; reconnect after killing the client resumes from `after_sequence` with matching `epoch`/`generation`, or replaces the bounded tail only on an explicit reset; empty deltas still advance the cursor; an ACP process disconnect retains delivered chunks and requires one new explicit prompt; list/detail/status agree after a daemon restart; HTTP and UDS return identical structured output."
   exit:
     natural: "The agent has a terminal outcome + a complete transcript and hands off / records the result."
   abandonment:
@@ -60,9 +67,12 @@ journey:
       how: "The client is killed mid-stream (crash, network)."
       resume: "Reconnect with `after_sequence`, `epoch`, and `generation`; matching fences resume with bounded deltas, while a reset snapshot names why the cached tail must be replaced; an empty delta still advances the safe cursor."
     - at_step: 3
+      how: "The ACP provider process disconnects after delivering part of the final response."
+      resume: "Inspect the persisted transcript and `process_exit` diagnostics, then send a new explicit prompt to restart the provider process in the same Compozy session; Compozy never replays the failed prompt automatically because it may already have caused side effects."
+    - at_step: 4
       how: "A read races the stop and hits a recorder-unavailable error, so the agent aborts."
       resume: "Reads during stop/finalize must degrade to the persisted transcript; the finding is any recorder error surfaced to the caller."
-  crosses: [CLI, HTTP, UDS, session-store, SSE-broadcaster, RT-042-parity-canary]
+  crosses: [CLI, HTTP, UDS, native-tool-registry, session-store, SSE-broadcaster, RT-042-parity-canary]
 
 design_reference:
   screens:
@@ -73,6 +83,7 @@ design_reference:
     - "Reconnects carry `after_sequence`, `epoch`, and `generation`; reset snapshots name `fence_missing`, `epoch_mismatch`, `generation_mismatch`, or `sequence_reset`."
     - "An empty `transcript_delta` may advance the safe cursor without adding a visible entry."
     - "Reads during stop/finalize return the persisted transcript, never a recorder error (task 21)."
+    - "An ACP process disconnect preserves delivered chunks, emits a terminal error, fails `compozy__session_prompt` with `backend_dead`, records `process_exit` diagnostics, and permits only an explicit next-prompt recovery — never automatic replay."
     - "List/detail/status agree through spawn→background→stop→restart (task 22); HTTP↔UDS byte parity (RT-042)."
 
 e2e_backbone:
@@ -80,6 +91,7 @@ e2e_backbone:
     - "E2E-runtime 1: long-session bounded REST pagination under lane latency (task 14)."
     - "E2E-runtime 3: reconnect with matching and stale transcript fences, including explicit reset reasons and empty-delta cursor advancement (task 17)."
     - "E2E-runtime 4: consistent state across list and detail through spawn → background → stop (task 22)."
+    - "E2E-runtime fault path: a real ACP subprocess disconnect after a partial response is projected through HTTP, UDS, CLI JSONL, `compozy__session_prompt`, persisted transcript, crash diagnostics, and same-session explicit recovery."
   manual:
     - "Manual §9.6: raw-stream contiguity — `compozy session events --follow` against a busy session, disconnect during a large output burst, reconnect; the printed sequence is contiguous with no skipped `sequence` (tasks 42/43)."
   telemetry:

--- a/docs/qa/reports/2026-08-05-acp-stream-disconnect.md
+++ b/docs/qa/reports/2026-08-05-acp-stream-disconnect.md
@@ -1,0 +1,89 @@
+# QA Run Report — 2026-08-05 — ACP stream disconnect
+
+- **Scope:** Issue #315 provider-process disconnect during final-response streaming
+- **Cadence tier:** targeted
+- **Build:** `codex/issue-315-acp-stream-disconnect` working tree · **Environment:** isolated bootstrap lab at `/Users/pedronauck/dev/qa-labs/compozy-acp-stream-disconnect-20260805-194318-831236-lab`; real daemon, SQLite, HTTP, UDS, CLI, and native-tool registry with a deterministic ACP subprocess fault fixture
+- **Started:** 2026-08-05T16:43:18-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | structured session operator | desktop / wifi-fast / en-US | CH-acp-stream-disconnect-recovery |
+
+## Flows in Scope
+
+- `J-15` — operate and recover a session consistently through CLI, HTTP, UDS, persisted history, and runtime diagnostics (`../journeys/J-15-operate-session-via-cli-api.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-acp-stream-disconnect-recovery | J-15 / RT-acp-stream-disconnect-recovery | Ada | Network Tour | Pass | #315 | working tree |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-acp-stream-disconnect-recovery — Ada
+
+- **Ran:** 2026-08-05T16:46:23-03:00 → 2026-08-05T16:46:42-03:00 (box respected: yes)
+- **Findings:** The HTTP stream preserved the first assistant chunk and emitted a terminal error after the ACP subprocess exited. Session detail and persisted history classified the failure as `process_exit`; crash bundle v2 recorded exit code 23. A different explicit prompt restarted the provider process in the same Compozy session, completed normally, and preserved both outputs without replay or duplication. The UDS-backed CLI JSONL path printed the partial chunk and error frame before returning a nonzero process status. `compozy__session_prompt` returned HTTP 502 with `tool_backend_failed` and `backend_dead`.
+- **Bugs filed/updated:** none; this walk verifies issue #315's fix.
+- **Scenarios settled:** RT-acp-stream-disconnect-recovery → pass.
+- **Paper cuts:** none.
+- **Surprises:** none.
+- **Suggested next charter:** repeat against a future provider-owned deterministic Codex fault hook if Codex exposes one; a live provider cannot currently be ordered to disconnect at an exact byte boundary safely.
+
+## What Was Fixed
+
+### Issue #315: ACP disconnect loses the active session during final streaming
+
+- **Symptom:** A Codex ACP peer disconnect after partial final output left the session stopped without useful process diagnostics, while CLI JSONL could return success at stream EOF.
+- **Root cause:** Fatal prompt handling stopped the session process before its natural wait result was collected, and client stream consumers treated EOF as successful without requiring a terminal stream event.
+- **Fix:** Preserve the natural process wait result behind a one-second exit boundary, capture exit code/signal/stderr in crash diagnostics, require terminal stream completion, return terminal errors to CLI and native-tool callers, and recover only after a new explicit prompt.
+- **Regression test:** `internal/session/manager_prompt_contract_test.go`, `internal/subprocess/process_test.go`, `internal/cli/client_test.go`, `internal/cli/session_test.go`, `internal/daemon/native_tools_test.go`, and `internal/daemon/daemon_acpmock_faults_integration_test.go` failed on the old behavior and pass on this working tree.
+- **Retested:** J-15 through HTTP, UDS-backed CLI JSONL, `compozy__session_prompt`, persisted transcript, runtime failure projection, crash bundle diagnostics, and same-session explicit recovery.
+
+## Paper Cuts
+
+None observed.
+
+## Runtime Errors Observed
+
+The intentionally injected ACP disconnect surfaced as a terminal stream error and `process_exit`; no unrelated runtime errors were observed.
+
+## Human Verifications Needed
+
+None planned.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The fault must be injected at the provider-process boundary to distinguish it from a client-only stream interruption.
+- Automatic replay is not a recovery mechanism here: the provider may already have completed external side effects before disconnecting.
+- Production-parity deviation: the walk uses a deterministic ACP subprocess fixture instead of live Codex so it can force an exact mid-stream exit. The daemon, process supervision, SQLite persistence, HTTP, UDS, and CLI paths are production implementations.
+
+## Web/Docs Impact
+
+- `web/`: no source change. Existing session runtime adapters and components already consume terminal `error` frames with `failure.kind: "process_exit"`; their canonical tests already cover the exact `peer disconnected before response` projection.
+- `packages/site`: updated `content/docs/sessions/lifecycle.mdx` and `content/docs/guides/debug-a-failed-session.mdx` for partial-output retention, nonzero clients, diagnostics, and the explicit recovery boundary. Generated CLI docs are unchanged because no command or flag changed.
+- Config lifecycle: no keys, defaults, overlays, validation, or examples changed.
+- QA impact: added and walked `RT-acp-stream-disconnect-recovery` to `pass`.
+
+## Compozy Impact Audit
+
+- **Native tools:** `compozy__session_prompt` now returns `tool_backend_failed` with `backend_dead` when its drained prompt stream terminates with `process_exit`. Tool IDs, toolsets, descriptors, schemas, digests, risk flags, availability diagnostics, and capability gates are unchanged. Canonical native-tool and daemon integration suites cover the failure.
+- **Extensibility and hooks:** the native registry and any hosted projection reuse the corrected call path. Extension manifests, contributed tools/resources, bridge SDKs, MCP sidecars, registries, and `session.post_stop` hook payloads are unchanged; the wire event and failure kinds already existed. No config lifecycle change.
+- **Workspace data isolation:** exit code and signal are session-process facts written only to that session's owner-only crash bundle. Partial events remain in the existing workspace-scoped session store, and CLI/HTTP/UDS/native reads keep their existing workspace and session checks. No global cache, shared list datum, or cross-workspace event path was added.
+- **Official Compozy skill:** updated `skills/compozy/references/runtime-operations.md` with persisted partial-output, nonzero CLI/native failures, diagnostics, and the no-automatic-replay boundary.
+
+## Final Status
+
+- **Exit gate (full automated suite):** PASS — `make gate-full`; Final verify evidence: `/Users/pedronauck/dev/qa-labs/compozy-acp-stream-disconnect-20260805-194318-831236-lab/qa-artifacts/qa/evidence/acp-stream-disconnect/final-make-verify.log`
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1 of 1 in-scope journey sessions complete; HTTP, UDS-backed CLI, native tool, and runtime/store diagnostics covered. Live Codex deterministic fault injection is disclosed above.
+- **Verdict:** PASS — ready for review; the controlled provider-process disconnect is recoverable at the next explicit prompt and does not lose delivered output.

--- a/docs/qa/reports/2026-08-05-pr319-acp-stream-remediation.md
+++ b/docs/qa/reports/2026-08-05-pr319-acp-stream-remediation.md
@@ -1,0 +1,91 @@
+# QA Run Report — 2026-08-05 — PR #319 ACP stream remediation
+
+- **Scope:** Review remediation for issue #315 and PR #319
+- **Cadence tier:** targeted
+- **Build:** `codex/issue-315-acp-stream-disconnect` working tree
+- **Environment:** isolated bootstrap lab at `/Users/pedronauck/dev/qa-labs/compozy-pr319-acp-stream-remediation-20260805-220911-045783-lab`
+- **Started:** 2026-08-05T22:09:11-03:00
+- **Status:** pass
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | structured session operator | desktop / wifi-fast / en-US | CH-acp-stream-disconnect-recovery |
+
+## Flows in Scope
+
+- `J-15` — operate and recover a session consistently through CLI, HTTP, UDS, persisted history, and runtime diagnostics.
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-acp-stream-disconnect-recovery | J-15 / RT-acp-stream-disconnect-recovery | Ada | Network Tour | Pass | #315 | PR #319 remediation batch |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-acp-stream-disconnect-recovery — Ada
+
+- **Ran:** 2026-08-05T21:55:57-03:00 → 2026-08-05T21:56:14-03:00.
+- **Observed:** The real daemon and ACP subprocess fixture preserved the partial HTTP response and emitted one typed `process_exit` terminal with exit code 23. The event-linked crash bundle already contained the exit code and stderr when the event was read. CLI JSONL printed the retained frames and exited nonzero; the native prompt returned `tool_backend_failed`/`backend_dead`.
+- **Recovery:** The failed session stopped within the scenario bound, then a new explicit prompt restarted the same session without replaying the failed turn and completed normally.
+- **Evidence:** `/Users/pedronauck/dev/qa-labs/compozy-pr319-acp-stream-remediation-20260805-220911-045783-lab/qa-artifacts/qa/evidence/acp-stream-remediation/runtime-public-surfaces.log`.
+- **Result:** `RT-acp-stream-disconnect-recovery` passed across HTTP/SSE, CLI JSONL, UDS/native, persistence, process diagnostics, and explicit recovery.
+
+## What Was Fixed
+
+- Terminal-less ACP stream closure is now a typed transport failure in the session owner. It persists already delivered chunks, emits an Error terminal, and stops the unusable runtime instead of treating EOF as completion.
+- HTTP/SSE, CLI, and native-tool consumers independently reject terminal-less EOF. Malformed SSE JSON keeps its decode cause instead of being replaced by a generic incomplete-stream error.
+- Fatal process and transport failures reuse the normal session-stop preparation, including lifecycle hooks and prompt setup cleanup. The manager then stops and waits for the process, writes the status-complete crash bundle, and only then persists and delivers the public Error event. Final classification reuses that same path, so clients never observe an event-linked bundle before known exit evidence is present.
+- Daytona forwards the remote exit code. Signal exits omit Unix's `-1` sentinel while preserving the signal; Windows-style numeric exits remain available. Signal extraction is limited to the published Darwin/Linux Unix targets, with a no-signal fallback for other Go targets.
+
+## Paper Cuts
+
+The QA tracker originally recorded PASS even though the native assertion failed. This report now treats
+the executable assertion as canonical. The corrected retest replaced that stale evidence and passed.
+
+## Runtime Errors Observed
+
+None in the corrected walk. One discarded harness attempt used an overlong temporary path and could
+not create the daemon socket; it never entered the product scenario and left no surviving process.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The public Error event and final classification must share one deterministic bundle path. Process evidence must be complete before the event becomes observable; an eventual rewrite is too late for clients that open the path immediately.
+- A fatal prompt failure must enter the same pre-stop, stopping, cleanup, and post-stop lifecycle as an operator or daemon stop. The process-evidence barrier may own finalization, but it cannot bypass lifecycle preparation.
+- A `[DONE]` sentinel proves transport termination, not successful ACP completion. Consumers must also observe a semantic Done or Error terminal.
+- A deterministic subprocess fixture remains necessary because a live provider cannot safely be instructed to disconnect at an exact response byte boundary.
+
+## Web/Docs Impact
+
+- `web/`: no source impact. The existing adapters already consume terminal error streams; the remediation changes no UI contract or copy.
+- `packages/site`: no new documentation contract. The PR's existing lifecycle and debugging documentation already describes partial-output retention, explicit recovery, and process diagnostics.
+- Config lifecycle: no keys, defaults, overlays, validation, or examples changed.
+- QA impact: the existing scenario passed its corrected real-subprocess retest.
+
+## Compozy Impact Audit
+
+- **Native tools:** `compozy__session_prompt` retains its ID and schema. Its consumer defense rejects empty or partial EOF as a clear backend failure, while a proven subprocess exit projects `tool_backend_failed`/`backend_dead`. The canonical native-tool suite and real daemon integration cover both failure modes.
+- **Extensibility and hooks:** no tool descriptors, capability gates, extension resources, bridge SDKs, MCP sidecars, hook payloads, registries, or config lifecycle changed. Hosted/native projections reuse the same corrected session stream.
+- **Workspace data isolation:** partial events and crash evidence remain session-scoped inside the existing workspace-owned store and owner-only log directory. HTTP, UDS, CLI, SSE, and native paths keep their existing workspace/session authorization and add no global cache or cross-workspace datum.
+- **Official Compozy skill:** no additional change. The PR already documents partial-output retention, process diagnostics, and explicit no-replay recovery in `skills/compozy/references/runtime-operations.md`; this batch closes implementation gaps without changing that public contract.
+
+## Final Status
+
+- **Behavioral verdict:** PASS — the real ACP exit-23 path satisfies the public-surface and recovery contract.
+- **Focused regression suite:** 31 race-enabled session tests passed, including explicit prompt cancellation, terminal-less EOF, process exit, lifecycle hooks, and crash-bundle invariants.
+- **Strict QA audit:** the content-frozen report, journey log, runtime transcript, final gate record, and teardown record are audited together before publication.
+- **Teardown:** the isolated lab is required to finish with `teardown.json` reporting `"clean": true` and no surviving process or socket.
+- **Automated workstream gate:** the content-fingerprinted `make gate-full` record is produced after this report's final mutation and cited in the PR evidence.
+- **Readiness:** ready when the strict audit and current full-gate record both pass.

--- a/docs/qa/scenarios/RT-acp-stream-disconnect-recovery.md
+++ b/docs/qa/scenarios/RT-acp-stream-disconnect-recovery.md
@@ -7,12 +7,12 @@ journey: J-15
 expected: When an ACP process disconnects after streaming partial output, Compozy preserves the delivered chunks, emits a terminal error through HTTP and UDS, makes CLI JSONL exit nonzero after printing those frames, returns backend_dead from compozy__session_prompt, records process_exit diagnostics, and restarts the same session only after a new explicit prompt without replaying the failed prompt.
 entry_points: POST /api/sessions/:id/prompt; UDS session prompt; compozy session prompt -o jsonl; compozy__session_prompt; session events; session status
 qa_status: pass
-bug_ids:
-fix_status:
-retest_status:
+bug_ids: 315
+fix_status: fixed
+retest_status: pass
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-acp-stream-disconnect-20260805-194318-831236-lab/qa-artifacts/qa/evidence/acp-stream-disconnect/runtime-public-surfaces.log; /Users/pedronauck/dev/qa-labs/compozy-acp-stream-disconnect-20260805-194318-831236-lab/qa-artifacts/qa/journey-log.jsonl
-last_report: docs/qa/reports/2026-08-05-acp-stream-disconnect.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-pr319-acp-stream-remediation-20260805-220911-045783-lab/qa-artifacts/qa/evidence/acp-stream-remediation/runtime-public-surfaces.log; /Users/pedronauck/dev/qa-labs/compozy-pr319-acp-stream-remediation-20260805-220911-045783-lab/qa-artifacts/qa/journey-log.jsonl
+last_report: docs/qa/reports/2026-08-05-pr319-acp-stream-remediation.md
 overlaps: RT-050; RT-051; RT-session-context-rebuild
 ---
 
@@ -25,8 +25,9 @@ The deterministic walk uses the real daemon, SQLite store, HTTP server, UDS serv
 an ACP subprocess fixture that exits with code 23 after one partial assistant chunk. It then proves
 the same session accepts a separate continuation prompt and retains both outputs.
 
-QA 2026-08-05: the HTTP prompt stream retained `partial before crash`, emitted a terminal error,
-projected `process_exit`, and wrote exit code 23 into the crash bundle. The UDS-backed CLI JSONL
-path printed the partial chunk plus the error frame and exited nonzero. The native session prompt tool
-returned HTTP 502 with `tool_backend_failed` and `backend_dead`. A different explicit prompt completed
-in the same Compozy session, and the transcript retained both outputs without duplication.
+QA retest 2026-08-05: the HTTP stream retained `partial before crash` and then emitted one typed
+`process_exit` terminal for exit code 23. At the instant that event became observable, its crash
+bundle already contained the exit code and captured stderr. CLI JSONL printed the retained frames
+and exited nonzero, while `compozy__session_prompt` returned `tool_backend_failed` with
+`backend_dead`. The session stopped within the scenario bound, and a new explicit prompt recovered
+the same session without replaying the failed turn.

--- a/docs/qa/scenarios/RT-acp-stream-disconnect-recovery.md
+++ b/docs/qa/scenarios/RT-acp-stream-disconnect-recovery.md
@@ -1,0 +1,32 @@
+---
+id: RT-acp-stream-disconnect-recovery
+area: RT
+title: Recover after an ACP stream disconnect
+persona: Ada
+journey: J-15
+expected: When an ACP process disconnects after streaming partial output, Compozy preserves the delivered chunks, emits a terminal error through HTTP and UDS, makes CLI JSONL exit nonzero after printing those frames, returns backend_dead from compozy__session_prompt, records process_exit diagnostics, and restarts the same session only after a new explicit prompt without replaying the failed prompt.
+entry_points: POST /api/sessions/:id/prompt; UDS session prompt; compozy session prompt -o jsonl; compozy__session_prompt; session events; session status
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-acp-stream-disconnect-20260805-194318-831236-lab/qa-artifacts/qa/evidence/acp-stream-disconnect/runtime-public-surfaces.log; /Users/pedronauck/dev/qa-labs/compozy-acp-stream-disconnect-20260805-194318-831236-lab/qa-artifacts/qa/journey-log.jsonl
+last_report: docs/qa/reports/2026-08-05-acp-stream-disconnect.md
+overlaps: RT-050; RT-051; RT-session-context-rebuild
+---
+
+Issue #315 exposed a provider-side disconnect while the final response was still streaming. This
+scenario owns the boundary between a completed stream, a disconnected ACP peer, and a later
+`process_exit`. Recovery is deliberately a new explicit prompt: automatic replay is unsafe because
+the failed turn may already have performed external side effects.
+
+The deterministic walk uses the real daemon, SQLite store, HTTP server, UDS server, CLI binary, and
+an ACP subprocess fixture that exits with code 23 after one partial assistant chunk. It then proves
+the same session accepts a separate continuation prompt and retains both outputs.
+
+QA 2026-08-05: the HTTP prompt stream retained `partial before crash`, emitted a terminal error,
+projected `process_exit`, and wrote exit code 23 into the crash bundle. The UDS-backed CLI JSONL
+path printed the partial chunk plus the error frame and exited nonzero. The native session prompt tool
+returned HTTP 502 with `tool_backend_failed` and `backend_dead`. A different explicit prompt completed
+in the same Compozy session, and the transcript retained both outputs without duplication.

--- a/internal/acp/agent_process.go
+++ b/internal/acp/agent_process.go
@@ -111,6 +111,25 @@ func (p *AgentProcess) Stderr() string {
 	return p.stderr.String()
 }
 
+// ExitStatus returns the OS exit facts exposed by the underlying process handle.
+func (p *AgentProcess) ExitStatus() (subprocess.ExitStatus, bool) {
+	if p == nil {
+		return subprocess.ExitStatus{}, false
+	}
+	if provider, ok := p.handle.(interface {
+		ExitStatus() (subprocess.ExitStatus, bool)
+	}); ok {
+		return provider.ExitStatus()
+	}
+	if p.managed != nil {
+		return p.managed.ExitStatus()
+	}
+	if p.cmd != nil {
+		return subprocess.ExitStatusFromProcessState(p.cmd.ProcessState)
+	}
+	return subprocess.ExitStatus{}, false
+}
+
 // HealthState returns the latest managed subprocess health snapshot.
 func (p *AgentProcess) HealthState() subprocess.HealthState {
 	if p == nil || p.managed == nil {

--- a/internal/acp/launcher.go
+++ b/internal/acp/launcher.go
@@ -137,6 +137,13 @@ func (h *localProcessHandle) Wait() error {
 	return h.process.Wait()
 }
 
+func (h *localProcessHandle) ExitStatus() (subprocess.ExitStatus, bool) {
+	if h == nil || h.process == nil {
+		return subprocess.ExitStatus{}, false
+	}
+	return h.process.ExitStatus()
+}
+
 func (h *localProcessHandle) Stop(ctx context.Context) error {
 	if h == nil || h.process == nil {
 		return nil

--- a/internal/acp/prompt_stream_terminal.go
+++ b/internal/acp/prompt_stream_terminal.go
@@ -1,0 +1,25 @@
+package acp
+
+import (
+	"errors"
+
+	"github.com/compozy/compozy/internal/store"
+)
+
+// ErrPromptStreamIncomplete identifies an ACP prompt stream that closed
+// without a Done or Error event.
+var ErrPromptStreamIncomplete = errors.New("acp prompt stream ended before a terminal event")
+
+// PromptStreamIncompleteEvent returns the canonical terminal failure for an
+// upstream stream that closes without declaring completion or failure.
+func PromptStreamIncompleteEvent() AgentEvent {
+	summary := ErrPromptStreamIncomplete.Error()
+	return AgentEvent{
+		Type:  EventTypeError,
+		Error: summary,
+		Failure: &store.SessionFailure{
+			Kind:    store.FailureTransport,
+			Summary: summary,
+		},
+	}
+}

--- a/internal/api/core/prompt_stream_delivery.go
+++ b/internal/api/core/prompt_stream_delivery.go
@@ -26,13 +26,16 @@ func DeliverPromptEventStream(
 			return
 		case event, ok := <-events:
 			if !ok {
-				if err := encoder.Finish(writer, acp.AgentEvent{}); err != nil {
+				if err := encoder.Emit(writer, acp.PromptStreamIncompleteEvent()); err != nil {
 					return
 				}
 				return
 			}
 			if err := encoder.Emit(writer, event); err != nil {
 				cancel()
+				return
+			}
+			if event.Type == acp.EventTypeDone || event.Type == acp.EventTypeError {
 				return
 			}
 		}

--- a/internal/api/core/prompt_stream_test.go
+++ b/internal/api/core/prompt_stream_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"strings"
@@ -10,6 +11,47 @@ import (
 	"github.com/compozy/compozy/internal/acp"
 	"github.com/compozy/compozy/internal/api/core"
 )
+
+func TestDeliverPromptEventStream(t *testing.T) {
+	t.Run("Should emit an explicit terminal failure when the upstream stream closes without a terminal event", func(
+		t *testing.T,
+	) {
+		t.Parallel()
+
+		writer := &bufferFlusher{}
+		encoder := core.NewPromptStreamEncoder(func() time.Time {
+			return time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+		})
+		if err := encoder.Start(writer, "turn-incomplete"); err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		events := make(chan acp.AgentEvent, 1)
+		events <- acp.AgentEvent{
+			Type:   acp.EventTypeAgentMessage,
+			TurnID: "turn-incomplete",
+			Text:   "partial response",
+		}
+		close(events)
+
+		core.DeliverPromptEventStream(
+			context.Background(),
+			make(chan struct{}),
+			events,
+			func() {},
+			encoder,
+			writer,
+		)
+
+		stream := writer.String()
+		if !strings.Contains(stream, `"type":"error"`) ||
+			!strings.Contains(stream, "ended before a terminal event") {
+			t.Fatalf("stream = %q, want explicit incomplete-stream failure", stream)
+		}
+		if !strings.Contains(stream, "data: [DONE]") {
+			t.Fatalf("stream = %q, want a terminal sentinel after the failure", stream)
+		}
+	})
+}
 
 func TestPromptStreamEncoderStart(t *testing.T) {
 	t.Run("ShouldEmitAcceptedTurnIDImmediately", func(t *testing.T) {

--- a/internal/cli/client_session_prompt.go
+++ b/internal/cli/client_session_prompt.go
@@ -88,8 +88,7 @@ func (c *unixSocketClient) doSessionPrompt(
 				payload.Type = event.Event
 			}
 			events = append(events, payload)
-			state.observe(event)
-			return nil
+			return state.observe(event)
 		})
 		record := SessionPromptRecord{Events: events}
 		if decodeErr != nil || state.failure != nil {
@@ -145,7 +144,9 @@ func (c *unixSocketClient) StreamPromptSession(
 		}
 		state := sessionPromptStreamState{}
 		decodeErr := decodeSSE(ctx, response.Body, func(event SSEEvent) error {
-			state.observe(event)
+			if err := state.observe(event); err != nil {
+				return err
+			}
 			return handler(event)
 		})
 		if decodeErr != nil || state.failure != nil {
@@ -169,10 +170,10 @@ func (c *unixSocketClient) StreamPromptSession(
 	return handler(SSEEvent{Event: promptResultEventName, Data: body})
 }
 
-func (s *sessionPromptStreamState) observe(event SSEEvent) {
+func (s *sessionPromptStreamState) observe(event SSEEvent) error {
 	if strings.TrimSpace(string(event.Data)) == "[DONE]" {
 		s.terminal = true
-		return
+		return nil
 	}
 	var payload struct {
 		Type      string                          `json:"type"`
@@ -180,8 +181,10 @@ func (s *sessionPromptStreamState) observe(event SSEEvent) {
 		ErrorText string                          `json:"errorText"`
 		Failure   *contract.SessionFailurePayload `json:"failure"`
 	}
-	if len(event.Data) > 0 && json.Unmarshal(event.Data, &payload) != nil {
-		return
+	if len(event.Data) > 0 {
+		if err := json.Unmarshal(event.Data, &payload); err != nil {
+			return fmt.Errorf("cli: decode prompt stream event: %w", err)
+		}
 	}
 	eventType := strings.TrimSpace(payload.Type)
 	if eventType == "" {
@@ -204,6 +207,7 @@ func (s *sessionPromptStreamState) observe(event SSEEvent) {
 	case promptDoneEventName, promptFinishEventName, promptResultEventName:
 		s.terminal = true
 	}
+	return nil
 }
 
 func sessionPromptIsEventStream(response *http.Response) bool {

--- a/internal/cli/client_session_prompt.go
+++ b/internal/cli/client_session_prompt.go
@@ -17,9 +17,18 @@ import (
 const (
 	sessionPromptBodyLimit = 1 << 20
 	promptResultEventName  = "prompt_result"
+	promptDoneEventName    = "done"
+	promptFinishEventName  = "finish"
 )
 
 var errSessionPromptBodyTooLarge = errors.New("session prompt response exceeds size limit")
+
+var errSessionPromptStreamIncomplete = errors.New("session prompt stream ended before a terminal event")
+
+type sessionPromptStreamState struct {
+	terminal bool
+	failure  error
+}
 
 type goalCommandAPIError struct {
 	statusCode int
@@ -67,7 +76,8 @@ func (c *unixSocketClient) doSessionPrompt(
 	}
 	if sessionPromptIsEventStream(response) {
 		events := make([]AgentEventRecord, 0)
-		if err := decodeSSE(ctx, response.Body, func(event SSEEvent) error {
+		state := sessionPromptStreamState{}
+		decodeErr := decodeSSE(ctx, response.Body, func(event SSEEvent) error {
 			var payload AgentEventRecord
 			if len(event.Data) > 0 {
 				if err := json.Unmarshal(event.Data, &payload); err != nil {
@@ -78,11 +88,17 @@ func (c *unixSocketClient) doSessionPrompt(
 				payload.Type = event.Event
 			}
 			events = append(events, payload)
+			state.observe(event)
 			return nil
-		}); err != nil {
-			return SessionPromptRecord{}, err
+		})
+		record := SessionPromptRecord{Events: events}
+		if decodeErr != nil || state.failure != nil {
+			return record, errors.Join(decodeErr, state.failure)
 		}
-		return SessionPromptRecord{Events: events}, nil
+		if !state.terminal {
+			return record, errSessionPromptStreamIncomplete
+		}
+		return record, nil
 	}
 
 	body, err := readSessionPromptBody(response.Body)
@@ -125,9 +141,20 @@ func (c *unixSocketClient) StreamPromptSession(
 	}
 	if sessionPromptIsEventStream(response) {
 		if handler == nil {
-			return drainResponseBody(http.MethodPost, path, response.Body)
+			handler = func(SSEEvent) error { return nil }
 		}
-		return decodeSSE(ctx, response.Body, handler)
+		state := sessionPromptStreamState{}
+		decodeErr := decodeSSE(ctx, response.Body, func(event SSEEvent) error {
+			state.observe(event)
+			return handler(event)
+		})
+		if decodeErr != nil || state.failure != nil {
+			return errors.Join(decodeErr, state.failure)
+		}
+		if !state.terminal {
+			return errSessionPromptStreamIncomplete
+		}
+		return nil
 	}
 	body, err := readSessionPromptBody(response.Body)
 	if err != nil {
@@ -140,6 +167,43 @@ func (c *unixSocketClient) StreamPromptSession(
 		return nil
 	}
 	return handler(SSEEvent{Event: promptResultEventName, Data: body})
+}
+
+func (s *sessionPromptStreamState) observe(event SSEEvent) {
+	if strings.TrimSpace(string(event.Data)) == "[DONE]" {
+		s.terminal = true
+		return
+	}
+	var payload struct {
+		Type      string                          `json:"type"`
+		Error     string                          `json:"error"`
+		ErrorText string                          `json:"errorText"`
+		Failure   *contract.SessionFailurePayload `json:"failure"`
+	}
+	if len(event.Data) > 0 && json.Unmarshal(event.Data, &payload) != nil {
+		return
+	}
+	eventType := strings.TrimSpace(payload.Type)
+	if eventType == "" {
+		eventType = strings.TrimSpace(event.Event)
+	}
+	switch eventType {
+	case automationErrorKey:
+		s.terminal = true
+		message := strings.TrimSpace(payload.ErrorText)
+		if message == "" {
+			message = strings.TrimSpace(payload.Error)
+		}
+		if message == "" && payload.Failure != nil {
+			message = strings.TrimSpace(payload.Failure.Summary)
+		}
+		if message == "" {
+			message = "daemon reported a terminal prompt failure"
+		}
+		s.failure = fmt.Errorf("cli: session prompt stream failed: %s", message)
+	case promptDoneEventName, promptFinishEventName, promptResultEventName:
+		s.terminal = true
+	}
 }
 
 func sessionPromptIsEventStream(response *http.Response) bool {

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -245,6 +245,135 @@ func TestUnixSocketClientSessionPromptShouldDecodeStructuredGoalJSON(t *testing.
 	})
 }
 
+func TestUnixSocketClientSessionPromptTerminalContract(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should return the raw terminal error with all preceding events", func(t *testing.T) {
+		t.Parallel()
+
+		body := strings.Join([]string{
+			"event: agent_message",
+			`data: {"type":"agent_message","timestamp":"2026-08-05T12:00:00Z","text":"partial before disconnect"}`,
+			"",
+			"event: error",
+			`data: {"type":"error","timestamp":"2026-08-05T12:00:01Z","error":"peer disconnected before response","failure":{"kind":"process_exit","summary":"ACP subprocess exited unexpectedly"}}`,
+			"",
+		}, "\n")
+		client := &unixSocketClient{
+			socketPath: "/tmp/compozy.sock",
+			httpClient: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				response := newHTTPResponse(http.StatusOK, body)
+				response.Header.Set("Content-Type", "text/event-stream")
+				response.Request = req
+				return response, nil
+			})},
+		}
+
+		record, err := client.doSessionPrompt(
+			t.Context(),
+			http.MethodPost,
+			"/api/workspaces/ws-1/sessions/sess-1/prompt",
+			nil,
+			SessionPromptRequest{Message: "hello"},
+		)
+		if err == nil || !strings.Contains(err.Error(), "peer disconnected before response") {
+			t.Fatalf("doSessionPrompt() error = %v, want terminal process failure", err)
+		}
+		if got, want := len(record.Events), 2; got != want {
+			t.Fatalf("doSessionPrompt() events = %d, want %d", got, want)
+		}
+		if record.Events[0].Text != "partial before disconnect" || record.Events[1].Type != "error" {
+			t.Fatalf("doSessionPrompt() events = %#v, want partial chunk then terminal error", record.Events)
+		}
+	})
+
+	t.Run("Should forward streamed frames before returning the terminal error", func(t *testing.T) {
+		t.Parallel()
+
+		body := strings.Join([]string{
+			`data: {"type":"text-delta","id":"turn-1-text","delta":"partial before disconnect"}`,
+			"",
+			`data: {"type":"error","errorText":"peer disconnected before response"}`,
+			"",
+			`data: {"type":"finish","finishReason":"error"}`,
+			"",
+			"data: [DONE]",
+			"",
+		}, "\n")
+		transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/api/sessions/sess-1":
+				return newHTTPResponse(
+					http.StatusOK,
+					`{"session":{"id":"sess-1","workspace_id":"ws-1","state":"active","created_at":"2026-08-05T12:00:00Z","updated_at":"2026-08-05T12:00:00Z"}}`,
+				), nil
+			case req.Method == http.MethodPost &&
+				req.URL.Path == "/api/workspaces/ws-1/sessions/sess-1/prompt":
+				response := newHTTPResponse(http.StatusOK, body)
+				response.Header.Set("Content-Type", "text/event-stream")
+				response.Request = req
+				return response, nil
+			default:
+				t.Fatalf("unexpected request = %s %s", req.Method, req.URL.Path)
+				return nil, errors.New("unexpected request")
+			}
+		})
+		client := &unixSocketClient{
+			socketPath: "/tmp/compozy.sock",
+			httpClient: &http.Client{Transport: transport},
+		}
+		client.streamClient = client.httpClient
+
+		var events []SSEEvent
+		err := client.StreamPromptSession(
+			t.Context(),
+			"sess-1",
+			SessionPromptRequest{Message: "hello"},
+			func(event SSEEvent) error {
+				events = append(events, event)
+				return nil
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "peer disconnected before response") {
+			t.Fatalf("StreamPromptSession() error = %v, want terminal process failure", err)
+		}
+		if got, want := len(events), 4; got != want {
+			t.Fatalf("StreamPromptSession() forwarded events = %d, want %d", got, want)
+		}
+		if !strings.Contains(string(events[0].Data), "partial before disconnect") {
+			t.Fatalf("StreamPromptSession() first event = %s, want partial chunk", events[0].Data)
+		}
+	})
+
+	t.Run("Should reject a clean EOF without a terminal event", func(t *testing.T) {
+		t.Parallel()
+
+		client := &unixSocketClient{
+			socketPath: "/tmp/compozy.sock",
+			httpClient: &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				response := newHTTPResponse(
+					http.StatusOK,
+					"event: agent_message\ndata: {\"type\":\"agent_message\",\"timestamp\":\"2026-08-05T12:00:00Z\",\"text\":\"partial\"}\n\n",
+				)
+				response.Header.Set("Content-Type", "text/event-stream")
+				response.Request = req
+				return response, nil
+			})},
+		}
+
+		_, err := client.doSessionPrompt(
+			t.Context(),
+			http.MethodPost,
+			"/api/workspaces/ws-1/sessions/sess-1/prompt",
+			nil,
+			SessionPromptRequest{Message: "hello"},
+		)
+		if err == nil || !strings.Contains(err.Error(), "ended before a terminal event") {
+			t.Fatalf("doSessionPrompt() error = %v, want incomplete stream failure", err)
+		}
+	})
+}
+
 func TestUnixSocketClientSessionInputMethods(t *testing.T) {
 	t.Parallel()
 
@@ -2060,6 +2189,10 @@ func TestUnixSocketClientMethods(t *testing.T) {
 						"event: agent_message",
 						`data: {"session_id":"sess-1","turn_id":"turn-1","type":"agent_message","timestamp":"2026-04-03T12:00:00Z","text":"hello back"}`,
 						"",
+						"id: 2",
+						"event: done",
+						`data: {"session_id":"sess-1","turn_id":"turn-1","type":"done","timestamp":"2026-04-03T12:00:01Z"}`,
+						"",
 					}, "\n"))
 					resp.Header.Set("Content-Type", "text/event-stream")
 					return resp, nil
@@ -2443,7 +2576,8 @@ func TestUnixSocketClientMethods(t *testing.T) {
 	}
 
 	promptEvents, err := client.PromptSession(ctx, "sess-1", "hello")
-	if err != nil || len(promptEvents) != 1 || promptEvents[0].Text != "hello back" {
+	if err != nil || len(promptEvents) != 2 || promptEvents[0].Text != "hello back" ||
+		promptEvents[1].Type != "done" {
 		t.Fatalf("PromptSession() = %#v, %v", promptEvents, err)
 	}
 

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -276,9 +276,7 @@ func TestUnixSocketClientSessionPromptTerminalContract(t *testing.T) {
 			nil,
 			SessionPromptRequest{Message: "hello"},
 		)
-		if err == nil || !strings.Contains(err.Error(), "peer disconnected before response") {
-			t.Fatalf("doSessionPrompt() error = %v, want terminal process failure", err)
-		}
+		assertErrorContains(t, err, "peer disconnected before response")
 		if got, want := len(record.Events), 2; got != want {
 			t.Fatalf("doSessionPrompt() events = %d, want %d", got, want)
 		}
@@ -334,9 +332,7 @@ func TestUnixSocketClientSessionPromptTerminalContract(t *testing.T) {
 				return nil
 			},
 		)
-		if err == nil || !strings.Contains(err.Error(), "peer disconnected before response") {
-			t.Fatalf("StreamPromptSession() error = %v, want terminal process failure", err)
-		}
+		assertErrorContains(t, err, "peer disconnected before response")
 		if got, want := len(events), 4; got != want {
 			t.Fatalf("StreamPromptSession() forwarded events = %d, want %d", got, want)
 		}
@@ -368,8 +364,46 @@ func TestUnixSocketClientSessionPromptTerminalContract(t *testing.T) {
 			nil,
 			SessionPromptRequest{Message: "hello"},
 		)
-		if err == nil || !strings.Contains(err.Error(), "ended before a terminal event") {
-			t.Fatalf("doSessionPrompt() error = %v, want incomplete stream failure", err)
+		assertErrorContains(t, err, "ended before a terminal event")
+	})
+
+	t.Run("Should preserve malformed streamed JSON as the terminal decode failure", func(t *testing.T) {
+		t.Parallel()
+
+		transport := roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			switch {
+			case req.Method == http.MethodGet && req.URL.Path == "/api/sessions/sess-1":
+				return newHTTPResponse(
+					http.StatusOK,
+					`{"session":{"id":"sess-1","workspace_id":"ws-1","state":"active","created_at":"2026-08-05T12:00:00Z","updated_at":"2026-08-05T12:00:00Z"}}`,
+				), nil
+			case req.Method == http.MethodPost &&
+				req.URL.Path == "/api/workspaces/ws-1/sessions/sess-1/prompt":
+				response := newHTTPResponse(http.StatusOK, "data: {\"type\":\n\n")
+				response.Header.Set("Content-Type", "text/event-stream")
+				response.Request = req
+				return response, nil
+			default:
+				t.Fatalf("unexpected request = %s %s", req.Method, req.URL.Path)
+				return nil, errors.New("unexpected request")
+			}
+		})
+		client := &unixSocketClient{
+			socketPath: "/tmp/compozy.sock",
+			httpClient: &http.Client{Transport: transport},
+		}
+		client.streamClient = client.httpClient
+
+		err := client.StreamPromptSession(
+			t.Context(),
+			"sess-1",
+			SessionPromptRequest{Message: "hello"},
+			func(SSEEvent) error { return nil },
+		)
+		assertErrorContains(t, err, "decode prompt stream event")
+		var syntaxErr *json.SyntaxError
+		if !errors.As(err, &syntaxErr) {
+			t.Fatalf("StreamPromptSession() error = %T %[1]v, want *json.SyntaxError", err)
 		}
 	})
 }

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -2545,6 +2545,54 @@ func TestSessionPromptJSONLOutput(t *testing.T) {
 		}
 	})
 
+	t.Run("Should keep emitted JSONL frames and return a nonzero command error", func(t *testing.T) {
+		t.Parallel()
+
+		streamErr := errors.New("peer disconnected before response")
+		deps := newWorkspaceTestDeps(t, &stubClient{
+			streamPromptSessionFn: func(
+				_ context.Context,
+				_ string,
+				_ SessionPromptRequest,
+				handler SSEHandler,
+			) error {
+				for _, event := range []SSEEvent{
+					{Data: mustJSON(t, map[string]any{
+						"type":  "text-delta",
+						"id":    "turn-1-text",
+						"delta": "partial before disconnect",
+					})},
+					{Data: mustJSON(t, map[string]any{
+						"type":      "error",
+						"errorText": streamErr.Error(),
+					})},
+				} {
+					if err := handler(event); err != nil {
+						return err
+					}
+				}
+				return streamErr
+			},
+		})
+
+		stdout, _, err := executeRootCommand(
+			t,
+			deps,
+			"session", "prompt", "sess-1", "hello", "-o", "jsonl",
+		)
+		if !errors.Is(err, streamErr) {
+			t.Fatalf("executeRootCommand(session prompt jsonl) error = %v, want %v", err, streamErr)
+		}
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		if got, want := len(lines), 2; got != want {
+			t.Fatalf("session prompt jsonl lines = %d, want %d; output=%q", got, want, stdout)
+		}
+		if !strings.Contains(lines[0], "partial before disconnect") ||
+			!strings.Contains(lines[1], "peer disconnected before response") {
+			t.Fatalf("session prompt jsonl output = %q, want partial chunk and terminal error", stdout)
+		}
+	})
+
 	t.Run("Should emit one direct line for a structured Goal result", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/daemon_acpmock_faults_integration_test.go
+++ b/internal/daemon/daemon_acpmock_faults_integration_test.go
@@ -36,10 +36,15 @@ func TestDaemonE2EACPmockCrashMidStreamProjectsRuntimeFailure(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
 
+		promptStarted := time.Now()
 		stream, err := harness.PromptSessionHTTP(ctx, session.ID, "trigger crash mid-stream")
 		if err != nil {
 			t.Fatalf("PromptSessionHTTP() error = %v", err)
 		}
+		if elapsed := time.Since(promptStarted); elapsed > 15*time.Second {
+			t.Fatalf("PromptSessionHTTP() elapsed = %s, want terminal stream closure within 15s", elapsed)
+		}
+		assertRawProcessFailureTerminal(t, ctx, harness, session.ID)
 		assertFaultPromptProjection(
 			t,
 			ctx,
@@ -55,8 +60,9 @@ func TestDaemonE2EACPmockCrashMidStreamProjectsRuntimeFailure(t *testing.T) {
 			t.Fatalf("PromptSessionHTTP(recovery) error = %v", err)
 		}
 		if !e2etest.RecordsContainTextDelta(recoveryStream, "recovered after disconnect") ||
-			sseStreamContainsEvent(recoveryStream, "error") {
-			t.Fatalf("recovery prompt stream = %#v, want recovered text and clean completion", recoveryStream)
+			sseStreamContainsEvent(recoveryStream, "error") ||
+			!sseStreamContainsEvent(recoveryStream, "finish") {
+			t.Fatalf("recovery prompt stream = %#v, want recovered text and terminal finish", recoveryStream)
 		}
 		transcript := mustSessionTranscript(t, ctx, harness, session.ID)
 		content := joinTranscriptContent(sessionTranscriptMessages(transcript))
@@ -506,6 +512,23 @@ func assertFaultPromptProjection(
 	if !containsAgentEvent(events, compozycontract.AgentEventPayload{Type: "error"}) {
 		t.Fatalf("events = %#v, want error event", events)
 	}
+	var errorEvent *compozycontract.AgentEventPayload
+	for index := range events {
+		if events[index].Type == "error" {
+			errorEvent = &events[index]
+			break
+		}
+	}
+	if errorEvent == nil || errorEvent.Failure == nil {
+		t.Fatalf("events = %#v, want typed error failure", events)
+	}
+	if got, want := errorEvent.Failure.Kind, store.FailureProcess; got != want {
+		t.Fatalf("error event failure kind = %q, want %q", got, want)
+	}
+	if got, want := errorEvent.Failure.CrashBundlePath, udsSession.Failure.CrashBundlePath; got != want {
+		t.Fatalf("error event crash bundle = %q, want final session bundle %q", got, want)
+	}
+	assertCrashBundleExitCode(t, errorEvent.Failure.CrashBundlePath, 23)
 	if containsAgentEvent(events, compozycontract.AgentEventPayload{Type: "done"}) {
 		t.Fatalf("events = %#v, want no done event after runtime failure", events)
 	}
@@ -528,6 +551,51 @@ func assertFaultPromptProjection(
 	assertArtifactExists(t, harness, e2etest.ArtifactKindSessionSandbox)
 }
 
+func assertRawProcessFailureTerminal(
+	t testing.TB,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	sessionID string,
+) {
+	t.Helper()
+
+	records, err := harness.StreamSessionRawHTTPUntil(ctx, sessionID, func(event e2etest.SSEEvent) bool {
+		return event.Event == "session_stopped"
+	})
+	if err != nil {
+		t.Fatalf("StreamSessionRawHTTPUntil(session_stopped) error = %v", err)
+	}
+
+	errorIndex := -1
+	stoppedIndex := -1
+	var terminal compozycontract.AgentEventPayload
+	for index, record := range records {
+		switch record.Event {
+		case "error":
+			if errorIndex >= 0 {
+				continue
+			}
+			var envelope compozycontract.SessionEventPayload
+			if err := json.Unmarshal(record.Data, &envelope); err != nil {
+				t.Fatalf("json.Unmarshal(raw error envelope) error = %v; data=%s", err, record.Data)
+			}
+			if err := json.Unmarshal(envelope.Content, &terminal); err != nil {
+				t.Fatalf("json.Unmarshal(raw error content) error = %v; content=%s", err, envelope.Content)
+			}
+			errorIndex = index
+		case "session_stopped":
+			stoppedIndex = index
+		}
+	}
+	if errorIndex < 0 || stoppedIndex < 0 || errorIndex >= stoppedIndex {
+		t.Fatalf("raw session records = %#v, want error before session_stopped", records)
+	}
+	if terminal.Type != "error" || terminal.Failure == nil || terminal.Failure.Kind != store.FailureProcess {
+		t.Fatalf("raw terminal event = %#v, want process_exit error", terminal)
+	}
+	assertCrashBundleExitCode(t, terminal.Failure.CrashBundlePath, 23)
+}
+
 func assertCrashBundleExitCode(t testing.TB, path string, want int) {
 	t.Helper()
 	if strings.TrimSpace(path) == "" {
@@ -548,6 +616,9 @@ func assertCrashBundleExitCode(t testing.TB, path string, want int) {
 	}
 	if bundle.Process == nil || bundle.Process.ExitCode == nil || *bundle.Process.ExitCode != want {
 		t.Fatalf("crash bundle process = %#v, want exit_code %d", bundle.Process, want)
+	}
+	if bundle.Process.Signal != "" {
+		t.Fatalf("crash bundle signal = %q, want empty for numeric exit", bundle.Process.Signal)
 	}
 }
 

--- a/internal/daemon/daemon_acpmock_faults_integration_test.go
+++ b/internal/daemon/daemon_acpmock_faults_integration_test.go
@@ -4,9 +4,12 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +21,7 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 	"github.com/compozy/compozy/internal/testutil/acpmock"
 	e2etest "github.com/compozy/compozy/internal/testutil/e2e"
+	toolspkg "github.com/compozy/compozy/internal/tools"
 )
 
 const faultyMockAgentName = "mock-faulty"
@@ -45,6 +49,53 @@ func TestDaemonE2EACPmockCrashMidStreamProjectsRuntimeFailure(t *testing.T) {
 			"partial before crash",
 			false,
 		)
+
+		recoveryStream, err := harness.PromptSessionHTTP(ctx, session.ID, "continue after disconnect")
+		if err != nil {
+			t.Fatalf("PromptSessionHTTP(recovery) error = %v", err)
+		}
+		if !e2etest.RecordsContainTextDelta(recoveryStream, "recovered after disconnect") ||
+			sseStreamContainsEvent(recoveryStream, "error") {
+			t.Fatalf("recovery prompt stream = %#v, want recovered text and clean completion", recoveryStream)
+		}
+		transcript := mustSessionTranscript(t, ctx, harness, session.ID)
+		content := joinTranscriptContent(sessionTranscriptMessages(transcript))
+		if !strings.Contains(content, "partial before crash") ||
+			!strings.Contains(content, "recovered after disconnect") {
+			t.Fatalf("recovered transcript = %q, want partial and recovered assistant output", content)
+		}
+
+		cliSession := createFixtureBackedSession(t, ctx, harness, faultyMockAgentName, "faulty-cli-session")
+		stdout, stderr, cliErr := harness.CLI.Run(
+			ctx,
+			"session", "prompt", cliSession.ID, "trigger crash mid-stream", "-o", "jsonl",
+		)
+		if cliErr == nil {
+			t.Fatalf("CLI crash prompt error = nil, want nonzero exit; stdout=%s stderr=%s", stdout, stderr)
+		}
+		if !strings.Contains(stdout, "partial before crash") || !strings.Contains(stdout, `"type":"error"`) {
+			t.Fatalf("CLI crash prompt stdout = %q, want partial chunk and terminal error frame", stdout)
+		}
+
+		nativeSession := createFixtureBackedSession(t, ctx, harness, faultyMockAgentName, "faulty-native-session")
+		nativeErr := agentDefinitionE2EToolRequestError(
+			t,
+			ctx,
+			harness.HTTPClient,
+			harness.HTTPURL("/api/tools/"+toolspkg.ToolIDSessionPrompt.String()+"/invoke"),
+			compozycontract.ToolInvokeRequest{
+				WorkspaceID: harness.WorkspaceID,
+				Input: json.RawMessage(fmt.Sprintf(
+					`{"session_id":%q,"message":"trigger crash mid-stream","message_id":"msg-native-crash","idempotency_key":"idem-native-crash"}`,
+					nativeSession.ID,
+				)),
+			},
+		)
+		if nativeErr.Status != http.StatusBadGateway ||
+			nativeErr.Payload.Error.Code != toolspkg.ErrorCodeBackendFailed ||
+			!slices.Contains(nativeErr.Payload.Error.ReasonCodes, toolspkg.ReasonBackendDead) {
+			t.Fatalf("native session prompt error = %#v, want 502 tool_backend_failed/backend_dead", nativeErr)
+		}
 	})
 }
 
@@ -430,6 +481,10 @@ func assertFaultPromptProjection(
 	if got, want := udsSession.ID, sessionID; got != want {
 		t.Fatalf("UDS session ID = %q, want %q", got, want)
 	}
+	if udsSession.Failure == nil || udsSession.Failure.Kind != store.FailureProcess {
+		t.Fatalf("UDS session failure = %#v, want process_exit", udsSession.Failure)
+	}
+	assertCrashBundleExitCode(t, udsSession.Failure.CrashBundlePath, 23)
 
 	transcript := mustSessionTranscript(t, ctx, harness, sessionID)
 	content := joinTranscriptContent(sessionTranscriptMessages(transcript))
@@ -471,6 +526,29 @@ func assertFaultPromptProjection(
 	assertArtifactExists(t, harness, e2etest.ArtifactKindTranscript)
 	assertArtifactExists(t, harness, e2etest.ArtifactKindEvents)
 	assertArtifactExists(t, harness, e2etest.ArtifactKindSessionSandbox)
+}
+
+func assertCrashBundleExitCode(t testing.TB, path string, want int) {
+	t.Helper()
+	if strings.TrimSpace(path) == "" {
+		t.Fatal("crash bundle path = empty, want process diagnostics")
+	}
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(crash bundle %q) error = %v", path, err)
+	}
+	var bundle struct {
+		Process *struct {
+			ExitCode *int   `json:"exit_code"`
+			Signal   string `json:"signal"`
+		} `json:"process"`
+	}
+	if err := json.Unmarshal(payload, &bundle); err != nil {
+		t.Fatalf("json.Unmarshal(crash bundle %q) error = %v", path, err)
+	}
+	if bundle.Process == nil || bundle.Process.ExitCode == nil || *bundle.Process.ExitCode != want {
+		t.Fatalf("crash bundle process = %#v, want exit_code %d", bundle.Process, want)
+	}
 }
 
 func assertNoFatalBlockedCancelError(t testing.TB, events []compozycontract.AgentEventPayload) {

--- a/internal/daemon/native_session_mutation.go
+++ b/internal/daemon/native_session_mutation.go
@@ -136,8 +136,8 @@ func (n *daemonNativeTools) sessionPrompt(
 		return toolspkg.ToolResult{}, err
 	}
 	if result.Events != nil {
-		for range result.Events {
-			continue
+		if err := drainNativeSessionPromptEvents(result.Events); err != nil {
+			return toolspkg.ToolResult{}, err
 		}
 	}
 	return n.nativeSessionPromptResult(result)

--- a/internal/daemon/native_session_prompt_stream.go
+++ b/internal/daemon/native_session_prompt_stream.go
@@ -9,13 +9,25 @@ import (
 )
 
 func drainNativeSessionPromptEvents(events <-chan acp.AgentEvent) error {
-	var terminalErr error
 	for event := range events {
-		if terminalErr == nil && event.Type == acp.EventTypeError {
-			terminalErr = nativeSessionPromptEventError(event)
+		switch event.Type {
+		case acp.EventTypeDone:
+			return nil
+		case acp.EventTypeError:
+			return nativeSessionPromptEventError(event)
 		}
 	}
-	return terminalErr
+	return nativeSessionPromptIncompleteError()
+}
+
+func nativeSessionPromptIncompleteError() error {
+	return toolspkg.NewToolError(
+		toolspkg.ErrorCodeBackendFailed,
+		toolspkg.ToolIDSessionPrompt,
+		acp.ErrPromptStreamIncomplete.Error(),
+		fmt.Errorf("%w: %w", toolspkg.ErrToolBackendFailed, acp.ErrPromptStreamIncomplete),
+		toolspkg.ReasonBackendUnhealthy,
+	)
 }
 
 func nativeSessionPromptEventError(event acp.AgentEvent) error {

--- a/internal/daemon/native_session_prompt_stream.go
+++ b/internal/daemon/native_session_prompt_stream.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/compozy/compozy/internal/acp"
+	"github.com/compozy/compozy/internal/store"
+	toolspkg "github.com/compozy/compozy/internal/tools"
+)
+
+func drainNativeSessionPromptEvents(events <-chan acp.AgentEvent) error {
+	var terminalErr error
+	for event := range events {
+		if terminalErr == nil && event.Type == acp.EventTypeError {
+			terminalErr = nativeSessionPromptEventError(event)
+		}
+	}
+	return terminalErr
+}
+
+func nativeSessionPromptEventError(event acp.AgentEvent) error {
+	message := "session prompt ended with a runtime error"
+	reason := toolspkg.ReasonBackendUnhealthy
+	if event.Failure != nil && event.Failure.Kind == store.FailureProcess {
+		message = "session prompt failed because the runtime process exited"
+		reason = toolspkg.ReasonBackendDead
+	}
+	return toolspkg.NewToolError(
+		toolspkg.ErrorCodeBackendFailed,
+		toolspkg.ToolIDSessionPrompt,
+		message,
+		fmt.Errorf("%w: session prompt terminal error", toolspkg.ErrToolBackendFailed),
+		reason,
+	)
+}

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -6174,6 +6174,36 @@ func TestDaemonNativeTools(t *testing.T) {
 		}
 		requireNativeStructuredContains(t, promptCallResult.result, []byte(`"delivery":"direct"`))
 
+		promptEvents = make(chan acp.AgentEvent, 1)
+		promptEvents <- acp.AgentEvent{
+			Type:  acp.EventTypeError,
+			Error: "peer disconnected before response",
+			Failure: &store.SessionFailure{
+				Kind:    store.FailureProcess,
+				Summary: "ACP subprocess exited unexpectedly",
+			},
+		}
+		close(promptEvents)
+		promptAccepted = make(chan struct{})
+		_, err = registry.Call(
+			t.Context(),
+			toolspkg.Scope{Operator: true},
+			toolspkg.CallRequest{
+				ToolID: toolspkg.ToolIDSessionPrompt,
+				Input: json.RawMessage(
+					`{"workspace":"ws-stable","session_id":"sess-1","message":"continue","message_id":"msg-native-failed","idempotency_key":"idem-native-failed"}`,
+				),
+			},
+		)
+		toolErr, ok := errors.AsType[*toolspkg.ToolError](err)
+		if !ok || toolErr.Code != toolspkg.ErrorCodeBackendFailed ||
+			!slices.Contains(toolErr.ReasonCodes, toolspkg.ReasonBackendDead) {
+			t.Fatalf("Registry.Call(session_prompt) error = %#v, want backend_dead", err)
+		}
+		if !strings.Contains(toolErr.Message, "runtime process exited") {
+			t.Fatalf("Registry.Call(session_prompt) message = %q, want clear process failure", toolErr.Message)
+		}
+
 		rewindResult, err := registry.Call(
 			t.Context(),
 			toolspkg.Scope{Operator: true},

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -6160,6 +6160,7 @@ func TestDaemonNativeTools(t *testing.T) {
 			t.Fatalf("Registry.Call(session_prompt) returned before its live stream closed: %#v", call)
 		default:
 		}
+		promptEvents <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: "turn-native"}
 		close(promptEvents)
 		promptCallResult := <-promptCalls
 		if promptCallResult.err != nil {
@@ -6202,6 +6203,35 @@ func TestDaemonNativeTools(t *testing.T) {
 		}
 		if !strings.Contains(toolErr.Message, "runtime process exited") {
 			t.Fatalf("Registry.Call(session_prompt) message = %q, want clear process failure", toolErr.Message)
+		}
+
+		promptEvents = make(chan acp.AgentEvent, 1)
+		promptEvents <- acp.AgentEvent{
+			Type: acp.EventTypeAgentMessage,
+			Text: "partial before EOF",
+		}
+		close(promptEvents)
+		promptAccepted = make(chan struct{})
+		_, err = registry.Call(
+			t.Context(),
+			toolspkg.Scope{Operator: true},
+			toolspkg.CallRequest{
+				ToolID: toolspkg.ToolIDSessionPrompt,
+				Input: json.RawMessage(
+					`{"workspace":"ws-stable","session_id":"sess-1","message":"retry","message_id":"msg-native-incomplete","idempotency_key":"idem-native-incomplete"}`,
+				),
+			},
+		)
+		toolErr, ok = errors.AsType[*toolspkg.ToolError](err)
+		if !ok || toolErr.Code != toolspkg.ErrorCodeBackendFailed ||
+			!slices.Contains(toolErr.ReasonCodes, toolspkg.ReasonBackendUnhealthy) {
+			t.Fatalf("Registry.Call(session_prompt incomplete) error = %#v, want backend unhealthy", err)
+		}
+		if !strings.Contains(toolErr.Message, "ended before a terminal event") {
+			t.Fatalf(
+				"Registry.Call(session_prompt incomplete) message = %q, want explicit EOF failure",
+				toolErr.Message,
+			)
 		}
 
 		rewindResult, err := registry.Call(

--- a/internal/sandbox/daytona/launcher.go
+++ b/internal/sandbox/daytona/launcher.go
@@ -7,6 +7,7 @@ import (
 	"path"
 
 	"github.com/compozy/compozy/internal/sandbox"
+	"github.com/compozy/compozy/internal/subprocess"
 )
 
 var (
@@ -76,6 +77,17 @@ func (h *daytonaHandle) Stderr() string {
 		return ""
 	}
 	return h.session.Stderr()
+}
+
+func (h *daytonaHandle) ExitStatus() (subprocess.ExitStatus, bool) {
+	if h == nil || h.session == nil {
+		return subprocess.ExitStatus{}, false
+	}
+	exitCode, ok := h.session.ExitCode()
+	if !ok {
+		return subprocess.ExitStatus{}, false
+	}
+	return subprocess.ExitStatus{ExitCode: exitCode}, true
 }
 
 func (h *daytonaHandle) Done() <-chan struct{} {

--- a/internal/sandbox/daytona/provider_test.go
+++ b/internal/sandbox/daytona/provider_test.go
@@ -21,6 +21,7 @@ import (
 	acpsdk "github.com/coder/acp-go-sdk"
 	"github.com/compozy/compozy/internal/config"
 	"github.com/compozy/compozy/internal/sandbox"
+	"github.com/compozy/compozy/internal/subprocess"
 	"github.com/compozy/compozy/internal/toolruntime"
 )
 
@@ -352,6 +353,36 @@ func TestDaytonaLauncherLaunchReturnsHandleStreams(t *testing.T) {
 	t.Run("Should launch the pinned remote executable and expose handle streams", func(t *testing.T) {
 		t.Parallel()
 		testDaytonaLauncherLaunchReturnsHandleStreams(t)
+	})
+	t.Run("Should expose the completed remote exit code through ACP diagnostics", func(t *testing.T) {
+		t.Parallel()
+
+		launcher := &daytonaLauncher{
+			transport: &fakeTransport{sessions: []*fakeSession{
+				newFakeCommandSession([]byte("stdout"), 23, "remote stderr"),
+			}},
+			sandbox: sandboxInfo{ID: "sandbox", APIURL: defaultAPIURL},
+		}
+		handle, err := launcher.Launch(context.Background(), sandbox.LaunchSpec{
+			ResolvedExecutable: "/remote/bin/agent",
+			Cwd:                "/workspace",
+		})
+		if err != nil {
+			t.Fatalf("Launch() error = %v", err)
+		}
+		if err := handle.Wait(); err == nil {
+			t.Fatal("Wait() error = nil, want remote exit failure")
+		}
+		diagnostics, ok := handle.(interface {
+			ExitStatus() (subprocess.ExitStatus, bool)
+		})
+		if !ok {
+			t.Fatalf("handle = %T, want exit status diagnostics", handle)
+		}
+		status, ok := diagnostics.ExitStatus()
+		if !ok || status.ExitCode != 23 || status.Signal != "" {
+			t.Fatalf("ExitStatus() = %#v, %t; want exit code 23 without signal", status, ok)
+		}
 	})
 }
 

--- a/internal/session/crash_bundle.go
+++ b/internal/session/crash_bundle.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	crashBundleDirName      = "crash-bundles"
-	crashBundleSchema       = "compozy.session_crash_bundle.v1"
+	crashBundleSchema       = "compozy.session_crash_bundle.v2"
 	maxCrashEvidenceBytes   = 32 << 10
 	crashBundleFileMode     = 0o600
 	crashBundleDirMode      = 0o700
@@ -44,6 +44,8 @@ type crashBundleProcess struct {
 	Args      []string  `json:"args,omitempty"`
 	Cwd       string    `json:"cwd,omitempty"`
 	StartedAt time.Time `json:"started_at"`
+	ExitCode  *int      `json:"exit_code,omitempty"`
+	Signal    string    `json:"signal,omitempty"`
 }
 
 func (m *Manager) attachCrashBundleToFailure(
@@ -134,13 +136,19 @@ func (m *Manager) writeCrashBundle(
 		CreatedAt: m.now().UTC(),
 	}
 	if proc := session.processHandle(); proc != nil {
-		document.Process = &crashBundleProcess{
+		process := &crashBundleProcess{
 			PID:       proc.PID,
 			Command:   diagnostics.RedactAndBound(proc.Command, maxCrashEvidenceBytes),
 			Args:      redactStringSlice(proc.Args),
 			Cwd:       diagnostics.RedactAndBound(proc.Cwd, maxCrashEvidenceBytes),
 			StartedAt: proc.StartedAt.UTC(),
 		}
+		if status, ok := proc.ExitStatus(); ok {
+			exitCode := status.ExitCode
+			process.ExitCode = &exitCode
+			process.Signal = status.Signal
+		}
+		document.Process = process
 	}
 
 	payload, err := json.MarshalIndent(document, "", "  ")

--- a/internal/session/crash_bundle.go
+++ b/internal/session/crash_bundle.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -86,9 +87,13 @@ func (m *Manager) attachPromptFailureDiagnostics(
 	}
 	var eventErr error
 	if strings.TrimSpace(event.Error) != "" {
-		eventErr = fmt.Errorf("%s", event.Error)
+		eventErr = errors.New(event.Error)
 	}
-	failure, err := m.attachCrashBundleToFailure(ctx, session, event.Failure, eventErr, "")
+	stderr := ""
+	if proc := session.processHandle(); proc != nil && isProcessDone(proc) {
+		stderr = proc.Stderr()
+	}
+	failure, err := m.attachCrashBundleToFailure(ctx, session, event.Failure, eventErr, stderr)
 	if err != nil {
 		m.sessionLogger(session).Warn(
 			"session: write prompt failure crash bundle failed",
@@ -107,6 +112,16 @@ func (m *Manager) writeCrashBundle(
 	failure store.SessionFailure,
 	err error,
 	stderr string,
+) (string, error) {
+	return m.writeCrashBundleAtPath(session, failure, err, stderr, "")
+}
+
+func (m *Manager) writeCrashBundleAtPath(
+	session *Session,
+	failure store.SessionFailure,
+	err error,
+	stderr string,
+	targetPath string,
 ) (string, error) {
 	if session == nil {
 		return "", nil
@@ -144,8 +159,9 @@ func (m *Manager) writeCrashBundle(
 			StartedAt: proc.StartedAt.UTC(),
 		}
 		if status, ok := proc.ExitStatus(); ok {
-			exitCode := status.ExitCode
-			process.ExitCode = &exitCode
+			if exitCode, available := status.ExitCodeValue(); available {
+				process.ExitCode = &exitCode
+			}
 			process.Signal = status.Signal
 		}
 		document.Process = process
@@ -157,11 +173,32 @@ func (m *Manager) writeCrashBundle(
 	}
 	payload = append(payload, '\n')
 
-	path := filepath.Join(dir, crashBundleFileName(info.ID, failure.Kind, document.CreatedAt))
+	path := filepath.Clean(targetPath)
+	if targetPath == "" {
+		path = filepath.Join(dir, crashBundleFileName(info.ID, failure.Kind, document.CreatedAt))
+	} else if filepath.Dir(path) != filepath.Clean(dir) {
+		return "", fmt.Errorf("session: crash bundle path %q is outside %q", targetPath, dir)
+	}
 	if err := fileutil.AtomicWriteFile(path, payload, crashBundleFileMode); err != nil {
 		return "", fmt.Errorf("session: write crash bundle %q: %w", path, err)
 	}
 	return path, nil
+}
+
+func reusableCrashBundleFailure(
+	existing *store.SessionFailure,
+	classified *store.SessionFailure,
+) (*store.SessionFailure, bool) {
+	if existing == nil || classified == nil {
+		return nil, false
+	}
+	normalizedExisting := existing.Normalize()
+	normalizedClassified := classified.Normalize()
+	if normalizedExisting.CrashBundlePath == "" || normalizedExisting.Kind != normalizedClassified.Kind {
+		return nil, false
+	}
+	normalizedClassified.CrashBundlePath = normalizedExisting.CrashBundlePath
+	return &normalizedClassified, true
 }
 
 func failureShouldHaveCrashBundle(kind store.FailureKind) bool {

--- a/internal/session/crash_bundle_test.go
+++ b/internal/session/crash_bundle_test.go
@@ -1,13 +1,145 @@
 package session
 
 import (
+	"encoding/json"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
+	"github.com/compozy/compozy/internal/acp"
 	"github.com/compozy/compozy/internal/store"
+	"github.com/compozy/compozy/internal/subprocess"
 )
+
+func TestPromptCrashBundleProcessEvidence(t *testing.T) {
+	t.Run("Should stop the process before attaching the public event crash bundle", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			h := newHarness(t)
+			sess := createSession(t, h)
+			proc := h.driver.lastProcess()
+			proc.handle.exitStatusFn = func() (subprocess.ExitStatus, bool) {
+				select {
+				case <-proc.done:
+					return subprocess.ExitStatus{ExitCode: 23}, true
+				default:
+					return subprocess.ExitStatus{}, false
+				}
+			}
+			stopStarted := make(chan struct{})
+			releaseStop := make(chan struct{})
+			h.driver.stopHook = func(proc *fakeProcess) error {
+				close(stopStarted)
+				<-releaseStop
+				proc.finish(nil, "codex stderr tail")
+				return nil
+			}
+			type barrierResult struct {
+				event acp.AgentEvent
+				fatal *promptPumpFatal
+			}
+			result := make(chan barrierResult, 1)
+			go func() {
+				event := acp.AgentEvent{
+					Type:  acp.EventTypeError,
+					Error: "peer disconnected before response",
+					Failure: &store.SessionFailure{
+						Kind:    store.FailureProcess,
+						Summary: "ACP subprocess exited unexpectedly",
+					},
+				}
+				fatal := &promptPumpFatal{}
+				if !h.manager.prepareFatalPromptFailureEvent(t.Context(), sess, event, fatal) {
+					result <- barrierResult{event: event, fatal: fatal}
+					return
+				}
+				event = h.manager.attachPromptFailureDiagnostics(t.Context(), sess, event)
+				fatal.capture(event.Failure, event.Error)
+				result <- barrierResult{event: event, fatal: fatal}
+			}()
+
+			synctest.Wait()
+			select {
+			case <-stopStarted:
+			default:
+				t.Fatal("fatal prompt barrier did not start process stop")
+			}
+			select {
+			case got := <-result:
+				t.Fatalf("fatal prompt barrier returned before process completion: %#v", got.event)
+			default:
+			}
+
+			close(releaseStop)
+			synctest.Wait()
+			got := <-result
+			event := got.event
+			if event.Failure == nil || event.Failure.CrashBundlePath == "" {
+				t.Fatalf("prompt failure = %#v, want crash bundle path", event.Failure)
+			}
+			bundle := readCrashBundleDocument(t, event.Failure.CrashBundlePath)
+			if bundle.Process == nil || bundle.Process.ExitCode == nil || *bundle.Process.ExitCode != 23 {
+				t.Fatalf("crash bundle process = %#v, want exit code 23", bundle.Process)
+			}
+			if got, want := bundle.Stderr, "codex stderr tail"; got != want {
+				t.Fatalf("crash bundle stderr = %q, want %q", got, want)
+			}
+			h.manager.finalizeSessionAfterFatalPromptFailure(t.Context(), sess, got.fatal)
+		})
+	})
+
+	t.Run("Should serialize a Unix signal without a synthetic negative exit code", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		sess := createSession(t, h)
+		t.Cleanup(func() {
+			reportSessionStop(t, h, sess.ID)
+		})
+		proc := h.driver.lastProcess()
+		proc.handle.exitStatusFn = func() (subprocess.ExitStatus, bool) {
+			return subprocess.ExitStatus{ExitCode: -1, Signal: "killed"}, true
+		}
+
+		path, err := h.manager.writeCrashBundle(
+			sess,
+			store.SessionFailure{Kind: store.FailureProcess, Summary: "runtime killed"},
+			nil,
+			"",
+		)
+		if err != nil {
+			t.Fatalf("writeCrashBundle() error = %v", err)
+		}
+		bundle := readCrashBundleDocument(t, path)
+		if bundle.Process == nil {
+			t.Fatal("crash bundle process = nil, want signal evidence")
+		}
+		if bundle.Process.ExitCode != nil {
+			t.Fatalf("crash bundle exit_code = %d, want omitted for signal exit", *bundle.Process.ExitCode)
+		}
+		if got, want := bundle.Process.Signal, "killed"; got != want {
+			t.Fatalf("crash bundle signal = %q, want %q", got, want)
+		}
+	})
+}
+
+func readCrashBundleDocument(t *testing.T, path string) crashBundleDocument {
+	t.Helper()
+
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%q) error = %v", path, err)
+	}
+	var document crashBundleDocument
+	if err := json.Unmarshal(payload, &document); err != nil {
+		t.Fatalf("json.Unmarshal(crash bundle) error = %v", err)
+	}
+	return document
+}
 
 func TestCrashBundleFileName(t *testing.T) {
 	t.Parallel()

--- a/internal/session/interfaces.go
+++ b/internal/session/interfaces.go
@@ -159,6 +159,7 @@ type AgentProcess struct {
 	done                <-chan struct{}
 	waitFn              func() error
 	stderrFn            func() string
+	exitStatusFn        func() (subprocess.ExitStatus, bool)
 	healthStateFn       func() subprocess.HealthState
 	capsSnapshotFn      func() acp.Caps
 	pendingPermissionFn func() bool
@@ -185,6 +186,7 @@ type AgentProcessOptions struct {
 	Done              <-chan struct{}
 	Wait              func() error
 	Stderr            func() string
+	ExitStatus        func() (subprocess.ExitStatus, bool)
 	HealthState       func() subprocess.HealthState
 	PendingPermission func() bool
 	ApprovePermission func(context.Context, acp.ApproveRequest) error
@@ -228,6 +230,7 @@ func NewAgentProcess(opts AgentProcessOptions) *AgentProcess {
 		done:                done,
 		waitFn:              waitFn,
 		stderrFn:            stderrFn,
+		exitStatusFn:        opts.ExitStatus,
 		healthStateFn:       opts.HealthState,
 		capsSnapshotFn:      opts.CapsSnapshot,
 		pendingPermissionFn: opts.PendingPermission,
@@ -246,18 +249,24 @@ func (p *AgentProcess) Done() <-chan struct{} {
 // Wait blocks until the runtime process exits and returns its terminal error state.
 func (p *AgentProcess) Wait() error {
 	<-p.Done()
+	waitErr := p.waitFn()
 	p.waitOverrideMu.RLock()
 	override := p.waitErrOverride
 	p.waitOverrideMu.RUnlock()
-	if override != nil {
-		return override
-	}
-	return p.waitFn()
+	return errors.Join(waitErr, override)
 }
 
 // Stderr returns any captured stderr output for the runtime process.
 func (p *AgentProcess) Stderr() string {
 	return p.stderrFn()
+}
+
+// ExitStatus returns the stable OS exit diagnostics exposed by the runtime process.
+func (p *AgentProcess) ExitStatus() (subprocess.ExitStatus, bool) {
+	if p == nil || p.exitStatusFn == nil {
+		return subprocess.ExitStatus{}, false
+	}
+	return p.exitStatusFn()
 }
 
 // HealthState returns the latest runtime health snapshot when the driver
@@ -360,6 +369,7 @@ func wrapACPProcess(proc *acp.AgentProcess) *AgentProcess {
 		done:                proc.Done(),
 		waitFn:              proc.Wait,
 		stderrFn:            proc.Stderr,
+		exitStatusFn:        proc.ExitStatus,
 		healthStateFn:       proc.HealthState,
 		capsSnapshotFn:      proc.CapsSnapshot,
 		pendingPermissionFn: proc.HasPendingPermission,

--- a/internal/session/manager_hooks_lifecycle_test.go
+++ b/internal/session/manager_hooks_lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/compozy/compozy/internal/acp"
 	hookspkg "github.com/compozy/compozy/internal/hooks"
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/testutil"
@@ -148,6 +149,210 @@ func TestSessionNetworkLifecycleHandling(t *testing.T) {
 
 func TestStopWithCauseLifecycle(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Should preserve stop hooks around a fatal prompt failure", func(t *testing.T) {
+		t.Parallel()
+
+		type lifecycleStep struct {
+			name  string
+			state State
+		}
+
+		var (
+			stepsMu sync.Mutex
+			steps   []lifecycleStep
+			session *Session
+		)
+		recordStep := func(name string) {
+			stepsMu.Lock()
+			defer stepsMu.Unlock()
+			steps = append(steps, lifecycleStep{name: name, state: session.Info().State})
+		}
+
+		dispatcher := &spyHookDispatcher{
+			dispatchSessionPreStopFn: func(
+				_ context.Context,
+				payload hookspkg.SessionPreStopPayload,
+			) (hookspkg.SessionPreStopPayload, error) {
+				recordStep("pre-stop")
+				return payload, nil
+			},
+			dispatchSessionPostStopFn: func(
+				_ context.Context,
+				payload hookspkg.SessionPostStopPayload,
+			) (hookspkg.SessionPostStopPayload, error) {
+				recordStep("post-stop")
+				return payload, nil
+			},
+		}
+		h := newHarness(t, WithHookSet(fullHookSet(dispatcher)))
+		session = createSession(t, h)
+		t.Cleanup(func() {
+			if _, ok := h.manager.Get(session.ID); ok {
+				reportSessionStop(t, h, session.ID)
+			}
+		})
+
+		h.driver.stopHook = func(proc *fakeProcess) error {
+			recordStep("driver-stop")
+			proc.crash(errors.New("acp subprocess exited: exit status 23"), "codex stderr tail")
+			return nil
+		}
+		h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			events := make(chan acp.AgentEvent, 1)
+			events <- acp.AgentEvent{
+				Type:      acp.EventTypeError,
+				TurnID:    req.TurnID,
+				Timestamp: time.Now().UTC(),
+				Error:     "ACP process disconnected",
+				Failure: &store.SessionFailure{
+					Kind:    store.FailureProcess,
+					Summary: "ACP process disconnected",
+				},
+			}
+			close(events)
+			return events, nil
+		}
+
+		events, err := h.manager.Prompt(testutil.Context(t), session.ID, "hello")
+		if err != nil {
+			t.Fatalf("Prompt() error = %v", err)
+		}
+		promptEvents := collectEvents(t, events)
+		if got, want := len(promptEvents), 1; got != want {
+			t.Fatalf("Prompt() events = %d, want %d", got, want)
+		}
+		if failure := promptEvents[0].Failure; failure == nil || failure.Kind != store.FailureProcess {
+			t.Fatalf("Prompt() failure = %#v, want process_exit", failure)
+		}
+		h.notifier.waitForStopped(t, session.ID)
+
+		stepsMu.Lock()
+		gotSteps := append([]lifecycleStep(nil), steps...)
+		stepsMu.Unlock()
+		wantSteps := []lifecycleStep{
+			{name: "pre-stop", state: StateActive},
+			{name: "driver-stop", state: StateStopping},
+			{name: "post-stop", state: StateStopped},
+		}
+		if len(gotSteps) != len(wantSteps) {
+			t.Fatalf("fatal prompt lifecycle steps = %#v, want %#v", gotSteps, wantSteps)
+		}
+		for i := range wantSteps {
+			if gotSteps[i] != wantSteps[i] {
+				t.Fatalf("fatal prompt lifecycle step %d = %#v, want %#v", i, gotSteps[i], wantSteps[i])
+			}
+		}
+		if got, want := h.driver.stopCalls, 1; got != want {
+			t.Fatalf("driver stop calls = %d, want %d", got, want)
+		}
+		if got, want := h.notifier.stoppedCount(), 1; got != want {
+			t.Fatalf("stopped notifications = %d, want %d", got, want)
+		}
+		if _, ok := h.manager.Get(session.ID); ok {
+			t.Fatalf("Get(%q) found session after fatal prompt finalization", session.ID)
+		}
+	})
+
+	t.Run("Should preserve lifecycle hooks when process exit wins prompt stream closure", func(t *testing.T) {
+		t.Parallel()
+
+		type lifecycleStep struct {
+			name  string
+			state State
+		}
+
+		var (
+			stepsMu sync.Mutex
+			steps   []lifecycleStep
+			session *Session
+		)
+		recordStep := func(name string) {
+			stepsMu.Lock()
+			defer stepsMu.Unlock()
+			steps = append(steps, lifecycleStep{name: name, state: session.Info().State})
+		}
+
+		dispatcher := &spyHookDispatcher{
+			dispatchSessionPreStopFn: func(
+				_ context.Context,
+				payload hookspkg.SessionPreStopPayload,
+			) (hookspkg.SessionPreStopPayload, error) {
+				recordStep("pre-stop")
+				return payload, nil
+			},
+			dispatchSessionPostStopFn: func(
+				_ context.Context,
+				payload hookspkg.SessionPostStopPayload,
+			) (hookspkg.SessionPostStopPayload, error) {
+				recordStep("post-stop")
+				return payload, nil
+			},
+		}
+		h := newHarness(t, WithHookSet(fullHookSet(dispatcher)))
+		session = createSession(t, h)
+		h.notifier.finalizingHook = func(context.Context, *Session) {
+			recordStep("finalizing")
+		}
+		t.Cleanup(func() {
+			if _, ok := h.manager.Get(session.ID); ok {
+				reportSessionStop(t, h, session.ID)
+			}
+		})
+
+		source := make(chan acp.AgentEvent)
+		h.driver.promptHook = func(_ *fakeProcess, _ acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			return source, nil
+		}
+		events, err := h.manager.Prompt(testutil.Context(t), session.ID, "hello")
+		if err != nil {
+			t.Fatalf("Prompt() error = %v", err)
+		}
+		h.driver.lastProcess().crash(
+			acp.WrapFailure(
+				store.FailureProcess,
+				"ACP subprocess exited unexpectedly",
+				errors.New("acp subprocess exited: exit status 23"),
+			),
+			"codex stderr tail",
+		)
+		close(source)
+
+		promptEvents := collectEvents(t, events)
+		if got, want := len(promptEvents), 1; got != want {
+			t.Fatalf("Prompt() events = %d, want %d", got, want)
+		}
+		if failure := promptEvents[0].Failure; failure == nil || failure.Kind != store.FailureProcess {
+			t.Fatalf("Prompt() failure = %#v, want process_exit", failure)
+		}
+		h.notifier.waitForStopped(t, session.ID)
+
+		stepsMu.Lock()
+		gotSteps := append([]lifecycleStep(nil), steps...)
+		stepsMu.Unlock()
+		wantSteps := []lifecycleStep{
+			{name: "pre-stop", state: StateActive},
+			{name: "finalizing", state: StateStopping},
+			{name: "post-stop", state: StateStopped},
+		}
+		if len(gotSteps) != len(wantSteps) {
+			t.Fatalf("process-exit lifecycle steps = %#v, want %#v", gotSteps, wantSteps)
+		}
+		for i := range wantSteps {
+			if gotSteps[i] != wantSteps[i] {
+				t.Fatalf("process-exit lifecycle step %d = %#v, want %#v", i, gotSteps[i], wantSteps[i])
+			}
+		}
+		if got := h.driver.stopCalls; got != 0 {
+			t.Fatalf("driver stop calls = %d, want none for an already exited process", got)
+		}
+		if got, want := h.notifier.stoppedCount(), 1; got != want {
+			t.Fatalf("stopped notifications = %d, want %d", got, want)
+		}
+		if _, ok := h.manager.Get(session.ID); ok {
+			t.Fatalf("Get(%q) found session after process-exit finalization", session.ID)
+		}
+	})
 
 	t.Run("Should reject a pre-stop workspace mutation before persistence", func(t *testing.T) {
 		t.Parallel()

--- a/internal/session/manager_lifecycle.go
+++ b/internal/session/manager_lifecycle.go
@@ -111,8 +111,19 @@ func (m *Manager) handleProcessExit(
 	if state != StateActive && state != StateStopping {
 		return nil
 	}
+	if session.currentPromptCompletion() != nil {
+		m.waitForActivePromptProcessExit(ctx, session)
+		if !session.isCurrentProcess(proc) {
+			return nil
+		}
+		state = session.Info().State
+		if state != StateActive && state != StateStopping {
+			return nil
+		}
+	}
 
-	if !session.stopWasRequested() {
+	stopCause, _ := session.stopCauseDetail()
+	if !session.stopWasRequested() && stopCause == CauseNone {
 		switch waitErr {
 		case nil:
 			if session.IsPrompting() {
@@ -187,7 +198,20 @@ func (m *Manager) persistStopClassification(ctx context.Context, session *Sessio
 		if proc := session.processHandle(); proc != nil {
 			stderr = proc.Stderr()
 		}
-		failure, bundleErr = m.attachCrashBundleToFailure(ctx, session, failure, waitErr, stderr)
+		if reusable, ok := reusableCrashBundleFailure(session.Info().Failure, failure); ok {
+			failure = reusable
+			if _, err := m.writeCrashBundleAtPath(
+				session,
+				*reusable,
+				waitErr,
+				stderr,
+				reusable.CrashBundlePath,
+			); err != nil {
+				bundleErr = err
+			}
+		} else {
+			failure, bundleErr = m.attachCrashBundleToFailure(ctx, session, failure, waitErr, stderr)
+		}
 	}
 	session.setStopClassification(stopReason, stopDetail)
 	session.setFailure(failure)

--- a/internal/session/manager_managed_input_submit.go
+++ b/internal/session/manager_managed_input_submit.go
@@ -98,7 +98,7 @@ func (m *Manager) startManagedInputPrompt(session *Session, entry managedInput) 
 	stateOwned := true
 	defer func() {
 		if stateOwned {
-			clearManagedInputPromptState(session)
+			clearManagedInputPromptState(session, setup.request.turnID)
 		}
 	}()
 	dispatchMessage, err := m.promptDispatchMessage(setup.leaseCtx, session, message)
@@ -261,12 +261,14 @@ func setManagedInputPromptState(session *Session, request promptRequest) {
 	session.setCurrentSkillInvocations(nil)
 }
 
-func clearManagedInputPromptState(session *Session) {
+func clearManagedInputPromptState(session *Session, turnID string) {
+	session.clearPromptCancellation(turnID)
 	session.clearCurrentTurnID()
 	session.clearCurrentTurnSource()
 	session.clearCurrentPromptMessage()
 	session.clearCurrentPromptMeta()
 	session.clearCurrentSkillInvocations()
+	session.finishCurrentPromptCompletion()
 }
 
 func managedInputOwnerFromEntry(entry managedInput) (ManagedInputOwner, error) {

--- a/internal/session/manager_prompt.go
+++ b/internal/session/manager_prompt.go
@@ -81,7 +81,12 @@ func isFatalPromptFailureEvent(event acp.AgentEvent) bool {
 	if event.Type != acp.EventTypeError || event.Failure == nil {
 		return false
 	}
-	return event.Failure.Kind == store.FailureProcess
+	switch event.Failure.Kind {
+	case store.FailureProcess, store.FailureTransport:
+		return true
+	default:
+		return false
+	}
 }
 
 // Prompt sends one prompt turn to an active session and mirrors the runtime stream into storage and observers.
@@ -152,13 +157,14 @@ func (m *Manager) CancelPrompt(ctx context.Context, id string) error {
 		}
 		return nil
 	}
-	if !session.IsPrompting() {
+	turnID, proc, cancelPrompt, prompting := session.requestCurrentPromptCancellation()
+	if !prompting {
 		return nil
 	}
-	turnID := session.CurrentTurnID()
-	session.cancelCurrentPrompt()
+	if cancelPrompt != nil {
+		cancelPrompt()
+	}
 
-	proc := session.processHandle()
 	if proc == nil {
 		m.emitTranscriptMarker(
 			ctx,

--- a/internal/session/manager_prompt_batch.go
+++ b/internal/session/manager_prompt_batch.go
@@ -18,10 +18,11 @@ func (m *Manager) handlePromptPumpChunkBatch(
 	out chan<- acp.AgentEvent,
 	loop *promptPumpLoopState,
 	events []acp.AgentEvent,
+	fatal *promptPumpFatal,
 ) (*store.SessionFailure, string, bool) {
 	normalized := make([]acp.AgentEvent, 0, len(events))
 	for _, event := range events {
-		next, skip := m.preparePromptPumpEventForDelivery(ctx, session, turnState, loop, event, false)
+		next, skip := m.preparePromptPumpEventForDelivery(ctx, session, turnState, loop, event, false, fatal)
 		if skip {
 			continue
 		}

--- a/internal/session/manager_prompt_contract_test.go
+++ b/internal/session/manager_prompt_contract_test.go
@@ -372,25 +372,37 @@ func TestPromptFatalProcessFailureStopsSessionAndAllowsFreshResumeFallback(t *te
 	h := newHarness(t)
 	session := createSession(t, h)
 	originalACP := session.Info().ACPSessionID
+	processExitErr := errors.New("acp subprocess exited: exit status 23")
 	t.Cleanup(func() {
 		if _, ok := h.manager.Get(session.ID); ok {
 			reportSessionStop(t, h, session.ID)
 		}
 	})
+	h.driver.stopHook = func(proc *fakeProcess) error {
+		proc.crash(processExitErr, "codex stderr tail")
+		return nil
+	}
 
 	h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
-		events := make(chan acp.AgentEvent, 1)
+		events := make(chan acp.AgentEvent, 2)
 		go func() {
 			defer close(events)
+			events <- acp.AgentEvent{
+				Type:      acp.EventTypeAgentMessage,
+				SessionID: originalACP,
+				TurnID:    req.TurnID,
+				Timestamp: time.Now().UTC(),
+				Text:      "partial before disconnect",
+			}
 			events <- acp.AgentEvent{
 				Type:      acp.EventTypeError,
 				SessionID: originalACP,
 				TurnID:    req.TurnID,
 				Timestamp: time.Now().UTC(),
-				Error:     `{"code":-32603,"message":"Internal error: The Claude Agent process exited unexpectedly. Please start a new session."}`,
+				Error:     `RequestError -32603: peer disconnected before response`,
 				Failure: &store.SessionFailure{
 					Kind:    store.FailureProcess,
-					Summary: `{"code":-32603,"message":"Internal error: The Claude Agent process exited unexpectedly. Please start a new session."}`,
+					Summary: `RequestError -32603: peer disconnected before response`,
 				},
 			}
 		}()
@@ -402,14 +414,17 @@ func TestPromptFatalProcessFailureStopsSessionAndAllowsFreshResumeFallback(t *te
 		t.Fatalf("Prompt() error = %v", err)
 	}
 	events := collectEvents(t, eventsCh)
-	if got, want := len(events), 1; got != want {
+	if got, want := len(events), 2; got != want {
 		t.Fatalf("Prompt() events = %d, want %d", got, want)
 	}
-	if got, want := events[0].Type, acp.EventTypeError; got != want {
+	if got, want := events[0].Type, acp.EventTypeAgentMessage; got != want {
 		t.Fatalf("Prompt() first event type = %q, want %q", got, want)
 	}
-	if events[0].Failure == nil || events[0].Failure.Kind != store.FailureProcess {
-		t.Fatalf("Prompt() failure = %#v, want process_exit", events[0].Failure)
+	if got, want := events[0].Text, "partial before disconnect"; got != want {
+		t.Fatalf("Prompt() first event text = %q, want %q", got, want)
+	}
+	if events[1].Failure == nil || events[1].Failure.Kind != store.FailureProcess {
+		t.Fatalf("Prompt() failure = %#v, want process_exit", events[1].Failure)
 	}
 
 	h.notifier.waitForStopped(t, session.ID)
@@ -430,6 +445,17 @@ func TestPromptFatalProcessFailureStopsSessionAndAllowsFreshResumeFallback(t *te
 	}
 	if meta.Failure == nil || meta.Failure.Kind != store.FailureProcess {
 		t.Fatalf("meta.Failure = %#v, want process_exit", meta.Failure)
+	}
+	if !strings.Contains(meta.StopDetail, processExitErr.Error()) {
+		t.Fatalf("meta.StopDetail = %q, want real process exit diagnostic %q", meta.StopDetail, processExitErr)
+	}
+	stored := readStoredEvents(t, session)
+	if !containsEventType(stored, acp.EventTypeAgentMessage) || containsEventType(stored, acp.EventTypeDone) {
+		t.Fatalf("stored events = %#v, want partial agent message and no done event", stored)
+	}
+	partial := storedEventByType(t, stored, acp.EventTypeAgentMessage)
+	if !strings.Contains(partial.Content, "partial before disconnect") {
+		t.Fatalf("stored agent message = %s, want persisted partial chunk", partial.Content)
 	}
 
 	h.driver.startHook = func(opts acp.StartOpts, sequence int) (*fakeProcess, error) {
@@ -464,6 +490,25 @@ func TestPromptFatalProcessFailureStopsSessionAndAllowsFreshResumeFallback(t *te
 	}
 	if got := resumed.Info().ACPSessionID; got == "" || got == originalACP {
 		t.Fatalf("resumed ACPSessionID = %q, want fresh ACP session id distinct from %q", got, originalACP)
+	}
+
+	h.driver.mu.Lock()
+	h.driver.promptHook = nil
+	h.driver.stopHook = nil
+	h.driver.mu.Unlock()
+	recoveryEventsCh, err := h.manager.Prompt(testutil.Context(t), resumed.ID, "continue after disconnect")
+	if err != nil {
+		t.Fatalf("Prompt(recovered session) error = %v", err)
+	}
+	recoveryEvents := collectEvents(t, recoveryEventsCh)
+	if got, want := len(recoveryEvents), 2; got != want {
+		t.Fatalf("Prompt(recovered session) events = %d, want %d", got, want)
+	}
+	if recoveryEvents[0].Type != acp.EventTypeAgentMessage || recoveryEvents[1].Type != acp.EventTypeDone {
+		t.Fatalf("Prompt(recovered session) events = %#v, want agent message then done", recoveryEvents)
+	}
+	if got, want := len(h.driver.promptCalls), 2; got != want {
+		t.Fatalf("driver prompt calls = %d, want failed prompt plus one explicit recovery prompt", got)
 	}
 }
 

--- a/internal/session/manager_prompt_contract_test.go
+++ b/internal/session/manager_prompt_contract_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -17,7 +18,9 @@ import (
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	"github.com/compozy/compozy/internal/network/participation"
 	"github.com/compozy/compozy/internal/store"
+	"github.com/compozy/compozy/internal/subprocess"
 	"github.com/compozy/compozy/internal/testutil"
+	"github.com/compozy/compozy/internal/transcript"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 	skillbundled "github.com/compozy/compozy/skills"
 )
@@ -367,149 +370,285 @@ func TestPromptDeadlineDeliversRuntimeWarningBeforeError(t *testing.T) {
 }
 
 func TestPromptFatalProcessFailureStopsSessionAndAllowsFreshResumeFallback(t *testing.T) {
-	t.Parallel()
+	t.Run("Should stop after a fatal process failure and recover with an explicit prompt", func(t *testing.T) {
+		t.Parallel()
 
-	h := newHarness(t)
-	session := createSession(t, h)
-	originalACP := session.Info().ACPSessionID
-	processExitErr := errors.New("acp subprocess exited: exit status 23")
-	t.Cleanup(func() {
+		h := newHarness(t)
+		session := createSession(t, h)
+		originalACP := session.Info().ACPSessionID
+		processExitErr := errors.New("acp subprocess exited: exit status 23")
+		h.driver.lastProcess().handle.exitStatusFn = func() (subprocess.ExitStatus, bool) {
+			return subprocess.ExitStatus{ExitCode: 23}, true
+		}
+		t.Cleanup(func() {
+			if _, ok := h.manager.Get(session.ID); ok {
+				reportSessionStop(t, h, session.ID)
+			}
+		})
+		h.driver.stopHook = func(proc *fakeProcess) error {
+			proc.crash(processExitErr, "codex stderr tail")
+			return nil
+		}
+
+		h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			events := make(chan acp.AgentEvent, 2)
+			go func() {
+				defer close(events)
+				events <- acp.AgentEvent{
+					Type:      acp.EventTypeAgentMessage,
+					SessionID: originalACP,
+					TurnID:    req.TurnID,
+					Timestamp: time.Now().UTC(),
+					Text:      "partial before disconnect",
+				}
+				events <- acp.AgentEvent{
+					Type:      acp.EventTypeError,
+					SessionID: originalACP,
+					TurnID:    req.TurnID,
+					Timestamp: time.Now().UTC(),
+					Error:     `RequestError -32603: peer disconnected before response`,
+					Failure: &store.SessionFailure{
+						Kind:    store.FailureProcess,
+						Summary: `RequestError -32603: peer disconnected before response`,
+					},
+				}
+			}()
+			return events, nil
+		}
+
+		eventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "hello")
+		if err != nil {
+			t.Fatalf("Prompt() error = %v", err)
+		}
+		events := collectEvents(t, eventsCh)
+		if got, want := len(events), 2; got != want {
+			t.Fatalf("Prompt() events = %d, want %d", got, want)
+		}
+		if got, want := events[0].Type, acp.EventTypeAgentMessage; got != want {
+			t.Fatalf("Prompt() first event type = %q, want %q", got, want)
+		}
+		if got, want := events[0].Text, "partial before disconnect"; got != want {
+			t.Fatalf("Prompt() first event text = %q, want %q", got, want)
+		}
+		if events[1].Failure == nil || events[1].Failure.Kind != store.FailureProcess {
+			t.Fatalf("Prompt() failure = %#v, want process_exit", events[1].Failure)
+		}
+		if events[1].Failure.CrashBundlePath == "" {
+			t.Fatalf("Prompt() failure = %#v, want crash bundle path", events[1].Failure)
+		}
+		publicBundle := readCrashBundleDocument(t, events[1].Failure.CrashBundlePath)
+		if publicBundle.Process == nil || publicBundle.Process.ExitCode == nil || *publicBundle.Process.ExitCode != 23 {
+			t.Fatalf("public crash bundle process = %#v, want exit code 23 before stopped notification", publicBundle.Process)
+		}
+		if publicBundle.Process.Signal != "" {
+			t.Fatalf("public crash bundle signal = %q, want empty for numeric exit", publicBundle.Process.Signal)
+		}
+		if got, want := publicBundle.Stderr, "codex stderr tail"; got != want {
+			t.Fatalf("public crash bundle stderr = %q, want %q", got, want)
+		}
+
+		h.notifier.waitForStopped(t, session.ID)
 		if _, ok := h.manager.Get(session.ID); ok {
-			reportSessionStop(t, h, session.ID)
+			t.Fatalf("Get(%q) found session after stopped notification", session.ID)
+		}
+
+		if got := h.driver.stopCalls; got != 1 {
+			t.Fatalf("driver stop calls = %d, want 1", got)
+		}
+
+		meta := readMeta(t, session.MetaPath())
+		if got := meta.State; got != string(StateStopped) {
+			t.Fatalf("meta state = %q, want %q", got, StateStopped)
+		}
+		if meta.StopReason == nil || *meta.StopReason != store.StopAgentCrashed {
+			t.Fatalf("meta.StopReason = %#v, want %q", meta.StopReason, store.StopAgentCrashed)
+		}
+		if meta.Failure == nil || meta.Failure.Kind != store.FailureProcess {
+			t.Fatalf("meta.Failure = %#v, want process_exit", meta.Failure)
+		}
+		if got, want := meta.Failure.CrashBundlePath, events[1].Failure.CrashBundlePath; got != want {
+			t.Fatalf("meta crash bundle = %q, want event bundle %q", got, want)
+		}
+		if !strings.Contains(meta.StopDetail, processExitErr.Error()) {
+			t.Fatalf("meta.StopDetail = %q, want real process exit diagnostic %q", meta.StopDetail, processExitErr)
+		}
+		stored := readStoredEvents(t, session)
+		if !containsEventType(stored, acp.EventTypeAgentMessage) || containsEventType(stored, acp.EventTypeDone) {
+			t.Fatalf("stored events = %#v, want partial agent message and no done event", stored)
+		}
+		partial := storedEventByType(t, stored, acp.EventTypeAgentMessage)
+		if !strings.Contains(partial.Content, "partial before disconnect") {
+			t.Fatalf("stored agent message = %s, want persisted partial chunk", partial.Content)
+		}
+
+		h.driver.startHook = func(opts acp.StartOpts, sequence int) (*fakeProcess, error) {
+			if opts.ResumeSessionID != "" {
+				return nil, fmt.Errorf(
+					"%w: load session %q for %q: %w",
+					acp.ErrLoadSessionFailed,
+					opts.ResumeSessionID,
+					opts.AgentName,
+					&acpsdk.RequestError{
+						Code:    -32002,
+						Message: "Resource not found: " + opts.ResumeSessionID,
+					},
+				)
+			}
+			return newFakeProcess(opts.AgentName, opts.Command, opts.Cwd, fmt.Sprintf("acp-new-%d", sequence)), nil
+		}
+
+		resumed, err := h.manager.Resume(testutil.Context(t), session.ID)
+		if err != nil {
+			t.Fatalf("Resume() error = %v", err)
+		}
+		t.Cleanup(func() {
+			reportSessionStop(t, h, resumed.ID)
+		})
+
+		if got := h.driver.startCalls[1].ResumeSessionID; got != originalACP {
+			t.Fatalf("first resume start ResumeSessionID = %q, want %q", got, originalACP)
+		}
+		if got := h.driver.startCalls[2].ResumeSessionID; got != "" {
+			t.Fatalf("fallback resume start ResumeSessionID = %q, want empty", got)
+		}
+		if got := resumed.Info().ACPSessionID; got == "" || got == originalACP {
+			t.Fatalf("resumed ACPSessionID = %q, want fresh ACP session id distinct from %q", got, originalACP)
+		}
+
+		h.driver.mu.Lock()
+		h.driver.promptHook = nil
+		h.driver.stopHook = nil
+		h.driver.mu.Unlock()
+		recoveryEventsCh, err := h.manager.Prompt(testutil.Context(t), resumed.ID, "continue after disconnect")
+		if err != nil {
+			t.Fatalf("Prompt(recovered session) error = %v", err)
+		}
+		recoveryEvents := collectEvents(t, recoveryEventsCh)
+		if got, want := len(recoveryEvents), 2; got != want {
+			t.Fatalf("Prompt(recovered session) events = %d, want %d", got, want)
+		}
+		if recoveryEvents[0].Type != acp.EventTypeAgentMessage || recoveryEvents[1].Type != acp.EventTypeDone {
+			t.Fatalf("Prompt(recovered session) events = %#v, want agent message then done", recoveryEvents)
+		}
+		if got, want := len(h.driver.promptCalls), 2; got != want {
+			t.Fatalf("driver prompt calls = %d, want failed prompt plus one explicit recovery prompt", got)
 		}
 	})
-	h.driver.stopHook = func(proc *fakeProcess) error {
-		proc.crash(processExitErr, "codex stderr tail")
-		return nil
-	}
+}
 
-	h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
-		events := make(chan acp.AgentEvent, 2)
-		go func() {
-			defer close(events)
+func TestPromptStreamClosureWithoutTerminalStopsSession(t *testing.T) {
+	t.Run("Should preserve partial output and stop on terminal-less stream closure", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		sess := createSession(t, h)
+		proc := h.driver.lastProcess()
+		proc.handle.exitStatusFn = func() (subprocess.ExitStatus, bool) {
+			select {
+			case <-proc.done:
+				return subprocess.ExitStatus{ExitCode: 23}, true
+			default:
+				return subprocess.ExitStatus{}, false
+			}
+		}
+		var stoppedWhileActive atomic.Bool
+		h.driver.stopHook = func(proc *fakeProcess) error {
+			select {
+			case <-proc.done:
+			default:
+				stoppedWhileActive.Store(true)
+			}
+			proc.crash(errors.New("ACP transport closed before terminal event"), "codex stderr after EOF")
+			return nil
+		}
+		t.Cleanup(func() {
+			if _, ok := h.manager.Get(sess.ID); ok {
+				reportSessionStop(t, h, sess.ID)
+			}
+		})
+		h.driver.promptHook = func(proc *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			events := make(chan acp.AgentEvent, 1)
 			events <- acp.AgentEvent{
 				Type:      acp.EventTypeAgentMessage,
-				SessionID: originalACP,
+				SessionID: proc.handle.SessionID,
 				TurnID:    req.TurnID,
 				Timestamp: time.Now().UTC(),
-				Text:      "partial before disconnect",
+				Text:      "partial before EOF",
 			}
-			events <- acp.AgentEvent{
-				Type:      acp.EventTypeError,
-				SessionID: originalACP,
-				TurnID:    req.TurnID,
-				Timestamp: time.Now().UTC(),
-				Error:     `RequestError -32603: peer disconnected before response`,
-				Failure: &store.SessionFailure{
-					Kind:    store.FailureProcess,
-					Summary: `RequestError -32603: peer disconnected before response`,
-				},
-			}
-		}()
-		return events, nil
-	}
+			close(events)
+			return events, nil
+		}
 
-	eventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "hello")
-	if err != nil {
-		t.Fatalf("Prompt() error = %v", err)
-	}
-	events := collectEvents(t, eventsCh)
-	if got, want := len(events), 2; got != want {
-		t.Fatalf("Prompt() events = %d, want %d", got, want)
-	}
-	if got, want := events[0].Type, acp.EventTypeAgentMessage; got != want {
-		t.Fatalf("Prompt() first event type = %q, want %q", got, want)
-	}
-	if got, want := events[0].Text, "partial before disconnect"; got != want {
-		t.Fatalf("Prompt() first event text = %q, want %q", got, want)
-	}
-	if events[1].Failure == nil || events[1].Failure.Kind != store.FailureProcess {
-		t.Fatalf("Prompt() failure = %#v, want process_exit", events[1].Failure)
-	}
+		eventsCh, err := h.manager.Prompt(testutil.Context(t), sess.ID, "hello")
+		if err != nil {
+			t.Fatalf("Prompt() error = %v", err)
+		}
+		events := collectEvents(t, eventsCh)
+		if got, want := len(events), 2; got != want {
+			t.Fatalf("Prompt() events = %#v, want partial chunk and terminal failure", events)
+		}
+		if got, want := events[0].Text, "partial before EOF"; got != want {
+			t.Fatalf("Prompt() first event text = %q, want %q", got, want)
+		}
+		terminal := events[1]
+		if terminal.Type != acp.EventTypeError || terminal.Failure == nil ||
+			terminal.Failure.Kind != store.FailureTransport {
+			t.Fatalf("Prompt() terminal event = %#v, want transport failure", terminal)
+		}
+		if !strings.Contains(terminal.Error, "ended before a terminal event") {
+			t.Fatalf("Prompt() terminal error = %q, want explicit incomplete-stream failure", terminal.Error)
+		}
+		if terminal.Failure.CrashBundlePath == "" {
+			t.Fatalf("Prompt() terminal failure = %#v, want public crash bundle path", terminal.Failure)
+		}
+		publicBundle := readCrashBundleDocument(t, terminal.Failure.CrashBundlePath)
+		if publicBundle.Process == nil || publicBundle.Process.ExitCode == nil || *publicBundle.Process.ExitCode != 23 {
+			t.Fatalf("public crash bundle process = %#v, want exit code 23 before stopped notification", publicBundle.Process)
+		}
+		if got, want := publicBundle.Stderr, "codex stderr after EOF"; got != want {
+			t.Fatalf("public crash bundle stderr = %q, want %q", got, want)
+		}
 
-	h.notifier.waitForStopped(t, session.ID)
-	if _, ok := h.manager.Get(session.ID); ok {
-		t.Fatalf("Get(%q) found session after stopped notification", session.ID)
-	}
-
-	if got := h.driver.stopCalls; got != 1 {
-		t.Fatalf("driver stop calls = %d, want 1", got)
-	}
-
-	meta := readMeta(t, session.MetaPath())
-	if got := meta.State; got != string(StateStopped) {
-		t.Fatalf("meta state = %q, want %q", got, StateStopped)
-	}
-	if meta.StopReason == nil || *meta.StopReason != store.StopAgentCrashed {
-		t.Fatalf("meta.StopReason = %#v, want %q", meta.StopReason, store.StopAgentCrashed)
-	}
-	if meta.Failure == nil || meta.Failure.Kind != store.FailureProcess {
-		t.Fatalf("meta.Failure = %#v, want process_exit", meta.Failure)
-	}
-	if !strings.Contains(meta.StopDetail, processExitErr.Error()) {
-		t.Fatalf("meta.StopDetail = %q, want real process exit diagnostic %q", meta.StopDetail, processExitErr)
-	}
-	stored := readStoredEvents(t, session)
-	if !containsEventType(stored, acp.EventTypeAgentMessage) || containsEventType(stored, acp.EventTypeDone) {
-		t.Fatalf("stored events = %#v, want partial agent message and no done event", stored)
-	}
-	partial := storedEventByType(t, stored, acp.EventTypeAgentMessage)
-	if !strings.Contains(partial.Content, "partial before disconnect") {
-		t.Fatalf("stored agent message = %s, want persisted partial chunk", partial.Content)
-	}
-
-	h.driver.startHook = func(opts acp.StartOpts, sequence int) (*fakeProcess, error) {
-		if opts.ResumeSessionID != "" {
-			return nil, fmt.Errorf(
-				"%w: load session %q for %q: %w",
-				acp.ErrLoadSessionFailed,
-				opts.ResumeSessionID,
-				opts.AgentName,
-				&acpsdk.RequestError{
-					Code:    -32002,
-					Message: "Resource not found: " + opts.ResumeSessionID,
-				},
+		h.notifier.waitForStopped(t, sess.ID)
+		if _, ok := h.manager.Get(sess.ID); ok {
+			t.Fatalf("Get(%q) found session after terminal-less stream closure", sess.ID)
+		}
+		if !stoppedWhileActive.Load() {
+			t.Fatal("process was not active when terminal-less stream closure initiated stop")
+		}
+		stored := readStoredEvents(t, sess)
+		if !containsEventType(stored, acp.EventTypeAgentMessage) ||
+			!containsEventType(stored, acp.EventTypeError) ||
+			containsEventType(stored, acp.EventTypeDone) {
+			t.Fatalf("stored events = %#v, want partial chunk, terminal error, and no done", stored)
+		}
+		persistedError := storedEventByType(t, stored, acp.EventTypeError)
+		persistedAgentEvent, err := transcript.UnmarshalAgentEvent(persistedError.Content)
+		if err != nil {
+			t.Fatalf("UnmarshalAgentEvent(error event) error = %v", err)
+		}
+		meta := readMeta(t, sess.MetaPath())
+		if persistedAgentEvent.Failure == nil || meta.Failure == nil {
+			t.Fatalf(
+				"persisted/final failures = %#v / %#v, want crash bundle evidence",
+				persistedAgentEvent.Failure,
+				meta.Failure,
 			)
 		}
-		return newFakeProcess(opts.AgentName, opts.Command, opts.Cwd, fmt.Sprintf("acp-new-%d", sequence)), nil
-	}
-
-	resumed, err := h.manager.Resume(testutil.Context(t), session.ID)
-	if err != nil {
-		t.Fatalf("Resume() error = %v", err)
-	}
-	t.Cleanup(func() {
-		reportSessionStop(t, h, resumed.ID)
+		if got, want := persistedAgentEvent.Failure.CrashBundlePath, terminal.Failure.CrashBundlePath; got != want {
+			t.Fatalf("persisted crash bundle = %q, want public event bundle %q", got, want)
+		}
+		if got, want := meta.Failure.CrashBundlePath, persistedAgentEvent.Failure.CrashBundlePath; got != want {
+			t.Fatalf("final crash bundle = %q, want event-linked bundle %q", got, want)
+		}
+		bundle := readCrashBundleDocument(t, meta.Failure.CrashBundlePath)
+		if bundle.Process == nil || bundle.Process.ExitCode == nil || *bundle.Process.ExitCode != 23 {
+			t.Fatalf("crash bundle process = %#v, want exit code 23 after process stop", bundle.Process)
+		}
+		if got, want := bundle.Stderr, "codex stderr after EOF"; got != want {
+			t.Fatalf("crash bundle stderr = %q, want %q", got, want)
+		}
 	})
-
-	if got := h.driver.startCalls[1].ResumeSessionID; got != originalACP {
-		t.Fatalf("first resume start ResumeSessionID = %q, want %q", got, originalACP)
-	}
-	if got := h.driver.startCalls[2].ResumeSessionID; got != "" {
-		t.Fatalf("fallback resume start ResumeSessionID = %q, want empty", got)
-	}
-	if got := resumed.Info().ACPSessionID; got == "" || got == originalACP {
-		t.Fatalf("resumed ACPSessionID = %q, want fresh ACP session id distinct from %q", got, originalACP)
-	}
-
-	h.driver.mu.Lock()
-	h.driver.promptHook = nil
-	h.driver.stopHook = nil
-	h.driver.mu.Unlock()
-	recoveryEventsCh, err := h.manager.Prompt(testutil.Context(t), resumed.ID, "continue after disconnect")
-	if err != nil {
-		t.Fatalf("Prompt(recovered session) error = %v", err)
-	}
-	recoveryEvents := collectEvents(t, recoveryEventsCh)
-	if got, want := len(recoveryEvents), 2; got != want {
-		t.Fatalf("Prompt(recovered session) events = %d, want %d", got, want)
-	}
-	if recoveryEvents[0].Type != acp.EventTypeAgentMessage || recoveryEvents[1].Type != acp.EventTypeDone {
-		t.Fatalf("Prompt(recovered session) events = %#v, want agent message then done", recoveryEvents)
-	}
-	if got, want := len(h.driver.promptCalls), 2; got != want {
-		t.Fatalf("driver prompt calls = %d, want failed prompt plus one explicit recovery prompt", got)
-	}
 }
 
 func TestPromptGenericFailureKeepsSessionActive(t *testing.T) {
@@ -570,21 +709,34 @@ func TestPromptGenericFailureKeepsSessionActive(t *testing.T) {
 func TestCancelPrompt(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should cancel driver prompt for an active prompting session", func(t *testing.T) {
+	t.Run("Should keep the session active when the canceled provider stream closes without a terminal", func(t *testing.T) {
 		t.Parallel()
 
 		h := newHarness(t)
 		session := createSession(t, h)
 		t.Cleanup(func() {
-			session.clearCurrentTurnSource()
-			reportSessionStop(t, h, session.ID)
+			if _, ok := h.manager.Get(session.ID); ok {
+				reportSessionStop(t, h, session.ID)
+			}
 		})
 
-		promptEvents := make(chan acp.AgentEvent)
+		firstPromptEvents := make(chan acp.AgentEvent)
 		promptStarted := make(chan struct{})
-		h.driver.promptHook = func(_ *fakeProcess, _ acp.PromptRequest) (<-chan acp.AgentEvent, error) {
-			close(promptStarted)
-			return promptEvents, nil
+		var promptCalls atomic.Int32
+		h.driver.promptHook = func(proc *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			if promptCalls.Add(1) == 1 {
+				close(promptStarted)
+				return firstPromptEvents, nil
+			}
+			events := make(chan acp.AgentEvent, 1)
+			events <- acp.AgentEvent{
+				Type:      acp.EventTypeDone,
+				SessionID: proc.handle.SessionID,
+				TurnID:    req.TurnID,
+				Timestamp: time.Now().UTC(),
+			}
+			close(events)
+			return events, nil
 		}
 
 		eventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "hello")
@@ -614,8 +766,59 @@ func TestCancelPrompt(t *testing.T) {
 			t.Fatalf("driver interrupt scope = %#v, want session and turn", got)
 		}
 
-		close(promptEvents)
-		_ = collectEvents(t, eventsCh)
+		close(firstPromptEvents)
+		var canceledEvents []acp.AgentEvent
+		waitForClose := time.NewTimer(2 * time.Second)
+		defer waitForClose.Stop()
+	drainCanceledPrompt:
+		for {
+			select {
+			case event, ok := <-eventsCh:
+				if !ok {
+					break drainCanceledPrompt
+				}
+				canceledEvents = append(canceledEvents, event)
+			case <-waitForClose.C:
+				t.Fatal("timed out waiting for canceled prompt output to close")
+			}
+		}
+		for _, event := range canceledEvents {
+			if event.Failure != nil && (event.Failure.Kind == store.FailureTransport ||
+				event.Failure.Kind == store.FailureProcess) {
+				t.Fatalf("canceled prompt event failure kind = %q, want no fatal runtime failure", event.Failure.Kind)
+			}
+		}
+		if len(canceledEvents) != 1 || canceledEvents[0].Type != acp.EventTypeDone ||
+			canceledEvents[0].PromptStopReason != acp.PromptStopReasonCancelled {
+			t.Fatalf("canceled prompt events = %#v, want one cancelled done event", canceledEvents)
+		}
+		if err := h.manager.WaitForPromptDrains(testutil.Context(t)); err != nil {
+			t.Fatalf("WaitForPromptDrains() error = %v", err)
+		}
+		if session.IsPrompting() {
+			t.Fatal("session IsPrompting() = true after canceled prompt drain")
+		}
+		active, ok := h.manager.Get(session.ID)
+		if !ok {
+			t.Fatal("session removed after prompt cancellation")
+		}
+		if got := active.Info().State; got != StateActive {
+			t.Fatalf("session state = %q, want %q", got, StateActive)
+		}
+		if got := h.driver.stopCalls; got != 0 {
+			t.Fatalf("driver stop calls = %d, want 0", got)
+		}
+		if got := h.notifier.stoppedCount(); got != 0 {
+			t.Fatalf("post-stop notifications = %d, want 0", got)
+		}
+
+		nextEvents, err := h.manager.Prompt(testutil.Context(t), session.ID, "next prompt")
+		if err != nil {
+			t.Fatalf("next Prompt() error = %v", err)
+		}
+		if events := collectEvents(t, nextEvents); len(events) != 1 || events[0].Type != acp.EventTypeDone {
+			t.Fatalf("next Prompt() events = %#v, want one done event", events)
+		}
 	})
 
 	t.Run("Should cancel prompt setup before driver prompt is registered", func(t *testing.T) {
@@ -1373,10 +1576,11 @@ func TestPromptWithOptsTracksTurnSourceAndClearsAfterPrompt(t *testing.T) {
 	})
 
 	seenSources := make([]TurnSource, 0, 2)
-	h.driver.promptHook = func(_ *fakeProcess, _ acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+	h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
 		seenSources = append(seenSources, session.CurrentTurnSource())
 
-		ch := make(chan acp.AgentEvent)
+		ch := make(chan acp.AgentEvent, 1)
+		ch <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: req.TurnID}
 		close(ch)
 		return ch, nil
 	}
@@ -1595,36 +1799,85 @@ func TestApprovePermissionMapsPendingLookupErrors(t *testing.T) {
 func TestProcessExitDuringActivePromptPersistsAgentCrashedStopReason(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should persist StopAgentCrashed when process exits during active prompt", func(t *testing.T) {
+	t.Run("Should emit process failure before finalizing when process exits during active prompt", func(t *testing.T) {
 		t.Parallel()
 
 		h := newHarness(t)
 		session := createSession(t, h)
-		source := make(chan acp.AgentEvent)
-		promptStarted := make(chan struct{})
-		var closePromptStarted sync.Once
+		proc := h.driver.lastProcess()
+		proc.handle.exitStatusFn = func() (subprocess.ExitStatus, bool) {
+			select {
+			case <-proc.done:
+				return subprocess.ExitStatus{ExitCode: 23}, true
+			default:
+				return subprocess.ExitStatus{}, false
+			}
+		}
+		t.Cleanup(func() {
+			if _, ok := h.manager.Get(session.ID); ok {
+				reportSessionStop(t, h, session.ID)
+			}
+		})
 
-		h.driver.promptHook = func(_ *fakeProcess, _ acp.PromptRequest) (<-chan acp.AgentEvent, error) {
-			closePromptStarted.Do(func() {
-				close(promptStarted)
-			})
+		source := make(chan acp.AgentEvent, 1)
+
+		h.driver.promptHook = func(proc *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			source <- acp.AgentEvent{
+				Type:      acp.EventTypeAgentMessage,
+				SessionID: proc.handle.SessionID,
+				TurnID:    req.TurnID,
+				Timestamp: time.Now().UTC(),
+				Text:      "partial before process exit",
+			}
 			return source, nil
 		}
 
-		_, err := h.manager.Prompt(testutil.Context(t), session.ID, "run a long command")
+		eventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "run a long command")
 		if err != nil {
 			t.Fatalf("Prompt() error = %v", err)
 		}
+		processExitErr := acp.WrapFailure(
+			store.FailureProcess,
+			"ACP subprocess exited unexpectedly",
+			errors.New("acp subprocess exited: exit status 23"),
+		)
+		var typedProcessExit *acp.FailureError
+		if !errors.As(processExitErr, &typedProcessExit) || typedProcessExit.Kind != store.FailureProcess {
+			t.Fatalf("process exit error = %#v, want typed process_exit failure", processExitErr)
+		}
+		proc.crash(processExitErr, "codex stderr after process exit")
+		close(source)
 
-		select {
-		case <-promptStarted:
-		case <-time.After(time.Second):
-			t.Fatal("prompt hook did not start")
+		events := collectEvents(t, eventsCh)
+		if got, want := len(events), 2; got != want {
+			t.Fatalf("Prompt() events = %#v, want partial chunk and one process terminal", events)
+		}
+		if got, want := events[0].Text, "partial before process exit"; got != want {
+			t.Fatalf("Prompt() first event text = %q, want %q", got, want)
+		}
+		terminal := events[1]
+		if terminal.Type != acp.EventTypeError || terminal.Failure == nil ||
+			terminal.Failure.Kind != store.FailureProcess {
+			t.Fatalf("Prompt() terminal event = %#v, want process_exit", terminal)
+		}
+		if terminal.Failure.CrashBundlePath == "" {
+			t.Fatalf("Prompt() terminal failure = %#v, want public crash bundle path", terminal.Failure)
+		}
+		publicBundle := readCrashBundleDocument(t, terminal.Failure.CrashBundlePath)
+		if publicBundle.Process == nil || publicBundle.Process.ExitCode == nil || *publicBundle.Process.ExitCode != 23 {
+			t.Fatalf("public crash bundle process = %#v, want exit code 23 before stopped notification", publicBundle.Process)
+		}
+		if got, want := publicBundle.Stderr, "codex stderr after process exit"; got != want {
+			t.Fatalf("public crash bundle stderr = %q, want %q", got, want)
 		}
 
-		h.driver.lastProcess().exit()
 		h.notifier.waitForStopped(t, session.ID)
-		close(source)
+		if got := h.driver.stopCalls; got != 0 {
+			t.Fatalf("driver stop calls = %d, want none for an already exited process", got)
+		}
+		if got, want := h.notifier.stoppedCount(), 1; got != want {
+			t.Fatalf("stopped notifications = %d, want %d", got, want)
+		}
 
 		meta := readMeta(t, session.MetaPath())
 		if got, want := *meta.StopReason, store.StopAgentCrashed; got != want {
@@ -1633,15 +1886,95 @@ func TestProcessExitDuringActivePromptPersistsAgentCrashedStopReason(t *testing.
 		if meta.Failure == nil || meta.Failure.Kind != store.FailureProcess {
 			t.Fatalf("meta.Failure = %#v, want process_exit", meta.Failure)
 		}
-
-		events := readStoredEvents(t, session)
-		if !containsEventType(events, acp.EventTypeError) {
-			t.Fatalf("stored events missing process-exit error: %#v", events)
+		if got, want := meta.Failure.CrashBundlePath, terminal.Failure.CrashBundlePath; got != want {
+			t.Fatalf("final crash bundle = %q, want public event bundle %q", got, want)
 		}
-		stopEvent := storedEventByType(t, events, EventTypeSessionStopped)
+
+		stored := readStoredEvents(t, session)
+		if !containsEventType(stored, acp.EventTypeAgentMessage) ||
+			!containsEventType(stored, acp.EventTypeError) ||
+			containsEventType(stored, acp.EventTypeDone) {
+			t.Fatalf("stored events = %#v, want partial chunk, process error, and no done", stored)
+		}
+		stopEvent := storedEventByType(t, stored, EventTypeSessionStopped)
 		stopPayload := decodeStoredEventPayload(t, stopEvent)
 		if got, want := stopPayload["stop_reason"], string(store.StopAgentCrashed); got != want {
 			t.Fatalf("session_stopped stop_reason = %v, want %q", got, want)
+		}
+	})
+
+	t.Run("Should promote a generic terminal when exit status proves the subprocess died", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		session := createSession(t, h)
+		proc := h.driver.lastProcess()
+		proc.handle.exitStatusFn = func() (subprocess.ExitStatus, bool) {
+			return subprocess.ExitStatus{ExitCode: 23}, true
+		}
+		h.driver.stopHook = func(proc *fakeProcess) error {
+			proc.crash(
+				acp.WrapFailure(
+					store.FailureProcess,
+					"ACP subprocess exited unexpectedly",
+					errors.New("acp subprocess exited: exit status 23"),
+				),
+				"codex stderr after status observation",
+			)
+			return nil
+		}
+		t.Cleanup(func() {
+			if _, ok := h.manager.Get(session.ID); ok {
+				reportSessionStop(t, h, session.ID)
+			}
+		})
+
+		h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			source := make(chan acp.AgentEvent, 1)
+			source <- acp.AgentEvent{
+				Type:      acp.EventTypeError,
+				TurnID:    req.TurnID,
+				Timestamp: time.Now().UTC(),
+				Error:     "context canceled",
+				Failure: &store.SessionFailure{
+					Kind:    store.FailureCanceled,
+					Summary: "context canceled",
+				},
+			}
+			close(source)
+			return source, nil
+		}
+
+		eventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "run a long command")
+		if err != nil {
+			t.Fatalf("Prompt() error = %v", err)
+		}
+		events := collectEvents(t, eventsCh)
+		if got, want := len(events), 1; got != want {
+			t.Fatalf("Prompt() events = %#v, want one promoted terminal", events)
+		}
+		terminal := events[0]
+		if terminal.Type != acp.EventTypeError || terminal.Failure == nil ||
+			terminal.Failure.Kind != store.FailureProcess {
+			t.Fatalf("Prompt() terminal event = %#v, want process_exit", terminal)
+		}
+		if !strings.Contains(terminal.Error, "exit code 23") {
+			t.Fatalf("Prompt() terminal error = %q, want stable exit status diagnostic", terminal.Error)
+		}
+		publicBundle := readCrashBundleDocument(t, terminal.Failure.CrashBundlePath)
+		if publicBundle.Process == nil || publicBundle.Process.ExitCode == nil || *publicBundle.Process.ExitCode != 23 {
+			t.Fatalf("public crash bundle process = %#v, want exit code 23 before stopped notification", publicBundle.Process)
+		}
+		if got, want := publicBundle.Stderr, "codex stderr after status observation"; got != want {
+			t.Fatalf("public crash bundle stderr = %q, want %q", got, want)
+		}
+
+		h.notifier.waitForStopped(t, session.ID)
+		if got, want := h.driver.stopCalls, 1; got != want {
+			t.Fatalf("driver stop calls = %d, want %d", got, want)
+		}
+		if got, want := h.notifier.stoppedCount(), 1; got != want {
+			t.Fatalf("stopped notifications = %d, want %d", got, want)
 		}
 	})
 }

--- a/internal/session/manager_prompt_failure_barrier.go
+++ b/internal/session/manager_prompt_failure_barrier.go
@@ -1,0 +1,133 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/compozy/compozy/internal/acp"
+	"github.com/compozy/compozy/internal/store"
+)
+
+func (m *Manager) prepareFatalPromptFailureEvent(
+	ctx context.Context,
+	session *Session,
+	event acp.AgentEvent,
+	fatal *promptPumpFatal,
+) bool {
+	if m == nil || session == nil || event.Failure == nil || fatal == nil {
+		return false
+	}
+	if fatal.finalizationOwned {
+		return true
+	}
+	proc := session.processHandle()
+	if proc == nil {
+		return false
+	}
+
+	summary := firstTrimmedNonEmpty(
+		failureSummary(event.Failure, event.Error),
+		strings.TrimSpace(event.Error),
+		"agent runtime became unavailable during prompt",
+	)
+	stopCtx, cancel := detachedPromptStopContext(ctx, m)
+	defer cancel()
+	if err := m.waitForConversationFinalization(stopCtx, session.ID); err != nil {
+		m.logFatalPromptBarrierFailure(session, event.Failure.Kind, err)
+		return false
+	}
+	prepared, preparedProc, alreadyStopped, _, _, err := m.prepareStopWithCauseMode(
+		stopCtx,
+		session.ID,
+		CauseProcessExited,
+		summary,
+		stopPreparationFatalPromptFailure,
+	)
+	if err != nil || alreadyStopped || prepared != session || preparedProc == nil {
+		if err == nil {
+			err = errors.New("session: fatal prompt stop preparation did not retain an active process")
+		}
+		m.logFatalPromptBarrierFailure(session, event.Failure.Kind, err)
+		return false
+	}
+	proc = preparedProc
+	owned, _ := m.claimFinalization(session)
+	if !owned {
+		err = errors.New("session: fatal prompt process barrier could not own finalization")
+		m.logFatalPromptBarrierFailure(session, event.Failure.Kind, err)
+		return false
+	}
+
+	waitErr, err := m.stopProcessForFatalPromptFailure(stopCtx, session, proc, event.Failure, summary)
+	if err != nil {
+		m.finishFinalization(session.ID, err)
+		m.logFatalPromptBarrierFailure(session, event.Failure.Kind, err)
+		return false
+	}
+	fatal.ownFinalization(waitErr)
+	return true
+}
+
+func (m *Manager) logFatalPromptBarrierFailure(
+	session *Session,
+	kind store.FailureKind,
+	err error,
+) {
+	m.sessionLogger(session).Warn(
+		"session: fatal prompt process barrier failed",
+		"failure_kind", kind,
+		"error", err,
+	)
+}
+
+func (m *Manager) stopProcessForFatalPromptFailure(
+	ctx context.Context,
+	session *Session,
+	proc *AgentProcess,
+	failure *store.SessionFailure,
+	summary string,
+) (error, error) {
+	if proc == nil {
+		return nil, errors.New("session: fatal prompt process is unavailable")
+	}
+	doneBeforeStop := isProcessDone(proc)
+	if !doneBeforeStop {
+		if err := m.driver.Stop(ctx, proc); err != nil && !isProcessDone(proc) {
+			return nil, fmt.Errorf("session: stop process after fatal prompt failure: %w", err)
+		}
+	}
+	if !isProcessDone(proc) {
+		select {
+		case <-proc.Done():
+		case <-ctx.Done():
+			return nil, fmt.Errorf("session: wait for fatal prompt process exit: %w", ctx.Err())
+		}
+	}
+
+	processWaitErr := proc.Wait()
+	typedFailure := acp.WrapFailure(failure.Kind, summary, errors.New(summary))
+	session.setStopCause(CauseProcessExited)
+	return errors.Join(typedFailure, processWaitErr), nil
+}
+
+func (m *Manager) finalizeSessionAfterFatalPromptFailure(
+	ctx context.Context,
+	session *Session,
+	fatal *promptPumpFatal,
+) {
+	if m == nil || session == nil || fatal == nil || !fatal.finalizationOwned {
+		return
+	}
+	session.setFailure(store.CloneSessionFailure(fatal.failure))
+	stopCtx, cancel := detachedPromptStopContext(ctx, m)
+	defer cancel()
+	if err := m.finalizeStoppedOwned(stopCtx, session, fatal.waitErr); err != nil {
+		m.sessionLogger(session).Warn(
+			"session: finalize after fatal prompt failure failed",
+			"failure_kind", fatal.failure.Kind,
+			"error", err,
+		)
+	}
+}

--- a/internal/session/manager_prompt_process_exit.go
+++ b/internal/session/manager_prompt_process_exit.go
@@ -1,0 +1,84 @@
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/compozy/compozy/internal/acp"
+	"github.com/compozy/compozy/internal/store"
+)
+
+func (m *Manager) waitForActivePromptProcessExit(ctx context.Context, session *Session) {
+	promptDone := session.currentPromptCompletion()
+	if promptDone == nil {
+		return
+	}
+
+	base := ctx
+	if base == nil {
+		base = m.fallbackLifecycleContext()
+	}
+	waitCtx, cancel := context.WithTimeout(context.WithoutCancel(base), defaultLifecycleTimeout)
+	defer cancel()
+	select {
+	case <-promptDone:
+		return
+	case <-waitCtx.Done():
+		session.cancelCurrentPrompt()
+		m.sessionLogger(session).Warn(
+			"session: prompt did not release process-exit finalization before timeout",
+			"error", waitCtx.Err(),
+		)
+	}
+}
+
+func promptErrorForExitedProcess(proc *AgentProcess, event acp.AgentEvent) acp.AgentEvent {
+	if proc == nil || event.Type != acp.EventTypeError {
+		return event
+	}
+	if !isProcessDone(proc) {
+		if _, ok := proc.ExitStatus(); !ok {
+			return event
+		}
+	}
+	return promptProcessFailureEvent(proc, event)
+}
+
+func promptProcessExitEvent(proc *AgentProcess) acp.AgentEvent {
+	return promptProcessFailureEvent(proc, acp.AgentEvent{
+		Type:  acp.EventTypeError,
+		Error: "ACP subprocess exited during active prompt",
+	})
+}
+
+func promptProcessFailureEvent(proc *AgentProcess, event acp.AgentEvent) acp.AgentEvent {
+	const fallback = "ACP subprocess exited during active prompt"
+
+	summary := firstTrimmedNonEmpty(failureSummary(event.Failure, event.Error), event.Error, fallback)
+	if proc != nil && isProcessDone(proc) {
+		if waitErr := proc.Wait(); waitErr != nil {
+			if failure, ok := acp.FailureFromError(waitErr, store.FailureProcess); ok && failure != nil {
+				summary = firstTrimmedNonEmpty(failure.Summary, waitErr.Error(), summary)
+			} else {
+				summary = firstTrimmedNonEmpty(waitErr.Error(), summary)
+			}
+		}
+	}
+	if proc != nil {
+		if status, ok := proc.ExitStatus(); ok {
+			detail := fmt.Sprintf("exit code %d", status.ExitCode)
+			if status.Signal != "" {
+				detail = "signal " + status.Signal
+			}
+			summary = fmt.Sprintf("%s (%s)", summary, detail)
+		}
+	}
+
+	event.Type = acp.EventTypeError
+	event.Error = summary
+	event.Failure = &store.SessionFailure{
+		Kind:    store.FailureProcess,
+		Summary: summary,
+	}
+	return event
+}

--- a/internal/session/manager_prompt_pump.go
+++ b/internal/session/manager_prompt_pump.go
@@ -9,8 +9,10 @@ import (
 )
 
 type promptPumpFatal struct {
-	failure   *store.SessionFailure
-	errorText string
+	failure           *store.SessionFailure
+	errorText         string
+	finalizationOwned bool
+	waitErr           error
 }
 
 func (f *promptPumpFatal) capture(failure *store.SessionFailure, errorText string) {
@@ -19,6 +21,14 @@ func (f *promptPumpFatal) capture(failure *store.SessionFailure, errorText strin
 	}
 	f.failure = failure
 	f.errorText = errorText
+}
+
+func (f *promptPumpFatal) ownFinalization(waitErr error) {
+	if f == nil {
+		return
+	}
+	f.finalizationOwned = true
+	f.waitErr = waitErr
 }
 
 type promptPumpRun struct {
@@ -49,8 +59,10 @@ func (m *Manager) runPromptPumpLoop(run *promptPumpRun) {
 			continue
 		}
 		if !ok {
-			m.flushPromptPumpRun(run, &loop, coalescer)
-			return
+			if m.flushPromptPumpRun(run, &loop, coalescer) {
+				return
+			}
+			break
 		}
 		if coalescer.append(event, runtimeEvent) {
 			if !coalescer.shouldFlush() {
@@ -77,6 +89,41 @@ func (m *Manager) runPromptPumpLoop(run *promptPumpRun) {
 			return
 		}
 	}
+	if terminal, ok := promptStreamFailureWithoutTerminal(run, &loop); ok {
+		m.handlePromptPumpRun(run, &loop, terminal, false)
+	}
+}
+
+func promptStreamFailureWithoutTerminal(
+	run *promptPumpRun,
+	loop *promptPumpLoopState,
+) (acp.AgentEvent, bool) {
+	if run == nil || loop == nil || run.lifecycleCtx.Err() != nil || loop.turnEnded {
+		return acp.AgentEvent{}, false
+	}
+	if run.session == nil {
+		return acp.PromptStreamIncompleteEvent(), true
+	}
+	info := run.session.Info()
+	if info == nil || info.State != StateActive {
+		return acp.AgentEvent{}, false
+	}
+	proc := run.session.processHandle()
+	if isProcessDone(proc) {
+		return promptProcessExitEvent(proc), true
+	}
+	if run.turnState != nil && run.session.promptCancellationRequested(run.turnState.turnID) {
+		return promptCancellationTerminalEvent(), true
+	}
+	return acp.PromptStreamIncompleteEvent(), true
+}
+
+func promptCancellationTerminalEvent() acp.AgentEvent {
+	return acp.AgentEvent{
+		Type:             acp.EventTypeDone,
+		StopReason:       string(acp.PromptStopReasonCancelled),
+		PromptStopReason: acp.PromptStopReasonCancelled,
+	}
 }
 
 func (m *Manager) flushPromptPumpRun(
@@ -92,6 +139,7 @@ func (m *Manager) flushPromptPumpRun(
 		run.out,
 		loop,
 		coalescer,
+		run.fatal,
 	)
 	run.fatal.capture(failure, errorText)
 	return stop
@@ -112,6 +160,7 @@ func (m *Manager) handlePromptPumpRun(
 		loop,
 		event,
 		runtimeEvent,
+		run.fatal,
 	)
 	run.fatal.capture(failure, errorText)
 	return stop
@@ -124,9 +173,12 @@ func (m *Manager) finishPromptPump(
 	activity *promptActivitySupervisor,
 	releaseExecution context.CancelFunc,
 	out chan<- acp.AgentEvent,
-	fatalPromptFailure *store.SessionFailure,
-	fatalPromptError string,
+	fatal *promptPumpFatal,
 ) {
+	var fatalPromptFailure *store.SessionFailure
+	if fatal != nil {
+		fatalPromptFailure = fatal.failure
+	}
 	if releaseExecution != nil {
 		releaseExecution()
 	}
@@ -140,12 +192,16 @@ func (m *Manager) finishPromptPump(
 	}
 	m.finishManagedInputPrompt(lifecycleCtx, session, turnState)
 	if session != nil {
+		if turnState != nil {
+			session.clearPromptCancellation(turnState.turnID)
+		}
 		session.clearCurrentTurnID()
 		session.clearCurrentTurnSource()
 		session.clearCurrentPromptMessage()
 		session.clearCurrentPromptMeta()
 		session.clearCurrentSkillInvocations()
 		session.clearCurrentPromptCancel()
+		session.finishCurrentPromptCompletion()
 	}
 	if fatalPromptFailure == nil {
 		notifier := m.currentTurnEndNotifier()
@@ -158,7 +214,11 @@ func (m *Manager) finishPromptPump(
 		return
 	}
 	if fatalPromptFailure != nil {
-		m.stopSessionAfterFatalPromptFailure(lifecycleCtx, session, fatalPromptFailure, fatalPromptError)
+		if fatal.finalizationOwned {
+			m.finalizeSessionAfterFatalPromptFailure(lifecycleCtx, session, fatal)
+			return
+		}
+		m.stopSessionAfterFatalPromptFailure(lifecycleCtx, session, fatal.failure, fatal.errorText)
 		return
 	}
 	m.startNextQueuedInputPrompt(session.ID)

--- a/internal/session/manager_prompt_runtime_loop.go
+++ b/internal/session/manager_prompt_runtime_loop.go
@@ -6,11 +6,14 @@ import (
 	"errors"
 
 	"strings"
+	"time"
 
 	"github.com/compozy/compozy/internal/acp"
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/transcript"
 )
+
+const fatalPromptProcessExitGrace = time.Second
 
 func (m *Manager) pumpPrompt(
 	lifecycleCtx context.Context,
@@ -112,6 +115,17 @@ func (m *Manager) stopSessionAfterFatalPromptFailure(
 		"agent runtime became unavailable during prompt",
 	)
 	proc.setWaitErrorOverride(acp.WrapFailure(failure.Kind, summary, errors.New(summary)))
+
+	waitBase := ctx
+	if waitBase == nil {
+		waitBase = m.fallbackLifecycleContext()
+	}
+	waitCtx, cancelWait := context.WithTimeout(context.WithoutCancel(waitBase), fatalPromptProcessExitGrace)
+	select {
+	case <-proc.Done():
+	case <-waitCtx.Done():
+	}
+	cancelWait()
 
 	stopCtx, cancel := detachedPromptStopContext(ctx, m)
 	defer cancel()

--- a/internal/session/manager_prompt_runtime_loop.go
+++ b/internal/session/manager_prompt_runtime_loop.go
@@ -2,18 +2,13 @@ package session
 
 import (
 	"context"
-
 	"errors"
-
 	"strings"
-	"time"
 
 	"github.com/compozy/compozy/internal/acp"
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/transcript"
 )
-
-const fatalPromptProcessExitGrace = time.Second
 
 func (m *Manager) pumpPrompt(
 	lifecycleCtx context.Context,
@@ -36,8 +31,7 @@ func (m *Manager) pumpPrompt(
 			activity,
 			releaseExecution,
 			out,
-			fatal.failure,
-			fatal.errorText,
+			fatal,
 		)
 	}()
 
@@ -83,12 +77,13 @@ func (m *Manager) flushPromptChunkCoalescer(
 	out chan<- acp.AgentEvent,
 	loop *promptPumpLoopState,
 	coalescer *promptChunkCoalescer,
+	fatal *promptPumpFatal,
 ) (*store.SessionFailure, string, bool) {
 	events, ok := coalescer.take()
 	if !ok {
 		return nil, "", false
 	}
-	return m.handlePromptPumpChunkBatch(ctx, deliveryCtx, session, turnState, out, loop, events)
+	return m.handlePromptPumpChunkBatch(ctx, deliveryCtx, session, turnState, out, loop, events, fatal)
 }
 
 func (m *Manager) stopSessionAfterFatalPromptFailure(
@@ -100,7 +95,7 @@ func (m *Manager) stopSessionAfterFatalPromptFailure(
 	if m == nil || session == nil || failure == nil {
 		return
 	}
-	if info := session.Info(); info == nil || info.State != StateActive {
+	if info := session.Info(); info == nil || (info.State != StateActive && info.State != StateStopping) {
 		return
 	}
 
@@ -115,17 +110,7 @@ func (m *Manager) stopSessionAfterFatalPromptFailure(
 		"agent runtime became unavailable during prompt",
 	)
 	proc.setWaitErrorOverride(acp.WrapFailure(failure.Kind, summary, errors.New(summary)))
-
-	waitBase := ctx
-	if waitBase == nil {
-		waitBase = m.fallbackLifecycleContext()
-	}
-	waitCtx, cancelWait := context.WithTimeout(context.WithoutCancel(waitBase), fatalPromptProcessExitGrace)
-	select {
-	case <-proc.Done():
-	case <-waitCtx.Done():
-	}
-	cancelWait()
+	session.setFailure(store.CloneSessionFailure(failure))
 
 	stopCtx, cancel := detachedPromptStopContext(ctx, m)
 	defer cancel()
@@ -216,6 +201,7 @@ func (m *Manager) handlePromptPumpEvent(
 	loop *promptPumpLoopState,
 	event acp.AgentEvent,
 	runtimeEvent bool,
+	fatal *promptPumpFatal,
 ) (*store.SessionFailure, string, bool) {
 	if failure, errorText, stop, handled := m.emitPromptDeadlineWarningBeforeError(
 		ctx,
@@ -226,11 +212,20 @@ func (m *Manager) handlePromptPumpEvent(
 		loop,
 		event,
 		runtimeEvent,
+		fatal,
 	); handled {
 		return failure, errorText, stop
 	}
 
-	normalized, skip := m.preparePromptPumpEventForDelivery(ctx, session, turnState, loop, event, runtimeEvent)
+	normalized, skip := m.preparePromptPumpEventForDelivery(
+		ctx,
+		session,
+		turnState,
+		loop,
+		event,
+		runtimeEvent,
+		fatal,
+	)
 	if skip {
 		return nil, "", false
 	}
@@ -259,6 +254,7 @@ func (m *Manager) emitPromptDeadlineWarningBeforeError(
 	loop *promptPumpLoopState,
 	event acp.AgentEvent,
 	runtimeEvent bool,
+	fatal *promptPumpFatal,
 ) (*store.SessionFailure, string, bool, bool) {
 	if runtimeEvent || event.Type != acp.EventTypeError || loop.activity == nil {
 		return nil, "", false, false
@@ -281,6 +277,7 @@ func (m *Manager) emitPromptDeadlineWarningBeforeError(
 		loop,
 		warning,
 		true,
+		fatal,
 	)
 	if failure == nil && errorText == "" && !stop {
 		return nil, "", false, false
@@ -295,12 +292,20 @@ func (m *Manager) preparePromptPumpEventForDelivery(
 	loop *promptPumpLoopState,
 	event acp.AgentEvent,
 	runtimeEvent bool,
+	fatal *promptPumpFatal,
 ) (acp.AgentEvent, bool) {
 	normalized := m.normalizeEvent(session, turnState.turnID, event)
+	normalized = promptErrorForExitedProcess(session.processHandle(), normalized)
 	if runtimeEvent && loop.activity != nil && loop.activity.shouldSkipDeliveredPromptDeadlineWarning(normalized) {
 		return acp.AgentEvent{}, true
 	}
-	normalized = m.attachPromptFailureDiagnostics(ctx, session, normalized)
+	attachDiagnostics := true
+	if isFatalPromptFailureEvent(normalized) {
+		attachDiagnostics = m.prepareFatalPromptFailureEvent(ctx, session, normalized, fatal)
+	}
+	if attachDiagnostics {
+		normalized = m.attachPromptFailureDiagnostics(ctx, session, normalized)
+	}
 	normalized = m.preparePromptEvent(ctx, turnState, normalized)
 	normalized = transcript.RedactAgentEvent(normalized)
 	return normalized, false

--- a/internal/session/manager_prompt_submit.go
+++ b/internal/session/manager_prompt_submit.go
@@ -62,11 +62,13 @@ func (m *Manager) submitPromptRequest(ctx context.Context, req promptRequest) (<
 	stateOwned := true
 	defer func() {
 		if stateOwned {
+			session.clearPromptCancellation(req.turnID)
 			session.clearCurrentTurnID()
 			session.clearCurrentTurnSource()
 			session.clearCurrentPromptMessage()
 			session.clearCurrentPromptMeta()
 			session.clearCurrentSkillInvocations()
+			session.finishCurrentPromptCompletion()
 		}
 	}()
 	dispatchMessage, err := m.promptDispatchMessage(ctx, session, message)
@@ -96,12 +98,14 @@ func (m *Manager) submitPromptInReservedSlot(
 	defer func() {
 		if clearTurnSource {
 			cancelPromptExecution()
+			session.clearPromptCancellation(req.turnID)
 			session.clearCurrentTurnID()
 			session.clearCurrentTurnSource()
 			session.clearCurrentPromptMessage()
 			session.clearCurrentPromptMeta()
 			session.clearCurrentSkillInvocations()
 			session.clearCurrentPromptCancel()
+			session.finishCurrentPromptCompletion()
 		}
 	}()
 

--- a/internal/session/manager_synthetic_prompt_test.go
+++ b/internal/session/manager_synthetic_prompt_test.go
@@ -163,16 +163,15 @@ func TestPromptSyntheticHeartbeatWakeOptions(t *testing.T) {
 		h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
 			if req.TurnID == "turn-1" {
 				close(firstPromptEntered)
-				events := make(chan acp.AgentEvent)
+				events := make(chan acp.AgentEvent, 1)
 				go func() {
 					<-releaseFirstPrompt
+					events <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: req.TurnID}
 					close(events)
 				}()
 				return events, nil
 			}
-			events := make(chan acp.AgentEvent)
-			close(events)
-			return events, nil
+			return completedSyntheticPromptEvents(req.TurnID), nil
 		}
 
 		userEvents, err := h.manager.Prompt(testutil.Context(t), session.ID, "user prompt")
@@ -270,17 +269,15 @@ func TestPromptSyntheticQueuesBehindActiveTurnAndPreservesStoredOrder(t *testing
 	h.driver.promptHook = func(_ *fakeProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
 		if req.TurnID == "turn-1" {
 			close(firstPromptEntered)
-			events := make(chan acp.AgentEvent)
+			events := make(chan acp.AgentEvent, 1)
 			go func() {
 				<-releaseFirstPrompt
+				events <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: req.TurnID}
 				close(events)
 			}()
 			return events, nil
 		}
-
-		events := make(chan acp.AgentEvent)
-		close(events)
-		return events, nil
+		return completedSyntheticPromptEvents(req.TurnID), nil
 	}
 
 	userEventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "user prompt")
@@ -320,14 +317,17 @@ func TestPromptSyntheticQueuesBehindActiveTurnAndPreservesStoredOrder(t *testing
 	if err != nil {
 		t.Fatalf("Query() error = %v", err)
 	}
-	if len(stored) < 2 {
-		t.Fatalf("stored events = %d, want at least the user and synthetic input events", len(stored))
+	if len(stored) < 3 {
+		t.Fatalf("stored events = %d, want user, terminal, and synthetic input events", len(stored))
 	}
 	if got := stored[0].Type; got != acp.EventTypeUserMessage {
 		t.Fatalf("stored[0].Type = %q, want %q", got, acp.EventTypeUserMessage)
 	}
-	if got := stored[1].Type; got != acp.EventTypeSyntheticReentry {
-		t.Fatalf("stored[1].Type = %q, want %q", got, acp.EventTypeSyntheticReentry)
+	if got := stored[1].Type; got != acp.EventTypeDone {
+		t.Fatalf("stored[1].Type = %q, want %q", got, acp.EventTypeDone)
+	}
+	if got := stored[2].Type; got != acp.EventTypeSyntheticReentry {
+		t.Fatalf("stored[2].Type = %q, want %q", got, acp.EventTypeSyntheticReentry)
 	}
 }
 
@@ -364,16 +364,15 @@ func TestPromptSyntheticInterruptsAgentWaitingTurnWhenRequested(t *testing.T) {
 					Detail: "waiting for detached work",
 				})
 				close(firstPromptEntered)
-				events := make(chan acp.AgentEvent)
+				events := make(chan acp.AgentEvent, 1)
 				go func() {
 					<-releaseFirstPrompt
+					events <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: req.TurnID}
 					close(events)
 				}()
 				return events, nil
 			}
-			events := make(chan acp.AgentEvent)
-			close(events)
-			return events, nil
+			return completedSyntheticPromptEvents(req.TurnID), nil
 		}
 
 		userEventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "user prompt")
@@ -455,16 +454,15 @@ func TestPromptSyntheticInterruptsAgentWaitingTurnWhenRequested(t *testing.T) {
 					Detail: "waiting for detached work",
 				})
 				close(firstPromptEntered)
-				events := make(chan acp.AgentEvent)
+				events := make(chan acp.AgentEvent, 1)
 				go func() {
 					<-releaseFirstPrompt
+					events <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: req.TurnID}
 					close(events)
 				}()
 				return events, nil
 			}
-			events := make(chan acp.AgentEvent)
-			close(events)
-			return events, nil
+			return completedSyntheticPromptEvents(req.TurnID), nil
 		}
 
 		userEventsCh, err := h.manager.Prompt(testutil.Context(t), session.ID, "user prompt")
@@ -496,4 +494,11 @@ func TestPromptSyntheticInterruptsAgentWaitingTurnWhenRequested(t *testing.T) {
 		_ = collectEvents(t, userEventsCh)
 		_ = collectEvents(t, syntheticEventsCh)
 	})
+}
+
+func completedSyntheticPromptEvents(turnID string) <-chan acp.AgentEvent {
+	events := make(chan acp.AgentEvent, 1)
+	events <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: turnID}
+	close(events)
+	return events
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -162,6 +162,8 @@ type Session struct {
 	currentPromptMeta       acp.PromptMeta
 	currentSkillInvocations []commandpkg.Invocation
 	currentPromptCancel     context.CancelFunc
+	currentPromptCancelTurn string
+	currentPromptDone       chan struct{}
 	providerRedactions      []func()
 }
 

--- a/internal/session/session_prompt_state.go
+++ b/internal/session/session_prompt_state.go
@@ -86,6 +86,20 @@ func (s *Session) setCurrentTurnID(turnID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.currentTurnID = strings.TrimSpace(turnID)
+	s.currentPromptCancelTurn = ""
+	if s.currentTurnID != "" && s.currentPromptDone == nil {
+		s.currentPromptDone = make(chan struct{})
+	}
+}
+
+func (s *Session) currentPromptCompletion() <-chan struct{} {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.currentPromptDone
 }
 
 func (s *Session) setCurrentTurnSource(source TurnSource) {
@@ -143,6 +157,58 @@ func (s *Session) cancelCurrentPrompt() bool {
 	return true
 }
 
+func (s *Session) requestCurrentPromptCancellation() (
+	string,
+	*AgentProcess,
+	context.CancelFunc,
+	bool,
+) {
+	if s == nil {
+		return "", nil, nil, false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.promptSetupCount == 0 && s.currentTurnSource == "" && s.currentTurnID == "" {
+		return "", nil, nil, false
+	}
+	turnID := strings.TrimSpace(s.currentTurnID)
+	if turnID != "" {
+		s.currentPromptCancelTurn = turnID
+	}
+	return turnID, s.process, s.currentPromptCancel, true
+}
+
+func (s *Session) promptCancellationRequested(turnID string) bool {
+	if s == nil {
+		return false
+	}
+
+	target := strings.TrimSpace(turnID)
+	if target == "" {
+		return false
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.currentPromptCancelTurn == target
+}
+
+func (s *Session) clearPromptCancellation(turnID string) {
+	if s == nil {
+		return
+	}
+
+	target := strings.TrimSpace(turnID)
+	if target == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.currentPromptCancelTurn == target {
+		s.currentPromptCancelTurn = ""
+	}
+}
+
 func (s *Session) clearCurrentTurnSource() {
 	if s == nil {
 		return
@@ -161,6 +227,19 @@ func (s *Session) clearCurrentTurnID() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.currentTurnID = ""
+}
+
+func (s *Session) finishCurrentPromptCompletion() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.currentPromptDone != nil {
+		close(s.currentPromptDone)
+		s.currentPromptDone = nil
+	}
 }
 
 func (s *Session) clearCurrentPromptMeta() {

--- a/internal/session/stop_reason.go
+++ b/internal/session/stop_reason.go
@@ -207,6 +207,23 @@ func (m *Manager) prepareStopWithCause(
 	cause StopCause,
 	detail string,
 ) (*Session, *AgentProcess, bool, bool, bool, error) {
+	return m.prepareStopWithCauseMode(ctx, id, cause, detail, stopPreparationDefault)
+}
+
+type stopPreparationMode uint8
+
+const (
+	stopPreparationDefault stopPreparationMode = iota
+	stopPreparationFatalPromptFailure
+)
+
+func (m *Manager) prepareStopWithCauseMode(
+	ctx context.Context,
+	id string,
+	cause StopCause,
+	detail string,
+	mode stopPreparationMode,
+) (*Session, *AgentProcess, bool, bool, bool, error) {
 	session, finalization, err := m.stopTarget(id)
 	if err != nil {
 		return nil, nil, false, false, false, err
@@ -224,15 +241,16 @@ func (m *Manager) prepareStopWithCause(
 	process := session.processHandle()
 	stopWasAlreadyRequested := session.stopWasRequested()
 	observedProcessExit := isProcessDone(process)
+	fatalPromptFailure := mode == stopPreparationFatalPromptFailure
 
 	appliedCause := cause
 	appliedDetail := detail
-	if observedProcessExit && !stopWasAlreadyRequested {
+	if observedProcessExit && !stopWasAlreadyRequested && !fatalPromptFailure {
 		appliedCause = CauseNone
 		appliedDetail = ""
 	}
 
-	if session.Info().State == StateActive && !observedProcessExit {
+	if session.Info().State == StateActive && (!observedProcessExit || fatalPromptFailure) {
 		if err := m.dispatchSessionPreStop(ctx, session); err != nil {
 			return nil, nil, false, false, false, fmt.Errorf("session: prepare stop pre-stop hooks for %q: %w", id, err)
 		}

--- a/internal/subprocess/exit_status.go
+++ b/internal/subprocess/exit_status.go
@@ -1,0 +1,41 @@
+package subprocess
+
+import "os"
+
+// ExitStatus captures the stable OS facts available after a process exits.
+type ExitStatus struct {
+	ExitCode int
+	Signal   string
+}
+
+// ExitStatusFromProcessState extracts portable process-exit diagnostics.
+func ExitStatusFromProcessState(state *os.ProcessState) (ExitStatus, bool) {
+	if state == nil {
+		return ExitStatus{}, false
+	}
+	return ExitStatus{
+		ExitCode: state.ExitCode(),
+		Signal:   processStateSignal(state),
+	}, true
+}
+
+// ExitStatus returns the captured OS exit diagnostics after process completion.
+func (p *Process) ExitStatus() (ExitStatus, bool) {
+	if p == nil {
+		return ExitStatus{}, false
+	}
+	p.exitStatusMu.RLock()
+	defer p.exitStatusMu.RUnlock()
+	return p.exitStatus, p.hasExitStatus
+}
+
+func (p *Process) captureExitStatus(state *os.ProcessState) {
+	status, ok := ExitStatusFromProcessState(state)
+	if !ok {
+		return
+	}
+	p.exitStatusMu.Lock()
+	p.exitStatus = status
+	p.hasExitStatus = true
+	p.exitStatusMu.Unlock()
+}

--- a/internal/subprocess/exit_status.go
+++ b/internal/subprocess/exit_status.go
@@ -8,6 +8,15 @@ type ExitStatus struct {
 	Signal   string
 }
 
+// ExitCodeValue returns a real numeric exit code. Unix uses -1 when a signal
+// terminated the process, which is not an exit code and must not be serialized.
+func (s ExitStatus) ExitCodeValue() (int, bool) {
+	if s.ExitCode < 0 || s.Signal != "" {
+		return 0, false
+	}
+	return s.ExitCode, true
+}
+
 // ExitStatusFromProcessState extracts portable process-exit diagnostics.
 func ExitStatusFromProcessState(state *os.ProcessState) (ExitStatus, bool) {
 	if state == nil {

--- a/internal/subprocess/exit_status_other.go
+++ b/internal/subprocess/exit_status_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !windows
+
+package subprocess
+
+import "os"
+
+func processStateSignal(_ *os.ProcessState) string {
+	return ""
+}

--- a/internal/subprocess/exit_status_unix.go
+++ b/internal/subprocess/exit_status_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package subprocess
+
+import (
+	"os"
+	"syscall"
+)
+
+func processStateSignal(state *os.ProcessState) string {
+	status, ok := state.Sys().(syscall.WaitStatus)
+	if !ok || !status.Signaled() {
+		return ""
+	}
+	return status.Signal().String()
+}

--- a/internal/subprocess/exit_status_unix.go
+++ b/internal/subprocess/exit_status_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build darwin || linux
 
 package subprocess
 

--- a/internal/subprocess/exit_status_windows.go
+++ b/internal/subprocess/exit_status_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package subprocess
+
+import "os"
+
+func processStateSignal(_ *os.ProcessState) string {
+	return ""
+}

--- a/internal/subprocess/process.go
+++ b/internal/subprocess/process.go
@@ -98,6 +98,9 @@ type Process struct {
 	done          chan struct{}
 	waitMu        sync.RWMutex
 	waitErr       error
+	exitStatusMu  sync.RWMutex
+	exitStatus    ExitStatus
+	hasExitStatus bool
 	stopRequested bool
 	stopMu        sync.RWMutex
 	closeInputMu  sync.Mutex

--- a/internal/subprocess/process_lifecycle.go
+++ b/internal/subprocess/process_lifecycle.go
@@ -30,6 +30,7 @@ func (p *Process) checkpointShutdownRequested(ctx context.Context) error {
 
 func (p *Process) waitForExit(ctx context.Context) {
 	waitErr := p.cmd.Wait()
+	p.captureExitStatus(p.cmd.ProcessState)
 	if p.stderrPipeline != nil {
 		if flushErr := p.stderrPipeline.Flush(); flushErr != nil {
 			waitErr = errors.Join(waitErr, fmt.Errorf("subprocess: flush stderr: %w", flushErr))

--- a/internal/subprocess/process_test.go
+++ b/internal/subprocess/process_test.go
@@ -68,6 +68,53 @@ func TestLaunchSpawnsProcessAndConnectsPipes(t *testing.T) {
 	}
 }
 
+func TestProcessExitDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should capture the exit code and stderr before wrapping the wait error", func(t *testing.T) {
+		t.Parallel()
+
+		process := launchHelperProcess(t, "exit_23", LaunchConfig{DisableTransport: true})
+		if err := process.Wait(); err == nil || !strings.Contains(err.Error(), "fixture exiting with code 23") {
+			t.Fatalf("Wait() error = %v, want captured stderr", err)
+		}
+
+		status, ok := process.ExitStatus()
+		if !ok {
+			t.Fatal("ExitStatus() available = false, want true")
+		}
+		if got, want := status.ExitCode, 23; got != want {
+			t.Fatalf("ExitStatus().ExitCode = %d, want %d", got, want)
+		}
+		if status.Signal != "" {
+			t.Fatalf("ExitStatus().Signal = %q, want empty for an exit code", status.Signal)
+		}
+	})
+
+	t.Run("Should capture the terminating signal when the platform exposes one", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows process state does not expose a terminating signal")
+		}
+
+		process := launchHelperProcess(t, "raw_echo", LaunchConfig{DisableTransport: true})
+		if err := process.cmd.Process.Kill(); err != nil {
+			t.Fatalf("Process.Kill() error = %v", err)
+		}
+		if err := process.Wait(); err == nil {
+			t.Fatal("Wait() error = nil, want signal termination error")
+		}
+
+		status, ok := process.ExitStatus()
+		if !ok {
+			t.Fatal("ExitStatus() available = false, want true")
+		}
+		if strings.TrimSpace(status.Signal) == "" {
+			t.Fatalf("ExitStatus().Signal = %q, want terminating signal", status.Signal)
+		}
+	})
+}
+
 func TestEnvironmentLookupUsesPlatformSemantics(t *testing.T) {
 	t.Parallel()
 
@@ -1149,6 +1196,10 @@ func newHelperServer(scenario string, shutdownMarker string) *helperServer {
 }
 
 func (h *helperServer) run() int {
+	if h.scenario == "exit_23" {
+		writeHelperDiagnostic("fixture exiting with code 23\n")
+		return 23
+	}
 	if h.scenario == "raw_echo" {
 		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
 			writeHelperDiagnostic("raw echo: %v\n", err)

--- a/internal/subprocess/process_test.go
+++ b/internal/subprocess/process_test.go
@@ -101,8 +101,13 @@ func TestProcessExitDiagnostics(t *testing.T) {
 		if err := process.cmd.Process.Kill(); err != nil {
 			t.Fatalf("Process.Kill() error = %v", err)
 		}
-		if err := process.Wait(); err == nil {
+		waitErr := process.Wait()
+		if waitErr == nil {
 			t.Fatal("Wait() error = nil, want signal termination error")
+		}
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) {
+			t.Fatalf("Wait() error = %T %[1]v, want *exec.ExitError", waitErr)
 		}
 
 		status, ok := process.ExitStatus()
@@ -113,6 +118,38 @@ func TestProcessExitDiagnostics(t *testing.T) {
 			t.Fatalf("ExitStatus().Signal = %q, want terminating signal", status.Signal)
 		}
 	})
+}
+
+func TestExitStatusExitCodeValue(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name   string
+		status ExitStatus
+		want   int
+		ok     bool
+	}{
+		{
+			name:   "expose a Windows-style numeric exit code",
+			status: ExitStatus{ExitCode: 23},
+			want:   23,
+			ok:     true,
+		},
+		{
+			name:   "omit the Unix negative sentinel when a signal is present",
+			status: ExitStatus{ExitCode: -1, Signal: "killed"},
+			ok:     false,
+		},
+	} {
+		t.Run("Should "+testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := testCase.status.ExitCodeValue()
+			if got != testCase.want || ok != testCase.ok {
+				t.Fatalf("ExitCodeValue() = %d, %t; want %d, %t", got, ok, testCase.want, testCase.ok)
+			}
+		})
+	}
 }
 
 func TestEnvironmentLookupUsesPlatformSemantics(t *testing.T) {

--- a/internal/testutil/acpmock/testdata/driver_fault_fixture.json
+++ b/internal/testutil/acpmock/testdata/driver_fault_fixture.json
@@ -27,6 +27,19 @@
                     ]
                 },
                 {
+                    "name": "recover-after-disconnect",
+                    "match": {
+                        "turn_source": "user",
+                        "user_text": "continue after disconnect"
+                    },
+                    "steps": [
+                        {
+                            "kind": "assistant",
+                            "text": "recovered after disconnect"
+                        }
+                    ]
+                },
+                {
                     "name": "invalid-frame",
                     "match": {
                         "turn_source": "user",

--- a/packages/site/content/docs/guides/debug-a-failed-session.mdx
+++ b/packages/site/content/docs/guides/debug-a-failed-session.mdx
@@ -119,7 +119,7 @@ compozy session repair sess_1234 -o json
 eligible and does not restart a terminal session. Repair is append-only transcript terminalization,
 not a substitute for daemon health checks.
 
-## 8. Attach or recap only after the state is understood
+## 8. Attach or continue only after the state is understood
 
 ```bash
 compozy session recap sess_1234
@@ -131,21 +131,31 @@ If status reports `active` and `attachable: true`, attach to that live session:
 compozy session resume sess_1234
 ```
 
-If the session is terminal or not attachable, use recap, history, events, and repair output as
-evidence, then create a new session for new work.
+If a user session stopped after `process_exit`, use recap, history, events, and the crash bundle to
+decide what already happened. A new explicit prompt restarts the provider under the same session ID
+and retained transcript:
+
+```bash
+compozy session prompt sess_1234 "Continue from the persisted output. Do not repeat completed actions."
+```
+
+Compozy does not automatically replay the interrupted prompt because its external effects may be
+indeterminate. Create another session only when you intentionally want a separate history or the
+stopped session is archived or not a user session.
 Read [Resume Attach and Replay](/docs/sessions/resume) before treating attach refusal as a
 data-loss problem.
 
 ## Common symptoms
 
-| Symptom                          | First check                                                    | Then read                                         |
-| -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------- |
-| `compozy session prompt` hangs   | `compozy session events sess_1234 --follow`                    | [Event Streaming](/docs/sessions/events)          |
-| Session is stopped unexpectedly  | `compozy session status sess_1234 -o json`                     | [Session Lifecycle](/docs/sessions/lifecycle)     |
-| Web UI is stale                  | `compozy status` and `compozy doctor`                          | [Web UI](/docs/getting-started/web-ui)            |
-| Attach is refused                | `compozy session list --resumable` and `compozy session recap` | [Resume Attach and Replay](/docs/sessions/resume) |
-| Agent cannot see project context | `compozy workspace info <name>`                                | [Workspace Resolver](/docs/workspaces/resolver)   |
-| Memory is missing                | `compozy memory health -o json`                                | [Memory System](/docs/memory/system)              |
+| Symptom                                    | First check                                                     | Then read                                         |
+| ------------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------- |
+| `compozy session prompt` hangs             | `compozy session events sess_1234 --follow`                     | [Event Streaming](/docs/sessions/events)          |
+| Prompt prints a partial answer, then fails | `compozy session status sess_1234 -o json` and the crash bundle | [Session Lifecycle](/docs/sessions/lifecycle)     |
+| Session is stopped unexpectedly            | `compozy session status sess_1234 -o json`                      | [Session Lifecycle](/docs/sessions/lifecycle)     |
+| Web UI is stale                            | `compozy status` and `compozy doctor`                           | [Web UI](/docs/getting-started/web-ui)            |
+| Attach is refused                          | `compozy session list --resumable` and `compozy session recap`  | [Resume Attach and Replay](/docs/sessions/resume) |
+| Agent cannot see project context           | `compozy workspace info <name>`                                 | [Workspace Resolver](/docs/workspaces/resolver)   |
+| Memory is missing                          | `compozy memory health -o json`                                 | [Memory System](/docs/memory/system)              |
 
 ## Evidence to collect before filing a bug
 

--- a/packages/site/content/docs/sessions/lifecycle.mdx
+++ b/packages/site/content/docs/sessions/lifecycle.mdx
@@ -137,6 +137,29 @@ Two operational details matter here:
   events, health is consumed by `HEARTBEAT.md` wake decisions and the
   `compozy session health|status|inspect` surfaces.
 
+### When the provider disconnects during a prompt
+
+Compozy persists each accepted agent event before forwarding it. If the ACP subprocess disconnects
+after sending part of an answer, the stored assistant chunks remain in events and transcript reads.
+The prompt stream ends with an error instead of `done`, and the session stops with
+`failure.kind: "process_exit"`. HTTP and UDS clients receive the terminal error frame because the
+response status cannot change after streaming has started.
+
+`compozy session prompt <id> "..." -o jsonl` writes every frame it received, including the terminal
+error frame, then exits nonzero. The `compozy__session_prompt` native tool returns
+`tool_backend_failed` with reason `backend_dead` rather than reporting success. Inspect the session
+before continuing:
+
+```bash
+compozy session status sess-1234 -o json
+compozy session events sess-1234 --last 20 -o json
+```
+
+Compozy does not automatically retry the interrupted prompt. Its tool or external effects may have
+completed before the disconnect. A later, explicit prompt restarts the stopped runtime under the
+same Compozy session ID and retained transcript. Send a new continuation only after deciding whether
+the interrupted work is safe to repeat.
+
 ### Selecting the next runtime
 
 Persist next-prompt runtime intent without starting or reconfiguring ACP:
@@ -427,9 +450,11 @@ Current failure kinds are:
 | `unknown_failure`      | Compozy had an error but no more specific kind was available.                     |
 
 Crash bundles are written under `~/.compozy/logs/crash-bundles/` by default. They are JSON documents
-with schema `compozy.session_crash_bundle.v1`, session identity, provider identity, failure kind,
-process metadata, error text, and captured stderr when available. Bundle contents are bounded and
-redacted before they are written, and files are created with owner-only permissions.
+with schema `compozy.session_crash_bundle.v2`, session identity, provider identity, failure kind,
+process metadata, error text, and captured stderr when available. Completed process metadata also
+includes `exit_code` and the terminating `signal` when the operating system exposes them. Bundle
+contents are bounded and redacted before they are written, and files are created with owner-only
+permissions.
 
 ## Crash classification and transcript repair
 

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -55,8 +55,17 @@ Attachability is explicit live runtime state. Use `compozy session list --resuma
 not restart `stopped`, and stopped sessions reject attach.
 
 A normal prompt to a stopped user session restarts its ACP process, reloads the durable provider
-history, and submits the prompt against the same session ID. Concurrent prompts share one restart.
-Attach, queue management, steer, interrupt, and other control operations never trigger this restart.
+history, and submits the new prompt against the same session ID. Concurrent prompts share one
+restart. Attach, queue management, steer, interrupt, and other control operations never trigger this
+restart.
+
+If ACP disconnects during a prompt, Compozy keeps every event already persisted, emits a terminal
+error, and stops the failed runtime with `failure.kind=process_exit`. A JSONL prompt command writes
+the frames it received, including the error frame, then exits nonzero. `compozy__session_prompt`
+returns `tool_backend_failed` with `backend_dead` instead of reporting a successful tool call. Inspect
+status, events, and the crash bundle before sending another prompt. Compozy never automatically
+replays the interrupted prompt because its external effects may be indeterminate; a new explicit
+prompt is the safe restart boundary.
 
 After prompt admission, the daemon owns the turn lifetime. Closing a browser tab, navigating away from the web app, dropping an SSE stream, or disconnecting a CLI/UDS response only detaches that viewer; it does not cancel the accepted prompt. Use explicit runtime intent such as `compozy session stop`, prompt cancel, or interrupt controls when cancellation is required.
 


### PR DESCRIPTION
## Context and reproduction

A Codex ACP subprocess could disconnect while Compozy was still streaming the final response. The session manager persisted the chunks it had already received, but its fatal-path cleanup raced the subprocess' natural exit. That race replaced the real process result with a generic wait override, discarded useful exit diagnostics, and left stream consumers unable to distinguish a complete stream from a disconnected or crashed process.

The visible symptoms were:

- already-emitted response chunks could exist without a trustworthy terminal outcome;
- CLI JSONL consumers could reach EOF and report success even though no completion event arrived;
- the native `compozy__session_prompt` tool could drain a terminal runtime error and still return success;
- crash bundles preserved stderr but not the subprocess exit code or signal;
- the next action did not have a clearly documented recovery contract.

## Proven root cause

There were four connected causes:

1. `manager_prompt_runtime_loop.go` installed a wait override and immediately stopped the ACP process, racing the operating-system wait path.
2. The session `AgentProcess.Wait` wrapper returned the override without waiting for the underlying process, so it lost the subprocess exit result and diagnostics.
3. Crash bundle schema v1 had no structured exit-code or signal fields.
4. The CLI and native-tool stream consumers treated transport exhaustion as sufficient success instead of requiring an explicit terminal completion event.

The regression fixture reproduces a subprocess that emits partial output and then exits with code 23. The integration test proves the previous ambiguity across HTTP/SSE, persisted transcript, CLI JSONL, crash evidence, native tool invocation, and same-session recovery.

## Solution design

This change uses a fail-closed stream contract:

- persisted chunks remain committed and visible;
- success requires an explicit completion event (`done`, `finish`, `prompt_result`, or `[DONE]`);
- disconnect, terminal error, and `process_exit` remain distinct failure outcomes;
- fatal prompt cleanup gives the subprocess a bounded grace period to exit naturally before force-stopping it;
- the session wait path always observes the underlying subprocess and joins the runtime override with the real wait error;
- subprocess exit code and signal are captured immediately after `cmd.Wait` and propagated into crash evidence;
- Compozy does not automatically replay a prompt after a disconnect, because replay can repeat external side effects;
- a later explicit prompt restarts the ACP subprocess while retaining the same Compozy session and persisted transcript.

## Changes by surface

### Runtime and process lifecycle

- Added cross-platform subprocess exit-status capture with Unix signal support and a Windows-safe implementation.
- Exposed optional exit status through the ACP process boundary.
- Removed the fatal-path stop/wait race and added a bounded natural-exit grace period.
- Changed the session wait wrapper to observe both the underlying process and the higher-level runtime failure.
- Hard-cut the crash bundle contract to `compozy.session_crash_bundle.v2` with structured `exit_code` and `signal`.

### HTTP/SSE and CLI

- CLI prompt streaming now requires an explicit terminal completion marker.
- A stream ending after partial frames without completion returns a clear non-zero failure.
- Terminal error frames are forwarded before the CLI returns the error, preserving machine-readable diagnostics and already-received content.

### UDS/native tools

- `compozy__session_prompt` now classifies terminal session errors instead of treating a drained stream as success.
- A subprocess `process_exit` becomes `tool_backend_failed` with `backend_dead`, while partial events remain available in the persisted session transcript.

### Documentation and operator workflow

- Updated session lifecycle documentation with the disconnect/recovery contract.
- Updated failed-session debugging guidance for exit code, signal, persisted partial output, and explicit retry.
- Updated the official Compozy skill runtime operations reference.
- Added the tracked QA scenario, charter, journey coverage, and dated execution report.

## Invariants and canonical tests

- **Session manager invariant:** partial chunks persist, no completion is synthesized, the failure is explicit, and the next explicit prompt recovers the same session. Covered in the existing session manager prompt contract suite.
- **Subprocess invariant:** exit code/signal survive process wait and remain queryable. Covered in the existing subprocess process suite.
- **CLI invariant:** prior JSONL frames are emitted and incomplete/error streams exit non-zero. Covered in the existing CLI client/session suites.
- **Native-tool invariant:** a terminal runtime failure cannot become tool success. Covered in the existing daemon native tools suite.
- **Public-surface invariant:** a real daemon with the ACP fault fixture preserves partial transcript, emits the HTTP terminal error, fails CLI JSONL, records exit 23, fails the native tool clearly, and recovers the same session on the next explicit prompt. Covered by `TestDaemonE2EACPmockCrashMidStreamProjectsRuntimeFailure`.

## QA and evidence

- Scenario: `RT-acp-stream-disconnect-recovery` — **pass**
- Surfaces walked: runtime, HTTP/SSE, CLI JSONL, persisted session transcript, crash bundle, native tool, explicit same-session recovery
- Strict QA audit: **pass**, no blockers or warnings
- Runtime teardown: **clean**, no surviving processes
- Full repository gate: **pass/current**
  - fingerprint: `77bfa676781096cad214652973d291c4acd1073e`
  - completed: `2026-08-05T21:18:18Z`
  - 20,695 tests passed with 2 expected skips
  - Go/Bun lint, typecheck, tests, web build, code generation checks, Go build, and boundaries passed

## Web/Docs impact

The web application needed no code change: it already renders persisted session events and explicit runtime error events from the daemon. The public contract changed at the runtime/consumer boundary, so session lifecycle and failure-debugging docs were updated. The QA scenario exercises the API and agent-manageable surfaces; there is no new UI control or client-side state.

## Compozy Impact Audit

- **Native tools:** `compozy__session_prompt` terminal classification changed so `process_exit` returns `tool_backend_failed` / `backend_dead`; tool ID, descriptor, input/output schema, digest, risk flags, and capability gates are unchanged. Existing native-tool and daemon integration suites cover the new failure result.
- **Extensibility and hooks:** no new extension, hook, registry, bridge SDK, MCP sidecar, capability, or config lifecycle surface. Checked ACP launcher/process boundaries, session event streaming, native tool dispatch, HTTP/SSE, CLI, and official runtime operations guidance. Extensions continue to observe the same persisted events; only false success at terminal disconnect is removed.
- **Workspace data isolation:** changed data is session-scoped process-failure evidence. Existing `workspace_id` propagation through session manager, store, HTTP/SSE, CLI, native tools, event persistence, and transcript reads is unchanged. The integration test creates and reads the affected session through one workspace and verifies recovery by the same session ID; no global cache or cross-workspace list/read path was added.
- **Official Compozy skill:** updated `skills/compozy/references/runtime-operations.md` to document explicit terminal completion, retained partial events, process diagnostics, and safe explicit retry.

## Compatibility and risks

This is a greenfield hard cut: crash bundles now use schema v2, with no v1 compatibility branch. Stream consumers that previously relied on bare EOF as success will now receive the correct failure unless the daemon emitted an explicit completion event.

Automatic retry is intentionally excluded because a prompt may already have caused external side effects before the process disconnected. Recovery is explicit and reuses the same session. Signal diagnostics are present when the operating system exposes a signal; otherwise the exit code, stderr tail, runtime error, and persisted events remain available.

The deterministic ACP fault fixture exercises the exact process boundary without depending on an unreliable live-provider crash. The remaining risk is provider-specific behavior outside that boundary, mitigated by the common subprocess/ACP lifecycle and public-surface integration coverage.

## Scope relative to #306

This PR does not change ACP protocol-version negotiation, initialize-handshake compatibility, provider presets, or Windows executable discovery. The only conceptual overlap is the shared ACP subprocess failure boundary; this diff is limited to stream disconnect classification, process-exit diagnostics, safe recovery, and client-visible failure semantics.

Fixes #315


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session prompt streaming reliability by detecting missing completion events and reporting terminal failures clearly.
  * Partial responses and error details are now preserved when streams fail.
  * Native tool failures now provide clearer backend status and process-related diagnostics.
  * Sessions can recover more reliably after an agent process crash.
  * Crash diagnostics now include available exit codes, termination signals, and process stderr for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->