### PR TITLE
fix: resolve desktop and session usability issues

### DIFF
--- a/desktop/src-tauri/capabilities/main-zoom.json
+++ b/desktop/src-tauri/capabilities/main-zoom.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "../gen/schemas/desktop-schema.json",
+    "identifier": "main-zoom",
+    "description": "Page zoom shortcuts for the daemon-served main product window",
+    "local": false,
+    "remote": {
+        "urls": ["http://localhost:*", "http://127.0.0.1:*"]
+    },
+    "windows": ["main"],
+    "permissions": ["core:webview:allow-set-webview-zoom"]
+}

--- a/desktop/src-tauri/src/windowing.rs
+++ b/desktop/src-tauri/src/windowing.rs
@@ -72,6 +72,7 @@ pub fn create_main_window(
         .title("CompozyOS")
         .inner_size(1280.0, 800.0)
         .min_inner_size(MAIN_MIN_WIDTH as f64, MAIN_MIN_HEIGHT as f64)
+        .zoom_hotkeys_enabled(true)
         .visible(false)
         .background_color(tauri::window::Color(19, 18, 17, 255))
         .on_navigation(

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
             }
         ],
         "security": {
-            "capabilities": ["boot"],
+            "capabilities": ["boot", "main-zoom"],
             "csp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
         }
     },

--- a/desktop/src-tauri/tests/contracts.rs
+++ b/desktop/src-tauri/tests/contracts.rs
@@ -312,6 +312,13 @@ fn should_grant_zoom_only_to_the_daemon_served_main_window() {
         capability["permissions"],
         serde_json::json!(["core:webview:allow-set-webview-zoom"])
     );
+
+    let windowing_source = fs::read_to_string(manifest_dir().join("src/windowing.rs"))
+        .expect("window builder source reads");
+    assert!(
+        windowing_source.contains(".zoom_hotkeys_enabled(true)"),
+        "daemon-served main window must enable native zoom hotkeys"
+    );
 }
 
 #[test]

--- a/desktop/src-tauri/tests/contracts.rs
+++ b/desktop/src-tauri/tests/contracts.rs
@@ -294,6 +294,27 @@ fn should_grant_only_desktop_control_to_the_local_boot_window() {
 }
 
 #[test]
+fn should_grant_zoom_only_to_the_daemon_served_main_window() {
+    let config = read_json(manifest_dir().join("tauri.conf.json"));
+    assert_eq!(
+        config["app"]["security"]["capabilities"],
+        serde_json::json!(["boot", "main-zoom"])
+    );
+
+    let capability = read_json(manifest_dir().join("capabilities/main-zoom.json"));
+    assert_eq!(capability["local"], false);
+    assert_eq!(capability["windows"], serde_json::json!(["main"]));
+    assert_eq!(
+        capability["remote"]["urls"],
+        serde_json::json!(["http://localhost:*", "http://127.0.0.1:*"])
+    );
+    assert_eq!(
+        capability["permissions"],
+        serde_json::json!(["core:webview:allow-set-webview-zoom"])
+    );
+}
+
+#[test]
 fn should_initialize_updater_plugin_from_base_tauri_config() {
     let config = serde_json::from_value(read_json(manifest_dir().join("tauri.conf.json")))
         .expect("base Tauri config parses");

--- a/docs/qa/bugs/BUG-20260812-rename-dialog-double-escape.md
+++ b/docs/qa/bugs/BUG-20260812-rename-dialog-double-escape.md
@@ -1,0 +1,41 @@
+# BUG-20260812-rename-dialog-double-escape: Keyboard users needed two Escapes to close session rename
+
+- **Status:** verified
+- **Impact (user-side):** Friction
+- **Severity:** Medium · **Priority:** P2
+- **Persona Affected:** Dora
+- **Journey Step:** J-rename-session, step 1
+- **Scenarios:** RT-session-rename-durable
+- **Found:** 2026-08-12 · **Report:** docs/qa/reports/2026-08-12-pr-351-review-round-1.md
+
+## Summary
+
+After opening Rename session from More actions, a keyboard user had to press Escape twice because the closing menu consumed the first key press behind the visible dialog.
+
+## Reproduction
+
+- **Charter:** CH-rename-session-parity · **Tour:** Feature Tour
+- **Environment:** desktop / wifi-fast / en-US, isolated local daemon and Web dev server
+
+1. Open a stopped user session.
+2. Open More actions and choose Rename session.
+3. Press Escape once after the dialog appears.
+
+**Expected:** The visible rename dialog closes with one Escape.
+**Actual:** The hidden overflow menu consumed the first Escape; a second Escape was required.
+
+## Evidence
+
+- `docs/qa/evidence/2026-08-12-pr-351-review-round-1/CH-rename-session-parity-single-escape.png`
+- The fresh browser replay showed no Rename session dialog after one Escape.
+
+## Fix
+
+- **Root cause:** The dialog opened in the menu-item click before Base UI completed the overflow menu's close transition, leaving both layers active.
+- **Fix commit:** review-round-1 commit (this commit)
+- **Regression test:** `web/src/systems/session/hooks/__tests__/use-session-topbar-slot.test.tsx` — `Should close overflow before opening rename so one Escape dismisses the dialog`
+
+## Verification
+
+- **Retested:** 2026-08-12, Dora / J-rename-session · **Report:** docs/qa/reports/2026-08-12-pr-351-review-round-1.md
+- **Result:** Rename opens after the overflow transition completes, and one Escape dismisses the dialog.

--- a/docs/qa/charters/CH-add-workspace-from-root.md
+++ b/docs/qa/charters/CH-add-workspace-from-root.md
@@ -1,0 +1,26 @@
+# CH-add-workspace-from-root: Reach a project outside home from the picker
+
+```yaml
+charter:
+  id: CH-add-workspace-from-root
+  mission: "As Lea, discover a filesystem root in Add workspace, navigate from it, and register one project only after submit."
+  mode: scenario-based
+  persona:
+    name: Lea
+    device: laptop
+    network: wifi-fast
+    locale: en-US
+  journey: J-add-workspace-by-browsing
+  scenarios: [RT-038, MS-051, MS-web-workspace-add-directory-browser]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Compare HTTP and UDS browse roots, then use every displayed Locations action in the real dialog."
+      - "Navigate outside home, cancel once to prove no write, then reopen and submit once."
+      - "Refresh and confirm the exact chosen root remains registered."
+    must_avoid:
+      - "Do not type an absolute path as a workaround or inspect the database."
+```
+
+<!-- Immutable charter: each run's debrief belongs in its dated report. -->

--- a/docs/qa/charters/CH-desktop-page-zoom.md
+++ b/docs/qa/charters/CH-desktop-page-zoom.md
@@ -1,0 +1,26 @@
+# CH-desktop-page-zoom: Scale the desktop product with platform shortcuts
+
+```yaml
+charter:
+  id: CH-desktop-page-zoom
+  mission: "As Dora on macOS, scale and reset the daemon-served desktop product with standard page-zoom shortcuts without invoking Compozy window Zoom."
+  mode: charter-with-tour
+  persona:
+    name: Dora
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-desktop-attach-daily
+  scenarios: [APP-desktop-page-zoom]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Use Command-plus, Command-minus, and Command-zero in the native main window and observe whole-product scale."
+      - "Use the in-product window Zoom control separately and confirm it still changes one Compozy window only."
+      - "Relaunch and confirm the app remains attached to the same healthy runtime."
+    must_avoid:
+      - "Do not treat browser-only zoom or a static capability manifest as the native observable."
+```
+
+<!-- Immutable charter: each run's debrief belongs in its dated report. -->

--- a/docs/qa/charters/CH-rename-session-parity.md
+++ b/docs/qa/charters/CH-rename-session-parity.md
@@ -1,0 +1,26 @@
+# CH-rename-session-parity: Rename one session through every public plane
+
+```yaml
+charter:
+  id: CH-rename-session-parity
+  mission: "As Dora, rename active and archived user sessions and prove durable Web, CLI, HTTP, UDS, and native-tool parity without changing their work."
+  mode: strategy-based
+  persona:
+    name: Dora
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-rename-session
+  scenarios: [RT-session-rename-durable]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Rename from a row and from a session topbar; refresh and compare structured public reads."
+      - "Rename an archived session and confirm its archive marker and history remain."
+      - "Try blank, overlong, managed, and foreign-workspace requests and confirm no mutation."
+    must_avoid:
+      - "Do not use database or metadata-file reads as verdict evidence."
+```
+
+<!-- Immutable charter: each run's debrief belongs in its dated report. -->

--- a/docs/qa/charters/CH-runtime-selector-scroll-boundary.md
+++ b/docs/qa/charters/CH-runtime-selector-scroll-boundary.md
@@ -1,0 +1,26 @@
+# CH-runtime-selector-scroll-boundary: Keep runtime-list scrolling inside its popup
+
+```yaml
+charter:
+  id: CH-runtime-selector-scroll-boundary
+  mission: "As Sol, scroll a long runtime catalog to both ends and keep the session page fixed behind the accessible selector."
+  mode: charter-with-tour
+  persona:
+    name: Sol
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-17
+  scenarios: [RT-068]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Open the selector from the session composer and use wheel, trackpad-equivalent, keyboard, and Escape."
+      - "Reach both list boundaries, continue scrolling, and confirm the product behind the popup never moves."
+      - "Select a model afterward and prove the next prompt retains normal runtime selection."
+    must_avoid:
+      - "Do not settle broader model curation or provider-auth behavior."
+```
+
+<!-- Immutable charter: each run's debrief belongs in its dated report. -->

--- a/docs/qa/charters/CH-window-layer-seam.md
+++ b/docs/qa/charters/CH-window-layer-seam.md
@@ -1,0 +1,26 @@
+# CH-window-layer-seam: Keep floating windows above structural seams
+
+```yaml
+charter:
+  id: CH-window-layer-seam
+  mission: "As Bruno, overlap a floating window with a tiled resize seam and keep both the covered window and uncovered seam operable."
+  mode: charter-with-tour
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-administer-window-manager
+  scenarios: [ET-window-manager-layout-gestures]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Tile two windows, place a floating window across their seam, and interact at the overlap point."
+      - "Drag an uncovered segment of the same seam and prove both tiled siblings resize."
+      - "Refresh and confirm the topology and weights remain durable."
+    must_avoid:
+      - "Do not change semantic focus ordering or global z-index tokens to force the outcome."
+```
+
+<!-- Immutable charter: each run's debrief belongs in its dated report. -->

--- a/docs/qa/journeys/J-add-workspace-by-browsing.md
+++ b/docs/qa/journeys/J-add-workspace-by-browsing.md
@@ -1,0 +1,52 @@
+# J-add-workspace-by-browsing: Add a workspace from any local filesystem root
+
+```mermaid
+flowchart TD
+    A[Entry: desktop workspace menu → Add workspace] --> B[Directory browser opens at operator home]
+    B --> C[Locations lists every filesystem root]
+    C --> D[Navigate from a root into the intended project]
+    D --> E[Choose the folder and review session defaults]
+    E --> F[Submit once]
+    F --> G[Workspace appears and becomes usable]
+    G --> H[Refresh]
+    H --> I[True end: workspace remains registered with the chosen absolute root]
+    C -->|root cannot be read| R[Plain error; another location remains reachable]
+    E -.->|close dialog| X[Abandon: no workspace was registered]
+```
+
+```yaml
+journey:
+  id: J-add-workspace-by-browsing
+  name: "Add a workspace from any local filesystem root"
+  value_statement: "A person can discover and register a project outside their home directory without knowing or typing its absolute path."
+  personas: [Lea, Dora]
+  entry_points:
+    - url: "desktop workspace menu → Add workspace"
+      origin: in-app-nav
+    - url: "first-run workspace setup"
+      origin: direct
+  actions:
+    - step: 1
+      verb: "Open the workspace directory browser"
+      expected_observable: "The current path, home action, and every filesystem root are visible."
+    - step: 2
+      verb: "Choose a filesystem root and navigate to a project"
+      expected_observable: "The browser reads that absolute path and keeps other roots reachable."
+    - step: 3
+      verb: "Choose the project and submit"
+      expected_observable: "One workspace is registered only after submit."
+    - step: 4
+      verb: "Refresh and return to the workspace"
+      expected_observable: "The chosen absolute root remains registered and usable."
+  goal:
+    observable: "A project on any discoverable local root becomes one usable workspace."
+    side_effects: [workspace-registered]
+  true_end_state: "A fresh catalog read contains one workspace with the chosen root; closing before submit creates none."
+  exit:
+    natural: "The operator starts work in the registered workspace."
+  abandonment:
+    - at_step: 3
+      how: "The operator closes the dialog after browsing."
+      resume: "A later open starts from durable catalog state with no half-created workspace."
+  crosses: [filesystem-browse, HTTP, UDS, onboarding, workspace-catalog]
+```

--- a/docs/qa/journeys/J-desktop-attach-daily.md
+++ b/docs/qa/journeys/J-desktop-attach-daily.md
@@ -14,7 +14,8 @@ flowchart TD
     B -->|running but unhealthy| G[Honest degraded state, retry in place]
     C --> H[Product UI: same workspaces, sessions, and local UI state as the browser tab]
     D --> H
-    H --> I[Work: act in app and browser side by side - both reflect live]
+    H --> Z[Use standard page-zoom shortcuts when the product needs scaling]
+    Z --> I[Work: act in app and browser side by side - both reflect live]
     I --> J{Runtime dies mid-use?}
     J -->|kill -9| K[Disconnected state within the interval + reconnect and restart-runtime affordances]
     K -->|restart affordance| H
@@ -42,12 +43,15 @@ journey:
       verb: "Open the app with the runtime installed but stopped"
       expected_observable: "Visible starting progress, then the product UI; no dead white screen"
     - step: 3
+      verb: "Scale the product with standard page-zoom shortcuts"
+      expected_observable: "Command or Control plus, minus, and zero change or reset the whole product scale without triggering Compozy's single-window Zoom action"
+    - step: 4
       verb: "Work with app and browser tab side by side"
       expected_observable: "Actions in one surface appear live in the other"
-    - step: 4
+    - step: 5
       verb: "Kill the daemon under the app, then restart it"
       expected_observable: "Disconnected state within a perceivable interval; reconnect returns to the product without app restart"
-    - step: 5
+    - step: 6
       verb: "Quit the app"
       expected_observable: "Window closes; `compozy status` still healthy; the active session survives"
   goal:

--- a/docs/qa/journeys/J-rename-session.md
+++ b/docs/qa/journeys/J-rename-session.md
@@ -1,0 +1,53 @@
+# J-rename-session: Rename a session without changing its work
+
+```mermaid
+flowchart TD
+    A[Entry: user-session row, session topbar, CLI, or native tool] --> B[Choose Rename]
+    B --> C[Enter a non-empty name of at most 64 characters]
+    C --> D[Commit workspace-scoped rename]
+    D --> E[Detail and catalog show the new name]
+    E --> F[Refresh and read through another public surface]
+    F --> G[True end: name persists while id, transcript, runtime, archive state, and lineage are unchanged]
+    C -->|invalid name| V[Inline or structured validation; old name remains]
+    B -.->|cancel| X[Abandon: old name remains]
+    D -->|managed or foreign session| N[Not renameable; no identity is disclosed or changed]
+```
+
+```yaml
+journey:
+  id: J-rename-session
+  name: "Rename a session without changing its work"
+  value_statement: "People and agents can give a user session a durable recognizable name without changing its runtime or history."
+  personas: [Dora, Ada]
+  entry_points:
+    - url: "web session row or session topbar → Rename session"
+      origin: in-app-nav
+    - url: "compozy session rename <id> <name>"
+      origin: direct
+    - url: "compozy__session_rename"
+      origin: direct
+  actions:
+    - step: 1
+      verb: "Choose rename for a user session"
+      expected_observable: "A labelled name field opens with the current durable name."
+    - step: 2
+      verb: "Save a valid new name"
+      expected_observable: "The detail title and catalog reconcile to the new name."
+    - step: 3
+      verb: "Refresh and read the same session through another surface"
+      expected_observable: "Web, CLI, HTTP, UDS, and the native tool agree on the name and session identity."
+    - step: 4
+      verb: "Try invalid, managed, and foreign-session renames"
+      expected_observable: "Each rejection preserves the old identity and workspace boundary."
+  goal:
+    observable: "The new name is durable and consistent everywhere."
+    side_effects: [session-name-updated, catalog-wake-published]
+  true_end_state: "After refresh or daemon restart, only the display name changed; id, transcript, runtime, archive state, and lineage are intact."
+  exit:
+    natural: "The operator recognizes the session and continues its work."
+  abandonment:
+    - at_step: 2
+      how: "The operator cancels or closes the dialog."
+      resume: "The prior name remains and a later rename starts from it."
+  crosses: [web, CLI, HTTP, UDS, native-tools, session-manager, catalog-stream, workspace-isolation]
+```

--- a/docs/qa/reports/2026-08-11-open-issues.md
+++ b/docs/qa/reports/2026-08-11-open-issues.md
@@ -1,0 +1,77 @@
+# QA Run Report — 2026-08-11 — open issues
+
+- **Scope:** Targeted branch validation for issues #341, #342, #344, #345, and #346: runtime-selector scroll containment, filesystem-root discovery, durable session rename, desktop page zoom, and floating-window visual ordering.
+- **Cadence tier:** targeted
+- **Build:** `ab319b53` + working tree · **Environment:** isolated lab `compozy-open-issues-20260812-002435-338441`
+- **Started:** 2026-08-12T00:22:30Z · **Status:** pass
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Sol | Accessibility-Reliant | desktop / wifi-fast / en-US | CH-runtime-selector-scroll-boundary |
+| Lea | New User | laptop / wifi-fast / en-US | CH-add-workspace-from-root |
+| Dora | Runtime Administrator | desktop / wifi-fast / en-US | CH-rename-session-parity, CH-desktop-page-zoom |
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-window-layer-seam |
+
+## Flows in Scope
+
+- `J-17` — launch a session, then choose its next-prompt runtime (`../journeys/J-17-session-create-unified-selector.md`)
+- `J-add-workspace-by-browsing` — register a project from any local root (`../journeys/J-add-workspace-by-browsing.md`)
+- `J-rename-session` — change a durable display name without changing session work (`../journeys/J-rename-session.md`)
+- `J-administer-window-manager` — preserve structural behavior while changing presentation (`../journeys/J-administer-window-manager.md`)
+- `J-desktop-attach-daily` — operate the native window on the owned runtime (`../journeys/J-desktop-attach-daily.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-runtime-selector-scroll-boundary | J-17 / RT-068 | Sol | Feature Tour | Pass | #341 | working tree |
+| 2 | CH-add-workspace-from-root | J-add-workspace-by-browsing / RT-038; MS-051; MS-web-workspace-add-directory-browser | Lea | Feature Tour | Pass | #342 | working tree |
+| 3 | CH-rename-session-parity | J-rename-session / RT-session-rename-durable | Dora | Feature Tour | Pass | #344 | working tree |
+| 4 | CH-window-layer-seam | J-administer-window-manager / ET-window-manager-layout-gestures | Bruno | Feature Tour | Pass | #346 | working tree |
+| 5 | CH-desktop-page-zoom | J-desktop-attach-daily / APP-desktop-page-zoom | Dora | Feature Tour | Pass | #345 | working tree |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+- **Runtime selector:** the live list had 19,740px of content in a 328px scroll owner. It reached the 19,412px lower boundary; a second wheel gesture stayed there and left `document.scrollY` at `0`.
+- **Filesystem roots:** `GET /api/fs/browse` returned `roots: ["/"]` with the requested home entries. The Add workspace dialog exposed `/` under Locations, browsed back to the isolated project, and registered it once.
+- **Session rename:** Web, `compozy session rename`, and workspace-scoped HTTP PATCH renamed the same stopped user session. After a daemon restart, the catalog still returned the final name with the original session id, stopped state, and workspace id.
+- **Window layers:** a real four-window grid rendered tiled windows at layer `1` and its shared seams at layer `2`; floating the active Tasks window raised it to layer `7`, keeping it above the seam without letting focused tiled windows cover resize targets.
+- **Desktop page zoom:** the native Tauri main window accepted Command-plus, Command-minus, and Command-zero. Captures show whole-page enlargement, reduction, and exact reset while the in-product window layout remained intact.
+
+## What Was Fixed
+
+No QA-discovered follow-up fixes were needed.
+
+## Paper Cuts
+
+None recorded yet.
+
+## Runtime Errors Observed
+
+None recorded yet.
+
+## Human Verifications Needed
+
+None recorded yet.
+
+## Decisions for a Human
+
+None recorded yet.
+
+## Learnings
+
+- The filesystem root belongs to the daemon response instead of browser guesses, so HTTP, UDS, Web, and onboarding share one operating-system view.
+- The session name is workspace-scoped data. Restart evidence preserved the name without changing identity or ownership.
+- Window layers must encode semantics: tiled content stays below seams, and floating content stays above both.
+- Network throttling was skipped because none of these fixes changes request timing, retries, or offline recovery.
+
+## Final Status
+
+- **Exit gate (full automated suite):** PASS — `make gate-full` completed its full `make verify` lane; 21,519 Go tests passed with 2 platform skips, plus codegen, installer, product-language, zero-warning lint, typecheck, frontend tests/builds, Go build, and boundaries. Evidence: `/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/final-make-verify.log`.
+- **Issues by user impact:** 0 critical · 0 major · 0 minor · 0 paper cuts
+- **Coverage:** 5/5 journeys walked; required `web`, `cli`, `api`, and `runtime` surfaces recorded in `journey-log.jsonl`
+- **Verdict:** PASS

--- a/docs/qa/reports/2026-08-12-pr-351-review-round-1.md
+++ b/docs/qa/reports/2026-08-12-pr-351-review-round-1.md
@@ -1,0 +1,76 @@
+# QA Run Report — 2026-08-12 — PR 351 review round 1
+
+- **Scope:** Targeted validation of the Web session-rename rejection and recovery path added during CodeRabbit review round 1, with successful CLI/API rename as adjacent canaries.
+- **Cadence tier:** targeted
+- **Build:** `558654a7` plus review-round working tree · **Environment:** `http://127.0.0.1:55812`, isolated local daemon and Web dev server; local production code with no service mocks.
+- **Started:** 2026-08-12T03:03:41Z · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Dora | Runtime Administrator | desktop / wifi-fast with one deliberate daemon interruption / en-US | CH-rename-session-parity |
+
+## Flows in Scope
+
+- `J-rename-session` — rename a session without changing its work (`../journeys/J-rename-session.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-rename-session-parity | J-rename-session / RT-session-rename-durable | Dora | Feature Tour | Fixed | BUG-20260812-rename-dialog-double-escape | working tree |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-rename-session-parity — Dora
+
+- **Ran:** 2026-08-12T03:07:00Z → 2026-08-12T03:17:00Z (box respected: yes)
+- **Findings:**
+  - A temporary daemon interruption returned a visible inline 502 error while preserving the dialog and entered name; retry succeeded after the daemon returned.
+  - The overflow menu initially consumed the first Escape behind the rename dialog (Friction); the same round fixed and re-walked it.
+- **Bugs filed/updated:** BUG-20260812-rename-dialog-double-escape
+- **Scenarios settled:** RT-session-rename-durable → pass
+- **Paper cuts:** None remaining after the governed fix.
+- **Surprises:** The disconnected shell correctly exposed its separate sync-retry state while the rename dialog kept its own recoverable error.
+- **Suggested next charter:** Repeat error-recovery behavior for the row-level rename entry point during a future broader session-catalog pass.
+
+## What Was Fixed
+
+### BUG-20260812-rename-dialog-double-escape: Keyboard users needed two Escapes
+
+- **Symptom:** The closing More actions menu consumed the first Escape behind the visible rename dialog.
+- **Root cause:** Rename opened before Base UI completed the menu close transition.
+- **Fix:** review-round-1 commit (this commit); the dialog now opens from `onOpenChangeComplete`.
+- **Regression test:** `web/src/systems/session/hooks/__tests__/use-session-topbar-slot.test.tsx`
+- **Retested:** J-rename-session in a fresh page load; one Escape closed the dialog.
+
+## Paper Cuts
+
+None remaining.
+
+## Runtime Errors Observed
+
+- Expected HTTP 502 and transcript fetch error during the deliberate daemon interruption; recovery and fresh reload were clean.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- Menu-to-dialog transitions must complete in sequence; otherwise a visually hidden menu can keep keyboard ownership.
+
+## Final Status
+
+- **Exit gate (full automated suite):** `make gate` — PASS for the project-required intermediate review batch; evidence: `/Users/pedronauck/dev/qa-labs/compozy-pr-351-review-round-1-20260812-030348-308615-lab/qa-artifacts/final-make-verify.log`.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 1 fixed · Cosmetic 0
+- **Coverage:** 1/1 in-scope journey walked; successful rename, daemon-interrupted rejection/retry, blank and overlong validation, foreign-workspace denial, CLI/API parity, refresh durability, and keyboard cancellation covered. Managed-session rejection was unchanged by this review batch and was not repeated in this targeted walk.
+- **Parity:** Latest local production code ran against the real daemon and Web dev server in Chrome with seeded demo data; no provider session, browser matrix, or production deployment artifact was required for this bounded local behavior pass.
+- **Verdict:** ready — the review-round behavior and its QA-discovered keyboard friction are fixed, re-walked, and backed by public-surface evidence.

--- a/docs/qa/scenarios/APP-desktop-page-zoom.md
+++ b/docs/qa/scenarios/APP-desktop-page-zoom.md
@@ -1,0 +1,21 @@
+---
+id: APP-desktop-page-zoom
+area: APP
+title: Scale and reset the desktop product with standard shortcuts
+persona: Dora
+journey: J-desktop-attach-daily
+expected: In the daemon-served main desktop window, Command or Control plus, minus, and zero scale or reset the whole product page while the in-product single-window Zoom action remains separate and boot-window privileges do not expand.
+entry_points: native desktop main window keyboard shortcuts
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/desktop-zoom-in-pass.png;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/desktop-zoom-out-pass.png;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/desktop-zoom-reset-pass.png
+last_report: docs/qa/reports/2026-08-11-open-issues.md
+overlaps: ET-window-manager-layout-gestures
+---
+
+Introduced for issue #345. The permission is limited to the remote daemon-served `main` window and standard loopback origins.
+
+2026-08-11 retest: passed in the native Tauri shell. Command-plus enlarged the entire product page, Command-minus reduced it, and Command-zero restored the original scale without invoking the in-product window Zoom action.

--- a/docs/qa/scenarios/ET-window-manager-layout-gestures.md
+++ b/docs/qa/scenarios/ET-window-manager-layout-gestures.md
@@ -11,8 +11,8 @@ bug_ids: BUG-20260724-arrange-preset-overlap-reject; BUG-20260724-placement-cycl
 fix_status: pending
 retest_status: pass
 fix_commits:
-evidence: docs/qa/evidence/2026-08-01-window-tabs/keyboard-04-dragged-network-window.png; docs/qa/evidence/2026-08-01-window-tabs/keyboard-05-resized-network-window.png
-last_report: docs/qa/reports/2026-08-01-window-tabs.md
+evidence: docs/qa/evidence/2026-08-01-window-tabs/keyboard-04-dragged-network-window.png; docs/qa/evidence/2026-08-01-window-tabs/keyboard-05-resized-network-window.png;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/web-window-z-index-pass.png
+last_report: docs/qa/reports/2026-08-11-open-issues.md
 overlaps: ET-web-window-routing-lifecycle; ET-window-manager-layout-recovery; ET-web-command-palette-shortcuts; ET-web-ui-resilience
 ---
 
@@ -61,3 +61,7 @@ which resizes floating rects and solo islands in place and detaches a split memb
 island at the released frame, siblings keeping their exact zones (middle members split the
 remainder into islands). Growth clamps at the nearest island live via rnd max bounds. Flag only;
 this cycle owns live retesting.
+
+qa-impact: 2026-08-11 separated semantic ordering from visual layers: tiled windows render below structural seams, while every floating layer renders above them. Reset to prove a covered seam cannot intercept the floating window and an uncovered segment still resizes its siblings.
+
+2026-08-11 retest: passed for layer ordering. A live four-window grid kept tiled windows at layer 1 and shared seams at layer 2; floating the active window raised it to layer 7.

--- a/docs/qa/scenarios/MS-051.md
+++ b/docs/qa/scenarios/MS-051.md
@@ -4,15 +4,15 @@ area: MS
 title: Browse local filesystem
 persona: Lea
 journey:
-expected: `GET /api/fs/browse?path=&show_hidden=&dirs_only=` lists entries; abs path required; control chars 400; symlink-resolved.
+expected: `GET /api/fs/browse?path=&show_hidden=&dirs_only=` lists entries and discoverable filesystem roots; abs path required; control chars 400; symlink-resolved.
 entry_points: Web onboarding picker; fs/browse route
 qa_status: pass
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: `internal/api/core/fs_browse.go:19-137`; `routes.go` (UDS :54-56); qa/evidence/batch-027-vault-model-support-logs/ms038-ms052-vault-model-support-logs.json
-last_report:
+evidence: `internal/api/core/fs_browse.go:19-137`; `routes.go` (UDS :54-56); qa/evidence/batch-027-vault-model-support-logs/ms038-ms052-vault-model-support-logs.json;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/api-filesystem-roots.json
+last_report: docs/qa/reports/2026-08-11-open-issues.md
 overlaps: RT-038
 ---
 
@@ -27,3 +27,7 @@ Absolute repo path listed entries; dirs_only returned directories only; relative
 src: docs/qa/_seeds/feature-stories/05_analysis_memory-settings.md
 
 inventory: Needs QA
+
+2026-08-11 qa-impact: filesystem roots became part of the browse contract. Reset with RT-038 as the canonical owner.
+
+2026-08-11 retest: passed with RT-038. The live HTTP response included the canonical Unix root and 23 entries for the requested directory.

--- a/docs/qa/scenarios/MS-web-workspace-add-directory-browser.md
+++ b/docs/qa/scenarios/MS-web-workspace-add-directory-browser.md
@@ -6,13 +6,13 @@ persona: Dora
 journey: J-operate-workspace-context
 expected: Add workspace opens as a two-pane extra-wide dialog. The left pane keeps the one-click global-default workspace card, then a filesystem browser (home/up toolbar, mono current path, "Use this folder", hover-reveal row picks) that chooses the root; there is no plain path input anywhere. Picking a root only updates the draft — it must not register a workspace — and it autofills the display name from the folder name until the operator types their own. The right pane carries optional session defaults: default agent, sandbox profile, and additional directories as removable chips. Exactly one `POST /api/workspaces` is issued when the footer primary is pressed, carrying `root_dir` plus any of `name`, `add_dirs`, `default_agent`, and `sandbox_ref` that are set. A failed registration reports inline and keeps every entered value. Below 980px the two panes collapse to one column with session defaults stacked underneath. The browser's reading, empty, and permission-error states are all visible. The first-run onboarding page renders the same panes and the same single-create submit.
 entry_points: web desktop shell → Add workspace; web workspaces overview → New workspace; web first-run onboarding
-qa_status: blocked-verify
+qa_status: pass
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: .compozy/tasks/modals-redesign/evidence/visual/task_02/VC-03;/Users/pedronauck/dev/qa-labs/compozy-ms-wave2-current-20260730-061842-796290-lab/qa-artifacts/qa
-last_report: docs/qa/reports/2026-07-28-untested-full.md
+evidence: .compozy/tasks/modals-redesign/evidence/visual/task_02/VC-03;/Users/pedronauck/dev/qa-labs/compozy-ms-wave2-current-20260730-061842-796290-lab/qa-artifacts/qa;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/web-workspace-root-pass.png
+last_report: docs/qa/reports/2026-08-11-open-issues.md
 overlaps: MS-web-entity-modal-shell
 ---
 
@@ -25,3 +25,7 @@ Introduced by the modal redesign (`.compozy/tasks/modals-redesign/`, `_techspec.
 src: web/src/systems/workspace/components/workspace-setup.tsx; web/src/systems/workspace/components/workspace-setup-location-pane.tsx; web/src/systems/workspace/components/workspace-setup-defaults-pane.tsx; web/src/systems/workspace/hooks/use-workspace-setup-content.ts; web/src/systems/onboarding/components/directory-browser.tsx
 
 inventory: Needs QA
+
+2026-08-11 qa-impact: the picker gained a Locations row sourced from the daemon's filesystem roots, making paths outside the operator home discoverable without manual typing. Reset for targeted browser re-walk.
+
+2026-08-11 retest: passed. The Locations row opened `/`, the operator browsed to the isolated QA project, selected it, and one submit registered and activated the workspace.

--- a/docs/qa/scenarios/RT-038.md
+++ b/docs/qa/scenarios/RT-038.md
@@ -4,15 +4,15 @@ area: RT
 title: Filesystem browse for setup
 persona: Lea
 journey:
-expected: `GET /api/fs/browse` returns directory listing for the workspace/onboarding directory picker.
+expected: `GET /api/fs/browse` returns the directory listing plus every operating-system filesystem root so the workspace/onboarding picker can navigate outside the operator home.
 entry_points: HTTP+UDS `/api/fs/browse`; web directory-browser
 qa_status: pass
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: `routes.go:63-66`; `onboarding/components/directory-browser.tsx`; qa/evidence/batch-004-context-settings/rt038-*
-last_report:
+evidence: `routes.go:63-66`; `onboarding/components/directory-browser.tsx`; qa/evidence/batch-004-context-settings/rt038-*;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/api-filesystem-roots.json
+last_report: docs/qa/reports/2026-08-11-open-issues.md
 overlaps: MS-051
 ---
 
@@ -27,3 +27,7 @@ Browse handler requires absolute paths and rejects non-directory paths; web dire
 src: docs/qa/_seeds/feature-stories/01_analysis_runtime-sessions.md
 
 inventory: Needs QA
+
+2026-08-11 qa-impact: the browse response gained `roots`, with Unix `/` and discovered Windows drive roots. Reset for HTTP/UDS/Web parity re-walk.
+
+2026-08-11 retest: passed. The isolated daemon returned `/` in `roots` alongside the requested home-directory entries, and the browser navigated from `/` back to the QA project.

--- a/docs/qa/scenarios/RT-068.md
+++ b/docs/qa/scenarios/RT-068.md
@@ -4,15 +4,15 @@ area: RT
 title: Runtime selector keyboard and a11y
 persona: Sol
 journey: J-17
-expected: The session-composer "Next prompt" RuntimeSelector opens its role=dialog popup from one trigger; search is focused on open, arrows skip disabled rows and wrap, Enter selects, Esc restores trigger focus, and the reasoning slider supports arrow/Home/End and labelled stops before the next prompt is sent.
+expected: The session-composer "Next prompt" RuntimeSelector opens its role=dialog popup from one trigger; its model list scrolls to either boundary without moving the page behind it; search is focused on open, arrows skip disabled rows and wrap, Enter selects, Esc restores trigger focus, and the reasoning slider supports arrow/Home/End and labelled stops before the next prompt is sent.
 entry_points: web session-composer RuntimeSelector (keyboard + screen reader)
 qa_status: pass
 bug_ids: BUG-20260730-runtime-selector-escape-stale
 fix_status: fixed
 retest_status: pass
 fix_commits: 9904270
-evidence: /Users/pedronauck/dev/qa-labs/compozy-model-selector-20260710-194713-914643-lab/qa-artifacts/qa/model-selector-evidence.md;docs/qa/reports/2026-07-10-model-selector.md;/Users/pedronauck/dev/qa-labs/compozy-qa-rt-current-source-20260730-20260730-061631-252740-lab/qa-artifacts/qa;/Users/pedronauck/dev/qa-labs/compozy-web-settled-popover-20260730-071400-207447-lab/qa-artifacts/qa/evidence/web-settled-popover;docs/qa/evidence/2026-07-30-session-runtime-selector/runtime-selector-proof.md
-last_report: docs/qa/reports/2026-07-30-session-runtime-selector.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-model-selector-20260710-194713-914643-lab/qa-artifacts/qa/model-selector-evidence.md;docs/qa/reports/2026-07-10-model-selector.md;/Users/pedronauck/dev/qa-labs/compozy-qa-rt-current-source-20260730-20260730-061631-252740-lab/qa-artifacts/qa;/Users/pedronauck/dev/qa-labs/compozy-web-settled-popover-20260730-071400-207447-lab/qa-artifacts/qa/evidence/web-settled-popover;docs/qa/evidence/2026-07-30-session-runtime-selector/runtime-selector-proof.md;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/web-runtime-scroll-pass.png
+last_report: docs/qa/reports/2026-08-11-open-issues.md
 overlaps:
 ---
 
@@ -25,3 +25,7 @@ Review round 001 batch 021-025: degraded-state warning icon now has accessible n
 2026-07-22 selector redesign: single-button trigger (segments + deep-link focus routing deleted, ⌘J removed), reasoning strip replaced by a slider (no None/Default stops; model default preselected). Keyboard/a11y contract re-specified; retest in next cycle.
 
 2026-07-30 retest: passed. Escape immediately removed the exit-preserved popup from the accessibility tree, restored focus to the trigger, and Enter reopened it; the canonical popover suite covers the inert exit state.
+
+2026-08-11 qa-impact: the model-list scroll owner now contains wheel overscroll at both boundaries so the desktop behind the popup cannot move. Reset for targeted browser re-walk.
+
+2026-08-11 retest: passed. The real model list reached its 19,412px lower boundary; a second wheel gesture left both its scroll position and the document position unchanged (`document.scrollY = 0`).

--- a/docs/qa/scenarios/RT-session-rename-durable.md
+++ b/docs/qa/scenarios/RT-session-rename-durable.md
@@ -7,15 +7,19 @@ journey: J-rename-session
 expected: A valid workspace-scoped rename persists across refresh and daemon restart in Web, CLI, HTTP, UDS, and `compozy__session_rename`, while invalid, managed, and foreign-session requests change nothing.
 entry_points: web session row/topbar; compozy session rename; PATCH /api/workspaces/{workspace_id}/sessions/{session_id}; compozy__session_rename
 qa_status: pass
-bug_ids:
-fix_status:
-retest_status:
-fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/web-session-rename-pass.png;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/cli-session-rename.json;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/api-session-rename.json;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/cli-sessions-after-restart.json
-last_report: docs/qa/reports/2026-08-11-open-issues.md
+bug_ids: BUG-20260812-rename-dialog-double-escape
+fix_status: fixed
+retest_status: pass
+fix_commits: review-round-1 commit
+evidence: docs/qa/evidence/2026-08-12-pr-351-review-round-1/CH-rename-session-parity-error.png;docs/qa/evidence/2026-08-12-pr-351-review-round-1/CH-rename-session-parity-refresh.png;docs/qa/evidence/2026-08-12-pr-351-review-round-1/CH-rename-session-parity-single-escape.png;/Users/pedronauck/dev/qa-labs/compozy-pr-351-review-round-1-20260812-030348-308615-lab/qa-artifacts/cli-session-after-recovery.json;/Users/pedronauck/dev/qa-labs/compozy-pr-351-review-round-1-20260812-030348-308615-lab/qa-artifacts/api-session-after-recovery.json
+last_report: docs/qa/reports/2026-08-12-pr-351-review-round-1.md
 overlaps:
 ---
 
 Introduced for issue #344. The display name is the only mutable datum; session id, transcript, runtime, archive state, lineage, and workspace ownership remain authoritative.
 
 2026-08-11 retest: passed. Web, CLI, and HTTP renamed the same stopped user session; a daemon restart preserved the final name, session id, stopped state, and workspace id.
+
+2026-08-12 review round 1: qa_status reset to untested because a rejected Web rename now remains open and exposes a retryable inline error.
+
+2026-08-12 review round 1 retest: passed. A daemon interruption left the dialog and entered name intact with an inline error; recovery allowed the same dialog to retry successfully, refresh preserved the new name, CLI and HTTP agreed on identity, and a foreign-workspace PATCH remained denied. The same walk found and fixed BUG-20260812-rename-dialog-double-escape.

--- a/docs/qa/scenarios/RT-session-rename-durable.md
+++ b/docs/qa/scenarios/RT-session-rename-durable.md
@@ -1,0 +1,21 @@
+---
+id: RT-session-rename-durable
+area: RT
+title: Rename a user session without changing its identity
+persona: Dora
+journey: J-rename-session
+expected: A valid workspace-scoped rename persists across refresh and daemon restart in Web, CLI, HTTP, UDS, and `compozy__session_rename`, while invalid, managed, and foreign-session requests change nothing.
+entry_points: web session row/topbar; compozy session rename; PATCH /api/workspaces/{workspace_id}/sessions/{session_id}; compozy__session_rename
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/web-session-rename-pass.png;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/cli-session-rename.json;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/api-session-rename.json;/Users/pedronauck/dev/qa-labs/compozy-open-issues-20260812-002435-338441-lab/qa-artifacts/cli-sessions-after-restart.json
+last_report: docs/qa/reports/2026-08-11-open-issues.md
+overlaps:
+---
+
+Introduced for issue #344. The display name is the only mutable datum; session id, transcript, runtime, archive state, lineage, and workspace ownership remain authoritative.
+
+2026-08-11 retest: passed. Web, CLI, and HTTP renamed the same stopped user session; a daemon restart preserved the final name, session id, stopped state, and workspace id.

--- a/internal/api/contract/fs.go
+++ b/internal/api/contract/fs.go
@@ -12,5 +12,6 @@ type FSBrowseResponse struct {
 	Path    string           `json:"path"`
 	Parent  string           `json:"parent,omitempty"`
 	Home    string           `json:"home,omitempty"`
+	Roots   []string         `json:"roots"`
 	Entries []FSEntryPayload `json:"entries"`
 }

--- a/internal/api/contract/session_runtime_payloads.go
+++ b/internal/api/contract/session_runtime_payloads.go
@@ -31,6 +31,11 @@ type CreateSessionRequest struct {
 	NetworkParticipation *participation.Request `json:"network_participation,omitempty"`
 }
 
+// RenameSessionRequest changes the durable display name of one user session.
+type RenameSessionRequest struct {
+	Name string `json:"name"`
+}
+
 // ApproveSessionRequest is the interactive permission approval payload.
 type ApproveSessionRequest struct {
 	RequestID string `json:"request_id"`

--- a/internal/api/core/fs_browse.go
+++ b/internal/api/core/fs_browse.go
@@ -17,7 +17,12 @@ import (
 // picker can navigate the local filesystem. It is read-only and operator-scoped:
 // the daemon already runs with the operator's filesystem access.
 func (h *BaseHandlers) BrowseDirectory(c *gin.Context) {
-	home := operatorHomeDir()
+	home := h.daemonUserHomeDir()
+	roots, err := filesystemRoots()
+	if err != nil {
+		h.respondError(c, http.StatusInternalServerError, err)
+		return
+	}
 
 	requested := strings.TrimSpace(c.Query("path"))
 	if requested == "" {
@@ -54,6 +59,7 @@ func (h *BaseHandlers) BrowseDirectory(c *gin.Context) {
 	response := contract.FSBrowseResponse{
 		Path:    resolved,
 		Home:    home,
+		Roots:   roots,
 		Entries: entries,
 	}
 	if parent := filepath.Dir(resolved); parent != resolved {
@@ -134,12 +140,4 @@ func containsControlChar(path string) bool {
 		}
 	}
 	return false
-}
-
-func operatorHomeDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(home)
 }

--- a/internal/api/core/fs_browse_test.go
+++ b/internal/api/core/fs_browse_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func newFilesystemFixture(t *testing.T) *gin.Engine {
+func newFilesystemFixture(t *testing.T) (*gin.Engine, compozyconfig.HomePaths) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 	homePaths := testutil.NewTestHomePaths(t)
@@ -37,7 +37,7 @@ func newFilesystemFixture(t *testing.T) *gin.Engine {
 	engine := gin.New()
 	engine.Use(gin.Recovery())
 	engine.GET("/api/fs/browse", handlers.BrowseDirectory)
-	return engine
+	return engine, homePaths
 }
 
 func browse(
@@ -95,7 +95,30 @@ func TestBrowseDirectoryHandler(t *testing.T) {
 		t.Fatalf("EvalSymlinks(%q): %v", root, err)
 	}
 
-	engine := newFilesystemFixture(t)
+	engine, homePaths := newFilesystemFixture(t)
+	expectedHome, err := compozyconfig.ResolveOperatorHomeDir(homePaths)
+	if err != nil {
+		t.Fatalf("ResolveOperatorHomeDir() error = %v", err)
+	}
+
+	t.Run("Should default to the operator home and expose absolute filesystem roots", func(t *testing.T) {
+		t.Parallel()
+		rec, resp := browse(t, engine, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("browse = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+		}
+		if resp.Home != expectedHome || resp.Path != expectedHome {
+			t.Fatalf("home/path = %q/%q, want %q", resp.Home, resp.Path, expectedHome)
+		}
+		if len(resp.Roots) == 0 {
+			t.Fatal("roots are empty")
+		}
+		for _, root := range resp.Roots {
+			if !filepath.IsAbs(root) {
+				t.Fatalf("root = %q, want an absolute path", root)
+			}
+		}
+	})
 
 	t.Run("Should list directories first then files, hiding dotfiles", func(t *testing.T) {
 		t.Parallel()

--- a/internal/api/core/fs_roots_unix.go
+++ b/internal/api/core/fs_roots_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package core
+
+import "path/filepath"
+
+func filesystemRoots() ([]string, error) {
+	return []string{string(filepath.Separator)}, nil
+}

--- a/internal/api/core/fs_roots_windows.go
+++ b/internal/api/core/fs_roots_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package core
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/windows"
+)
+
+func filesystemRoots() ([]string, error) {
+	mask, err := windows.GetLogicalDrives()
+	if err != nil {
+		return nil, fmt.Errorf("api: enumerate filesystem roots: %w", err)
+	}
+
+	roots := make([]string, 0, 26)
+	for drive := 0; drive < 26; drive++ {
+		if mask&(1<<drive) == 0 {
+			continue
+		}
+		roots = append(roots, string(rune('A'+drive))+":\\")
+	}
+	return roots, nil
+}

--- a/internal/api/core/handlers_test.go
+++ b/internal/api/core/handlers_test.go
@@ -995,6 +995,94 @@ func TestSessionRuntimeSelectionHandlers(t *testing.T) {
 	})
 }
 
+func TestRenameSessionHandler(t *testing.T) {
+	t.Parallel()
+
+	base := testutil.NewSessionInfo("sess-rename")
+	base.WorkspaceID = "ws-rename"
+	base.Type = session.SessionTypeUser
+	renameCalls := 0
+	manager := testutil.StubSessionManager{
+		ListAllFn: func(context.Context) ([]*session.Info, error) {
+			return []*session.Info{base}, nil
+		},
+		RenameFn: func(
+			_ context.Context,
+			workspaceID string,
+			sessionID string,
+			name string,
+		) (*session.Info, error) {
+			renameCalls++
+			if workspaceID != base.WorkspaceID || sessionID != base.ID || name != "Checkout retries" {
+				t.Fatalf("Rename() = workspace %q session %q name %q", workspaceID, sessionID, name)
+			}
+			updated := *base
+			updated.Name = name
+			return &updated, nil
+		},
+	}
+	fixture := newHandlerFixture(
+		t,
+		manager,
+		testutil.StubObserver{},
+		testutil.StubWorkspaceService{},
+		nil,
+		nil,
+	)
+
+	t.Run("Should rename the workspace-scoped session", func(t *testing.T) {
+		response := performRequest(
+			t,
+			fixture.Engine,
+			http.MethodPatch,
+			"/workspaces/ws-rename/sessions/sess-rename",
+			[]byte(`{"name":"Checkout retries"}`),
+		)
+		if response.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusOK, response.Body.String())
+		}
+		var payload contract.SessionResponse
+		if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload.Session.Name != "Checkout retries" || renameCalls != 1 {
+			t.Fatalf("rename response = %#v calls=%d", payload.Session, renameCalls)
+		}
+	})
+
+	t.Run("Should reject unknown request fields", func(t *testing.T) {
+		response := performRequest(
+			t,
+			fixture.Engine,
+			http.MethodPatch,
+			"/workspaces/ws-rename/sessions/sess-rename",
+			[]byte(`{"name":"Checkout retries","legacy_name":"old"}`),
+		)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusBadRequest, response.Body.String())
+		}
+		if renameCalls != 1 {
+			t.Fatalf("Rename() calls = %d, want 1", renameCalls)
+		}
+	})
+
+	t.Run("Should hide a session outside the route workspace", func(t *testing.T) {
+		response := performRequest(
+			t,
+			fixture.Engine,
+			http.MethodPatch,
+			"/workspaces/ws-foreign/sessions/sess-rename",
+			[]byte(`{"name":"Checkout retries"}`),
+		)
+		if response.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusNotFound, response.Body.String())
+		}
+		if renameCalls != 1 {
+			t.Fatalf("Rename() calls = %d, want 1", renameCalls)
+		}
+	})
+}
+
 func TestSessionRecapUsesSingleBoundedTranscriptRead(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/core/handlers_test.go
+++ b/internal/api/core/handlers_test.go
@@ -1058,9 +1058,7 @@ func TestRenameSessionHandler(t *testing.T) {
 			"/workspaces/ws-rename/sessions/sess-rename",
 			[]byte(`{"name":"Checkout retries","legacy_name":"old"}`),
 		)
-		if response.Code != http.StatusBadRequest {
-			t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusBadRequest, response.Body.String())
-		}
+		assertAPIErrorResponse(t, response, http.StatusBadRequest, "legacy_name")
 		if renameCalls != 1 {
 			t.Fatalf("Rename() calls = %d, want 1", renameCalls)
 		}
@@ -1074,9 +1072,7 @@ func TestRenameSessionHandler(t *testing.T) {
 			"/workspaces/ws-foreign/sessions/sess-rename",
 			[]byte(`{"name":"Checkout retries"}`),
 		)
-		if response.Code != http.StatusNotFound {
-			t.Fatalf("status = %d, want %d; body=%s", response.Code, http.StatusNotFound, response.Body.String())
-		}
+		assertAPIErrorResponse(t, response, http.StatusNotFound, "workspace-scoped resource not found")
 		if renameCalls != 1 {
 			t.Fatalf("Rename() calls = %d, want 1", renameCalls)
 		}

--- a/internal/api/core/session_rename.go
+++ b/internal/api/core/session_rename.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/compozy/compozy/internal/api/contract"
+	"github.com/gin-gonic/gin"
+)
+
+// RenameSession changes one user session's durable display name.
+func (h *BaseHandlers) RenameSession(c *gin.Context) {
+	manager, ok := h.Sessions.(SessionRenameManager)
+	if !ok {
+		h.respondError(c, http.StatusServiceUnavailable, errors.New("api: session rename manager is required"))
+		return
+	}
+	scope, sessionID, _, ok := h.routeSessionInWorkspace(c)
+	if !ok {
+		return
+	}
+	var req contract.RenameSessionRequest
+	if err := decodeStrictJSONBody(c, &req); err != nil {
+		h.respondError(
+			c,
+			http.StatusBadRequest,
+			fmt.Errorf("%s: decode session rename request: %w", h.transportName(), err),
+		)
+		return
+	}
+	info, err := manager.Rename(
+		c.Request.Context(),
+		scope.SessionWorkspaceID(),
+		sessionID,
+		req.Name,
+	)
+	if err != nil {
+		h.respondError(c, StatusForSessionError(err), err)
+		return
+	}
+	c.JSON(http.StatusOK, contract.SessionResponse{Session: SessionPayloadFromInfo(info)})
+}

--- a/internal/api/core/session_rename_interfaces.go
+++ b/internal/api/core/session_rename_interfaces.go
@@ -1,0 +1,12 @@
+package core
+
+import (
+	"context"
+
+	"github.com/compozy/compozy/internal/session"
+)
+
+// SessionRenameManager owns durable workspace-scoped session display names.
+type SessionRenameManager interface {
+	Rename(ctx context.Context, workspaceID string, sessionID string, name string) (*session.Info, error)
+}

--- a/internal/api/core/test_helpers_test.go
+++ b/internal/api/core/test_helpers_test.go
@@ -327,6 +327,7 @@ func newHandlerFixtureWithAutomationTasksAndBridges(
 	engine.GET("/sessions/:session_id/owner", handlers.GetSessionOwner)
 	engine.POST("/sessions", handlers.CreateSession)
 	engine.GET("/workspaces/:workspace_id/sessions/:session_id", handlers.GetSession)
+	engine.PATCH("/workspaces/:workspace_id/sessions/:session_id", handlers.RenameSession)
 	engine.GET("/workspaces/:workspace_id/sessions/:session_id/commands", handlers.GetSessionCommands)
 	engine.DELETE("/workspaces/:workspace_id/sessions/:session_id", handlers.DeleteSession)
 	engine.POST("/workspaces/:workspace_id/sessions/:session_id/stop", handlers.StopSession)

--- a/internal/api/httpapi/handlers_test.go
+++ b/internal/api/httpapi/handlers_test.go
@@ -303,6 +303,7 @@ func assertRegisteredRouteContract(t *testing.T) {
 		"PATCH /api/workspaces/:workspace_id/network/channels/:channel",
 		"PATCH /api/workspaces/:workspace_id",
 		"PATCH /api/workspaces/:workspace_id/loops/:name",
+		"PATCH /api/workspaces/:workspace_id/sessions/:session_id",
 		"POST /api/agent/channels/:channel/send",
 		"POST /api/agent/channels/reply",
 		"POST /api/agent/soul/validate",

--- a/internal/api/httpapi/session_routes.go
+++ b/internal/api/httpapi/session_routes.go
@@ -12,6 +12,7 @@ func registerSessionRoutes(api gin.IRouter, handlers *Handlers) {
 
 	workspaceSessions := api.Group("/workspaces/:workspace_id/sessions")
 	workspaceSessions.GET("/:session_id", handlers.GetSession)
+	workspaceSessions.PATCH("/:session_id", handlers.RenameSession)
 	workspaceSessions.GET("/:session_id/goal", handlers.GetSessionGoal)
 	workspaceSessions.GET("/:session_id/commands", handlers.GetSessionCommands)
 	workspaceSessions.POST("/:session_id/soul/refresh", handlers.RefreshSessionSoul)

--- a/internal/api/spec/paths.go
+++ b/internal/api/spec/paths.go
@@ -3,4 +3,5 @@ package spec
 const (
 	specAgentTaskClaimNextPath = "/api/agent/tasks/claim-next"
 	specSessionsPath           = "/api/sessions"
+	specWorkspaceSessionPath   = "/api/workspaces/{workspace_id}/sessions/{session_id}"
 )

--- a/internal/api/spec/registry_filesystem.go
+++ b/internal/api/spec/registry_filesystem.go
@@ -7,7 +7,7 @@ func registryFilesystemOperations() []OperationSpec {
 		Method:      httpMethodGet,
 		Path:        "/api/fs/browse",
 		OperationID: "browseDirectory",
-		Summary:     "List directory entries for the workspace folder picker",
+		Summary:     "List directory entries and filesystem roots for the workspace folder picker",
 		Tags:        []string{specFilesystemKey},
 		Transports:  []Transport{TransportHTTP, TransportUDS},
 		Parameters: []ParameterSpec{

--- a/internal/api/spec/registry_sessions.go
+++ b/internal/api/spec/registry_sessions.go
@@ -48,6 +48,7 @@ func renameSessionOperationSpec() OperationSpec {
 			{Status: 200, Description: "OK", Body: contract.SessionResponse{}},
 			{Status: 400, Description: "Invalid session name", Body: contract.ErrorPayload{}},
 			{Status: 404, Description: specSessionNotFoundDescription, Body: contract.ErrorPayload{}},
+			{Status: 503, Description: "Session rename unavailable", Body: contract.ErrorPayload{}},
 			{Status: 500, Description: specInternalServerErrorDescription, Body: contract.ErrorPayload{}},
 		},
 	}

--- a/internal/api/spec/registry_sessions.go
+++ b/internal/api/spec/registry_sessions.go
@@ -8,6 +8,7 @@ func registrySessionOperations() []OperationSpec {
 		getSessionByIDOperationSpec(),
 		getSessionOwnerOperationSpec(),
 		getSessionOperationSpec(),
+		renameSessionOperationSpec(),
 		getSessionCommandsOperationSpec(),
 		deleteSessionOperationSpec(),
 		stopSessionOperationSpec(),
@@ -28,6 +29,27 @@ func registrySessionOperations() []OperationSpec {
 		listSessionEventsOperationSpec(),
 		getSessionHistoryOperationSpec(),
 		approveSessionOperationSpec(),
+	}
+}
+func renameSessionOperationSpec() OperationSpec {
+	return OperationSpec{
+		Method:      httpMethodPatch,
+		Path:        specWorkspaceSessionPath,
+		OperationID: "renameSession",
+		Summary:     "Rename one user session",
+		Tags:        []string{specSessionsKey},
+		Transports:  []Transport{TransportHTTP, TransportUDS},
+		Parameters: []ParameterSpec{
+			pathParam("workspace_id", "Workspace id"),
+			pathParam("session_id", "Session id"),
+		},
+		RequestBody: contract.RenameSessionRequest{},
+		Responses: []ResponseSpec{
+			{Status: 200, Description: "OK", Body: contract.SessionResponse{}},
+			{Status: 400, Description: "Invalid session name", Body: contract.ErrorPayload{}},
+			{Status: 404, Description: specSessionNotFoundDescription, Body: contract.ErrorPayload{}},
+			{Status: 500, Description: specInternalServerErrorDescription, Body: contract.ErrorPayload{}},
+		},
 	}
 }
 
@@ -90,7 +112,7 @@ func getSessionByIDOperationSpec() OperationSpec {
 func getSessionOperationSpec() OperationSpec {
 	return OperationSpec{
 		Method:      httpMethodGet,
-		Path:        "/api/workspaces/{workspace_id}/sessions/{session_id}",
+		Path:        specWorkspaceSessionPath,
 		OperationID: "getSession",
 		Summary:     "Get one session snapshot",
 		Tags:        []string{specSessionsKey},
@@ -110,7 +132,7 @@ func getSessionOperationSpec() OperationSpec {
 func deleteSessionOperationSpec() OperationSpec {
 	return OperationSpec{
 		Method:      httpMethodDelete,
-		Path:        "/api/workspaces/{workspace_id}/sessions/{session_id}",
+		Path:        specWorkspaceSessionPath,
 		OperationID: "deleteSession",
 		Summary:     "Delete one session and remove it from persisted history",
 		Tags:        []string{specSessionsKey},

--- a/internal/api/testutil/session_stub.go
+++ b/internal/api/testutil/session_stub.go
@@ -31,6 +31,7 @@ type StubSessionManager struct {
 	StopFn                  func(context.Context, string) error
 	ArchiveFn               func(context.Context, string, string) (*session.Info, error)
 	UnarchiveFn             func(context.Context, string, string) (*session.Info, error)
+	RenameFn                func(context.Context, string, string, string) (*session.Info, error)
 	StopWithCauseFn         func(context.Context, string, session.StopCause, string) error
 	ResumeFn                func(context.Context, string) (*session.Session, error)
 	AttachSessionFn         func(context.Context, store.SessionAttachRequest) (store.SessionAttach, error)
@@ -318,6 +319,18 @@ func (s StubSessionManager) AttachSession(
 		return s.AttachSessionFn(ctx, req)
 	}
 	return store.SessionAttach{}, store.ErrSessionNotFound
+}
+
+func (s StubSessionManager) Rename(
+	ctx context.Context,
+	workspaceID string,
+	sessionID string,
+	name string,
+) (*session.Info, error) {
+	if s.RenameFn != nil {
+		return s.RenameFn(ctx, workspaceID, sessionID, name)
+	}
+	return nil, session.ErrSessionNotFound
 }
 
 func (s StubSessionManager) ClearConversation(

--- a/internal/api/udsapi/handlers_test.go
+++ b/internal/api/udsapi/handlers_test.go
@@ -299,6 +299,7 @@ func TestRegisterRoutesCoversTechSpecEndpoints(t *testing.T) {
 			"PATCH /api/workspaces/:workspace_id/network/channels/:channel",
 			"PATCH /api/workspaces/:workspace_id",
 			"PATCH /api/workspaces/:workspace_id/loops/:name",
+			"PATCH /api/workspaces/:workspace_id/sessions/:session_id",
 			"POST /api/automation/jobs",
 			"POST /api/automation/jobs/:id/trigger",
 			"POST /api/automation/triggers",

--- a/internal/api/udsapi/session_routes.go
+++ b/internal/api/udsapi/session_routes.go
@@ -14,6 +14,7 @@ func registerSessionRoutes(api gin.IRouter, handlers *Handlers) {
 	workspaceSessions := api.Group("/workspaces/:workspace_id/sessions")
 	{
 		workspaceSessions.GET("/:session_id", handlers.GetSession)
+		workspaceSessions.PATCH("/:session_id", handlers.RenameSession)
 		workspaceSessions.GET("/:session_id/goal", handlers.GetSessionGoal)
 		workspaceSessions.GET("/:session_id/commands", handlers.GetSessionCommands)
 		workspaceSessions.POST("/:session_id/soul/refresh", handlers.RefreshSessionSoul)

--- a/internal/cli/client_session_api.go
+++ b/internal/cli/client_session_api.go
@@ -19,6 +19,7 @@ type sessionClientAPI interface {
 	StopSession(context.Context, string) error
 	ArchiveSession(context.Context, string) (SessionRecord, error)
 	UnarchiveSession(context.Context, string) (SessionRecord, error)
+	RenameSession(context.Context, string, RenameSessionRequest) (SessionRecord, error)
 	DeleteSession(context.Context, string) error
 	ResumeSession(context.Context, string) (SessionRecord, error)
 	SetSessionRuntime(context.Context, string, SetSessionRuntimeRequest) (SessionRecord, error)

--- a/internal/cli/client_session_rename.go
+++ b/internal/cli/client_session_rename.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/compozy/compozy/internal/api/contract"
+)
+
+func (c *daemonClient) RenameSession(
+	ctx context.Context,
+	id string,
+	request RenameSessionRequest,
+) (SessionRecord, error) {
+	var response contract.SessionResponse
+	path, err := c.sessionScopedPath(ctx, id, "")
+	if err != nil {
+		return SessionRecord{}, err
+	}
+	if err := c.doJSON(ctx, http.MethodPatch, path, nil, request, &response); err != nil {
+		return SessionRecord{}, err
+	}
+	return response.Session, nil
+}

--- a/internal/cli/client_session_types.go
+++ b/internal/cli/client_session_types.go
@@ -12,6 +12,9 @@ type CreateSessionRequest = contract.CreateSessionRequest
 // SessionRecord is the shared daemon session payload.
 type SessionRecord = contract.SessionPayload
 
+// RenameSessionRequest changes one user session's durable display name.
+type RenameSessionRequest = contract.RenameSessionRequest
+
 // SessionCommandsRecord is the unified session command catalog.
 type SessionCommandsRecord = contract.SessionCommandsResponse
 

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -2603,10 +2603,18 @@ func TestUnixSocketClientMethods(t *testing.T) {
 	if err := client.StopSession(ctx, "sess-1"); err != nil {
 		t.Fatalf("StopSession() error = %v", err)
 	}
-	renamed, err := client.RenameSession(ctx, "sess-1", RenameSessionRequest{Name: "Checkout retries"})
-	if err != nil || renamed.Name != "Checkout retries" {
-		t.Fatalf("RenameSession() = %#v, %v", renamed, err)
-	}
+	t.Run("Should rename a session through the workspace route", func(t *testing.T) {
+		t.Parallel()
+
+		renamed, renameErr := client.RenameSession(
+			ctx,
+			"sess-1",
+			RenameSessionRequest{Name: "Checkout retries"},
+		)
+		if renameErr != nil || renamed.Name != "Checkout retries" {
+			t.Fatalf("RenameSession() = %#v, %v", renamed, renameErr)
+		}
+	})
 	t.Run("Should archive and unarchive a session through the workspace routes", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cli/client_test.go
+++ b/internal/cli/client_test.go
@@ -2191,6 +2191,18 @@ func TestUnixSocketClientMethods(t *testing.T) {
 						http.StatusOK,
 						`{"session":{"id":"sess-1","agent_name":"coder","workspace_id":"ws-1","state":"stopped","archived_at":null,"created_at":"2026-04-03T12:00:00Z","updated_at":"2026-04-03T12:02:00Z"}}`,
 					), nil
+				case req.Method == http.MethodPatch && req.URL.Path == "/api/workspaces/ws-1/sessions/sess-1":
+					var body RenameSessionRequest
+					if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+						t.Fatalf("decode session rename request error = %v", err)
+					}
+					if body.Name != "Checkout retries" {
+						t.Fatalf("session rename name = %q", body.Name)
+					}
+					return newHTTPResponse(
+						http.StatusOK,
+						`{"session":{"id":"sess-1","name":"Checkout retries","agent_name":"coder","workspace_id":"ws-1","state":"stopped","archived_at":null,"created_at":"2026-04-03T12:00:00Z","updated_at":"2026-04-03T12:03:00Z"}}`,
+					), nil
 				case req.Method == http.MethodPost && req.URL.Path == "/api/workspaces/ws-1/sessions/sess-1/attach":
 					return newHTTPResponse(
 						http.StatusOK,
@@ -2590,6 +2602,10 @@ func TestUnixSocketClientMethods(t *testing.T) {
 
 	if err := client.StopSession(ctx, "sess-1"); err != nil {
 		t.Fatalf("StopSession() error = %v", err)
+	}
+	renamed, err := client.RenameSession(ctx, "sess-1", RenameSessionRequest{Name: "Checkout retries"})
+	if err != nil || renamed.Name != "Checkout retries" {
+		t.Fatalf("RenameSession() = %#v, %v", renamed, err)
 	}
 	t.Run("Should archive and unarchive a session through the workspace routes", func(t *testing.T) {
 		t.Parallel()

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -147,6 +147,7 @@ type stubClient struct {
 	stopSessionFn                func(context.Context, string) error
 	archiveSessionFn             func(context.Context, string) (SessionRecord, error)
 	unarchiveSessionFn           func(context.Context, string) (SessionRecord, error)
+	renameSessionFn              func(context.Context, string, RenameSessionRequest) (SessionRecord, error)
 	deleteSessionFn              func(context.Context, string) error
 	resumeSessionFn              func(context.Context, string) (SessionRecord, error)
 	setSessionRuntimeFn          func(context.Context, string, SetSessionRuntimeRequest) (SessionRecord, error)
@@ -1582,6 +1583,17 @@ func (s *stubClient) UnarchiveSession(ctx context.Context, id string) (SessionRe
 		return s.unarchiveSessionFn(ctx, id)
 	}
 	return SessionRecord{}, errors.New("unexpected UnarchiveSession call")
+}
+
+func (s *stubClient) RenameSession(
+	ctx context.Context,
+	id string,
+	request RenameSessionRequest,
+) (SessionRecord, error) {
+	if s.renameSessionFn != nil {
+		return s.renameSessionFn(ctx, id, request)
+	}
+	return SessionRecord{}, errors.New("unexpected RenameSession call")
 }
 
 func (s *stubClient) DeleteSession(ctx context.Context, id string) error {

--- a/internal/cli/session_command.go
+++ b/internal/cli/session_command.go
@@ -11,6 +11,7 @@ func newSessionCommand(deps commandDeps) *cobra.Command {
 	cmd.AddCommand(newSessionCreateCommand(deps))
 	cmd.AddCommand(newSessionListCommand(deps))
 	cmd.AddCommand(newSessionStopCommand(deps))
+	cmd.AddCommand(newSessionRenameCommand(deps))
 	cmd.AddCommand(newSessionArchiveCommand(deps))
 	cmd.AddCommand(newSessionUnarchiveCommand(deps))
 	cmd.AddCommand(newSessionRemoveCommand(deps))

--- a/internal/cli/session_rename.go
+++ b/internal/cli/session_rename.go
@@ -1,0 +1,28 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func newSessionRenameCommand(deps commandDeps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "rename <id> <name>",
+		Short: "Rename a user session",
+		Example: `  # Rename a session
+  compozy session rename sess_1234 "Checkout retries"`,
+		Args: exactTwoNonBlankArgs(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := clientFromDeps(deps)
+			if err != nil {
+				return err
+			}
+			record, err := client.RenameSession(
+				cmd.Context(),
+				args[0],
+				RenameSessionRequest{Name: args[1]},
+			)
+			if err != nil {
+				return err
+			}
+			return writeCommandOutput(cmd, sessionBundle(record, deps.now))
+		},
+	}
+}

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -923,47 +923,51 @@ func TestSessionArchiveCommandsReturnUpdatedSession(t *testing.T) {
 func TestSessionRenameCommandReturnsUpdatedSession(t *testing.T) {
 	t.Parallel()
 
-	deps := newWorkspaceTestDeps(t, &stubClient{
-		renameSessionFn: func(
-			_ context.Context,
-			id string,
-			request RenameSessionRequest,
-		) (SessionRecord, error) {
-			if id != "sess-1" || request.Name != "Checkout retries" {
-				t.Fatalf("RenameSession() = id %q request %#v", id, request)
-			}
-			return SessionRecord{
-				ID:          id,
-				Name:        request.Name,
-				AgentName:   "coder",
-				WorkspaceID: "ws-1",
-				State:       session.StateStopped,
-				CreatedAt:   fixedTestNow,
-				UpdatedAt:   fixedTestNow.Add(time.Minute),
-			}, nil
-		},
-	})
+	t.Run("Should rename a session and return the updated record", func(t *testing.T) {
+		t.Parallel()
 
-	stdout, _, err := executeRootCommand(
-		t,
-		deps,
-		"session",
-		"rename",
-		"sess-1",
-		"Checkout retries",
-		"-o",
-		"json",
-	)
-	if err != nil {
-		t.Fatalf("executeRootCommand(session rename) error = %v", err)
-	}
-	var renamed SessionRecord
-	if err := json.Unmarshal([]byte(stdout), &renamed); err != nil {
-		t.Fatalf("json.Unmarshal(session rename) error = %v", err)
-	}
-	if renamed.ID != "sess-1" || renamed.Name != "Checkout retries" {
-		t.Fatalf("session rename output = %#v", renamed)
-	}
+		deps := newWorkspaceTestDeps(t, &stubClient{
+			renameSessionFn: func(
+				_ context.Context,
+				id string,
+				request RenameSessionRequest,
+			) (SessionRecord, error) {
+				if id != "sess-1" || request.Name != "Checkout retries" {
+					t.Fatalf("RenameSession() = id %q request %#v", id, request)
+				}
+				return SessionRecord{
+					ID:          id,
+					Name:        request.Name,
+					AgentName:   "coder",
+					WorkspaceID: "ws-1",
+					State:       session.StateStopped,
+					CreatedAt:   fixedTestNow,
+					UpdatedAt:   fixedTestNow.Add(time.Minute),
+				}, nil
+			},
+		})
+
+		stdout, _, err := executeRootCommand(
+			t,
+			deps,
+			"session",
+			"rename",
+			"sess-1",
+			"Checkout retries",
+			"-o",
+			"json",
+		)
+		if err != nil {
+			t.Fatalf("executeRootCommand(session rename) error = %v", err)
+		}
+		var renamed SessionRecord
+		if err := json.Unmarshal([]byte(stdout), &renamed); err != nil {
+			t.Fatalf("json.Unmarshal(session rename) error = %v", err)
+		}
+		if renamed.ID != "sess-1" || renamed.Name != "Checkout retries" {
+			t.Fatalf("session rename output = %#v", renamed)
+		}
+	})
 }
 
 func TestSessionListRejectsConflictingArchiveFilters(t *testing.T) {

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -920,6 +920,52 @@ func TestSessionArchiveCommandsReturnUpdatedSession(t *testing.T) {
 	})
 }
 
+func TestSessionRenameCommandReturnsUpdatedSession(t *testing.T) {
+	t.Parallel()
+
+	deps := newWorkspaceTestDeps(t, &stubClient{
+		renameSessionFn: func(
+			_ context.Context,
+			id string,
+			request RenameSessionRequest,
+		) (SessionRecord, error) {
+			if id != "sess-1" || request.Name != "Checkout retries" {
+				t.Fatalf("RenameSession() = id %q request %#v", id, request)
+			}
+			return SessionRecord{
+				ID:          id,
+				Name:        request.Name,
+				AgentName:   "coder",
+				WorkspaceID: "ws-1",
+				State:       session.StateStopped,
+				CreatedAt:   fixedTestNow,
+				UpdatedAt:   fixedTestNow.Add(time.Minute),
+			}, nil
+		},
+	})
+
+	stdout, _, err := executeRootCommand(
+		t,
+		deps,
+		"session",
+		"rename",
+		"sess-1",
+		"Checkout retries",
+		"-o",
+		"json",
+	)
+	if err != nil {
+		t.Fatalf("executeRootCommand(session rename) error = %v", err)
+	}
+	var renamed SessionRecord
+	if err := json.Unmarshal([]byte(stdout), &renamed); err != nil {
+		t.Fatalf("json.Unmarshal(session rename) error = %v", err)
+	}
+	if renamed.ID != "sess-1" || renamed.Name != "Checkout retries" {
+		t.Fatalf("session rename output = %#v", renamed)
+	}
+}
+
 func TestSessionListRejectsConflictingArchiveFilters(t *testing.T) {
 	t.Run("Should reject conflicting archive filters", func(t *testing.T) {
 		t.Parallel()

--- a/internal/daemon/native_session_rename.go
+++ b/internal/daemon/native_session_rename.go
@@ -1,0 +1,47 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+
+	core "github.com/compozy/compozy/internal/api/core"
+	toolspkg "github.com/compozy/compozy/internal/tools"
+)
+
+type sessionRenameInput struct {
+	Workspace string `json:"workspace,omitempty"`
+	SessionID string `json:"session_id"`
+	Name      string `json:"name"`
+}
+
+func (n *daemonNativeTools) sessionRename(
+	ctx context.Context,
+	scope toolspkg.Scope,
+	req toolspkg.CallRequest,
+) (toolspkg.ToolResult, error) {
+	var input sessionRenameInput
+	if err := decodeNativeInput(req, &input); err != nil {
+		return toolspkg.ToolResult{}, err
+	}
+	resolved, err := n.nativeResolvedWorkspace(ctx, req.ToolID, input.Workspace, scope)
+	if err != nil {
+		return toolspkg.ToolResult{}, err
+	}
+	workspaceID, err := nativeResolvedRegistryWorkspaceID(&resolved)
+	if err != nil {
+		return toolspkg.ToolResult{}, nativeNetworkInputError(req.ToolID, err)
+	}
+	if _, err := n.nativeSessionInWorkspace(ctx, req.ToolID, workspaceID, input.SessionID); err != nil {
+		return toolspkg.ToolResult{}, err
+	}
+	manager, ok := n.deps.Sessions.(core.SessionRenameManager)
+	if !ok {
+		return toolspkg.ToolResult{}, errors.New("daemon: session rename manager is required")
+	}
+	info, err := manager.Rename(ctx, workspaceID, input.SessionID, input.Name)
+	if err != nil {
+		return toolspkg.ToolResult{}, err
+	}
+	payload := core.SessionPayloadFromInfo(info)
+	return structuredResult(map[string]any{nativeToolsSessionKey: payload}, payload.ID)
+}

--- a/internal/daemon/native_tool_binding_groups.go
+++ b/internal/daemon/native_tool_binding_groups.go
@@ -66,6 +66,10 @@ func (n *daemonNativeTools) sessionToolBindings(
 			call:         n.sessionUnarchive,
 			availability: catalogAvailability,
 		},
+		toolspkg.ToolIDSessionRename: {
+			call:         n.sessionRename,
+			availability: catalogAvailability,
+		},
 		toolspkg.ToolIDSessionCreate: {
 			call:         n.sessionCreate,
 			availability: n.sessionCreateAvailability(),

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -5677,6 +5677,8 @@ func TestDaemonNativeTools(t *testing.T) {
 		var clearedRuntimeRevision int64
 		var archiveTarget string
 		var unarchiveTarget string
+		var renamedTarget string
+		var renamedName string
 		promptSubmitCalls := 0
 		var listedInputSessionID string
 		var replacedInput struct {
@@ -5776,6 +5778,13 @@ func TestDaemonNativeTools(t *testing.T) {
 					restored := *info
 					restored.State = session.StateStopped
 					return &restored, nil
+				},
+				RenameFn: func(_ context.Context, workspaceID string, id string, name string) (*session.Info, error) {
+					renamedTarget = workspaceID + "/" + id
+					renamedName = name
+					renamed := *info
+					renamed.Name = name
+					return &renamed, nil
 				},
 				SetRuntimeSelectionFn: func(
 					_ context.Context,
@@ -6462,8 +6471,25 @@ func TestDaemonNativeTools(t *testing.T) {
 			}
 			requireNativeStructuredContains(t, result, []byte(`"archived_at":null`))
 		})
+		t.Run("Should rename a session", func(t *testing.T) {
+			result, callErr := registry.Call(
+				t.Context(),
+				toolspkg.Scope{Operator: true},
+				toolspkg.CallRequest{
+					ToolID: toolspkg.ToolIDSessionRename,
+					Input:  json.RawMessage(`{"workspace":"ws-stable","session_id":"sess-1","name":"Release review"}`),
+				},
+			)
+			if callErr != nil {
+				t.Fatalf("Registry.Call(session_rename) error = %v", callErr)
+			}
+			requireNativeStructuredContains(t, result, []byte(`"name":"Release review"`))
+		})
 		if archiveTarget != "ws-1/sess-1" || unarchiveTarget != "ws-1/sess-1" {
 			t.Fatalf("archive targets = %q/%q, want ws-1/sess-1", archiveTarget, unarchiveTarget)
+		}
+		if renamedTarget != "ws-1/sess-1" || renamedName != "Release review" {
+			t.Fatalf("rename request = %q/%q, want ws-1/sess-1 and Release review", renamedTarget, renamedName)
 		}
 
 		registryWithoutHealth := newDaemonNativeRegistry(t, &daemonNativeToolsDeps{

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -5679,6 +5679,7 @@ func TestDaemonNativeTools(t *testing.T) {
 		var unarchiveTarget string
 		var renamedTarget string
 		var renamedName string
+		renameCalls := 0
 		promptSubmitCalls := 0
 		var listedInputSessionID string
 		var replacedInput struct {
@@ -5780,6 +5781,7 @@ func TestDaemonNativeTools(t *testing.T) {
 					return &restored, nil
 				},
 				RenameFn: func(_ context.Context, workspaceID string, id string, name string) (*session.Info, error) {
+					renameCalls++
 					renamedTarget = workspaceID + "/" + id
 					renamedName = name
 					renamed := *info
@@ -6484,6 +6486,31 @@ func TestDaemonNativeTools(t *testing.T) {
 				t.Fatalf("Registry.Call(session_rename) error = %v", callErr)
 			}
 			requireNativeStructuredContains(t, result, []byte(`"name":"Release review"`))
+
+			callsBeforeDeniedRename := renameCalls
+			_, callErr = registry.Call(
+				t.Context(),
+				toolspkg.Scope{Operator: true},
+				toolspkg.CallRequest{
+					ToolID: toolspkg.ToolIDSessionRename,
+					Input: json.RawMessage(
+						`{"workspace":"ws-foreign-stable","session_id":"sess-1","name":"Foreign rename"}`,
+					),
+				},
+			)
+			requireToolReason(
+				t,
+				callErr,
+				toolspkg.ErrToolDenied,
+				toolspkg.ReasonWorkspaceAccessDenied,
+			)
+			if renameCalls != callsBeforeDeniedRename {
+				t.Fatalf(
+					"Rename() calls after denied foreign workspace = %d, want %d",
+					renameCalls,
+					callsBeforeDeniedRename,
+				)
+			}
 		})
 		if archiveTarget != "ws-1/sess-1" || unarchiveTarget != "ws-1/sess-1" {
 			t.Fatalf("archive targets = %q/%q, want ws-1/sess-1", archiveTarget, unarchiveTarget)

--- a/internal/session/manager_transition.go
+++ b/internal/session/manager_transition.go
@@ -82,10 +82,17 @@ func (m *Manager) persistSessionMetadataOnly(session *Session) error {
 }
 
 func (m *Manager) persistSessionCatalogFromMeta(ctx context.Context, meta store.SessionMeta) error {
+	return m.persistSessionCatalogSnapshot(ctx, meta, sessionInfoFromMeta(meta))
+}
+
+func (m *Manager) persistSessionCatalogSnapshot(
+	ctx context.Context,
+	meta store.SessionMeta,
+	info *Info,
+) error {
 	if m == nil || m.sessionCatalog == nil {
 		return nil
 	}
-	info := sessionInfoFromMeta(meta)
 	if info == nil {
 		return nil
 	}

--- a/internal/session/manager_transition_test.go
+++ b/internal/session/manager_transition_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -440,6 +441,153 @@ func TestManagerLifecycleCatalogTransitions(t *testing.T) {
 		h.driver.mu.Unlock()
 		if got := startsAfter; got != startsBefore {
 			t.Fatalf("driver starts after stopped selection = %d, want %d", got, startsBefore)
+		}
+	})
+
+	t.Run("Should rename an active user session across memory metadata catalog and events", func(t *testing.T) {
+		t.Parallel()
+
+		catalog := newRecordingSessionCatalog()
+		h := newHarness(t, WithSessionCatalog(catalog))
+		active := createSession(t, h)
+		t.Cleanup(func() { reportSessionStop(t, h, active.ID) })
+		events, cancel, err := h.manager.SubscribeSessionCatalogEvents(testutil.Context(t))
+		if err != nil {
+			t.Fatalf("SubscribeSessionCatalogEvents() error = %v", err)
+		}
+		defer cancel()
+
+		updated, err := h.manager.Rename(
+			testutil.Context(t),
+			h.workspaceID,
+			active.ID,
+			"  Checkout\n  webhook   retries  ",
+		)
+		if err != nil {
+			t.Fatalf("Rename() error = %v", err)
+		}
+		const want = "Checkout webhook retries"
+		catalogInfo, ok := catalog.get(active.ID)
+		if updated.Name != want || active.Info().Name != want ||
+			readMeta(t, active.MetaPath()).Name != want || !ok || catalogInfo.Name != want {
+			t.Fatalf("renamed identity = info %q memory %q catalog %#v", updated.Name, active.Info().Name, catalogInfo)
+		}
+		select {
+		case event := <-events:
+			if event.Kind != CatalogEventUpserted ||
+				event.WorkspaceID != h.workspaceID ||
+				event.SessionID != active.ID {
+				t.Fatalf("rename catalog event = %#v, want upserted %s/%s", event, h.workspaceID, active.ID)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("rename catalog event was not published")
+		}
+	})
+
+	t.Run("Should rename a stopped archived session without starting ACP or losing archive state", func(t *testing.T) {
+		t.Parallel()
+
+		catalog := newRecordingSessionCatalog()
+		h := newHarness(t, WithSessionCatalog(catalog))
+		active := createSession(t, h)
+		if err := h.manager.Stop(testutil.Context(t), active.ID); err != nil {
+			t.Fatalf("Stop() error = %v", err)
+		}
+		if _, err := h.manager.Archive(testutil.Context(t), h.workspaceID, active.ID); err != nil {
+			t.Fatalf("Archive() error = %v", err)
+		}
+		h.driver.mu.Lock()
+		startsBefore := len(h.driver.startCalls)
+		h.driver.mu.Unlock()
+
+		updated, err := h.manager.Rename(testutil.Context(t), h.workspaceID, active.ID, "Archived checkout")
+		if err != nil {
+			t.Fatalf("Rename(stopped) error = %v", err)
+		}
+		if updated.Name != "Archived checkout" || updated.ArchivedAt == nil {
+			t.Fatalf("Rename(stopped) = %#v, want renamed archived session", updated)
+		}
+		catalogInfo, ok := catalog.get(active.ID)
+		if !ok || catalogInfo.Name != updated.Name || catalogInfo.ArchivedAt == nil {
+			t.Fatalf("archived catalog after rename = %#v", catalogInfo)
+		}
+		h.driver.mu.Lock()
+		startsAfter := len(h.driver.startCalls)
+		h.driver.mu.Unlock()
+		if startsAfter != startsBefore {
+			t.Fatalf("driver starts after stopped rename = %d, want %d", startsAfter, startsBefore)
+		}
+	})
+
+	t.Run("Should reject invalid manual names managed sessions and foreign workspaces", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		active := createSession(t, h)
+		t.Cleanup(func() { reportSessionStop(t, h, active.ID) })
+		for _, test := range []struct {
+			name        string
+			workspaceID string
+			value       string
+			want        error
+		}{
+			{name: "empty", workspaceID: h.workspaceID, value: " \n\t ", want: ErrValidation},
+			{name: "too long", workspaceID: h.workspaceID, value: strings.Repeat("界", SessionNameMaxRunes+1), want: ErrValidation},
+			{name: "foreign workspace", workspaceID: "ws-foreign", value: "Private", want: ErrSessionNotFound},
+		} {
+			t.Run("Should reject "+test.name, func(t *testing.T) {
+				t.Parallel()
+				_, err := h.manager.Rename(testutil.Context(t), test.workspaceID, active.ID, test.value)
+				if !errors.Is(err, test.want) {
+					t.Fatalf("Rename() error = %v, want %v", err, test.want)
+				}
+			})
+		}
+
+		managed, err := h.manager.Create(testutil.Context(t), CreateOpts{
+			AgentName: "coder",
+			Workspace: h.workspaceID,
+			Type:      SessionTypeSystem,
+		})
+		if err != nil {
+			t.Fatalf("Create(system) error = %v", err)
+		}
+		t.Cleanup(func() { reportSessionStop(t, h, managed.ID) })
+		_, err = h.manager.Rename(
+			testutil.Context(t),
+			h.workspaceID,
+			managed.ID,
+			"Operator name",
+		)
+		if !errors.Is(err, ErrValidation) {
+			t.Fatalf("Rename(system) error = %v, want ErrValidation", err)
+		}
+	})
+
+	t.Run("Should roll back an active rename when catalog persistence fails", func(t *testing.T) {
+		t.Parallel()
+
+		catalog := newRecordingSessionCatalog()
+		h := newHarness(t, WithSessionCatalog(catalog))
+		active := createSession(t, h)
+		t.Cleanup(func() { reportSessionStop(t, h, active.ID) })
+		before := active.Info()
+		persistErr := errors.New("catalog rename unavailable")
+		catalog.registerHook = func(_ context.Context, info store.SessionInfo) error {
+			if info.Name == "New name" {
+				return persistErr
+			}
+			return nil
+		}
+
+		_, err := h.manager.Rename(testutil.Context(t), h.workspaceID, active.ID, "New name")
+		if !errors.Is(err, persistErr) {
+			t.Fatalf("Rename() error = %v, want catalog failure", err)
+		}
+		memoryName := active.Info().Name
+		metaName := readMeta(t, active.MetaPath()).Name
+		if memoryName != before.Name || metaName != before.Name {
+			t.Fatalf("failed rename changed identity: memory=%q meta=%q", memoryName, metaName)
 		}
 	})
 }

--- a/internal/session/session_rename.go
+++ b/internal/session/session_rename.go
@@ -1,0 +1,161 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/compozy/compozy/internal/store"
+)
+
+const SessionNameMaxRunes = 64
+
+// Rename changes the durable display name of one user session without altering
+// its runtime lifecycle or transcript identity.
+func (m *Manager) Rename(
+	ctx context.Context,
+	workspaceID string,
+	sessionID string,
+	name string,
+) (*Info, error) {
+	if m == nil {
+		return nil, errors.New("session: manager is required")
+	}
+	if ctx == nil {
+		return nil, errors.New("session: rename context is required")
+	}
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return nil, fmt.Errorf("%w: workspace id is required", ErrValidation)
+	}
+	target, err := normalizeStoredSessionID(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	normalizedName, err := normalizeManualSessionName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if active, ok := m.Get(target); ok {
+		return m.renameActiveSession(ctx, active, workspaceID, normalizedName)
+	}
+	return m.renameInactiveSession(ctx, target, workspaceID, normalizedName)
+}
+
+func normalizeManualSessionName(name string) (string, error) {
+	normalized := strings.Join(strings.Fields(name), " ")
+	if normalized == "" {
+		return "", fmt.Errorf("%w: session name is required", ErrValidation)
+	}
+	if utf8.RuneCountInString(normalized) > SessionNameMaxRunes {
+		return "", fmt.Errorf(
+			"%w: session name must be at most %d characters",
+			ErrValidation,
+			SessionNameMaxRunes,
+		)
+	}
+	return normalized, nil
+}
+
+func validateManualSessionRename(workspaceID string, sessionType Type, expectedWorkspaceID string) error {
+	if strings.TrimSpace(workspaceID) != strings.TrimSpace(expectedWorkspaceID) {
+		return ErrSessionNotFound
+	}
+	if normalizeSessionType(sessionType) != SessionTypeUser {
+		return fmt.Errorf("%w: managed sessions cannot be renamed", ErrValidation)
+	}
+	return nil
+}
+
+func (m *Manager) renameActiveSession(
+	ctx context.Context,
+	active *Session,
+	workspaceID string,
+	name string,
+) (*Info, error) {
+	active.persistMu.Lock()
+	defer active.persistMu.Unlock()
+
+	active.mu.Lock()
+	if err := validateManualSessionRename(workspaceID, active.Type, active.WorkspaceID); err != nil {
+		active.mu.Unlock()
+		return nil, err
+	}
+	if active.Name == name {
+		info := active.infoLocked()
+		active.mu.Unlock()
+		return info, nil
+	}
+
+	previousMeta := active.metaLocked()
+	active.Name = name
+	active.UpdatedAt = m.now()
+	meta := active.metaLocked()
+	info := active.infoLocked()
+	if err := m.persistSessionIdentitySnapshot(ctx, active.metaPath, meta, info); err != nil {
+		active.Name = previousMeta.Name
+		active.UpdatedAt = previousMeta.UpdatedAt
+		if rollbackErr := store.WriteSessionMeta(active.metaPath, previousMeta); rollbackErr != nil {
+			active.mu.Unlock()
+			return nil, errors.Join(err, fmt.Errorf("session: roll back rename: %w", rollbackErr))
+		}
+		active.mu.Unlock()
+		return nil, err
+	}
+	active.mu.Unlock()
+	m.publishSessionCatalogEvent(sessionCatalogEventFromInfo(CatalogEventUpserted, info))
+	return info, nil
+}
+
+func (m *Manager) renameInactiveSession(
+	ctx context.Context,
+	target string,
+	workspaceID string,
+	name string,
+) (*Info, error) {
+	m.lifecycleMu.Lock()
+	defer m.lifecycleMu.Unlock()
+
+	if active, ok := m.Get(target); ok {
+		return m.renameActiveSession(ctx, active, workspaceID, name)
+	}
+	if m.isPending(target) {
+		return nil, fmt.Errorf("%w: %s", ErrSessionNotActive, target)
+	}
+	meta, err := m.readMetaWithContext(ctx, target)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateManualSessionRename(workspaceID, Type(meta.SessionType), meta.WorkspaceID); err != nil {
+		return nil, err
+	}
+	info := m.sessionInfoFromMeta(ctx, meta)
+	if err := m.populateArchiveMetadata(ctx, info); err != nil {
+		return nil, err
+	}
+	if meta.Name == name {
+		return info, nil
+	}
+
+	previousMeta := meta
+	meta.Name = name
+	meta.UpdatedAt = m.now()
+	info.Name = name
+	info.UpdatedAt = meta.UpdatedAt
+	metaPath := store.SessionMetaFile(filepath.Join(m.homePaths.SessionsDir, target))
+	if err := store.WriteSessionMeta(metaPath, meta); err != nil {
+		return nil, fmt.Errorf("session: persist rename for %q: %w", target, err)
+	}
+	if err := m.persistSessionCatalogSnapshot(ctx, meta, info); err != nil {
+		if rollbackErr := store.WriteSessionMeta(metaPath, previousMeta); rollbackErr != nil {
+			return nil, errors.Join(err, fmt.Errorf("session: roll back rename: %w", rollbackErr))
+		}
+		return nil, err
+	}
+	m.publishSessionCatalogEvent(sessionCatalogEventFromInfo(CatalogEventUpserted, info))
+	return info, nil
+}

--- a/internal/toolmeta/native_entries.go
+++ b/internal/toolmeta/native_entries.go
@@ -184,6 +184,7 @@ var nativeEntries = map[string]Entry{
 	"compozy__session_inputs_list":            nativeEntry("Reading", " ", false, "💬", "auto"),
 	"compozy__session_list":                   nativeEntry("Reading", " ", false, "💬", "auto"),
 	"compozy__session_prompt":                 nativeEntry("Sending", " ", false, "💬", "auto"),
+	"compozy__session_rename":                 nativeEntry("Renaming", " ", false, "💬", "auto"),
 	"compozy__session_rewind":                 nativeEntry("Rewinding", " ", false, "💬", "auto"),
 	"compozy__session_runtime_clear":          nativeEntry("Clearing", " ", false, "💬", "auto"),
 	"compozy__session_runtime_set":            nativeEntry("Selecting", " ", false, "💬", "auto"),

--- a/internal/toolmeta/registry_test.go
+++ b/internal/toolmeta/registry_test.go
@@ -261,6 +261,7 @@ func expectedNativeEntries() map[string]toolmeta.Entry {
 		"compozy__session_inputs_list":            expectedNativeEntry("Reading", " ", false, "💬", "auto"),
 		"compozy__session_list":                   expectedNativeEntry("Reading", " ", false, "💬", "auto"),
 		"compozy__session_prompt":                 expectedNativeEntry("Sending", " ", false, "💬", "auto"),
+		"compozy__session_rename":                 expectedNativeEntry("Renaming", " ", false, "💬", "auto"),
 		"compozy__session_rewind":                 expectedNativeEntry("Rewinding", " ", false, "💬", "auto"),
 		"compozy__session_runtime_clear":          expectedNativeEntry("Clearing", " ", false, "💬", "auto"),
 		"compozy__session_runtime_set":            expectedNativeEntry("Selecting", " ", false, "💬", "auto"),

--- a/internal/tools/builtin/builtin_test.go
+++ b/internal/tools/builtin/builtin_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/compozy/compozy/internal/network/participation"
+	"github.com/compozy/compozy/internal/session"
 	toolspkg "github.com/compozy/compozy/internal/tools"
 	"github.com/compozy/compozy/internal/windowmanager"
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -166,6 +167,7 @@ func TestBuiltinNativeDescriptors(t *testing.T) {
 
 		descriptors := descriptorMap(NativeDescriptors())
 		assertSessionCreateMutationSchema(t, descriptors[toolspkg.ToolIDSessionCreate])
+		assertSessionRenameMutationSchema(t, descriptors[toolspkg.ToolIDSessionRename])
 		t.Run("Should validate the session archive schema", func(t *testing.T) {
 			t.Parallel()
 			assertSessionTargetMutationSchema(t, descriptors[toolspkg.ToolIDSessionArchive])
@@ -1184,6 +1186,8 @@ func nativeDescriptorExpectations() []nativeDescriptorExpectation {
 			readOnly: true, destructive: false, openWorld: false},
 		{id: "compozy__session_list", risk: toolspkg.RiskRead,
 			readOnly: true, destructive: false, openWorld: false},
+		{id: "compozy__session_rename", risk: toolspkg.RiskMutating,
+			readOnly: false, destructive: false, openWorld: false},
 		{id: "compozy__session_prompt", risk: toolspkg.RiskMutating,
 			readOnly: false, destructive: false, openWorld: false},
 		{id: "compozy__session_rewind", risk: toolspkg.RiskDestructive,
@@ -1364,6 +1368,7 @@ type nativeObjectSchema struct {
 	Pattern              string                     `json:"pattern"`
 	Minimum              *float64                   `json:"minimum"`
 	MinLength            int                        `json:"minLength"`
+	MaxLength            int                        `json:"maxLength"`
 	Items                json.RawMessage            `json:"items"`
 	AdditionalProperties *bool                      `json:"additionalProperties"`
 }
@@ -1477,6 +1482,26 @@ func assertSessionTargetMutationSchema(t *testing.T, descriptor toolspkg.Descrip
 	if _, ok := sessionSchema.Properties["archived_at"]; !ok {
 		t.Fatalf("%s session output schema omits archived_at", descriptor.ID)
 	}
+}
+
+func assertSessionRenameMutationSchema(t *testing.T, descriptor toolspkg.Descriptor) {
+	t.Helper()
+	var input nativeObjectSchema
+	if err := json.Unmarshal(descriptor.InputSchema, &input); err != nil {
+		t.Fatalf("%s input schema unmarshal error = %v", descriptor.ID, err)
+	}
+	assertClosedObjectSchema(t, descriptor.ID.String()+" input", input, []string{"name", "session_id", "workspace"})
+	if !slices.Equal(input.Required, []string{"session_id", "name"}) {
+		t.Fatalf("%s input required = %#v, want [session_id name]", descriptor.ID, input.Required)
+	}
+	var name nativeObjectSchema
+	if err := json.Unmarshal(input.Properties["name"], &name); err != nil {
+		t.Fatalf("%s name schema unmarshal error = %v", descriptor.ID, err)
+	}
+	if name.Type != "string" || name.MinLength != 1 || name.MaxLength != session.SessionNameMaxRunes {
+		t.Fatalf("%s name schema = %#v, want 1..%d characters", descriptor.ID, name, session.SessionNameMaxRunes)
+	}
+	assertSessionMutationEnvelopeSchema(t, descriptor.ID.String()+" output", descriptor.OutputSchema, "session")
 }
 
 func assertSessionPromptMutationSchema(t *testing.T, descriptor toolspkg.Descriptor) {
@@ -2306,6 +2331,7 @@ func TestBuiltinToolsetCatalog(t *testing.T) {
 		if !slices.Contains(sessions, toolspkg.ToolIDSessionList) ||
 			!slices.Contains(sessions, toolspkg.ToolIDSessionArchive) ||
 			!slices.Contains(sessions, toolspkg.ToolIDSessionUnarchive) ||
+			!slices.Contains(sessions, toolspkg.ToolIDSessionRename) ||
 			!slices.Contains(sessions, toolspkg.ToolIDSessionCreate) ||
 			!slices.Contains(sessions, toolspkg.ToolIDSessionPrompt) ||
 			!slices.Contains(sessions, toolspkg.ToolIDSessionRewind) ||

--- a/internal/tools/builtin/session_rename.go
+++ b/internal/tools/builtin/session_rename.go
@@ -1,0 +1,37 @@
+package builtin
+
+import (
+	"encoding/json"
+
+	toolspkg "github.com/compozy/compozy/internal/tools"
+)
+
+func sessionRenameDescriptor() toolspkg.Descriptor {
+	descriptor := nativeDescriptor(
+		toolspkg.ToolIDSessionRename,
+		"session_rename",
+		"Session Rename",
+		"Change one user session's durable display name.",
+		sessionRenameInputSchema,
+		toolspkg.RiskMutating,
+		false,
+		false,
+		false,
+		[]toolspkg.ToolsetID{toolspkg.ToolsetIDSessions},
+		[]string{sessionsSessionsKey, "rename"},
+		[]string{"rename session", "change session name"},
+	)
+	descriptor.OutputSchema = json.RawMessage(sessionStatusOutputSchema)
+	return descriptor
+}
+
+const sessionRenameInputSchema = `{
+	"type":"object",
+	"required":["session_id","name"],
+	"properties":{
+		"workspace":{"type":"string"},
+		"session_id":{"type":"string","minLength":1},
+		"name":{"type":"string","minLength":1,"maxLength":64}
+	},
+	"additionalProperties":false
+}`

--- a/internal/tools/builtin/sessions.go
+++ b/internal/tools/builtin/sessions.go
@@ -28,6 +28,7 @@ var sessionTools = []toolspkg.Descriptor{
 	commandListDescriptor(),
 	sessionArchiveDescriptor(true),
 	sessionArchiveDescriptor(false),
+	sessionRenameDescriptor(),
 	sessionCreateDescriptor(),
 	sessionPromptDescriptor(),
 	sessionRewindDescriptor(),

--- a/internal/tools/builtin/testdata/native-tool-catalog.json
+++ b/internal/tools/builtin/testdata/native-tool-catalog.json
@@ -2449,6 +2449,19 @@
     "output_schema_digest": "6bfe42af616ce76f2d303ffc1e98fb3a27f3f8665cef1dd03b1cee33a2b1b37f"
   },
   {
+    "tool_id": "compozy__session_rename",
+    "native_name": "session_rename",
+    "toolsets": [
+      "compozy__sessions"
+    ],
+    "risk": "mutating",
+    "read_only": false,
+    "destructive": false,
+    "open_world": false,
+    "input_schema_digest": "75fc8f99cefd0c271f7da0841b51b84e9f7d79c163d909b1c2d01138a5980711",
+    "output_schema_digest": "8d3bfa6a8b156cf8a52edb3e5af7f23d716bd0da84f9851445772d9ab8db3ee9"
+  },
+  {
     "tool_id": "compozy__session_rewind",
     "native_name": "session_rewind",
     "toolsets": [

--- a/internal/tools/builtin/toolsets.go
+++ b/internal/tools/builtin/toolsets.go
@@ -67,6 +67,7 @@ var builtinToolsets = []toolspkg.Toolset{
 			toolspkg.ToolIDSessionList.String(),
 			toolspkg.ToolIDSessionArchive.String(),
 			toolspkg.ToolIDSessionUnarchive.String(),
+			toolspkg.ToolIDSessionRename.String(),
 			toolspkg.ToolIDSessionCreate.String(),
 			toolspkg.ToolIDSessionPrompt.String(),
 			toolspkg.ToolIDSessionRewind.String(),

--- a/internal/tools/builtin_ids.go
+++ b/internal/tools/builtin_ids.go
@@ -70,6 +70,8 @@ const (
 	ToolIDSessionArchive ToolID = "compozy__session_archive"
 	// ToolIDSessionUnarchive restores one archived runtime session.
 	ToolIDSessionUnarchive ToolID = "compozy__session_unarchive"
+	// ToolIDSessionRename changes one user session's durable display name.
+	ToolIDSessionRename ToolID = "compozy__session_rename"
 	// ToolIDSessionCreate accepts one unbound logical user session.
 	ToolIDSessionCreate ToolID = "compozy__session_create"
 	// ToolIDSessionPrompt submits one prompt with an optional runtime snapshot.

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -271753,6 +271753,79 @@
               }
             },
             "description": "Internal server error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "diagnostic": {
+                      "nullable": true,
+                      "properties": {
+                        "category": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "data_freshness": {
+                          "type": "string"
+                        },
+                        "doc_url": {
+                          "type": "string"
+                        },
+                        "evidence": {
+                          "additionalProperties": {},
+                          "type": "object"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "severity": {
+                          "type": "string"
+                        },
+                        "suggested_command": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "category",
+                        "code",
+                        "data_freshness",
+                        "id",
+                        "message",
+                        "severity",
+                        "title"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Session rename unavailable"
           }
         },
         "summary": "Rename one user session",

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -77274,11 +77274,18 @@
                     },
                     "path": {
                       "type": "string"
+                    },
+                    "roots": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
                     }
                   },
                   "required": [
                     "entries",
-                    "path"
+                    "path",
+                    "roots"
                   ],
                   "type": "object"
                 }
@@ -77579,7 +77586,7 @@
             "description": "Internal server error"
           }
         },
-        "summary": "List directory entries for the workspace folder picker",
+        "summary": "List directory entries and filesystem roots for the workspace folder picker",
         "tags": [
           "filesystem"
         ],
@@ -270702,6 +270709,1053 @@
           }
         },
         "summary": "Get one session snapshot",
+        "tags": [
+          "sessions"
+        ],
+        "x-compozy-transports": [
+          "http",
+          "uds"
+        ]
+      },
+      "patch": {
+        "operationId": "renameSession",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session id",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ],
+                "type": "object"
+              }
+            }
+          },
+          "description": "JSON request body",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "session": {
+                      "properties": {
+                        "activity": {
+                          "nullable": true,
+                          "properties": {
+                            "current_tool": {
+                              "type": "string"
+                            },
+                            "deadline_at": {
+                              "format": "date-time",
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "elapsed_ms": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "elapsed_seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "idle_seconds": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "iteration_current": {
+                              "type": "integer"
+                            },
+                            "iteration_max": {
+                              "type": "integer"
+                            },
+                            "last_activity_at": {
+                              "format": "date-time",
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "last_activity_detail": {
+                              "type": "string"
+                            },
+                            "last_activity_kind": {
+                              "type": "string"
+                            },
+                            "last_progress_at": {
+                              "format": "date-time",
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "tool_call_id": {
+                              "type": "string"
+                            },
+                            "turn_id": {
+                              "type": "string"
+                            },
+                            "turn_source": {
+                              "type": "string"
+                            },
+                            "turn_started_at": {
+                              "format": "date-time",
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "elapsed_ms",
+                            "elapsed_seconds",
+                            "idle_seconds",
+                            "iteration_current",
+                            "iteration_max"
+                          ],
+                          "type": "object"
+                        },
+                        "agent_name": {
+                          "type": "string"
+                        },
+                        "archived_at": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "attach_expires_at": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string"
+                        },
+                        "attachable": {
+                          "type": "boolean"
+                        },
+                        "attached_to": {
+                          "type": "string"
+                        },
+                        "available_commands": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string"
+                              },
+                              "input": {
+                                "nullable": true,
+                                "properties": {
+                                  "hint": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "hint"
+                                ],
+                                "type": "object"
+                              },
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "description",
+                              "name"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "badge": {
+                          "type": "string"
+                        },
+                        "created_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "failure": {
+                          "nullable": true,
+                          "properties": {
+                            "crash_bundle_path": {
+                              "type": "string"
+                            },
+                            "kind": {
+                              "type": "string"
+                            },
+                            "summary": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "kind"
+                          ],
+                          "type": "object"
+                        },
+                        "health": {
+                          "nullable": true,
+                          "properties": {
+                            "active_prompt": {
+                              "type": "boolean"
+                            },
+                            "agent_name": {
+                              "type": "string"
+                            },
+                            "attachable": {
+                              "type": "boolean"
+                            },
+                            "eligible_for_wake": {
+                              "type": "boolean"
+                            },
+                            "health": {
+                              "enum": [
+                                "healthy",
+                                "degraded",
+                                "stale",
+                                "dead",
+                                "unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "ineligibility_reason": {
+                              "enum": [
+                                "session_prompt_active",
+                                "session_not_attachable",
+                                "session_unhealthy",
+                                "session_health_stale",
+                                "session_health_hung",
+                                "session_health_dead",
+                                "session_health_unknown"
+                              ],
+                              "type": "string"
+                            },
+                            "last_activity_at": {
+                              "format": "date-time",
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "last_error": {
+                              "type": "string"
+                            },
+                            "last_presence_at": {
+                              "format": "date-time",
+                              "nullable": true,
+                              "type": "string"
+                            },
+                            "session_id": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "enum": [
+                                "idle",
+                                "prompting",
+                                "stopped",
+                                "detached"
+                              ],
+                              "type": "string"
+                            },
+                            "updated_at": {
+                              "format": "date-time",
+                              "type": "string"
+                            },
+                            "workspace_id": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "active_prompt",
+                            "agent_name",
+                            "attachable",
+                            "eligible_for_wake",
+                            "health",
+                            "session_id",
+                            "state",
+                            "updated_at",
+                            "workspace_id"
+                          ],
+                          "type": "object"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "lineage": {
+                          "nullable": true,
+                          "properties": {
+                            "auto_stop_on_parent": {
+                              "type": "boolean"
+                            },
+                            "parent_session_id": {
+                              "type": "string"
+                            },
+                            "permission_policy": {
+                              "properties": {
+                                "mcp_servers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "network_channels": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "sandbox_profiles": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "skills": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "tools": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "workspace_paths": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "mcp_servers",
+                                "network_channels",
+                                "sandbox_profiles",
+                                "skills",
+                                "tools",
+                                "workspace_paths"
+                              ],
+                              "type": "object"
+                            },
+                            "root_session_id": {
+                              "type": "string"
+                            },
+                            "spawn_budget": {
+                              "properties": {
+                                "max_active_per_workspace": {
+                                  "type": "integer"
+                                },
+                                "max_children": {
+                                  "type": "integer"
+                                },
+                                "max_depth": {
+                                  "type": "integer"
+                                },
+                                "ttl_seconds": {
+                                  "format": "int64",
+                                  "type": "integer"
+                                }
+                              },
+                              "required": [
+                                "max_children",
+                                "max_depth",
+                                "ttl_seconds"
+                              ],
+                              "type": "object"
+                            },
+                            "spawn_depth": {
+                              "type": "integer"
+                            },
+                            "spawn_role": {
+                              "type": "string"
+                            },
+                            "ttl_expires_at": {
+                              "format": "date-time",
+                              "nullable": true,
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "auto_stop_on_parent",
+                            "permission_policy",
+                            "spawn_budget",
+                            "spawn_depth"
+                          ],
+                          "type": "object"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "resolved_network_participation": {
+                          "nullable": true,
+                          "oneOf": [
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "mode": {
+                                  "enum": [
+                                    "local"
+                                  ],
+                                  "type": "string"
+                                },
+                                "source": {
+                                  "enum": [
+                                    "explicit_request",
+                                    "task_profile",
+                                    "workspace_coordination",
+                                    "loop_definition",
+                                    "automation_job",
+                                    "built_in_local"
+                                  ],
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "enum": [
+                                    "network-participation/v1"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "mode",
+                                "source",
+                                "version"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "properties": {
+                                "bounds": {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "coalesce_window": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "max_input_tokens": {
+                                      "format": "int64",
+                                      "maximum": 9007199254740991,
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    },
+                                    "max_output_tokens": {
+                                      "format": "int64",
+                                      "maximum": 9007199254740991,
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    },
+                                    "max_total_wall_time": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "max_wake_depth": {
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    },
+                                    "max_wake_wall_time": {
+                                      "minLength": 1,
+                                      "type": "string"
+                                    },
+                                    "max_wakes": {
+                                      "minimum": 1,
+                                      "type": "integer"
+                                    }
+                                  },
+                                  "required": [
+                                    "coalesce_window",
+                                    "max_input_tokens",
+                                    "max_output_tokens",
+                                    "max_total_wall_time",
+                                    "max_wake_depth",
+                                    "max_wake_wall_time",
+                                    "max_wakes"
+                                  ],
+                                  "type": "object"
+                                },
+                                "channel_id": {
+                                  "pattern": "^[a-z0-9][a-z0-9_-]{0,63}$",
+                                  "type": "string"
+                                },
+                                "channel_strategy": {
+                                  "enum": [
+                                    "named",
+                                    "run",
+                                    "loop_run"
+                                  ],
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "enum": [
+                                    "live"
+                                  ],
+                                  "type": "string"
+                                },
+                                "source": {
+                                  "enum": [
+                                    "explicit_request",
+                                    "task_profile",
+                                    "workspace_coordination",
+                                    "loop_definition",
+                                    "automation_job",
+                                    "built_in_local"
+                                  ],
+                                  "type": "string"
+                                },
+                                "version": {
+                                  "enum": [
+                                    "network-participation/v1"
+                                  ],
+                                  "type": "string"
+                                },
+                                "workspace_id": {
+                                  "minLength": 1,
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "bounds",
+                                "channel_id",
+                                "channel_strategy",
+                                "mode",
+                                "source",
+                                "version",
+                                "workspace_id"
+                              ],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "runtime": {
+                          "properties": {
+                            "acp_caps": {
+                              "nullable": true,
+                              "properties": {
+                                "config_options": {
+                                  "items": {
+                                    "properties": {
+                                      "current": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      },
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "label": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "items": {
+                                          "properties": {
+                                            "description": {
+                                              "type": "string"
+                                            },
+                                            "label": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "value"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "required": [
+                                      "id",
+                                      "kind"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                "supported_modes": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "supports_load_session": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "supports_load_session"
+                              ],
+                              "type": "object"
+                            },
+                            "acp_session_id": {
+                              "type": "string"
+                            },
+                            "effective": {
+                              "nullable": true,
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "reasoning_effort": {
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ],
+                                  "type": "string"
+                                },
+                                "speed": {
+                                  "enum": [
+                                    "normal",
+                                    "fast"
+                                  ],
+                                  "type": "string"
+                                },
+                                "speed_resolution": {
+                                  "nullable": true,
+                                  "properties": {
+                                    "reason": {
+                                      "enum": [
+                                        "capability_absent",
+                                        "capability_ambiguous",
+                                        "value_ambiguous",
+                                        "provider_rejected"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "requested": {
+                                      "enum": [
+                                        "normal",
+                                        "fast"
+                                      ],
+                                      "type": "string"
+                                    },
+                                    "status": {
+                                      "enum": [
+                                        "applied",
+                                        "unsupported",
+                                        "rejected"
+                                      ],
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "requested",
+                                    "status"
+                                  ],
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "provider"
+                              ],
+                              "type": "object"
+                            },
+                            "failure": {
+                              "type": "string"
+                            },
+                            "selected": {
+                              "nullable": true,
+                              "properties": {
+                                "model": {
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "type": "string"
+                                },
+                                "reasoning_effort": {
+                                  "enum": [
+                                    "none",
+                                    "minimal",
+                                    "low",
+                                    "medium",
+                                    "high",
+                                    "xhigh",
+                                    "max"
+                                  ],
+                                  "type": "string"
+                                },
+                                "speed": {
+                                  "enum": [
+                                    "normal",
+                                    "fast"
+                                  ],
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "provider"
+                              ],
+                              "type": "object"
+                            },
+                            "selection_revision": {
+                              "format": "int64",
+                              "type": "integer"
+                            },
+                            "status": {
+                              "type": "string"
+                            },
+                            "transition": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "selection_revision",
+                            "status"
+                          ],
+                          "type": "object"
+                        },
+                        "sandbox": {
+                          "nullable": true,
+                          "properties": {
+                            "backend": {
+                              "type": "string"
+                            },
+                            "instance_id": {
+                              "type": "string"
+                            },
+                            "last_sync_error": {
+                              "type": "string"
+                            },
+                            "profile": {
+                              "type": "string"
+                            },
+                            "provider_state_json": {},
+                            "sandbox_id": {
+                              "type": "string"
+                            },
+                            "state": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "state": {
+                          "enum": [
+                            "starting",
+                            "active",
+                            "stopping",
+                            "stopped"
+                          ],
+                          "type": "string"
+                        },
+                        "stop_detail": {
+                          "type": "string"
+                        },
+                        "stop_reason": {
+                          "enum": [
+                            "completed",
+                            "user_canceled",
+                            "max_iterations",
+                            "loop_detected",
+                            "timeout",
+                            "budget_exceeded",
+                            "error",
+                            "agent_crashed",
+                            "hook_stopped",
+                            "shutdown"
+                          ],
+                          "type": "string"
+                        },
+                        "transcript_epoch": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "type": {
+                          "enum": [
+                            "user",
+                            "dream",
+                            "system",
+                            "coordinator",
+                            "spawned"
+                          ],
+                          "type": "string"
+                        },
+                        "updated_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "workspace_id": {
+                          "type": "string"
+                        },
+                        "workspace_path": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "agent_name",
+                        "archived_at",
+                        "attachable",
+                        "available_commands",
+                        "badge",
+                        "created_at",
+                        "id",
+                        "runtime",
+                        "state",
+                        "updated_at"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "session"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "diagnostic": {
+                      "nullable": true,
+                      "properties": {
+                        "category": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "data_freshness": {
+                          "type": "string"
+                        },
+                        "doc_url": {
+                          "type": "string"
+                        },
+                        "evidence": {
+                          "additionalProperties": {},
+                          "type": "object"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "severity": {
+                          "type": "string"
+                        },
+                        "suggested_command": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "category",
+                        "code",
+                        "data_freshness",
+                        "id",
+                        "message",
+                        "severity",
+                        "title"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid session name"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "diagnostic": {
+                      "nullable": true,
+                      "properties": {
+                        "category": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "data_freshness": {
+                          "type": "string"
+                        },
+                        "doc_url": {
+                          "type": "string"
+                        },
+                        "evidence": {
+                          "additionalProperties": {},
+                          "type": "object"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "severity": {
+                          "type": "string"
+                        },
+                        "suggested_command": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "category",
+                        "code",
+                        "data_freshness",
+                        "id",
+                        "message",
+                        "severity",
+                        "title"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Session not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "diagnostic": {
+                      "nullable": true,
+                      "properties": {
+                        "category": {
+                          "type": "string"
+                        },
+                        "code": {
+                          "type": "string"
+                        },
+                        "data_freshness": {
+                          "type": "string"
+                        },
+                        "doc_url": {
+                          "type": "string"
+                        },
+                        "evidence": {
+                          "additionalProperties": {},
+                          "type": "object"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "severity": {
+                          "type": "string"
+                        },
+                        "suggested_command": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "category",
+                        "code",
+                        "data_freshness",
+                        "id",
+                        "message",
+                        "severity",
+                        "title"
+                      ],
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Internal server error"
+          }
+        },
+        "summary": "Rename one user session",
         "tags": [
           "sessions"
         ],

--- a/packages/site/content/docs/cli/session/index.mdx
+++ b/packages/site/content/docs/cli/session/index.mdx
@@ -49,6 +49,7 @@ This command displays human-readable help and its subcommand list. The inherited
 | [compozy session prompt](/docs/cli/session/prompt)       | Send a prompt to a session                                 |
 | [compozy session recap](/docs/cli/session/recap)         | Show deterministic session recap                           |
 | [compozy session remove](/docs/cli/session/remove)       | Remove a session and its persisted history                 |
+| [compozy session rename](/docs/cli/session/rename)       | Rename a user session                                      |
 | [compozy session repair](/docs/cli/session/repair)       | Inspect and repair an interrupted session transcript       |
 | [compozy session resume](/docs/cli/session/resume)       | Attach to a resumable session                              |
 | [compozy session rewind](/docs/cli/session/rewind)       | Rewind a session before a user message                     |

--- a/packages/site/content/docs/cli/session/meta.json
+++ b/packages/site/content/docs/cli/session/meta.json
@@ -14,6 +14,7 @@
         "prompt",
         "recap",
         "remove",
+        "rename",
         "repair",
         "resume",
         "rewind",

--- a/packages/site/content/docs/cli/session/rename.mdx
+++ b/packages/site/content/docs/cli/session/rename.mdx
@@ -1,0 +1,49 @@
+---
+title: "compozy session rename"
+description: "Rename a user session"
+---
+
+## compozy session rename
+
+Rename a user session
+
+```
+compozy session rename <id> <name> [flags]
+```
+
+### Examples
+
+```
+  # Rename a session
+  compozy session rename sess_1234 "Checkout retries"
+```
+
+### Options
+
+```
+  -h, --help   help for rename
+```
+
+### Options inherited from parent commands
+
+```
+      --json            Emit JSON output
+  -o, --output string   Output format: human, json, jsonl, or toon (default "human")
+```
+
+## Output Formats
+
+The root `-o, --output` flag accepts these values. A renderer is supported only when this command writes that result; `jsonl` is for commands that emit one JSON record per line.
+
+| Format  | Command result                          |
+| ------- | --------------------------------------- |
+| `human` | Interactive terminal rendering          |
+| `json`  | Machine-readable JSON rendering         |
+| `jsonl` | One JSON record per line when supported |
+| `toon`  | Compact agent-readable rendering        |
+
+Example:
+
+```bash
+compozy session rename <id> <name> -o json
+```

--- a/skills/compozy/references/desktop.md
+++ b/skills/compozy/references/desktop.md
@@ -74,3 +74,10 @@ equivalent; use the local `compozy app` control surface.
 
 After every app mutation, perform a structured status read. Do not infer success from a process,
 window, or human-readable message alone.
+
+## Page zoom
+
+The desktop main window supports the standard page zoom shortcuts: `Command` + `+`, `Command` +
+`-`, and `Command` + `0` on macOS; use `Control` instead of `Command` on Windows and Linux. These
+shortcuts scale the whole product interface. The in-product Window > Zoom action has a different
+purpose: it expands one CompozyOS window inside the desktop workspace.

--- a/skills/compozy/references/native-tools.md
+++ b/skills/compozy/references/native-tools.md
@@ -47,7 +47,7 @@ Session tools: `compozy__session_list`, `compozy__session_create`, `compozy__ses
 `compozy__session_status`, `compozy__session_history`, `compozy__session_events`,
 `compozy__session_describe`, `compozy__session_health`, `compozy__session_runtime_set`,
 `compozy__session_runtime_clear`, `compozy__session_archive`,
-`compozy__session_unarchive`.
+`compozy__session_unarchive`, `compozy__session_rename`.
 
 `compozy__session_create` accepts only workspace, agent, and optional name. It creates an active
 logical session with `runtime.status="unbound"`; it does not accept or send a prompt or runtime.
@@ -88,6 +88,9 @@ search, resumability, health, archive visibility, sort, cursor, and limit inputs
 archived rows. Use `type: "user"` when a workflow needs operator-created sessions without
 daemon-managed dream, system, coordinator, or spawned sessions. Archive only stopped sessions;
 unarchive before prompting or resuming one. Both archive operations preserve the session history.
+`compozy__session_rename` changes the durable display name of a user session without changing its
+runtime or transcript identity. Pass `session_id` and a non-empty `name` of at most 64 characters;
+the CLI fallback is `compozy session rename <id> <name>`.
 
 Authored context tools: `compozy__agent_heartbeat_status`, `compozy__agent_heartbeat_wake`.
 
@@ -96,6 +99,10 @@ Workspace tools: `compozy__workspace_list`, `compozy__workspace_info`, `compozy_
 Fresh daemon boot registers the operator `$HOME` as the default workspace through the resolver, so `compozy__workspace_list` should return at least that workspace on a clean install.
 
 A successful workspace catalog read reconciles registered roots before returning: entries whose directories no longer exist are durably unregistered, while other filesystem or deletion failures fail the read instead of hiding uncertain state. `compozy__workspace_list`, `compozy workspace list`, and HTTP/UDS `GET /api/workspaces` share this catalog.
+
+The workspace setup browser reads `GET /api/fs/browse`; its response includes `home` and every
+filesystem `root` so the UI can navigate outside the operator home. Agents should register a known
+path through the workspace management surface instead of browsing interactively.
 
 Workspace unregister is atomic with credential cleanup: it removes workspace-scoped MCP OAuth rows and their encrypted access/refresh values, preserves global and sibling-workspace credentials, and leaves all state intact when cleanup fails.
 

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -298,6 +298,10 @@ archive marker. Use `session list --archived` for only archived sessions or
 is destructive: it stops an active runtime when necessary, then removes the catalog row and persisted
 session directory. Use removal only when the operator intends to discard that history.
 
+`compozy session rename <id> <name>` changes only a user session's durable display name. It works
+for active, stopped, and archived user sessions without starting or replacing ACP and preserves the
+session ID, transcript, archive state, and lineage.
+
 The session catalog is counted and workspace-scoped. Dream sessions are internal and never appear in catalog results. HTTP and UDS clients can filter exact public session type with `type=user|system|coordinator|spawned`; the CLI exposes the same filter as `--type`. Browser integrations should subscribe once to `/api/sessions/catalog-stream`, route each wake signal by its authoritative `workspace_id`, and refetch that workspace's catalog page instead of incrementing local counters.
 
 Sessions created from inside another session record creation provenance in `lineage`: `compozy__session_create` links the calling session automatically (same-workspace only), and `session new --parent <id>` / `parent_session_id` on `POST /api/sessions` link explicitly. Provenance keeps `type=user` and carries no TTL, auto-stop, budget, or permission narrowing — governed children still come only from `compozy spawn`. Query hierarchy with `parent=<id>` (direct children) or `root=<id>` (whole tree, root included) on the catalog — CLI `session list --parent/--root`, same fields on `compozy__session_list`.

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -1275,8 +1275,10 @@ test("E2E-028: the structural seam resizes both siblings and persists its weight
   const workspace = await prepareShell(appPage, runtime);
   const tasks = await openDockApp(appPage, "Tasks", "tasks");
   const settings = await openDockApp(appPage, "Settings", "settings");
+  const agents = await openDockApp(appPage, "Agents", "agents");
   const tasksID = await windowID(tasks);
   const settingsID = await windowID(settings);
+  const agentsID = await windowID(agents);
   await arrangeWindows(
     runtime,
     workspace.id,
@@ -1287,6 +1289,13 @@ test("E2E-028: the structural seam resizes both siblings and persists its weight
   );
   await expect(tasks).toHaveAttribute("data-window-placement", "tiled");
   await expect(settings).toHaveAttribute("data-window-placement", "tiled");
+  await moveWindowToNormalizedRect(runtime, workspace.id, agentsID, {
+    x: 0.4,
+    y: 0.25,
+    width: 0.2,
+    height: 0.5,
+  });
+  await expect(agents).toHaveAttribute("data-window-placement", "floating");
 
   const beforeWeights = splitWeightsForWindow(
     await windowManagerSnapshot(runtime, workspace.id),
@@ -1299,9 +1308,28 @@ test("E2E-028: the structural seam resizes both siblings and persists its weight
   await expect(seam).toHaveCount(1);
   const seamBox = await seam.boundingBox();
   if (!seamBox) throw new Error("structural seam must be visible");
-  await appPage.mouse.move(seamBox.x + seamBox.width / 2, seamBox.y + seamBox.height / 2);
+  const seamCenter = {
+    x: seamBox.x + seamBox.width / 2,
+    y: seamBox.y + seamBox.height / 2,
+  };
+  expect(
+    await appPage.evaluate(
+      ({ x, y, windowID }) =>
+        document
+          .elementFromPoint(x, y)
+          ?.closest(`[data-testid="os-window-${windowID}"]`)
+          ?.getAttribute("data-testid"),
+      { ...seamCenter, windowID: agentsID }
+    )
+  ).toBe(`os-window-${agentsID}`);
+
+  const exposedSeamPoint = {
+    x: seamBox.x + seamBox.width / 2,
+    y: seamBox.y + 20,
+  };
+  await appPage.mouse.move(exposedSeamPoint.x, exposedSeamPoint.y);
   await appPage.mouse.down();
-  await appPage.mouse.move(seamBox.x + seamBox.width / 2 + 150, seamBox.y + seamBox.height / 2, {
+  await appPage.mouse.move(exposedSeamPoint.x + 150, exposedSeamPoint.y, {
     steps: 8,
   });
   await appPage.mouse.up();

--- a/web/e2e/__tests__/session-provider-override.spec.ts
+++ b/web/e2e/__tests__/session-provider-override.spec.ts
@@ -43,6 +43,7 @@ function browserLifecycleSessionPath(sessionId: string): string {
 
 interface SessionPayload {
   id: string;
+  name: string;
   agent_name: string;
   runtime: {
     effective?: {
@@ -152,6 +153,27 @@ test("operator can create a provider/model override session and attach without l
   const sessionWin = sessionWindow(appPage, createdSession.session.id);
   const sessionUi = sessionWindowSelectors(sessionWin, appPage);
   await expect(sessionWin).toBeVisible();
+  await sessionUi.topbarOverflow.click();
+  await appPage.getByTestId("rename-button").click();
+  const renameResponsePromise = appPage.waitForResponse(
+    response =>
+      response.request().method() === "PATCH" &&
+      response
+        .url()
+        .endsWith(sessionAPIPath(createdSession.session.workspace_id, createdSession.session.id))
+  );
+  await appPage.getByTestId("session-rename-name").fill("Provider override review");
+  await appPage.getByTestId("session-rename-confirm").click();
+  expect((await renameResponsePromise).ok()).toBe(true);
+  await expect(sessionWin.locator('[data-slot="topbar-title"]')).toContainText(
+    "Provider override review"
+  );
+  await assertSessionNameParity(
+    runtime,
+    createdSession.session.workspace_id,
+    createdSession.session.id,
+    "Provider override review"
+  );
   const runtimeTrigger = sessionWin.getByTestId("session-prompt-runtime-select");
   await runtimeTrigger.click();
   await expect(appPage.getByTestId("runtime-selector-popup")).toBeVisible();
@@ -165,6 +187,18 @@ test("operator can create a provider/model override session and attach without l
     );
   expect(railProviders).toEqual(workspaceDetail.providers.map(provider => provider.name).sort());
   await appPage.locator(`[data-rail="${overrideProvider}"]`).click();
+  const selectorScroll = appPage.getByTestId("runtime-selector-scroll");
+  await expect
+    .poll(() => selectorScroll.evaluate(element => element.scrollHeight > element.clientHeight))
+    .toBe(true);
+  const documentScrollBefore = await appPage.evaluate(() => document.scrollingElement?.scrollTop);
+  await selectorScroll.hover();
+  await appPage.mouse.wheel(0, 100_000);
+  await expect.poll(() => selectorScroll.evaluate(element => element.scrollTop)).toBeGreaterThan(0);
+  await appPage.mouse.wheel(0, 1_000);
+  expect(await appPage.evaluate(() => document.scrollingElement?.scrollTop)).toBe(
+    documentScrollBefore
+  );
   await appPage.getByTestId("runtime-selector-search").fill("qa-browser-model");
   await appPage.getByTestId("runtime-selector-custom").click();
   await appPage.keyboard.press("Escape");
@@ -343,6 +377,35 @@ async function assertSessionParity(
   expect(cliRecord?.runtime.effective?.provider).toBe(expectedProvider);
 }
 
+async function assertSessionNameParity(
+  runtime: {
+    requestJSON: <T>(pathname: string, init?: RequestInit) => Promise<T>;
+    requestOperatorJSON?: <T>(pathname: string, init?: RequestInit) => Promise<T>;
+    paths?: { cliShim: string; homeDir: string };
+  },
+  workspaceID: string,
+  sessionID: string,
+  expectedName: string
+): Promise<void> {
+  const apiPath = sessionAPIPath(workspaceID, sessionID);
+  expect((await runtime.requestJSON<SessionEnvelope>(apiPath)).session.name).toBe(expectedName);
+  if (!runtime.requestOperatorJSON || !runtime.paths) {
+    throw new Error("rename parity check requires UDS and CLI access");
+  }
+  expect((await runtime.requestOperatorJSON<SessionEnvelope>(apiPath)).session.name).toBe(
+    expectedName
+  );
+  const { stdout } = await execFileAsync(
+    runtime.paths.cliShim,
+    ["session", "list", "--all", "-o", "json"],
+    { env: cliEnv(runtime.paths) }
+  );
+  const renamed = (JSON.parse(stdout) as SessionListEnvelope).sessions.find(
+    session => session.id === sessionID
+  );
+  expect(renamed?.name).toBe(expectedName);
+}
+
 function sessionAPIPath(workspaceID: string, sessionID: string, suffix = ""): string {
   return `/api/workspaces/${encodeURIComponent(workspaceID)}/sessions/${encodeURIComponent(
     sessionID
@@ -405,6 +468,14 @@ async function writeWorkspaceConfig(input: {
       `default_reasoning_effort = "medium"`,
       ""
     );
+    for (let index = 1; index <= 30; index += 1) {
+      lines.push(
+        `[[providers.${overrideProvider}.models.curated]]`,
+        `id = "qa-browser-model-${index.toString().padStart(2, "0")}"`,
+        `display_name = "QA Browser Model ${index.toString().padStart(2, "0")}"`,
+        ""
+      );
+    }
   }
 
   await writeFile(configPath, `${lines.join("\n")}\n`, "utf8");

--- a/web/e2e/__tests__/workspace-setup.spec.ts
+++ b/web/e2e/__tests__/workspace-setup.spec.ts
@@ -22,6 +22,7 @@ const reasoningCatalogModelLabel = "QA Browser Model Alt";
 
 test("operator runs onboarding, then re-opens the ruled workspace setup dialog from the sidebar add button", async ({
   appPage,
+  runtime,
 }) => {
   const ui = sessionLifecycleSelectors(appPage);
 
@@ -41,6 +42,14 @@ test("operator runs onboarding, then re-opens the ruled workspace setup dialog f
 
   const dialogGlobalCard = dialog.getByTestId("workspace-setup-global-card");
   await expect(dialogGlobalCard).toHaveAttribute("data-size", "compact");
+
+  const browse = await runtime.requestJSON<{ path: string; roots: string[] }>("/api/fs/browse");
+  expect(browse.roots.length).toBeGreaterThan(0);
+  for (const root of browse.roots) {
+    await expect(dialog.getByRole("button", { name: `Go to location ${root}` })).toBeVisible();
+  }
+  await dialog.getByRole("button", { name: `Go to location ${browse.roots[0]}` }).click();
+  await expect(dialog.getByTitle(browse.roots[0])).toBeVisible();
 
   // The ruled chrome means the trigger row uses px-5 / py-4. Verify computed rule via DOM box.
   const ruledHeaderBox = await ruledHeader.evaluate(node => {

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -108480,6 +108480,35 @@ export interface operations {
           };
         };
       };
+      /** @description Session rename unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            code?: string;
+            details?: {
+              [key: string]: string;
+            };
+            diagnostic?: {
+              category: string;
+              code: string;
+              data_freshness: string;
+              doc_url?: string;
+              evidence?: {
+                [key: string]: unknown;
+              };
+              id: string;
+              message: string;
+              severity: string;
+              suggested_command?: string;
+              title: string;
+            } | null;
+            error: string;
+          };
+        };
+      };
     };
   };
   approveSession: {

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -1240,7 +1240,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** List directory entries for the workspace folder picker */
+    /** List directory entries and filesystem roots for the workspace folder picker */
     get: operations["browseDirectory"];
     put?: never;
     post?: never;
@@ -5382,7 +5382,8 @@ export interface paths {
     delete: operations["deleteSession"];
     options?: never;
     head?: never;
-    patch?: never;
+    /** Rename one user session */
+    patch: operations["renameSession"];
     trace?: never;
   };
   "/api/workspaces/{workspace_id}/sessions/{session_id}/approve": {
@@ -33082,6 +33083,7 @@ export interface operations {
             home?: string;
             parent?: string;
             path: string;
+            roots: string[];
           };
         };
       };
@@ -108052,6 +108054,373 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Session not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            code?: string;
+            details?: {
+              [key: string]: string;
+            };
+            diagnostic?: {
+              category: string;
+              code: string;
+              data_freshness: string;
+              doc_url?: string;
+              evidence?: {
+                [key: string]: unknown;
+              };
+              id: string;
+              message: string;
+              severity: string;
+              suggested_command?: string;
+              title: string;
+            } | null;
+            error: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            code?: string;
+            details?: {
+              [key: string]: string;
+            };
+            diagnostic?: {
+              category: string;
+              code: string;
+              data_freshness: string;
+              doc_url?: string;
+              evidence?: {
+                [key: string]: unknown;
+              };
+              id: string;
+              message: string;
+              severity: string;
+              suggested_command?: string;
+              title: string;
+            } | null;
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  renameSession: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Workspace id */
+        workspace_id: string;
+        /** @description Session id */
+        session_id: string;
+      };
+      cookie?: never;
+    };
+    /** @description JSON request body */
+    requestBody: {
+      content: {
+        "application/json": {
+          name: string;
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            session: {
+              activity?: {
+                current_tool?: string;
+                /** Format: date-time */
+                deadline_at?: string | null;
+                /** Format: int64 */
+                elapsed_ms: number;
+                /** Format: int64 */
+                elapsed_seconds: number;
+                /** Format: int64 */
+                idle_seconds: number;
+                iteration_current: number;
+                iteration_max: number;
+                /** Format: date-time */
+                last_activity_at?: string | null;
+                last_activity_detail?: string;
+                last_activity_kind?: string;
+                /** Format: date-time */
+                last_progress_at?: string | null;
+                tool_call_id?: string;
+                turn_id?: string;
+                turn_source?: string;
+                /** Format: date-time */
+                turn_started_at?: string | null;
+              } | null;
+              agent_name: string;
+              /** Format: date-time */
+              archived_at: string | null;
+              /** Format: date-time */
+              attach_expires_at?: string | null;
+              attachable: boolean;
+              attached_to?: string;
+              available_commands: {
+                description: string;
+                input?: {
+                  hint: string;
+                } | null;
+                name: string;
+              }[];
+              badge: string;
+              /** Format: date-time */
+              created_at: string;
+              failure?: {
+                crash_bundle_path?: string;
+                kind: string;
+                summary?: string;
+              } | null;
+              health?: {
+                active_prompt: boolean;
+                agent_name: string;
+                attachable: boolean;
+                eligible_for_wake: boolean;
+                /** @enum {string} */
+                health: "healthy" | "degraded" | "stale" | "dead" | "unknown";
+                /** @enum {string} */
+                ineligibility_reason?:
+                  | "session_prompt_active"
+                  | "session_not_attachable"
+                  | "session_unhealthy"
+                  | "session_health_stale"
+                  | "session_health_hung"
+                  | "session_health_dead"
+                  | "session_health_unknown";
+                /** Format: date-time */
+                last_activity_at?: string | null;
+                last_error?: string;
+                /** Format: date-time */
+                last_presence_at?: string | null;
+                session_id: string;
+                /** @enum {string} */
+                state: "idle" | "prompting" | "stopped" | "detached";
+                /** Format: date-time */
+                updated_at: string;
+                workspace_id: string;
+              } | null;
+              id: string;
+              lineage?: {
+                auto_stop_on_parent: boolean;
+                parent_session_id?: string;
+                permission_policy: {
+                  mcp_servers: string[];
+                  network_channels: string[];
+                  sandbox_profiles: string[];
+                  skills: string[];
+                  tools: string[];
+                  workspace_paths: string[];
+                };
+                root_session_id?: string;
+                spawn_budget: {
+                  max_active_per_workspace?: number;
+                  max_children: number;
+                  max_depth: number;
+                  /** Format: int64 */
+                  ttl_seconds: number;
+                };
+                spawn_depth: number;
+                spawn_role?: string;
+                /** Format: date-time */
+                ttl_expires_at?: string | null;
+              } | null;
+              name?: string;
+              resolved_network_participation?:
+                | (
+                    | {
+                        /** @enum {string} */
+                        mode: "local";
+                        /** @enum {string} */
+                        source:
+                          | "explicit_request"
+                          | "task_profile"
+                          | "workspace_coordination"
+                          | "loop_definition"
+                          | "automation_job"
+                          | "built_in_local";
+                        /** @enum {string} */
+                        version: "network-participation/v1";
+                      }
+                    | {
+                        bounds: {
+                          coalesce_window: string;
+                          /** Format: int64 */
+                          max_input_tokens: number;
+                          /** Format: int64 */
+                          max_output_tokens: number;
+                          max_total_wall_time: string;
+                          max_wake_depth: number;
+                          max_wake_wall_time: string;
+                          max_wakes: number;
+                        };
+                        channel_id: string;
+                        /** @enum {string} */
+                        channel_strategy: "named" | "run" | "loop_run";
+                        /** @enum {string} */
+                        mode: "live";
+                        /** @enum {string} */
+                        source:
+                          | "explicit_request"
+                          | "task_profile"
+                          | "workspace_coordination"
+                          | "loop_definition"
+                          | "automation_job"
+                          | "built_in_local";
+                        /** @enum {string} */
+                        version: "network-participation/v1";
+                        workspace_id: string;
+                      }
+                  )
+                | null;
+              runtime: {
+                acp_caps?: {
+                  config_options?: {
+                    current?: string;
+                    description?: string;
+                    id: string;
+                    kind: string;
+                    label?: string;
+                    values?: {
+                      description?: string;
+                      label?: string;
+                      value: string;
+                    }[];
+                  }[];
+                  supported_modes?: string[];
+                  supports_load_session: boolean;
+                } | null;
+                acp_session_id?: string;
+                effective?: {
+                  model?: string;
+                  provider: string;
+                  /** @enum {string} */
+                  reasoning_effort?:
+                    | "none"
+                    | "minimal"
+                    | "low"
+                    | "medium"
+                    | "high"
+                    | "xhigh"
+                    | "max";
+                  /** @enum {string} */
+                  speed?: "normal" | "fast";
+                  speed_resolution?: {
+                    /** @enum {string} */
+                    reason?:
+                      | "capability_absent"
+                      | "capability_ambiguous"
+                      | "value_ambiguous"
+                      | "provider_rejected";
+                    /** @enum {string} */
+                    requested: "normal" | "fast";
+                    /** @enum {string} */
+                    status: "applied" | "unsupported" | "rejected";
+                  } | null;
+                } | null;
+                failure?: string;
+                selected?: {
+                  model?: string;
+                  provider: string;
+                  /** @enum {string} */
+                  reasoning_effort?:
+                    | "none"
+                    | "minimal"
+                    | "low"
+                    | "medium"
+                    | "high"
+                    | "xhigh"
+                    | "max";
+                  /** @enum {string} */
+                  speed?: "normal" | "fast";
+                } | null;
+                /** Format: int64 */
+                selection_revision: number;
+                status: string;
+                transition?: string;
+              };
+              sandbox?: {
+                backend?: string;
+                instance_id?: string;
+                last_sync_error?: string;
+                profile?: string;
+                provider_state_json?: unknown;
+                sandbox_id?: string;
+                state?: string;
+              } | null;
+              /** @enum {string} */
+              state: "starting" | "active" | "stopping" | "stopped";
+              stop_detail?: string;
+              /** @enum {string} */
+              stop_reason?:
+                | "completed"
+                | "user_canceled"
+                | "max_iterations"
+                | "loop_detected"
+                | "timeout"
+                | "budget_exceeded"
+                | "error"
+                | "agent_crashed"
+                | "hook_stopped"
+                | "shutdown";
+              /** Format: int64 */
+              transcript_epoch?: number;
+              /** @enum {string} */
+              type?: "user" | "dream" | "system" | "coordinator" | "spawned";
+              /** Format: date-time */
+              updated_at: string;
+              workspace_id?: string;
+              workspace_path?: string;
+            };
+          };
+        };
+      };
+      /** @description Invalid session name */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            code?: string;
+            details?: {
+              [key: string]: string;
+            };
+            diagnostic?: {
+              category: string;
+              code: string;
+              data_freshness: string;
+              doc_url?: string;
+              evidence?: {
+                [key: string]: unknown;
+              };
+              id: string;
+              message: string;
+              severity: string;
+              suggested_command?: string;
+              title: string;
+            } | null;
+            error: string;
+          };
+        };
       };
       /** @description Session not found */
       404: {

--- a/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
+++ b/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
@@ -10,6 +10,7 @@ const routeHookMocks = vi.hoisted(() => ({
   cancelSessionPrompt: vi.fn(),
   clearMutation: { isPending: false, mutate: vi.fn() },
   deleteMutation: { isPending: false, mutate: vi.fn() },
+  renameMutation: { isPending: false, mutateAsync: vi.fn() },
   resumeMutation: { isPending: false, mutateAsync: vi.fn() },
   unarchiveMutation: { isPending: false, mutate: vi.fn() },
   queuePromptMutation: { isPending: false, mutateAsync: vi.fn() },
@@ -52,6 +53,7 @@ vi.mock("@/systems/session", async () => {
     usePromoteSessionInput: () => routeHookMocks.promoteInputMutation,
     useQueueSessionPrompt: () => routeHookMocks.queuePromptMutation,
     useReplaceSessionInput: () => routeHookMocks.replaceInputMutation,
+    useRenameSession: () => routeHookMocks.renameMutation,
     useResumeSession: () => routeHookMocks.resumeMutation,
     useUnarchiveSession: () => routeHookMocks.unarchiveMutation,
     useSessionInputs: () => routeHookMocks.sessionInputsQuery,
@@ -138,6 +140,8 @@ describe("useSessionPageControls", () => {
     }
     routeHookMocks.resumeMutation.isPending = false;
     routeHookMocks.resumeMutation.mutateAsync.mockReset();
+    routeHookMocks.renameMutation.isPending = false;
+    routeHookMocks.renameMutation.mutateAsync.mockReset();
     routeHookMocks.unarchiveMutation.isPending = false;
     routeHookMocks.unarchiveMutation.mutate.mockReset();
     routeHookMocks.queuePromptMutation.isPending = false;

--- a/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
+++ b/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
@@ -65,7 +65,6 @@ vi.mock("@/systems/session", async () => {
 
 import type { SessionPayload } from "@/systems/session";
 import { useSessionPageControls } from "../use-session-page-controls";
-import { useSessionRenameDialog } from "../use-session-rename-dialog";
 
 const WORKSPACE_ID = "ws_alpha";
 
@@ -387,34 +386,5 @@ describe("useSessionPageControls", () => {
       await expect(result.current.handleQueuePrompt("keep draft")).rejects.toThrow("queue failed");
     });
     await waitFor(() => expect(result.current.isBusyInputPending).toBe(false));
-  });
-});
-
-describe("useSessionRenameDialog", () => {
-  it("Should keep the dialog open and expose the rename failure", async () => {
-    const onRename = vi.fn().mockRejectedValue(new Error("Rename unavailable."));
-    const { result } = renderHook(() => useSessionRenameDialog(onRename));
-
-    act(() => result.current.openDialog());
-    act(() => result.current.confirmRename("Release review"));
-
-    await waitFor(() => expect(result.current.error).toBe("Rename unavailable."));
-    expect(result.current.open).toBe(true);
-  });
-
-  it("Should close the dialog only after a successful rename", async () => {
-    const rename = createDeferredPromise<void>();
-    const { result } = renderHook(() => useSessionRenameDialog(() => rename.promise));
-
-    act(() => result.current.openDialog());
-    act(() => result.current.confirmRename("Release review"));
-    expect(result.current.open).toBe(true);
-
-    await act(async () => {
-      rename.resolve();
-      await rename.promise;
-    });
-    expect(result.current.open).toBe(false);
-    expect(result.current.error).toBeNull();
   });
 });

--- a/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
+++ b/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
@@ -65,6 +65,7 @@ vi.mock("@/systems/session", async () => {
 
 import type { SessionPayload } from "@/systems/session";
 import { useSessionPageControls } from "../use-session-page-controls";
+import { useSessionRenameDialog } from "../use-session-rename-dialog";
 
 const WORKSPACE_ID = "ws_alpha";
 
@@ -386,5 +387,34 @@ describe("useSessionPageControls", () => {
       await expect(result.current.handleQueuePrompt("keep draft")).rejects.toThrow("queue failed");
     });
     await waitFor(() => expect(result.current.isBusyInputPending).toBe(false));
+  });
+});
+
+describe("useSessionRenameDialog", () => {
+  it("Should keep the dialog open and expose the rename failure", async () => {
+    const onRename = vi.fn().mockRejectedValue(new Error("Rename unavailable."));
+    const { result } = renderHook(() => useSessionRenameDialog(onRename));
+
+    act(() => result.current.openDialog());
+    act(() => result.current.confirmRename("Release review"));
+
+    await waitFor(() => expect(result.current.error).toBe("Rename unavailable."));
+    expect(result.current.open).toBe(true);
+  });
+
+  it("Should close the dialog only after a successful rename", async () => {
+    const rename = createDeferredPromise<void>();
+    const { result } = renderHook(() => useSessionRenameDialog(() => rename.promise));
+
+    act(() => result.current.openDialog());
+    act(() => result.current.confirmRename("Release review"));
+    expect(result.current.open).toBe(true);
+
+    await act(async () => {
+      rename.resolve();
+      await rename.promise;
+    });
+    expect(result.current.open).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/web/src/hooks/routes/__tests__/use-session-rename-dialog.test.tsx
+++ b/web/src/hooks/routes/__tests__/use-session-rename-dialog.test.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useSessionRenameDialog } from "../use-session-rename-dialog";
+
+function createDeferredPromise<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("useSessionRenameDialog", () => {
+  it("Should keep the dialog open and expose the rename failure", async () => {
+    const onRename = vi.fn().mockRejectedValue(new Error("Rename unavailable."));
+    const { result } = renderHook(() => useSessionRenameDialog(onRename));
+
+    act(() => result.current.openDialog());
+    act(() => result.current.confirmRename("Release review"));
+
+    await waitFor(() => expect(result.current.error).toBe("Rename unavailable."));
+    expect(result.current.open).toBe(true);
+  });
+
+  it("Should close the dialog only after a successful rename", async () => {
+    const rename = createDeferredPromise<void>();
+    const { result } = renderHook(() => useSessionRenameDialog(() => rename.promise));
+
+    act(() => result.current.openDialog());
+    act(() => result.current.confirmRename("Release review"));
+    expect(result.current.open).toBe(true);
+
+    await act(async () => {
+      rename.resolve();
+      await rename.promise;
+    });
+    expect(result.current.open).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/web/src/hooks/routes/use-session-page-controls.ts
+++ b/web/src/hooks/routes/use-session-page-controls.ts
@@ -14,6 +14,7 @@ import {
   useQueueSessionPrompt,
   usePromoteSessionInput,
   useReplaceSessionInput,
+  useRenameSession,
   useResumeSession,
   useSteerSessionPrompt,
   useStopSession,
@@ -60,6 +61,7 @@ export function useSessionPageControls(
   const stopMutation = useStopSession({ workspaceId });
   const resumeMutation = useResumeSession({ workspaceId });
   const unarchiveMutation = useUnarchiveSession({ workspaceId });
+  const renameMutation = useRenameSession({ workspaceId });
   const clearMutation = useClearSessionConversation({ workspaceId });
   const queuePromptMutation = useQueueSessionPrompt({ workspaceId });
   const interruptPromptMutation = useInterruptSessionPrompt({ workspaceId });
@@ -102,6 +104,7 @@ export function useSessionPageControls(
   const isResuming = controlsState.resume.phase === "pending";
   const isUnarchiving = unarchiveMutation.isPending;
   const isDeleting = deleteMutation.isPending;
+  const isRenaming = renameMutation.isPending;
   const isClearing = clearMutation.isPending;
   const busyInputPending =
     isBusyInputPending(controlsState) ||
@@ -109,7 +112,13 @@ export function useSessionPageControls(
     replaceSessionInput.isPending ||
     promoteSessionInput.isPending;
   const controlsBusy =
-    isStopping || isResuming || isUnarchiving || isDeleting || isClearing || busyInputPending;
+    isStopping ||
+    isResuming ||
+    isUnarchiving ||
+    isDeleting ||
+    isRenaming ||
+    isClearing ||
+    busyInputPending;
   const hasConversationContent = messages.length > 0 || transcriptMessages.length > 0;
   const canClear = hasConversationContent && !controlsBusy && !effectiveRunning;
 
@@ -285,6 +294,19 @@ export function useSessionPageControls(
     });
   };
 
+  const handleRename = async (name: string) => {
+    if (controlsBusy) {
+      throw new Error("Session controls are busy.");
+    }
+    try {
+      await renameMutation.mutateAsync({ id: sessionId, name });
+      toast.success("Session renamed.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to rename session");
+      throw error;
+    }
+  };
+
   const handleClear = () => {
     if (controlsBusy || effectiveRunning) {
       return;
@@ -309,6 +331,7 @@ export function useSessionPageControls(
     handleQueuePrompt,
     handleRemoveQueuedPrompt,
     handleReplaceQueuedPrompt,
+    handleRename,
     handleResume,
     handleSteerPrompt,
     handleSteerQueuedPrompt,
@@ -317,6 +340,7 @@ export function useSessionPageControls(
     isBusyInputPending: busyInputPending,
     isClearing,
     isDeleting,
+    isRenaming,
     isResuming,
     isSessionRunning: daemonRunning,
     isStopping,

--- a/web/src/hooks/routes/use-session-rename-dialog.ts
+++ b/web/src/hooks/routes/use-session-rename-dialog.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 export interface UseSessionRenameDialogResult {
+  error: string | null;
   open: boolean;
   setOpen: (open: boolean) => void;
   openDialog: () => void;
@@ -12,17 +13,34 @@ export function useSessionRenameDialog(
   onRename: (name: string) => Promise<void>
 ): UseSessionRenameDialogResult {
   const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const setDialogOpen = (nextOpen: boolean) => {
+    setError(null);
+    setOpen(nextOpen);
+  };
 
   const confirmRename = (name: string) => {
-    void onRename(name)
-      .then(() => setOpen(false))
-      .catch(() => undefined);
+    setError(null);
+    void (async () => {
+      try {
+        await onRename(name);
+        setOpen(false);
+      } catch (renameError) {
+        setError(
+          renameError instanceof Error && renameError.message.trim().length > 0
+            ? renameError.message
+            : "Failed to rename session."
+        );
+      }
+    })();
   };
 
   return {
+    error,
     open,
-    setOpen,
-    openDialog: () => setOpen(true),
+    setOpen: setDialogOpen,
+    openDialog: () => setDialogOpen(true),
     confirmRename,
   };
 }

--- a/web/src/hooks/routes/use-session-rename-dialog.ts
+++ b/web/src/hooks/routes/use-session-rename-dialog.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+export interface UseSessionRenameDialogResult {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openDialog: () => void;
+  confirmRename: (name: string) => void;
+}
+
+/** Owns the detail-window rename dialog state and closes it after a successful rename. */
+export function useSessionRenameDialog(
+  onRename: (name: string) => Promise<void>
+): UseSessionRenameDialogResult {
+  const [open, setOpen] = useState(false);
+
+  const confirmRename = (name: string) => {
+    void onRename(name)
+      .then(() => setOpen(false))
+      .catch(() => undefined);
+  };
+
+  return {
+    open,
+    setOpen,
+    openDialog: () => setOpen(true),
+    confirmRename,
+  };
+}

--- a/web/src/systems/agent/components/__tests__/agent-sessions-list.test.tsx
+++ b/web/src/systems/agent/components/__tests__/agent-sessions-list.test.tsx
@@ -43,6 +43,7 @@ function sessionActions(): SessionLifecycleActionHandlers {
     pendingSessionId: null,
     onArchive: vi.fn(),
     onDelete: vi.fn(),
+    onRename: vi.fn(),
     onStop: vi.fn(),
     onUnarchive: vi.fn(),
   };

--- a/web/src/systems/agent/components/stories/agent-sessions-list.stories.tsx
+++ b/web/src/systems/agent/components/stories/agent-sessions-list.stories.tsx
@@ -91,6 +91,7 @@ const sessionActions: SessionLifecycleActionHandlers = {
   pendingSessionId: null,
   onArchive: fn(),
   onDelete: fn(),
+  onRename: fn(),
   onStop: fn(),
   onUnarchive: fn(),
 };

--- a/web/src/systems/onboarding/components/__tests__/directory-browser.test.tsx
+++ b/web/src/systems/onboarding/components/__tests__/directory-browser.test.tsx
@@ -5,8 +5,9 @@ import { describe, expect, it, vi } from "vitest";
 import { DirectoryBrowser } from "../directory-browser";
 
 describe("DirectoryBrowser", () => {
-  it("forwards native div attributes and events from its root wrapper", () => {
+  it("forwards native div attributes and navigates to an operating-system root", () => {
     const onClick = vi.fn();
+    const onNavigate = vi.fn();
     render(
       <UIProvider reducedMotion="always">
         <DirectoryBrowser
@@ -20,9 +21,10 @@ describe("DirectoryBrowser", () => {
           onClick={onClick}
           onGoHome={() => undefined}
           onGoParent={() => undefined}
-          onNavigate={() => undefined}
+          onNavigate={onNavigate}
           onPick={() => undefined}
           parentPath={null}
+          roots={["/"]}
           title="Choose a workspace directory"
         />
       </UIProvider>
@@ -33,5 +35,8 @@ describe("DirectoryBrowser", () => {
     expect(browser).toHaveAttribute("title", "Choose a workspace directory");
     fireEvent.click(browser);
     expect(onClick).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to location /" }));
+    expect(onNavigate).toHaveBeenCalledWith("/");
   });
 });

--- a/web/src/systems/onboarding/components/directory-browser.tsx
+++ b/web/src/systems/onboarding/components/directory-browser.tsx
@@ -1,4 +1,4 @@
-import { ChevronUp, Folder, FolderPlus, House, Plus, Spline } from "lucide-react";
+import { ChevronUp, Folder, FolderPlus, HardDrive, House, Plus, Spline } from "lucide-react";
 import type { ComponentProps } from "react";
 
 import { Button, Spinner, cn } from "@compozy/ui";
@@ -9,6 +9,7 @@ interface DirectoryBrowserProps extends ComponentProps<"div"> {
   currentPath: string;
   parentPath: string | null;
   homePath: string | null;
+  roots: string[];
   entries: FSEntry[];
   isBrowsing: boolean;
   browseError: string | null;
@@ -42,6 +43,7 @@ export function DirectoryBrowser({
   currentPath,
   parentPath,
   homePath,
+  roots,
   entries,
   isBrowsing,
   browseError,
@@ -101,6 +103,26 @@ export function DirectoryBrowser({
           </Button>
         </span>
       </div>
+
+      {roots.length > 0 ? (
+        <div className="flex flex-none items-center gap-1.5 overflow-x-auto border-b border-line px-3 py-1.5">
+          <span className="mr-0.5 text-micro font-medium text-faint">Locations</span>
+          {roots.map(root => (
+            <Button
+              aria-current={currentPath === root ? "location" : undefined}
+              aria-label={`Go to location ${root}`}
+              data-testid={`${testIdPrefix}-location`}
+              key={root}
+              onClick={() => onNavigate(root)}
+              size="sm"
+              variant="ghost"
+            >
+              <HardDrive className="size-3.5" />
+              {root}
+            </Button>
+          ))}
+        </div>
+      ) : null}
 
       <div className="min-h-0 flex-1 overflow-y-auto p-1.5">
         {isBrowsing ? (

--- a/web/src/systems/onboarding/components/step-workspaces.tsx
+++ b/web/src/systems/onboarding/components/step-workspaces.tsx
@@ -37,6 +37,7 @@ export function StepWorkspaces({ workspaces }: StepWorkspacesProps) {
             parentPath={workspaces.parent}
             pickPending={workspaces.isResolving}
             pickRowLabel={name => `Add ${name} as a workspace`}
+            roots={workspaces.roots}
             testIdPrefix="onboarding-directory-browser"
           />
           {workspaces.resolveError ? (

--- a/web/src/systems/onboarding/components/stories/directory-browser.stories.tsx
+++ b/web/src/systems/onboarding/components/stories/directory-browser.stories.tsx
@@ -35,6 +35,7 @@ const base = {
   currentPath: "/Users/you/Dev",
   parentPath: "/Users/you",
   homePath: "/Users/you",
+  roots: ["/"],
   entries,
   isBrowsing: false,
   browseError: null,

--- a/web/src/systems/onboarding/hooks/__tests__/use-onboarding-workspaces.test.tsx
+++ b/web/src/systems/onboarding/hooks/__tests__/use-onboarding-workspaces.test.tsx
@@ -47,6 +47,7 @@ vi.mock("../use-directory-browser", () => ({
       path: "/Users/operator",
       parent: null,
       home: "/Users/operator",
+      roots: ["/"],
       entries: [],
     },
     error: null,

--- a/web/src/systems/onboarding/hooks/use-onboarding-workspaces.ts
+++ b/web/src/systems/onboarding/hooks/use-onboarding-workspaces.ts
@@ -15,6 +15,7 @@ export interface OnboardingWorkspacesApi {
   currentPath: string;
   parent: string | null;
   home: string | null;
+  roots: string[];
   entries: FSEntry[];
   isBrowsing: boolean;
   browseError: string | null;
@@ -34,8 +35,8 @@ export interface OnboardingWorkspacesApi {
 }
 
 function basename(path: string): string {
-  const trimmed = path.replace(/\/+$/, "");
-  const segment = trimmed.split("/").pop();
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const segment = trimmed.split(/[\\/]/).pop();
   return segment && segment.length > 0 ? segment : trimmed;
 }
 
@@ -156,6 +157,7 @@ export function useOnboardingWorkspaces(): OnboardingWorkspacesApi {
     currentPath: data?.path ?? currentPath,
     parent: data?.parent ?? null,
     home: data?.home ?? null,
+    roots: data?.roots ?? [],
     entries: data?.entries ?? [],
     isBrowsing: browse.isLoading || browse.isFetching,
     browseError: browse.error

--- a/web/src/systems/onboarding/mocks/setup-fixtures.ts
+++ b/web/src/systems/onboarding/mocks/setup-fixtures.ts
@@ -71,6 +71,7 @@ export const onboardingWorkspacesFixture: OnboardingWorkspacesApi = {
   currentPath: "/Users/operator/Dev",
   parent: "/Users/operator",
   home: "/Users/operator",
+  roots: ["/"],
   entries: [
     { name: "compozy", path: "/Users/operator/Dev/compozy", is_dir: true },
     { name: "infra", path: "/Users/operator/Dev/infra", is_dir: true },

--- a/web/src/systems/os/apps/agents/agent-detail-location.tsx
+++ b/web/src/systems/os/apps/agents/agent-detail-location.tsx
@@ -29,7 +29,7 @@ import {
   type AgentInstructionFile,
   type AgentPayload,
 } from "@/systems/agent";
-import { SessionDeleteDialog, type SessionPayload } from "@/systems/session";
+import { SessionDeleteDialog, SessionRenameDialog, type SessionPayload } from "@/systems/session";
 import { useActiveWorkspace } from "@/systems/workspace";
 import { useAgentDetail } from "./use-agent-detail";
 
@@ -274,6 +274,15 @@ export function AgentDetailLocation({ name, rawSearch }: AgentDetailContentProps
                   session={page.sessionDeleteDialog.session}
                   isDeleting={page.sessionDeleteDialog.isDeleting}
                   onConfirm={page.sessionDeleteDialog.onConfirm}
+                />
+              ) : null}
+              {page.sessionRenameDialog.session ? (
+                <SessionRenameDialog
+                  open={page.sessionRenameDialog.open}
+                  onOpenChange={page.sessionRenameDialog.onOpenChange}
+                  session={page.sessionRenameDialog.session}
+                  isRenaming={page.sessionRenameDialog.isRenaming}
+                  onConfirm={page.sessionRenameDialog.onConfirm}
                 />
               ) : null}
             </TabsContent>

--- a/web/src/systems/os/apps/agents/use-agent-detail.ts
+++ b/web/src/systems/os/apps/agents/use-agent-detail.ts
@@ -64,6 +64,7 @@ export interface UseAgentDetailResult {
   deleteDialog: ReturnType<typeof useAgentDeleteFlow>["confirmDialog"];
   sessionActions: ReturnType<typeof useSessionLifecycleActions>["actions"];
   sessionDeleteDialog: ReturnType<typeof useSessionLifecycleActions>["deleteDialog"];
+  sessionRenameDialog: ReturnType<typeof useSessionLifecycleActions>["renameDialog"];
 }
 
 export function useAgentDetail(name: string, rawSearch: AgentDetailSearch): UseAgentDetailResult {
@@ -186,6 +187,7 @@ export function useAgentDetail(name: string, rawSearch: AgentDetailSearch): UseA
     deleteDialog: deleteFlow.confirmDialog,
     sessionActions: sessionLifecycle.actions,
     sessionDeleteDialog: sessionLifecycle.deleteDialog,
+    sessionRenameDialog: sessionLifecycle.renameDialog,
   };
 }
 

--- a/web/src/systems/os/apps/session/session-window-content.tsx
+++ b/web/src/systems/os/apps/session/session-window-content.tsx
@@ -142,6 +142,7 @@ export function SessionWindowContent({
         onOpenChange={renameDialog.setOpen}
         session={session}
         isRenaming={controls.isRenaming}
+        requestError={renameDialog.error}
         onConfirm={renameDialog.confirmRename}
       />
       {sidebar.rowDeleteDialog.session ? (

--- a/web/src/systems/os/apps/session/session-window-content.tsx
+++ b/web/src/systems/os/apps/session/session-window-content.tsx
@@ -3,6 +3,7 @@ import {
   SessionInspector,
   SessionDeleteDialog,
   SessionPromptRuntimeSelector,
+  SessionRenameDialog,
   SessionResumeFailure,
   SessionSidebar,
   type SessionPayload,
@@ -47,6 +48,7 @@ export function SessionWindowContent({
     inspectorUsage,
     sessionVault,
     deleteDialog,
+    renameDialog,
     clearDialog,
     commandCatalog,
     commandCatalogStatus,
@@ -135,6 +137,13 @@ export function SessionWindowContent({
         isDeleting={controls.isDeleting}
         onConfirm={deleteDialog.confirmDelete}
       />
+      <SessionRenameDialog
+        open={renameDialog.open}
+        onOpenChange={renameDialog.setOpen}
+        session={session}
+        isRenaming={controls.isRenaming}
+        onConfirm={renameDialog.confirmRename}
+      />
       {sidebar.rowDeleteDialog.session ? (
         <SessionDeleteDialog
           open={sidebar.rowDeleteDialog.open}
@@ -142,6 +151,15 @@ export function SessionWindowContent({
           session={sidebar.rowDeleteDialog.session}
           isDeleting={sidebar.rowDeleteDialog.isDeleting}
           onConfirm={sidebar.rowDeleteDialog.onConfirm}
+        />
+      ) : null}
+      {sidebar.rowRenameDialog.session ? (
+        <SessionRenameDialog
+          open={sidebar.rowRenameDialog.open}
+          onOpenChange={sidebar.rowRenameDialog.onOpenChange}
+          session={sidebar.rowRenameDialog.session}
+          isRenaming={sidebar.rowRenameDialog.isRenaming}
+          onConfirm={sidebar.rowRenameDialog.onConfirm}
         />
       ) : null}
       <SessionClearDialog

--- a/web/src/systems/os/apps/session/use-session-window-controller.tsx
+++ b/web/src/systems/os/apps/session/use-session-window-controller.tsx
@@ -1,5 +1,6 @@
 import { useSessionClearDialog } from "@/hooks/routes/use-session-clear-dialog";
 import { useSessionDeleteDialog } from "@/hooks/routes/use-session-delete-dialog";
+import { useSessionRenameDialog } from "@/hooks/routes/use-session-rename-dialog";
 import { useSessionPageControls } from "@/hooks/routes/use-session-page-controls";
 import {
   SessionGoalHeadAction,
@@ -58,6 +59,7 @@ export function useSessionWindowController(input: {
       }
     : null;
   const deleteDialog = useSessionDeleteDialog(controls.handleDelete);
+  const renameDialog = useSessionRenameDialog(controls.handleRename);
   const clearDialog = useSessionClearDialog(controls.handleClear);
   const inspector = useSessionInspectorState(sessionId);
   const sidebar = useSessionWindowSidebar({ windowId, workspaceId, sessionId });
@@ -70,6 +72,7 @@ export function useSessionWindowController(input: {
   useSessionTopbarSlot({
     session,
     isDeleting: controls.isDeleting,
+    isRenaming: controls.isRenaming,
     isStopping: controls.isStopping,
     isResuming: controls.isResuming,
     isUnarchiving: controls.isUnarchiving,
@@ -90,6 +93,7 @@ export function useSessionWindowController(input: {
     ),
     onInspectorToggle: inspector.toggle,
     onDelete: deleteDialog.openDialog,
+    onRename: renameDialog.openDialog,
     onStop: controls.handleStop,
     onResume: controls.handleResume,
     onUnarchive: controls.handleUnarchive,
@@ -104,6 +108,7 @@ export function useSessionWindowController(input: {
     inspectorUsage,
     sessionVault,
     deleteDialog,
+    renameDialog,
     clearDialog,
     commandCatalog: sessionCommands.catalog,
     commandCatalogStatus: sessionCommands.isPending ? ("loading" as const) : ("ready" as const),

--- a/web/src/systems/os/apps/session/use-session-window-sidebar.ts
+++ b/web/src/systems/os/apps/session/use-session-window-sidebar.ts
@@ -22,6 +22,7 @@ export interface SessionWindowSidebarModel {
   onNewSession: () => void;
   sessionActions: SessionLifecycleActionHandlers;
   rowDeleteDialog: ReturnType<typeof useSessionLifecycleActions>["deleteDialog"];
+  rowRenameDialog: ReturnType<typeof useSessionLifecycleActions>["renameDialog"];
 }
 
 /**
@@ -73,5 +74,6 @@ export function useSessionWindowSidebar({
     onNewSession: () => openForAgent(""),
     sessionActions: lifecycle.actions,
     rowDeleteDialog: lifecycle.deleteDialog,
+    rowRenameDialog: lifecycle.renameDialog,
   };
 }

--- a/web/src/systems/os/components/__tests__/os-window.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-window.test.tsx
@@ -11,6 +11,9 @@ import { useDesktop } from "../../hooks/use-desktop";
 import { useOsWindow, type OsWindowModel } from "../../hooks/use-os-window";
 import type { OsWindowFrameModel } from "../../lib/group-projection";
 import type { OsDesktopRuntimeStore, OsWindow as OsWindowState } from "../../lib/os-types";
+import type { LayoutProjection, ProjectedSeam } from "../../lib/window-manager-types";
+import { WINDOW_VISUAL_LAYER, windowVisualLayer } from "../../lib/window-visual-layer";
+import { OsSnapSeamLayer } from "../os-snap-seam";
 import { OsWindow } from "../os-window";
 
 vi.mock("../../hooks/use-desktop", () => ({ useDesktop: vi.fn() }));
@@ -179,6 +182,53 @@ describe("OsWindow", () => {
     view.rerender(<OsWindow frame={tiledFrame} />);
     expect(screen.getByTestId("os-window-frame-window:tasks").parentElement).toHaveStyle({
       zIndex: 1,
+    });
+
+    expect(windowVisualLayer(frameModel({ kind: "floating", layer: 1 }))).toBe(
+      WINDOW_VISUAL_LAYER.seam + 1
+    );
+  });
+
+  it("Should render resize seams on the semantic seam layer", () => {
+    const seam: ProjectedSeam = {
+      id: "split:main:0",
+      splitId: "split:main",
+      boundaryIndex: 0,
+      orientation: "vertical",
+      rect: { x: 320, y: 0, w: 0, h: 480 },
+      value: 320,
+      minValue: 200,
+      maxValue: 520,
+      axisSpan: 720,
+      leadingWeight: 0.5,
+      trailingWeight: 0.5,
+      leadingWindowIds: ["window:tasks"],
+      trailingWindowIds: ["window:jobs"],
+    };
+    const projection: LayoutProjection = {
+      revision: 1,
+      desktopId: "desktop:main",
+      workArea: { x: 0, y: 0, w: 720, h: 480 },
+      windows: [],
+      stacks: [],
+      seams: [seam],
+      frameSeams: [],
+      diagnostics: [],
+    };
+
+    render(
+      <OsSnapSeamLayer
+        projection={projection}
+        onResize={vi.fn()}
+        onFrameResize={vi.fn()}
+        onSeamPreview={vi.fn()}
+        onFrameSeamPreview={vi.fn()}
+        onSeamPreviewEnd={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("separator", { name: "Resize boundary 1" })).toHaveStyle({
+      zIndex: WINDOW_VISUAL_LAYER.seam,
     });
   });
 

--- a/web/src/systems/os/components/__tests__/os-window.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-window.test.tsx
@@ -1,6 +1,7 @@
 // Suite: OS window runtime component
 // Invariant: the live OsWindow frame mounts safely in StrictMode, keeps every member mounted
-// across minimize/compact/tab switches, and hosts the deck only at ≥2 members.
+// across minimize/compact/tab switches, hosts the deck only at ≥2 members, and maps semantic
+// frame order onto visual layers where floating windows remain above tiled resize seams.
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { createRef, StrictMode, useState } from "react";
 import type { Rnd } from "react-rnd";
@@ -165,6 +166,20 @@ describe("OsWindow", () => {
       "data-window-placement",
       "floating"
     );
+  });
+
+  it("Should render floating frames above tiled windows and their resize seams", () => {
+    const view = render(<OsWindow frame={frameModel({ layer: 2 })} />);
+
+    expect(screen.getByTestId("os-window-frame-window:tasks").parentElement).toHaveStyle({
+      zIndex: 4,
+    });
+
+    const tiledFrame = frameModel({ kind: "tiled", layer: 1 });
+    view.rerender(<OsWindow frame={tiledFrame} />);
+    expect(screen.getByTestId("os-window-frame-window:tasks").parentElement).toHaveStyle({
+      zIndex: 1,
+    });
   });
 
   it("Should keep minimized frames mounted while hiding floating and compact presentations", () => {

--- a/web/src/systems/os/components/__tests__/sessions-modal.test.tsx
+++ b/web/src/systems/os/components/__tests__/sessions-modal.test.tsx
@@ -50,6 +50,7 @@ const SESSION_ACTIONS: SessionLifecycleActionHandlers = {
   pendingSessionId: null,
   onArchive: () => {},
   onDelete: () => {},
+  onRename: () => {},
   onStop: () => {},
   onUnarchive: () => {},
 };

--- a/web/src/systems/os/components/desktop-shell.tsx
+++ b/web/src/systems/os/components/desktop-shell.tsx
@@ -8,6 +8,7 @@ import {
   SessionCreateDialogHost,
   SessionCreateProvider,
   SessionDeleteDialog,
+  SessionRenameDialog,
   useSessionCreateActions,
   useSessionLifecycleActions,
 } from "@/systems/session";
@@ -250,7 +251,7 @@ function DesktopShellBody({
       <OsSessionsModal
         open={overlays.activeOverlay === "sessions"}
         onOpenChange={open => overlays.setOverlayOpen("sessions", open)}
-        dismissalBlocked={sessionLifecycle.deleteDialog.open}
+        dismissalBlocked={sessionLifecycle.deleteDialog.open || sessionLifecycle.renameDialog.open}
         sessions={attention.sessions}
         archivedSessions={attention.archivedSessions}
         archivedTotal={attention.archivedSessionsTotal}
@@ -264,6 +265,15 @@ function DesktopShellBody({
           session={sessionLifecycle.deleteDialog.session}
           isDeleting={sessionLifecycle.deleteDialog.isDeleting}
           onConfirm={sessionLifecycle.deleteDialog.onConfirm}
+        />
+      ) : null}
+      {sessionLifecycle.renameDialog.session ? (
+        <SessionRenameDialog
+          open={sessionLifecycle.renameDialog.open}
+          onOpenChange={sessionLifecycle.renameDialog.onOpenChange}
+          session={sessionLifecycle.renameDialog.session}
+          isRenaming={sessionLifecycle.renameDialog.isRenaming}
+          onConfirm={sessionLifecycle.renameDialog.onConfirm}
         />
       ) : null}
       <OsShortcutsDialog

--- a/web/src/systems/os/components/os-snap-seam.tsx
+++ b/web/src/systems/os/components/os-snap-seam.tsx
@@ -7,6 +7,7 @@ import type {
   ProjectedFrameSeam,
   ProjectedSeam,
 } from "../lib/window-manager-types";
+import { WINDOW_VISUAL_LAYER } from "../lib/window-visual-layer";
 
 export type SeamGestureHandlers = {
   onResize: (splitId: string, boundaryIndex: number, delta: number) => void;
@@ -17,7 +18,7 @@ export type SeamGestureHandlers = {
 };
 
 const SEAM_CLASS_BASE = cn(
-  "absolute z-[2] touch-none rounded-pill outline-none",
+  "absolute touch-none rounded-pill outline-none",
   "before:absolute before:rounded-pill before:bg-line-strong",
   "hover:before:bg-accent focus-visible:shadow-focus-ring focus-visible:before:bg-accent"
 );
@@ -38,6 +39,7 @@ function seamStyle(vertical: boolean, rect: ProjectedSeam["rect"]) {
     top: rect.y - (vertical ? 0 : 6),
     width: vertical ? 12 : rect.w,
     height: vertical ? rect.h : 12,
+    zIndex: WINDOW_VISUAL_LAYER.seam,
   };
 }
 

--- a/web/src/systems/os/components/os-snap-seam.tsx
+++ b/web/src/systems/os/components/os-snap-seam.tsx
@@ -17,7 +17,7 @@ export type SeamGestureHandlers = {
 };
 
 const SEAM_CLASS_BASE = cn(
-  "absolute z-30 touch-none rounded-pill outline-none",
+  "absolute z-[2] touch-none rounded-pill outline-none",
   "before:absolute before:rounded-pill before:bg-line-strong",
   "hover:before:bg-accent focus-visible:shadow-focus-ring focus-visible:before:bg-accent"
 );

--- a/web/src/systems/os/components/os-window.tsx
+++ b/web/src/systems/os/components/os-window.tsx
@@ -17,6 +17,7 @@ import { useWindowMergeTarget } from "../hooks/use-window-merge-target";
 import { getOsApp, getOsAppMinimum } from "../lib/app-registry";
 import type { OsWindowFrameModel } from "../lib/group-projection";
 import { ensureWindowSlotStore } from "../lib/window-slot-registry";
+import { windowVisualLayer } from "../lib/window-visual-layer";
 import { OsWindowDeck } from "./os-window-deck";
 import { OsWindowErrorBoundary } from "./os-window-error-boundary";
 import { OsWindowChrome, OsWindowSurface } from "./os-window-frame";
@@ -91,7 +92,7 @@ export function OsWindow({ frame }: OsWindowProps) {
       onResizeStart={model.handleResizeStart}
       onResizeStop={model.handleResizeStop}
       style={{
-        zIndex: frame.layer,
+        zIndex: windowVisualLayer(frame),
         display: frame.minimized ? "none" : undefined,
       }}
     >

--- a/web/src/systems/os/components/stories/attention-surfaces.stories.tsx
+++ b/web/src/systems/os/components/stories/attention-surfaces.stories.tsx
@@ -64,6 +64,7 @@ const SESSION_ACTIONS: SessionLifecycleActionHandlers = {
   pendingSessionId: null,
   onArchive: fn(),
   onDelete: fn(),
+  onRename: fn(),
   onStop: fn(),
   onUnarchive: fn(),
 };

--- a/web/src/systems/os/lib/window-visual-layer.ts
+++ b/web/src/systems/os/lib/window-visual-layer.ts
@@ -1,0 +1,12 @@
+import type { OsWindowFrameModel } from "./group-projection";
+
+export const WINDOW_VISUAL_LAYER = {
+  tiled: 1,
+  seam: 2,
+} as const;
+
+export function windowVisualLayer(frame: Pick<OsWindowFrameModel, "kind" | "layer">): number {
+  return frame.kind === "floating"
+    ? WINDOW_VISUAL_LAYER.seam + frame.layer
+    : WINDOW_VISUAL_LAYER.tiled;
+}

--- a/web/src/systems/os/lib/window-visual-layer.ts
+++ b/web/src/systems/os/lib/window-visual-layer.ts
@@ -7,6 +7,6 @@ export const WINDOW_VISUAL_LAYER = {
 
 export function windowVisualLayer(frame: Pick<OsWindowFrameModel, "kind" | "layer">): number {
   return frame.kind === "floating"
-    ? WINDOW_VISUAL_LAYER.seam + frame.layer
+    ? WINDOW_VISUAL_LAYER.seam + Math.max(frame.layer, 1)
     : WINDOW_VISUAL_LAYER.tiled;
 }

--- a/web/src/systems/runtime/components/runtime-selector/model-list.tsx
+++ b/web/src/systems/runtime/components/runtime-selector/model-list.tsx
@@ -109,7 +109,10 @@ export function ModelList({
     // Outer scroller owns the overflow so sticky group heads stick to its top,
     // while the `role="listbox"` stays PURE options — the custom-ID affordance is an
     // action, not a selectable option, so it sits OUTSIDE the listbox.
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-1 pt-0.5 pb-1.5">
+    <div
+      className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain px-1 pt-0.5 pb-1.5"
+      data-testid="runtime-selector-scroll"
+    >
       {listModel.exactEntry ? null : (
         <div
           role={showsOptions ? "listbox" : "status"}

--- a/web/src/systems/runtime/mocks/handlers.ts
+++ b/web/src/systems/runtime/mocks/handlers.ts
@@ -84,6 +84,7 @@ const directoryEntriesByPath = new Map<
       home: directoryHome,
       parent: "/Users",
       path: directoryHome,
+      roots: ["/"],
     },
   ],
   [
@@ -96,6 +97,7 @@ const directoryEntriesByPath = new Map<
       home: directoryHome,
       parent: directoryHome,
       path: "/Users/pedronauck/Dev",
+      roots: ["/"],
     },
   ],
   [
@@ -105,6 +107,7 @@ const directoryEntriesByPath = new Map<
       home: directoryHome,
       parent: "/Users/pedronauck/Dev",
       path: "/Users/pedronauck/Dev/compozy",
+      roots: ["/"],
     },
   ],
 ]);
@@ -132,6 +135,7 @@ function directoryBrowseFixtureFor(
     home: directoryHome,
     parent: parentPath(requestedPath),
     path: requestedPath,
+    roots: ["/"],
   };
 }
 

--- a/web/src/systems/session/adapters/__tests__/session-api.test.ts
+++ b/web/src/systems/session/adapters/__tests__/session-api.test.ts
@@ -27,6 +27,7 @@ import {
   fetchSessionTranscript,
   fetchSessions,
   repairSession,
+  renameSession,
   promoteSessionInputToSteer,
   replaceSessionInput,
   rewindSession,
@@ -315,6 +316,24 @@ describe("fetchSession", () => {
     await fetchSession(WORKSPACE_ID, "id with spaces");
 
     await expectFetchRequest({ path: "/api/workspaces/ws_alpha/sessions/id%20with%20spaces" });
+  });
+});
+
+describe("renameSession", () => {
+  it("patches the workspace-scoped session name and returns the durable session", async () => {
+    const renamed = { ...mockSession, name: "Release review" };
+    mockJsonResponse({ session: renamed });
+    const controller = new AbortController();
+
+    await expect(
+      renameSession(WORKSPACE_ID, "sess-001", { name: "Release review" }, controller.signal)
+    ).resolves.toEqual(renamed);
+    await expectFetchRequest({
+      body: { name: "Release review" },
+      method: "PATCH",
+      path: "/api/workspaces/ws_alpha/sessions/sess-001",
+      signal: controller.signal,
+    });
   });
 });
 

--- a/web/src/systems/session/adapters/session-api.ts
+++ b/web/src/systems/session/adapters/session-api.ts
@@ -14,6 +14,7 @@ import type {
   SessionRecapPayload,
   SessionRepairPayload,
   SessionRepairQuery,
+  RenameSessionRequest,
   SetSessionRuntimeRequest,
   SessionUsagePayload,
   TurnHistoryPayload,
@@ -103,6 +104,26 @@ export async function deleteSession(
   if (apiRequestFailed(response, error)) {
     throwSessionRequestError(response, error, `Failed to delete session "${id}"`, id);
   }
+}
+
+export async function renameSession(
+  workspaceId: string,
+  id: string,
+  request: RenameSessionRequest,
+  signal?: AbortSignal
+): Promise<SessionPayload> {
+  const { data, error, response } = await apiClient.PATCH(
+    "/api/workspaces/{workspace_id}/sessions/{session_id}",
+    {
+      params: { path: { workspace_id: workspaceId, session_id: id } },
+      body: request,
+      signal,
+    }
+  );
+  if (apiRequestFailed(response, error)) {
+    throwSessionRequestError(response, error, `Failed to rename session "${id}"`, id);
+  }
+  return requireResponseData(data, response, `Failed to rename session "${id}"`).session;
 }
 
 export async function stopSession(

--- a/web/src/systems/session/components/__tests__/session-rename-dialog.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-rename-dialog.test.tsx
@@ -43,6 +43,22 @@ describe("SessionRenameDialog", () => {
     expect(onConfirm).toHaveBeenCalledWith("Release review");
   });
 
+  it("Should show a failed rename while allowing the user to retry", () => {
+    render(
+      <SessionRenameDialog
+        open
+        onOpenChange={vi.fn()}
+        session={primarySessionFixture}
+        isRenaming={false}
+        requestError="Session rename failed."
+        onConfirm={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId("session-rename-error")).toHaveTextContent("Session rename failed.");
+    expect(screen.getByTestId("session-rename-confirm")).toBeEnabled();
+  });
+
   it.each([
     ["blank", "   ", "Enter a session name."],
     ["too long", "a".repeat(65), "Use 64 characters or fewer."],

--- a/web/src/systems/session/components/__tests__/session-rename-dialog.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-rename-dialog.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { primarySessionFixture } from "../../testing";
+import { SessionRenameDialog } from "../session-rename-dialog";
+
+describe("SessionRenameDialog", () => {
+  it("Should discard a stale draft when the same session dialog reopens", () => {
+    const props = {
+      onOpenChange: vi.fn(),
+      session: primarySessionFixture,
+      isRenaming: false,
+      onConfirm: vi.fn(),
+    };
+    const { rerender } = render(<SessionRenameDialog {...props} open />);
+
+    fireEvent.change(screen.getByTestId("session-rename-name"), {
+      target: { value: "Unsaved draft" },
+    });
+    rerender(<SessionRenameDialog {...props} open={false} />);
+    rerender(<SessionRenameDialog {...props} open />);
+
+    expect(screen.getByTestId("session-rename-name")).toHaveValue(primarySessionFixture.name);
+  });
+
+  it("Should submit a valid trimmed name", () => {
+    const onConfirm = vi.fn();
+    render(
+      <SessionRenameDialog
+        open
+        onOpenChange={vi.fn()}
+        session={primarySessionFixture}
+        isRenaming={false}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("session-rename-name"), {
+      target: { value: "  Release review  " },
+    });
+    fireEvent.click(screen.getByTestId("session-rename-confirm"));
+
+    expect(onConfirm).toHaveBeenCalledWith("Release review");
+  });
+
+  it.each([
+    ["blank", "   ", "Enter a session name."],
+    ["too long", "a".repeat(65), "Use 64 characters or fewer."],
+  ])("Should block a %s name", (_case, name, message) => {
+    const onConfirm = vi.fn();
+    render(
+      <SessionRenameDialog
+        open
+        onOpenChange={vi.fn()}
+        session={primarySessionFixture}
+        isRenaming={false}
+        onConfirm={onConfirm}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("session-rename-name"), { target: { value: name } });
+
+    expect(screen.getByText(message)).toBeInTheDocument();
+    expect(screen.getByTestId("session-rename-confirm")).toBeDisabled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/systems/session/components/session-rename-dialog.tsx
+++ b/web/src/systems/session/components/session-rename-dialog.tsx
@@ -1,0 +1,135 @@
+import { useState, type FormEvent } from "react";
+import { Pencil } from "lucide-react";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Spinner,
+} from "@compozy/ui";
+
+import type { SessionPayload } from "../types";
+
+const SESSION_NAME_MAX_CHARACTERS = 64;
+
+export interface SessionRenameDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  session: SessionPayload;
+  isRenaming: boolean;
+  onConfirm: (name: string) => void;
+}
+
+interface SessionRenameFormProps {
+  session: SessionPayload;
+  isRenaming: boolean;
+  onCancel: () => void;
+  onConfirm: (name: string) => void;
+}
+
+function SessionRenameForm({ session, isRenaming, onCancel, onConfirm }: SessionRenameFormProps) {
+  const [name, setName] = useState(session.name ?? "");
+  const normalizedName = name.trim();
+  const characterCount = Array.from(normalizedName).length;
+  const error =
+    normalizedName.length === 0
+      ? "Enter a session name."
+      : characterCount > SESSION_NAME_MAX_CHARACTERS
+        ? `Use ${SESSION_NAME_MAX_CHARACTERS} characters or fewer.`
+        : null;
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isRenaming || error) return;
+    onConfirm(normalizedName);
+  };
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-4">
+      <DialogHeader>
+        <DialogTitle>Rename session</DialogTitle>
+      </DialogHeader>
+      <Field data-invalid={Boolean(error)}>
+        <FieldLabel htmlFor="session-rename-name">Name</FieldLabel>
+        <Input
+          id="session-rename-name"
+          value={name}
+          onChange={event => setName(event.target.value)}
+          disabled={isRenaming}
+          aria-invalid={Boolean(error)}
+          autoFocus
+          data-testid="session-rename-name"
+        />
+        {error ? <FieldError data-testid="session-rename-error">{error}</FieldError> : null}
+      </Field>
+      <DialogFooter className="gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onCancel}
+          disabled={isRenaming}
+          data-testid="session-rename-cancel"
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          disabled={isRenaming || Boolean(error)}
+          data-testid="session-rename-confirm"
+        >
+          {isRenaming ? (
+            <>
+              <Spinner className="size-3" />
+              Renaming
+            </>
+          ) : (
+            <>
+              <Pencil className="size-3" />
+              Rename session
+            </>
+          )}
+        </Button>
+      </DialogFooter>
+    </form>
+  );
+}
+
+/** Shared, workspace-scoped rename surface for every user-session entry point. */
+export function SessionRenameDialog({
+  open,
+  onOpenChange,
+  session,
+  isRenaming,
+  onConfirm,
+}: SessionRenameDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={nextOpen => {
+        if (isRenaming && !nextOpen) return;
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent
+        showCloseButton={!isRenaming}
+        className="max-w-md"
+        data-testid="session-rename-dialog"
+      >
+        <SessionRenameForm
+          key={`${session.id}:${open ? "open" : "closed"}`}
+          session={session}
+          isRenaming={isRenaming}
+          onCancel={() => onOpenChange(false)}
+          onConfirm={onConfirm}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/systems/session/components/session-rename-dialog.tsx
+++ b/web/src/systems/session/components/session-rename-dialog.tsx
@@ -24,30 +24,39 @@ export interface SessionRenameDialogProps {
   onOpenChange: (open: boolean) => void;
   session: SessionPayload;
   isRenaming: boolean;
+  requestError?: string | null;
   onConfirm: (name: string) => void;
 }
 
 interface SessionRenameFormProps {
   session: SessionPayload;
   isRenaming: boolean;
+  requestError: string | null;
   onCancel: () => void;
   onConfirm: (name: string) => void;
 }
 
-function SessionRenameForm({ session, isRenaming, onCancel, onConfirm }: SessionRenameFormProps) {
+function SessionRenameForm({
+  session,
+  isRenaming,
+  requestError,
+  onCancel,
+  onConfirm,
+}: SessionRenameFormProps) {
   const [name, setName] = useState(session.name ?? "");
   const normalizedName = name.trim();
   const characterCount = Array.from(normalizedName).length;
-  const error =
+  const validationError =
     normalizedName.length === 0
       ? "Enter a session name."
       : characterCount > SESSION_NAME_MAX_CHARACTERS
         ? `Use ${SESSION_NAME_MAX_CHARACTERS} characters or fewer.`
         : null;
+  const error = validationError ?? requestError;
 
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isRenaming || error) return;
+    if (isRenaming || validationError) return;
     onConfirm(normalizedName);
   };
 
@@ -81,7 +90,7 @@ function SessionRenameForm({ session, isRenaming, onCancel, onConfirm }: Session
         </Button>
         <Button
           type="submit"
-          disabled={isRenaming || Boolean(error)}
+          disabled={isRenaming || Boolean(validationError)}
           data-testid="session-rename-confirm"
         >
           {isRenaming ? (
@@ -107,6 +116,7 @@ export function SessionRenameDialog({
   onOpenChange,
   session,
   isRenaming,
+  requestError = null,
   onConfirm,
 }: SessionRenameDialogProps) {
   return (
@@ -126,6 +136,7 @@ export function SessionRenameDialog({
           key={`${session.id}:${open ? "open" : "closed"}`}
           session={session}
           isRenaming={isRenaming}
+          requestError={requestError}
           onCancel={() => onOpenChange(false)}
           onConfirm={onConfirm}
         />

--- a/web/src/systems/session/components/session-row-actions.tsx
+++ b/web/src/systems/session/components/session-row-actions.tsx
@@ -1,4 +1,4 @@
-import { Archive, RotateCcw, Square, Trash2 } from "lucide-react";
+import { Archive, Pencil, RotateCcw, Square, Trash2 } from "lucide-react";
 
 import {
   Button,
@@ -12,6 +12,7 @@ import {
 
 import type { SessionLifecycleActionHandlers } from "../hooks/use-session-lifecycle-actions";
 import { getSessionDisplayTitle } from "../lib/session-display-title";
+import { isUserControllableSession } from "../lib/session-running";
 import type { SessionPayload } from "../types";
 
 function isStopEligible(session: SessionPayload): boolean {
@@ -40,6 +41,16 @@ export function SessionRowActions({ session, actions }: SessionRowActionsProps) 
         {pending ? <Spinner className="size-3" /> : <TopbarOverflowIcon aria-hidden="true" />}
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {isUserControllableSession(session) ? (
+          <DropdownMenuItem
+            data-testid={`session-row-rename-${session.id}`}
+            disabled={disabled}
+            onClick={() => actions.onRename(session)}
+          >
+            <Pencil aria-hidden="true" className="size-3" />
+            Rename session
+          </DropdownMenuItem>
+        ) : null}
         {!isArchived && isStopEligible(session) ? (
           <DropdownMenuItem
             data-testid={`session-row-stop-${session.id}`}

--- a/web/src/systems/session/components/stories/session-sidebar.stories.tsx
+++ b/web/src/systems/session/components/stories/session-sidebar.stories.tsx
@@ -119,6 +119,7 @@ export const ProvenanceThreads: Story = {
       pendingSessionId: null,
       onArchive: fn(),
       onDelete: fn(),
+      onRename: fn(),
       onStop: fn(),
       onUnarchive: fn(),
     },

--- a/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
+++ b/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
@@ -12,6 +12,7 @@ import {
   useInterruptSessionPrompt,
   useQueueSessionPrompt,
   useRepairSession,
+  useRenameSession,
   useSteerSessionPrompt,
   useUnarchiveSession,
 } from "../use-session-actions";
@@ -38,6 +39,7 @@ vi.mock("../../adapters/session-api", () => ({
   createSession: vi.fn(),
   deleteSession: vi.fn(),
   repairSession: vi.fn(),
+  renameSession: vi.fn(),
   promoteSessionInputToSteer: vi.fn(),
   replaceSessionInput: vi.fn(),
   rewindSession: vi.fn(),
@@ -61,6 +63,7 @@ import {
   createSession,
   deleteSession,
   repairSession,
+  renameSession,
   promoteSessionInputToSteer,
   replaceSessionInput,
   rewindSession,
@@ -612,6 +615,67 @@ describe("session actions", () => {
     await act(async () => resolveDelete());
     await waitFor(() => expect(result.current.deleteDialog.open).toBe(false));
     expect(result.current.deleteDialog.session).toBeNull();
+  });
+
+  it("keeps the rename dialog open until the durable rename succeeds", async () => {
+    let resolveRename!: (session: SessionPayload) => void;
+    vi.mocked(renameSession).mockImplementation(
+      () =>
+        new Promise<SessionPayload>(resolve => {
+          resolveRename = resolve;
+        })
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { result } = renderHook(() => useSessionLifecycleActions(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => result.current.actions.onRename(createdSession));
+    expect(result.current.renameDialog.open).toBe(true);
+
+    act(() => result.current.renameDialog.onConfirm("Release review"));
+    await waitFor(() => expect(result.current.renameDialog.isRenaming).toBe(true));
+    expect(renameSession).toHaveBeenCalledWith(
+      WORKSPACE_ID,
+      createdSession.id,
+      { name: "Release review" },
+      expect.any(AbortSignal)
+    );
+
+    act(() => result.current.renameDialog.onOpenChange(false));
+    expect(result.current.renameDialog.open).toBe(true);
+
+    await act(async () => resolveRename({ ...createdSession, name: "Release review" }));
+    await waitFor(() => expect(result.current.renameDialog.open).toBe(false));
+    expect(result.current.renameDialog.session).toBeNull();
+  });
+
+  it("updates the detail cache and invalidates session views after rename", async () => {
+    const renamed = { ...createdSession, name: "Release review" };
+    vi.mocked(renameSession).mockResolvedValue(renamed);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+    const { result } = renderHook(() => useRenameSession(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: createdSession.id, name: "Release review" });
+    });
+
+    expect(queryClient.getQueryData(sessionKeys.detail(WORKSPACE_ID, createdSession.id))).toEqual(
+      renamed
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.detail(WORKSPACE_ID, createdSession.id),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.workspaceLists(WORKSPACE_ID),
+    });
   });
 
   it("useQueueSessionPrompt builds the canonical durable request from an action identity", async () => {

--- a/web/src/systems/session/hooks/__tests__/use-session-topbar-slot.test.tsx
+++ b/web/src/systems/session/hooks/__tests__/use-session-topbar-slot.test.tsx
@@ -14,12 +14,14 @@ import { useSessionTopbarSlot } from "../use-session-topbar-slot";
 
 function SessionPublisher({
   onStop,
+  onRename = vi.fn(),
   inspectorOpen = false,
   onInspectorToggle = vi.fn(),
   sidebarOpen = false,
   onSidebarToggle = vi.fn(),
 }: {
   onStop: () => void;
+  onRename?: () => void;
   inspectorOpen?: boolean;
   onInspectorToggle?: () => void;
   sidebarOpen?: boolean;
@@ -28,6 +30,7 @@ function SessionPublisher({
   useSessionTopbarSlot({
     session: primarySessionFixture,
     isDeleting: false,
+    isRenaming: false,
     isStopping: false,
     isResuming: false,
     isUnarchiving: false,
@@ -38,6 +41,7 @@ function SessionPublisher({
     onInspectorToggle,
     onSidebarToggle,
     onDelete: vi.fn(),
+    onRename,
     onStop,
     onResume: vi.fn(),
     onUnarchive: vi.fn(),
@@ -114,6 +118,7 @@ describe("useSessionTopbarSlot", () => {
       useSessionTopbarSlot({
         session: { ...primarySessionFixture, badge: "idle" },
         isDeleting: false,
+        isRenaming: false,
         isStopping: false,
         isResuming: false,
         isUnarchiving: false,
@@ -124,6 +129,7 @@ describe("useSessionTopbarSlot", () => {
         onSidebarToggle: vi.fn(),
         onInspectorToggle: vi.fn(),
         onDelete: vi.fn(),
+        onRename: vi.fn(),
         onStop,
         onResume: vi.fn(),
         onUnarchive: vi.fn(),
@@ -155,6 +161,7 @@ describe("useSessionTopbarSlot", () => {
           archived_at: "2026-08-04T12:00:00Z",
         },
         isDeleting: false,
+        isRenaming: false,
         isStopping: false,
         isResuming: false,
         isUnarchiving: false,
@@ -165,6 +172,7 @@ describe("useSessionTopbarSlot", () => {
         onSidebarToggle: vi.fn(),
         onInspectorToggle: vi.fn(),
         onDelete: vi.fn(),
+        onRename: vi.fn(),
         onStop: vi.fn(),
         onResume: vi.fn(),
         onUnarchive,
@@ -179,5 +187,15 @@ describe("useSessionTopbarSlot", () => {
     expect(onUnarchive).toHaveBeenCalledTimes(1);
     expect(screen.queryByRole("button", { name: "Attach session" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
+  });
+
+  it("Should offer rename from overflow for a user session", () => {
+    const onRename = vi.fn();
+    renderWithTopbar(<SessionPublisher onStop={vi.fn()} onRename={onRename} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename session" }));
+
+    expect(onRename).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/systems/session/hooks/__tests__/use-session-topbar-slot.test.tsx
+++ b/web/src/systems/session/hooks/__tests__/use-session-topbar-slot.test.tsx
@@ -4,11 +4,13 @@
 // Boundary IN: useSessionTopbarSlot and the real Topbar slot consumer.
 // Boundary OUT: daemon mutations and window manager behavior.
 
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { renderWithTopbar } from "@/test/render-with-topbar";
 
+import { SessionRenameDialog } from "../../components/session-rename-dialog";
 import { primarySessionFixture } from "../../mocks/fixtures";
 import { useSessionTopbarSlot } from "../use-session-topbar-slot";
 
@@ -189,13 +191,33 @@ describe("useSessionTopbarSlot", () => {
     expect(screen.queryByRole("button", { name: "Resume session" })).toBeNull();
   });
 
-  it("Should offer rename from overflow for a user session", () => {
-    const onRename = vi.fn();
-    renderWithTopbar(<SessionPublisher onStop={vi.fn()} onRename={onRename} />);
+  it("Should close overflow before opening rename so one Escape dismisses the dialog", async () => {
+    function RenameDialogPublisher() {
+      const [dialogOpen, setDialogOpen] = useState(false);
+      return (
+        <>
+          <SessionPublisher onStop={vi.fn()} onRename={() => setDialogOpen(true)} />
+          <SessionRenameDialog
+            open={dialogOpen}
+            onOpenChange={setDialogOpen}
+            session={primarySessionFixture}
+            isRenaming={false}
+            onConfirm={vi.fn()}
+          />
+        </>
+      );
+    }
+
+    renderWithTopbar(<RenameDialogPublisher />);
 
     fireEvent.click(screen.getByRole("button", { name: "More actions" }));
     fireEvent.click(screen.getByRole("menuitem", { name: "Rename session" }));
 
-    expect(onRename).toHaveBeenCalledTimes(1);
+    await screen.findByRole("heading", { name: "Rename session" });
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Rename session" })).toBeNull();
+    });
   });
 });

--- a/web/src/systems/session/hooks/use-session-actions.ts
+++ b/web/src/systems/session/hooks/use-session-actions.ts
@@ -10,6 +10,7 @@ import {
   type CreateSessionParams,
   deleteSession,
   repairSession,
+  renameSession,
   resumeSession,
   SessionApiError,
   sendSessionPrompt,
@@ -42,6 +43,32 @@ function requireWorkspace(workspaceId: string | null | undefined): string {
 
 interface UseSessionWorkspaceOptions {
   workspaceId?: string | null;
+}
+
+export interface RenameSessionParams {
+  id: string;
+  name: string;
+}
+
+export function useRenameSession(options: UseSessionWorkspaceOptions = {}) {
+  const queryClient = useQueryClient();
+  const { activeWorkspaceId } = useActiveWorkspace();
+  const workspaceId = resolveWorkspaceId(options.workspaceId, activeWorkspaceId);
+  const request = useAbortableMutationRequest();
+
+  return useMutation({
+    mutationFn: ({ id, name }: RenameSessionParams) =>
+      request(signal => renameSession(requireWorkspace(workspaceId), id, { name }, signal)),
+    onSuccess: session => {
+      const successWorkspaceId = requireWorkspace(session.workspace_id);
+      queryClient.setQueryData(sessionKeys.detail(successWorkspaceId, session.id), session);
+    },
+    onSettled: (_data, _error, variables) => {
+      if (workspaceId) {
+        void invalidateSessionMutationQueries(queryClient, workspaceId, variables.id);
+      }
+    },
+  });
 }
 
 function resolveWorkspaceId(

--- a/web/src/systems/session/hooks/use-session-lifecycle-actions.ts
+++ b/web/src/systems/session/hooks/use-session-lifecycle-actions.ts
@@ -5,16 +5,18 @@ import type { SessionPayload } from "../types";
 import {
   useArchiveSession,
   useDeleteSession,
+  useRenameSession,
   useStopSession,
   useUnarchiveSession,
 } from "./use-session-actions";
 
-export type SessionLifecycleAction = "stop" | "archive" | "unarchive" | "delete";
+export type SessionLifecycleAction = "rename" | "stop" | "archive" | "unarchive" | "delete";
 
 export interface SessionLifecycleActionHandlers {
   pendingAction: SessionLifecycleAction | null;
   pendingSessionId: string | null;
   onStop: (session: SessionPayload) => void;
+  onRename: (session: SessionPayload) => void;
   onArchive: (session: SessionPayload) => void;
   onUnarchive: (session: SessionPayload) => void;
   onDelete: (session: SessionPayload) => void;
@@ -28,9 +30,18 @@ export interface SessionDeleteConfirmation {
   onConfirm: () => void;
 }
 
+export interface SessionRenameConfirmation {
+  open: boolean;
+  session: SessionPayload | null;
+  isRenaming: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (name: string) => void;
+}
+
 export interface UseSessionLifecycleActionsResult {
   actions: SessionLifecycleActionHandlers;
   deleteDialog: SessionDeleteConfirmation;
+  renameDialog: SessionRenameConfirmation;
 }
 
 export interface UseSessionLifecycleActionsOptions {
@@ -53,11 +64,16 @@ export function useSessionLifecycleActions(
   const archive = useArchiveSession(options);
   const unarchive = useUnarchiveSession(options);
   const remove = useDeleteSession(options);
+  const rename = useRenameSession(options);
   const [deleteSession, setDeleteSession] = useState<SessionPayload | null>(null);
+  const [renameTarget, setRenameTarget] = useState<SessionPayload | null>(null);
 
   let pendingAction: SessionLifecycleAction | null = null;
   let pendingSessionId: string | null = null;
-  if (stop.isPending) {
+  if (rename.isPending) {
+    pendingAction = "rename";
+    pendingSessionId = rename.variables.id;
+  } else if (stop.isPending) {
     pendingAction = "stop";
     pendingSessionId = stop.variables;
   } else if (archive.isPending) {
@@ -82,10 +98,27 @@ export function useSessionLifecycleActions(
     });
   };
 
+  const confirmRename = (name: string) => {
+    if (!renameTarget || rename.isPending) return;
+    const { id } = renameTarget;
+    rename.mutate(
+      { id, name },
+      {
+        onError: error => reportActionError("rename", error),
+        onSuccess: () => {
+          setRenameTarget(current => (current?.id === id ? null : current));
+        },
+      }
+    );
+  };
+
   return {
     actions: {
       pendingAction,
       pendingSessionId,
+      onRename: session => {
+        if (!rename.isPending) setRenameTarget(session);
+      },
       onStop: session =>
         stop.mutate(session.id, { onError: error => reportActionError("stop", error) }),
       onArchive: session =>
@@ -104,6 +137,15 @@ export function useSessionLifecycleActions(
         if (!open && !remove.isPending) setDeleteSession(null);
       },
       onConfirm: confirmDelete,
+    },
+    renameDialog: {
+      open: renameTarget !== null,
+      session: renameTarget,
+      isRenaming: rename.isPending,
+      onOpenChange: open => {
+        if (!open && !rename.isPending) setRenameTarget(null);
+      },
+      onConfirm: confirmRename,
     },
   };
 }

--- a/web/src/systems/session/hooks/use-session-topbar-slot.tsx
+++ b/web/src/systems/session/hooks/use-session-topbar-slot.tsx
@@ -1,4 +1,4 @@
-import { Eraser, List, PanelRight, Play, RotateCcw, Square, Trash2 } from "lucide-react";
+import { Eraser, List, PanelRight, Pencil, Play, RotateCcw, Square, Trash2 } from "lucide-react";
 
 import {
   Button,
@@ -20,6 +20,7 @@ import { SessionStatusLine } from "../components/session-status-line";
 interface UseSessionTopbarSlotInput {
   session: SessionPayload;
   isDeleting: boolean;
+  isRenaming: boolean;
   isStopping: boolean;
   isResuming: boolean;
   isUnarchiving: boolean;
@@ -32,6 +33,7 @@ interface UseSessionTopbarSlotInput {
   onInspectorToggle: () => void;
   onSidebarToggle: () => void;
   onDelete: () => void;
+  onRename: () => void;
   onStop: () => void;
   onResume: () => void;
   onUnarchive: () => void;
@@ -42,6 +44,7 @@ interface UseSessionTopbarSlotInput {
 export function useSessionTopbarSlot({
   session,
   isDeleting,
+  isRenaming,
   isStopping,
   isResuming,
   isUnarchiving,
@@ -53,6 +56,7 @@ export function useSessionTopbarSlot({
   onInspectorToggle,
   onSidebarToggle,
   onDelete,
+  onRename,
   onStop,
   onResume,
   onUnarchive,
@@ -66,7 +70,7 @@ export function useSessionTopbarSlot({
     isUserControllableSession(session) &&
     !isSessionRunning(session);
   const showStopAction = isActive && !canResume;
-  const controlsBusy = isStopping || isResuming || isUnarchiving || isDeleting;
+  const controlsBusy = isStopping || isResuming || isUnarchiving || isDeleting || isRenaming;
 
   const primaryAction = isArchived ? (
     <Button
@@ -185,6 +189,16 @@ export function useSessionTopbarSlot({
           <TopbarOverflowIcon aria-hidden="true" className="size-3" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" data-testid="session-topbar-overflow-menu">
+          {isUserControllableSession(session) ? (
+            <DropdownMenuItem
+              data-testid="rename-button"
+              disabled={controlsBusy}
+              onClick={onRename}
+            >
+              {isRenaming ? <Spinner className="size-3" /> : <Pencil className="size-3" />}
+              Rename session
+            </DropdownMenuItem>
+          ) : null}
           {isActive && canResume ? (
             <DropdownMenuItem
               data-testid="stop-menu-item"

--- a/web/src/systems/session/hooks/use-session-topbar-slot.tsx
+++ b/web/src/systems/session/hooks/use-session-topbar-slot.tsx
@@ -1,4 +1,5 @@
 import { Eraser, List, PanelRight, Pencil, Play, RotateCcw, Square, Trash2 } from "lucide-react";
+import { useRef, useState } from "react";
 
 import {
   Button,
@@ -62,6 +63,9 @@ export function useSessionTopbarSlot({
   onUnarchive,
   onClear,
 }: UseSessionTopbarSlotInput): void {
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const renameRequested = useRef(false);
+
   const isActive = session.state === "active" || session.state === "starting";
   const isArchived = session.archived_at !== null;
   const canResume =
@@ -173,7 +177,15 @@ export function useSessionTopbarSlot({
       </>
     ),
     overflow: (
-      <DropdownMenu>
+      <DropdownMenu
+        open={overflowOpen}
+        onOpenChange={setOverflowOpen}
+        onOpenChangeComplete={open => {
+          if (open || !renameRequested.current) return;
+          renameRequested.current = false;
+          onRename();
+        }}
+      >
         <DropdownMenuTrigger
           aria-label="More actions"
           data-testid="session-topbar-overflow"
@@ -193,7 +205,10 @@ export function useSessionTopbarSlot({
             <DropdownMenuItem
               data-testid="rename-button"
               disabled={controlsBusy}
-              onClick={onRename}
+              onClick={() => {
+                renameRequested.current = true;
+                setOverflowOpen(false);
+              }}
             >
               {isRenaming ? <Spinner className="size-3" /> : <Pencil className="size-3" />}
               Rename session

--- a/web/src/systems/session/index.ts
+++ b/web/src/systems/session/index.ts
@@ -52,6 +52,7 @@ export type {
   SessionRepairPayload,
   SessionRepairQuery,
   SessionRepairResponse,
+  RenameSessionRequest,
   SessionRuntimeSelection,
   SessionResponse,
   SessionState,
@@ -113,6 +114,7 @@ export {
   fetchSessions,
   promoteSessionInputToSteer,
   repairSession,
+  renameSession,
   replaceSessionInput,
   rewindSession,
   resumeSession,
@@ -259,6 +261,7 @@ export {
   useInterruptSessionPrompt,
   useQueueSessionPrompt,
   useRepairSession,
+  useRenameSession,
   useResumeSession,
   useSendSessionPrompt,
   useSteerSessionPrompt,
@@ -266,6 +269,7 @@ export {
   useUnarchiveSession,
   type CancelQueuedSessionPromptParams,
   type RepairSessionParams,
+  type RenameSessionParams,
   type SendSessionPromptParams,
   type SessionPromptActionParams,
 } from "./hooks/use-session-actions";
@@ -275,6 +279,7 @@ export {
   type SessionDeleteConfirmation,
   type SessionLifecycleAction,
   type SessionLifecycleActionHandlers,
+  type SessionRenameConfirmation,
   type UseSessionLifecycleActionsOptions,
   type UseSessionLifecycleActionsResult,
 } from "./hooks/use-session-lifecycle-actions";
@@ -312,6 +317,10 @@ export {
   SessionDeleteDialog,
   type SessionDeleteDialogProps,
 } from "./components/session-delete-dialog";
+export {
+  SessionRenameDialog,
+  type SessionRenameDialogProps,
+} from "./components/session-rename-dialog";
 export { SessionRowActions, type SessionRowActionsProps } from "./components/session-row-actions";
 export { SessionList, type SessionListProps } from "./components/session-list/session-list";
 export { SessionSidebar, type SessionSidebarProps } from "./components/session-sidebar";

--- a/web/src/systems/session/types.ts
+++ b/web/src/systems/session/types.ts
@@ -15,6 +15,7 @@ export type SessionRuntimePayload = SessionPayload["runtime"];
 export type SessionRuntimeEffective = NonNullable<SessionRuntimePayload["effective"]>;
 export type SessionRuntimeSelection = NonNullable<SessionRuntimePayload["selected"]>;
 export type SetSessionRuntimeRequest = OperationRequestBody<"setSessionRuntime">;
+export type RenameSessionRequest = OperationRequestBody<"renameSession">;
 export type ACPCaps = NonNullable<SessionRuntimePayload["acp_caps"]>;
 export type SessionState = SessionPayload["state"];
 export type SessionFailurePayload = NonNullable<SessionPayload["failure"]>;

--- a/web/src/systems/workspace/components/__tests__/workspace-setup.test.tsx
+++ b/web/src/systems/workspace/components/__tests__/workspace-setup.test.tsx
@@ -30,6 +30,7 @@ const {
       path: "/Users/pedro/Dev",
       parent: "/Users/pedro",
       home: "/Users/pedro",
+      roots: ["/"],
       entries: [
         { name: "checkout-platform", path: "/Users/pedro/Dev/checkout-platform", is_dir: true },
         { name: "billing", path: "/Users/pedro/Dev/billing", is_dir: true },

--- a/web/src/systems/workspace/components/stories/workspace-setup.stories.tsx
+++ b/web/src/systems/workspace/components/stories/workspace-setup.stories.tsx
@@ -84,7 +84,12 @@ const browseLoading = storybookMswParameters({
   workspace: [
     compozyApiMock.get("/api/fs/browse", async () => {
       await delay("infinite");
-      return HttpResponse.json({ entries: [], home: "/Users/pedro", path: "/Users/pedro" });
+      return HttpResponse.json({
+        entries: [],
+        home: "/Users/pedro",
+        path: "/Users/pedro",
+        roots: ["/"],
+      });
     }),
   ],
 });
@@ -97,6 +102,7 @@ const browseEmpty = storybookMswParameters({
         home: "/Users/pedro",
         parent: "/Users",
         path: "/Users/pedro",
+        roots: ["/"],
       })
     ),
   ],

--- a/web/src/systems/workspace/components/workspace-setup-location-pane.tsx
+++ b/web/src/systems/workspace/components/workspace-setup-location-pane.tsx
@@ -100,6 +100,7 @@ export function WorkspaceSetupLocationPane({ setup, size }: WorkspaceSetupLocati
               onPick={setup.selectRoot}
               parentPath={setup.browse.parentPath}
               pickRowLabel={name => `Use ${name} as the workspace root`}
+              roots={setup.browse.roots}
               testIdPrefix="workspace-setup-browser"
             />
           </div>

--- a/web/src/systems/workspace/hooks/use-workspace-setup-content.ts
+++ b/web/src/systems/workspace/hooks/use-workspace-setup-content.ts
@@ -168,6 +168,7 @@ export function useWorkspaceSetupContent({
       currentPath: browseData?.path ?? browsePath,
       parentPath: browseData?.parent ?? null,
       homePath: browseData?.home ?? null,
+      roots: browseData?.roots ?? [],
       entries: browseData?.entries ?? [],
       isBrowsing: browse.isLoading || browse.isFetching,
       browseError: browse.error


### PR DESCRIPTION
## Summary

Resolve five open desktop and session usability issues as one cross-surface change:

- contain runtime-model scrolling inside the selector popup, including at both wheel boundaries;
- expose operating-system filesystem roots from the daemon and make them navigable in workspace/onboarding pickers;
- add durable, workspace-scoped user-session rename across Web, CLI, HTTP, UDS, and the native-tool surface;
- enable standard page-zoom shortcuts only for the Tauri main window and loopback daemon origins;
- keep tiled windows below shared resize seams while every floating window remains above them.

## Root-cause fixes

### Runtime selector scrolling

The model list is now the real bounded scroll owner and uses `overscroll-behavior: contain`, so wheel input at either end cannot escape into the desktop behind the popup.

### Filesystem roots

`GET /api/fs/browse` now returns daemon-owned roots alongside directory entries. Unix reports `/`; Windows discovers logical drives through the operating system. The shared directory browser renders these roots as Locations, without browser-side path guesses or config fallbacks.

### Durable session rename

Renames validate and normalize a user-session display name, enforce workspace ownership, and persist active, stopped, and archived sessions without changing identity, transcript, runtime, archive metadata, lineage, or ownership. The same contract ships through:

- `PATCH /api/workspaces/{workspace_id}/sessions/{session_id}` over HTTP and UDS;
- `compozy session rename <id> <name>`;
- `compozy__session_rename` in the sessions toolset;
- row actions and session topbar overflow in Web.

Generated OpenAPI/TypeScript contracts, CLI docs, native-tool catalog, and the official Compozy skill references are updated in the same commit.

### Desktop page zoom

Tauri's standard WebView zoom hotkeys are enabled, with a dedicated capability restricted to the `main` window and loopback daemon origins. The in-product single-window Zoom action remains a separate layout command.

### Window visual ordering

Visual layer is derived from semantic placement: tiled windows use layer 1, shared seams layer 2, and floating windows start above both before applying focus order. This preserves uncovered seam interaction without allowing a seam to intercept a floating window.

## Verification

- `make gate-full` — PASS, current full `make verify` record (`2b4e627dce87e186362ba92cd2da74ab0a3f7736`)
- 21,519 Go tests passed under `-race`; 2 platform-only skips
- Bun formatting/lint, typecheck, tests, and builds passed
- Go lint, build, code generation, installer, product-language, source-size, and boundaries passed
- strict targeted QA evidence audit passed
- isolated QA teardown passed with `clean: true`

Real-user QA walked all five changed journeys in Web, CLI, API, runtime, and the native desktop shell. Evidence and debriefs are recorded in `docs/qa/reports/2026-08-11-open-issues.md`.

## Compozy Impact Audit

- Native tools: added `compozy__session_rename`, sessions toolset membership, descriptor/catalog metadata, runtime binding, capability coverage, and contract tests; no native-tool impact for scroll, roots, desktop zoom, or visual layers after checking their registries and descriptors.
- Extensibility and hooks: session rename is available through CLI/HTTP/UDS/native-tool extension surfaces and documented in `skills/compozy/`; no hook, bridge SDK, MCP sidecar, registry, or `config.toml` lifecycle changes. Filesystem roots extend the existing browse response without a new setting.
- Workspace data isolation: session names remain workspace-scoped; workspace id is enforced through HTTP/UDS/core/store/Web cache invalidation, with foreign-workspace rejection tests. Filesystem roots are global host metadata and contain no workspace/session data. The other fixes are client-local presentation behavior.
- Official Compozy skill: updated desktop, runtime-operations, and native-tools references for page zoom and session rename; no new skill entry point was needed.

Closes #341
Closes #342
Closes #344
Closes #345
Closes #346


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session renaming through the web interface, CLI, API, and native tools.
  * Added validation for session names, including trimming and a 64-character limit.
  * Added filesystem root locations to workspace and onboarding directory browsers.
  * Enabled webview zoom keyboard shortcuts.

* **Bug Fixes**
  * Improved window layering so floating windows appear correctly above tiled windows.
  * Prevented dismissal of sessions while rename or delete dialogs are active.
  * Improved cross-platform path handling and directory navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->