### PR TITLE
fix: recover canceled Loop coordinators on restart

### DIFF
--- a/docs/qa/charters/CH-loop-cancel-restart.md
+++ b/docs/qa/charters/CH-loop-cancel-restart.md
@@ -1,0 +1,27 @@
+# CH-loop-cancel-restart: Recover a canceled Loop coordinator on restart
+
+```yaml
+charter:
+  id: CH-loop-cancel-restart
+  mission: "As Bruno, cancel interrupted Loop work and restart the daemon until I can trust that damaged coordinator state cannot lock me out of every workspace."
+  mode: charter-with-tour
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-recover-loop-node-failure
+  scenarios: [LP-cancel-restart-recovers]
+  tour: Interrupt Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Remove each bound session before cancellation, then cancel the deterministic coordinator task while the Loop remains nonterminal."
+      - "Restart the daemon twice and use a fresh workspace read after each start to prove readiness rather than trusting the start command alone."
+      - "Repeat recovery after canceling the first recovered coordinator run and confirm exactly one new coordinator becomes available."
+      - "Check a foreign workspace read so repaired work never crosses its workspace boundary."
+    must_avoid:
+      - "Reading SQLite as verdict evidence or repairing stored rows outside public CLI and HTTP surfaces."
+```
+
+<!-- The charter is durable and immutable: each run's debrief belongs in its dated report. -->

--- a/docs/qa/reports/2026-08-12-issue-348-loop-cancel-restart.md
+++ b/docs/qa/reports/2026-08-12-issue-348-loop-cancel-restart.md
@@ -1,0 +1,79 @@
+# QA Run Report — 2026-08-12 — Issue 348 Loop Cancel Restart
+
+- **Scope:** Targeted branch QA for missing-session Loop cancellation, canceled coordinator repair, daemon restart readiness, and workspace-read canary behavior.
+- **Cadence tier:** targeted
+- **Build:** `v0.3.0-beta.13-3-g7fc534a0-dirty` · **Environment:** fresh isolated daemon at `http://127.0.0.1:63558`, isolated UDS and runtime home, deterministic ACP provider
+- **Started:** 2026-08-12T03:51:29Z · **Status:** complete
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-loop-cancel-restart |
+
+## Flows in Scope
+
+- `J-recover-loop-node-failure` — interrupt Loop work, recover its coordinator, and keep the daemon usable after restart (`../journeys/J-recover-loop-node-failure.md`)
+- Adjacent canary: list the affected and a foreign workspace after each restart so readiness and isolation are independently observable.
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-loop-cancel-restart | J-recover-loop-node-failure / LP-cancel-restart-recovers | Bruno | Interrupt Tour | Pass | #348 | this PR |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-loop-cancel-restart — Bruno
+
+- **Ran:** 2026-08-12T03:51:29Z → 2026-08-12T03:57:25Z (box respected: yes)
+- **Findings:** The fixed build accepted cancellation after one bound ACP session was removed, repaired a canceled coordinator on boot, and preserved one open recovery run across an immediate second restart. Repeating the coordinator cancellation created one new causal recovery run and remained idempotent on the next restart.
+- **Bugs filed/updated:** Existing GitHub issue #348; no new QA registry bug.
+- **Scenarios settled:** LP-cancel-restart-recovers → pass
+- **Paper cuts:** `task inspect` rejects deterministic `loop.*` task ids, but `task get` and the documented HTTP task route expose the required state; recorded as an adjacent observation, not a failure of this journey.
+- **Surprises:** The CLI start path identifies as UDS, so the lab Loop needed to declare `start: uds`. The public task catalog presents a repaired task with an open queued run as `ready`; its event history exposes the persisted `canceled → in_progress` repair.
+- **Suggested next charter:** Re-run the broad `CH-003` Cancel/Kill UI charter when a Web surface changes; this backend-only fix did not change Web controls or payloads.
+
+## What Was Fixed
+
+### GitHub issue #348: daemon boot fails on canceled Loop coordinator
+
+- **Symptom:** Missing cancellation sessions left a nonterminal Loop with a canceled reusable coordinator task, causing every daemon start to fail before readiness.
+- **Root cause:** Canceled coordinator pulses were projected as task cancellation, boot recovery reused a terminal reservation identity, and the daemon treated a missing session as failed delivery.
+- **Fix:** This PR repairs only nonterminal Loop coordinator tasks, reserves causally distinct recovery runs, and treats only `session.ErrSessionNotFound` as already stopped.
+- **Regression test:** Canonical task-policy, task-catalog, Loop cancellation/boot, and daemon adapter suites; focused race-enabled runs passed before this session.
+- **Retested:** `J-recover-loop-node-failure` through public CLI, HTTP, UDS, runtime, scheduler, task, session, Loop, and ACP subprocess surfaces.
+
+## Paper Cuts
+
+None.
+
+## Runtime Errors Observed
+
+The attempted `task inspect loop.LOOP_RUN_ID.coordinator` returned the expected diagnostic that `inspect` accepts only `task_*`/`task-*` and `run_*`/`run-*` identifiers. The session continued through the public `task get` and HTTP task routes; no daemon error occurred.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- Journey and functional coverage are owned by the restart walk and fresh structured reads.
+- The Interrupt Tour covers absent sessions, repeated restart, repeated coordinator cancellation, and recovery continuity.
+- Workspace isolation is checked with affected and foreign workspace reads; browser, mobile, locale, and visual compatibility are deliberately out of scope because this diff changes no Web or copy surface.
+- Public evidence: `/Users/pedronauck/dev/qa-labs/compozy-issue-348-loop-cancel-restart-20260812-034715-623464-lab/qa-artifacts/qa/behavioral-evidence.md`.
+- Teardown evidence: `/Users/pedronauck/dev/qa-labs/compozy-issue-348-loop-cancel-restart-20260812-034715-623464-lab/qa-artifacts/qa/teardown.json` reports `clean: true` with no survivors.
+- Production-parity qualification: the provider is the repository's deterministic ACP mock. All affected runtime paths are real; external model output is not part of the cancellation/boot contract.
+
+## Final Status
+
+- **Exit gate (full automated suite):** `make gate` escalates to the full `make verify` suite for the SQL change; PASS evidence is copied to `/Users/pedronauck/dev/qa-labs/compozy-issue-348-loop-cancel-restart-20260812-034715-623464-lab/qa-artifacts/qa/final-make-verify.log`, and the content-keyed record is reported by `make gate-status`.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 journeys walked; affected and foreign workspace reads passed
+- **Verdict:** PASS — the missing-session cancellation and repeated restart walk passed, teardown is clean, and the full automated suite passed for the final tracked content.

--- a/docs/qa/scenarios/LP-cancel-restart-recovers.md
+++ b/docs/qa/scenarios/LP-cancel-restart-recovers.md
@@ -1,0 +1,19 @@
+---
+id: LP-cancel-restart-recovers
+area: LP
+title: Recover a canceled Loop coordinator during daemon restart
+persona: Bruno
+journey: J-recover-loop-node-failure
+expected: Cancel remains idempotent when bound sessions are already absent, and a canceled coordinator task is repaired without preventing the daemon from becoming ready after every restart.
+entry_points: `compozy loop cancel`; `compozy session remove`; `compozy task cancel`; `compozy daemon stop|start`; structured CLI reads
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-348-loop-cancel-restart-20260812-034715-623464-lab/qa-artifacts/qa/behavioral-evidence.md;/Users/pedronauck/dev/qa-labs/compozy-issue-348-loop-cancel-restart-20260812-034715-623464-lab/qa-artifacts/qa/teardown.json
+last_report: docs/qa/reports/2026-08-12-issue-348-loop-cancel-restart.md
+overlaps: LP-cancel-vs-kill
+---
+
+acceptance-walk: Start an active Loop, remove its bound sessions, request cooperative cancellation, and cancel the deterministic coordinator task before restarting the daemon twice. Confirm every start reaches readiness, cancellation reconciliation does not fail on the missing sessions, one replacement coordinator is reserved at a time, and fresh structured reads keep the Loop, task, and workspace in the correct workspace.

--- a/internal/daemon/loop_api_service.go
+++ b/internal/daemon/loop_api_service.go
@@ -162,14 +162,7 @@ func loopAPIServiceOptions(
 		looppkg.WithGoalRunActivator(loopGoalRunActivator{state: state}),
 		looppkg.WithCoordinatorRunActivator(loopCoordinatorRunActivator{state: state}),
 		looppkg.WithRuntimeCatalog(runtimeCatalog),
-		looppkg.WithCancellationSessionController(looppkg.CancellationSessionControllerFuncs{
-			Cancel: func(ctx context.Context, sessionID, _ string) error {
-				return state.sessions.CancelPrompt(ctx, sessionID)
-			},
-			Kill: func(ctx context.Context, sessionID, reason string) error {
-				return state.sessions.StopWithCause(ctx, sessionID, session.CauseUserRequested, reason)
-			},
-		}),
+		looppkg.WithCancellationSessionController(loopCancellationSessionController{sessions: state.sessions}),
 	}
 	if state.participationResolver != nil {
 		options = append(options, looppkg.WithParticipationResolver(state.participationResolver))

--- a/internal/daemon/loop_goal_managed_runtime_integration_test.go
+++ b/internal/daemon/loop_goal_managed_runtime_integration_test.go
@@ -142,11 +142,7 @@ func TestLoopGoalManagedRuntimeIntegration(t *testing.T) {
 			),
 			managedTestGoalRunPolicyResolver(),
 			looppkg.WithClock(time.Now),
-			looppkg.WithCancellationSessionController(looppkg.CancellationSessionControllerFuncs{
-				Cancel: func(ctx context.Context, id string, _ string) error {
-					return fixture.manager.CancelPrompt(ctx, id)
-				},
-			}),
+			looppkg.WithCancellationSessionController(loopCancellationSessionController{sessions: fixture.manager}),
 		)
 		if err != nil {
 			t.Fatalf("loop.NewService() error = %v", err)
@@ -279,11 +275,7 @@ func TestLoopGoalManagedRuntimeIntegration(t *testing.T) {
 			managedTestGoalRunPolicyResolver(),
 			looppkg.WithClock(time.Now),
 			looppkg.WithGoalPromptLeaseRevoker(loopGoalPromptLeaseRevoker{sessions: fixture.manager}),
-			looppkg.WithCancellationSessionController(looppkg.CancellationSessionControllerFuncs{
-				Cancel: func(ctx context.Context, id string, _ string) error {
-					return fixture.manager.CancelPrompt(ctx, id)
-				},
-			}),
+			looppkg.WithCancellationSessionController(loopCancellationSessionController{sessions: fixture.manager}),
 		)
 		if err != nil {
 			t.Fatalf("loop.NewService() error = %v", err)

--- a/internal/daemon/loop_runtime_adapters.go
+++ b/internal/daemon/loop_runtime_adapters.go
@@ -34,6 +34,33 @@ type loopJudgeSessionManager interface {
 	StopWithCause(ctx context.Context, id string, cause session.StopCause, detail string) error
 }
 
+type loopCancellationSessionManager interface {
+	CancelPrompt(context.Context, string) error
+	StopWithCause(context.Context, string, session.StopCause, string) error
+}
+
+type loopCancellationSessionController struct {
+	sessions loopCancellationSessionManager
+}
+
+var _ looppkg.CancellationSessionController = loopCancellationSessionController{}
+
+func (c loopCancellationSessionController) CancelLoopSession(ctx context.Context, id, _ string) error {
+	err := c.sessions.CancelPrompt(ctx, id)
+	if errors.Is(err, session.ErrSessionNotFound) {
+		return nil
+	}
+	return err
+}
+
+func (c loopCancellationSessionController) KillLoopSession(ctx context.Context, id, reason string) error {
+	err := c.sessions.StopWithCause(ctx, id, session.CauseUserRequested, reason)
+	if errors.Is(err, session.ErrSessionNotFound) {
+		return nil
+	}
+	return err
+}
+
 type loopGateJudgeRunner struct {
 	sessions            loopJudgeSessionManager
 	globalWorkspacePath string

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -75,6 +75,12 @@ func TestLoopCancellationSessionControllerShouldTreatMissingSessionsAsStopped(t 
 				if !slices.Equal(sessions.stopIDs, []string{"sess-cancel"}) {
 					t.Fatalf("StopWithCause session ids = %#v, want one exact session", sessions.stopIDs)
 				}
+				if !slices.Equal(sessions.stopCauses, []session.StopCause{session.CauseUserRequested}) {
+					t.Fatalf("StopWithCause causes = %#v, want user requested", sessions.stopCauses)
+				}
+				if !slices.Equal(sessions.stopDetails, []string{"operator request"}) {
+					t.Fatalf("StopWithCause details = %#v, want exact operator detail", sessions.stopDetails)
+				}
 				return
 			}
 			if !slices.Equal(sessions.cancelIDs, []string{"sess-cancel"}) {
@@ -990,6 +996,8 @@ type loopActionBinderSessionManager struct {
 	promptCalls              []session.PromptOpts
 	cancelIDs                []string
 	stopIDs                  []string
+	stopCauses               []session.StopCause
+	stopDetails              []string
 	stopSawCanceledContexts  []bool
 }
 
@@ -1111,12 +1119,14 @@ func (m *loopActionBinderSessionManager) CancelPrompt(_ context.Context, id stri
 func (m *loopActionBinderSessionManager) StopWithCause(
 	ctx context.Context,
 	id string,
-	_ session.StopCause,
-	_ string,
+	cause session.StopCause,
+	detail string,
 ) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stopIDs = append(m.stopIDs, id)
+	m.stopCauses = append(m.stopCauses, cause)
+	m.stopDetails = append(m.stopDetails, detail)
 	m.stopSawCanceledContexts = append(m.stopSawCanceledContexts, ctx.Err() != nil)
 	return m.stopErr
 }

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -22,6 +22,68 @@ import (
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 )
 
+func TestLoopCancellationSessionControllerShouldTreatMissingSessionsAsStopped(t *testing.T) {
+	t.Parallel()
+
+	operationErr := errors.New("session operation failed")
+	tests := []struct {
+		name    string
+		kill    bool
+		err     error
+		wantErr error
+	}{
+		{
+			name: "Should accept a missing prompt session as already canceled",
+			err:  fmt.Errorf("missing prompt session: %w", session.ErrSessionNotFound),
+		},
+		{
+			name: "Should accept a missing process session as already killed",
+			kill: true,
+			err:  fmt.Errorf("missing process session: %w", session.ErrSessionNotFound),
+		},
+		{
+			name:    "Should propagate prompt cancellation failures",
+			err:     operationErr,
+			wantErr: operationErr,
+		},
+		{
+			name:    "Should propagate process stop failures",
+			kill:    true,
+			err:     operationErr,
+			wantErr: operationErr,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			sessions := &loopActionBinderSessionManager{cancelErr: test.err, stopErr: test.err}
+			controller := loopCancellationSessionController{sessions: sessions}
+			var err error
+			if test.kill {
+				err = controller.KillLoopSession(t.Context(), "sess-cancel", "operator request")
+			} else {
+				err = controller.CancelLoopSession(t.Context(), "sess-cancel", "operator request")
+			}
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("session cancellation error = %v, want %v", err, test.wantErr)
+			}
+
+			sessions.mu.Lock()
+			defer sessions.mu.Unlock()
+			if test.kill {
+				if !slices.Equal(sessions.stopIDs, []string{"sess-cancel"}) {
+					t.Fatalf("StopWithCause session ids = %#v, want one exact session", sessions.stopIDs)
+				}
+				return
+			}
+			if !slices.Equal(sessions.cancelIDs, []string{"sess-cancel"}) {
+				t.Fatalf("CancelPrompt session ids = %#v, want one exact session", sessions.cancelIDs)
+			}
+		})
+	}
+}
+
 func TestLoopActionSessionBinderShouldApplyPolicyGate(t *testing.T) {
 	t.Parallel()
 
@@ -917,6 +979,7 @@ type loopActionBinderSessionManager struct {
 	createReleased           chan struct{}
 	createCanceled           chan struct{}
 	promptErr                error
+	cancelErr                error
 	stopErr                  error
 	events                   []acp.AgentEvent
 	blockPromptUntilCancel   bool
@@ -1042,7 +1105,7 @@ func (m *loopActionBinderSessionManager) CancelPrompt(_ context.Context, id stri
 	if released != nil {
 		m.promptReleaseOnce.Do(func() { close(released) })
 	}
-	return nil
+	return m.cancelErr
 }
 
 func (m *loopActionBinderSessionManager) StopWithCause(

--- a/internal/store/globaldb/global_db_loop_coordinator_seed.go
+++ b/internal/store/globaldb/global_db_loop_coordinator_seed.go
@@ -109,6 +109,43 @@ func (g *LoopRepo) ensureLoopCoordinatorTaskWithExecutor(
 	return taskID, nil
 }
 
+func (g *LoopRepo) repairLoopCoordinatorTaskWithExecutor(
+	ctx context.Context,
+	exec taskSQLExecutor,
+	run looppkg.Run,
+	taskID string,
+	now time.Time,
+) error {
+	expectedTaskID := loopCoordinatorTaskID(run.ID)
+	if strings.TrimSpace(taskID) != expectedTaskID {
+		return fmt.Errorf(
+			"%w: coordinator task %q does not own loop run %q",
+			taskpkg.ErrValidation,
+			taskID,
+			run.ID,
+		)
+	}
+	taskRecord, err := g.tasks.getTaskWithExecutor(ctx, exec, expectedTaskID)
+	if err != nil {
+		return err
+	}
+	if taskRecord.Status.Normalize() != taskpkg.TaskStatusCanceled || run.Status.Terminal() {
+		return nil
+	}
+	taskRecord.Status = taskpkg.TaskStatusInProgress
+	taskRecord.UpdatedAt = now.UTC()
+	taskRecord.ClosedAt = time.Time{}
+	actor := taskpkg.ActorContext{
+		Actor:     taskRecord.CreatedBy,
+		Origin:    taskRecord.Origin,
+		Authority: taskpkg.FullAccessAuthority(),
+	}
+	if err := g.tasks.updateTaskWithExecutor(ctx, exec, taskRecord, actor); err != nil {
+		return fmt.Errorf("store: reactivate loop coordinator task %q: %w", expectedTaskID, err)
+	}
+	return nil
+}
+
 func loopCoordinatorTaskRecordForRun(run looppkg.Run, taskID string, now time.Time) taskpkg.Task {
 	origin := loopCoordinatorStartOrigin()
 	return taskpkg.Task{
@@ -141,6 +178,19 @@ func loopCoordinatorRunID(loopRunID looppkg.RunID, generation int) string {
 
 func loopCoordinatorIdempotencyKey(loopRunID looppkg.RunID, generation int) string {
 	return fmt.Sprintf("loop.coordinator.%s.%d", strings.TrimSpace(string(loopRunID)), generation)
+}
+
+func loopCoordinatorRecoveryIdempotencyKey(
+	loopRunID looppkg.RunID,
+	generation int,
+	previousRunID string,
+) string {
+	return fmt.Sprintf(
+		"loop.coordinator.recovery.%s.%d.%s",
+		strings.TrimSpace(string(loopRunID)),
+		generation,
+		strings.TrimSpace(previousRunID),
+	)
 }
 
 func loopCoordinatorStartOrigin() taskpkg.Origin {

--- a/internal/store/globaldb/global_db_loop_reconcile_queries.go
+++ b/internal/store/globaldb/global_db_loop_reconcile_queries.go
@@ -61,14 +61,18 @@ func (g *LoopRepo) reconcileMissingRunningLoopCoordinators(
 			return nil, err
 		}
 		generation := candidate.generation + 1
+		previousRunID, err := lastCoordinatorRunIDForLoopRun(ctx, exec, string(current.ID))
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
 		run, added, err := g.reserveLoopCoordinatorRunWithExecutor(
 			ctx,
 			exec,
 			current,
 			origin,
 			now,
-			loopCoordinatorRunID(current.ID, generation),
-			loopCoordinatorIdempotencyKey(current.ID, generation),
+			"",
+			loopCoordinatorRecoveryIdempotencyKey(current.ID, generation, previousRunID),
 		)
 		if err != nil {
 			return nil, err
@@ -159,6 +163,9 @@ func (g *LoopRepo) reserveCoordinatorRun(
 	if err != nil {
 		return taskpkg.Run{}, false, err
 	}
+	if err := g.repairLoopCoordinatorTaskWithExecutor(ctx, exec, loopRun, taskID, now); err != nil {
+		return taskpkg.Run{}, false, err
+	}
 	reservation := queuedRunReservationInput{
 		taskID:         taskID,
 		runID:          reservedRunID,
@@ -228,6 +235,21 @@ func lastCoordinatorTaskIDForLoopRun(
 		return "", fmt.Errorf("store: find coordinator task for loop run %q: %w", loopRunID, err)
 	}
 	return taskNullStringValue(taskID), nil
+}
+
+func lastCoordinatorRunIDForLoopRun(
+	ctx context.Context,
+	exec taskSQLExecutor,
+	loopRunID string,
+) (string, error) {
+	runID, err := sqlcgen.New(exec).GetLastCoordinatorRunIDForLoopRun(ctx, nullString(loopRunID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", err
+		}
+		return "", fmt.Errorf("store: find last coordinator run for loop run %q: %w", loopRunID, err)
+	}
+	return strings.TrimSpace(runID), nil
 }
 
 func errorsIsNoRows(err error) bool {

--- a/internal/store/globaldb/global_db_loop_test.go
+++ b/internal/store/globaldb/global_db_loop_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/compozy/compozy/internal/api/contract"
+	hookspkg "github.com/compozy/compozy/internal/hooks"
 	looppkg "github.com/compozy/compozy/internal/loop"
 	"github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/compozy/compozy/internal/loop/gate"
@@ -583,6 +584,154 @@ func TestGlobalDBLoopRunCancellationShouldFenceBeforeTerminalizing(t *testing.T)
 			}
 		})
 	}
+
+	t.Run("Should repair a canceled coordinator task and replay boot reconciliation once", func(t *testing.T) {
+		t.Parallel()
+
+		db := openLoopTestGlobalDB(t)
+		ctx := testutil.Context(t)
+		repairAt := now.Add(10 * time.Minute)
+		cancelingRun, liveTaskRunID := seedLiveLoopLivenessCellForTest(t, db, repairAt)
+		if strings.TrimSpace(liveTaskRunID) == "" {
+			t.Fatal("seedLiveLoopLivenessCellForTest() task run id is empty")
+		}
+		cancelMutation := looppkg.CancellationMutation{
+			WorkspaceID: cancelingRun.WorkspaceID,
+			RunID:       cancelingRun.ID,
+			Kind:        looppkg.RunCancelCancel,
+			Reason:      "operator request",
+			Actor:       operatorActorContextForTest("operator:repair-cancel"),
+			RequestedAt: repairAt.Add(time.Minute),
+		}
+		if result, err := db.RequestRunCancellation(ctx, cancelMutation); err != nil {
+			t.Fatalf("RequestRunCancellation() error = %v", err)
+		} else if !result.Applied || result.Terminal {
+			t.Fatalf("RequestRunCancellation() = %#v, want durable non-terminal request", result)
+		}
+
+		coordinatorTaskID := loopCoordinatorTaskID(cancelingRun.ID)
+		manager, err := taskpkg.NewManager(
+			taskpkg.WithStore(db),
+			taskpkg.WithManagerNow(func() time.Time { return repairAt.Add(2 * time.Minute) }),
+		)
+		if err != nil {
+			t.Fatalf("task.NewManager() error = %v", err)
+		}
+		canceledTask, err := manager.CancelTask(
+			ctx,
+			coordinatorTaskID,
+			taskpkg.CancelTask{Reason: "simulate canceled coordinator pulse"},
+			operatorActorContextForTest("operator:cancel-coordinator"),
+		)
+		if err != nil {
+			t.Fatalf("CancelTask(coordinator) error = %v", err)
+		}
+		if canceledTask.Status != taskpkg.TaskStatusCanceled {
+			t.Fatalf("canceled coordinator task status = %q, want canceled", canceledTask.Status)
+		}
+
+		origin := taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "daemon.boot"}
+		recovered, err := db.ReconcileLoopCoordinatorsOnBoot(ctx, origin, repairAt.Add(3*time.Minute))
+		if err != nil {
+			t.Fatalf("ReconcileLoopCoordinatorsOnBoot() error = %v", err)
+		}
+		if len(recovered) != 1 {
+			t.Fatalf("recovered coordinator runs = %#v, want one", recovered)
+		}
+		if recovered[0].TaskID != coordinatorTaskID ||
+			recovered[0].LoopRunID != string(cancelingRun.ID) ||
+			recovered[0].WorkspaceID != string(cancelingRun.WorkspaceID) ||
+			recovered[0].RunKind.Normalize() != taskpkg.RunKindCoordinator {
+			t.Fatalf("recovered coordinator = %#v, want exact workspace-scoped Loop coordinator", recovered[0])
+		}
+		repairedTask, err := db.GetTask(ctx, coordinatorTaskID)
+		if err != nil {
+			t.Fatalf("GetTask(repaired coordinator) error = %v", err)
+		}
+		if repairedTask.Status != taskpkg.TaskStatusInProgress {
+			t.Fatalf("repaired coordinator task status = %q, want in_progress", repairedTask.Status)
+		}
+		if !repairedTask.ClosedAt.IsZero() || !repairedTask.UpdatedAt.Equal(repairAt.Add(3*time.Minute)) {
+			t.Fatalf(
+				"repaired coordinator task timestamps = updated %s closed %s, want repair time and open task",
+				repairedTask.UpdatedAt,
+				repairedTask.ClosedAt,
+			)
+		}
+
+		replayed, err := db.ReconcileLoopCoordinatorsOnBoot(ctx, origin, repairAt.Add(4*time.Minute))
+		if err != nil {
+			t.Fatalf("ReconcileLoopCoordinatorsOnBoot(replay) error = %v", err)
+		}
+		if len(replayed) != 0 {
+			t.Fatalf("replayed coordinator runs = %#v, want no duplicate", replayed)
+		}
+		if _, err := manager.CancelRun(
+			ctx,
+			recovered[0].ID,
+			taskpkg.CancelRun{Reason: "simulate canceled recovery pulse"},
+			coordinatorActorContextForTest(),
+		); err != nil {
+			t.Fatalf("CancelRun(recovered coordinator) error = %v", err)
+		}
+		recoveredAgain, err := db.ReconcileLoopCoordinatorsOnBoot(ctx, origin, repairAt.Add(5*time.Minute))
+		if err != nil {
+			t.Fatalf("ReconcileLoopCoordinatorsOnBoot(after canceled recovery) error = %v", err)
+		}
+		if len(recoveredAgain) != 1 || recoveredAgain[0].ID == recovered[0].ID {
+			t.Fatalf("recovered coordinator after canceled recovery = %#v, want one new run", recoveredAgain)
+		}
+		replayedAgain, err := db.ReconcileLoopCoordinatorsOnBoot(ctx, origin, repairAt.Add(6*time.Minute))
+		if err != nil {
+			t.Fatalf("ReconcileLoopCoordinatorsOnBoot(second replay) error = %v", err)
+		}
+		if len(replayedAgain) != 0 {
+			t.Fatalf("second replay coordinator runs = %#v, want no duplicate", replayedAgain)
+		}
+
+		if _, err := db.AdvanceRunCancellation(ctx, cancelMutation, looppkg.CancelStateDelivering); err != nil {
+			t.Fatalf("AdvanceRunCancellation(delivering) error = %v", err)
+		}
+		draining, err := db.AdvanceRunCancellation(ctx, cancelMutation, looppkg.CancelStateDraining)
+		if err != nil {
+			t.Fatalf("AdvanceRunCancellation(draining) error = %v", err)
+		}
+		if draining.Coordinator == nil || draining.Coordinator.ID != recoveredAgain[0].ID {
+			t.Fatalf(
+				"draining coordinator = %#v, want recovered run %q",
+				draining.Coordinator,
+				recoveredAgain[0].ID,
+			)
+		}
+
+		statusEvents, err := db.ListTaskEvents(ctx, taskpkg.EventQuery{
+			TaskID: coordinatorTaskID, EventType: string(hookspkg.HookTaskStatusChanged),
+		})
+		if err != nil {
+			t.Fatalf("ListTaskEvents(status changed) error = %v", err)
+		}
+		repairEvents := 0
+		for _, event := range statusEvents {
+			var statusPayload struct {
+				FromStatus string `json:"from_status"`
+				ToStatus   string `json:"to_status"`
+			}
+			if err := json.Unmarshal(event.Payload, &statusPayload); err != nil {
+				t.Fatalf("json.Unmarshal(status changed payload) error = %v", err)
+			}
+			if statusPayload.FromStatus == string(taskpkg.TaskStatusCanceled) &&
+				statusPayload.ToStatus == string(taskpkg.TaskStatusInProgress) {
+				repairEvents++
+				if event.Actor.Kind.Normalize() != taskpkg.ActorKindDaemon ||
+					event.Origin.Kind.Normalize() != taskpkg.OriginKindDaemon {
+					t.Fatalf("repair event actor/origin = %#v/%#v, want daemon ownership", event.Actor, event.Origin)
+				}
+			}
+		}
+		if repairEvents != 1 {
+			t.Fatalf("canceled to in_progress repair events = %d, want one", repairEvents)
+		}
+	})
 }
 
 // Invariant: node cancellation fences only that node, delivers only its managed session,

--- a/internal/store/globaldb/global_db_task_catalog_sql.go
+++ b/internal/store/globaldb/global_db_task_catalog_sql.go
@@ -201,7 +201,7 @@ catalog_derived AS (
 			WHEN COALESCE(rp.has_active, 0) = 1 THEN 'in_progress'
 			WHEN t.status IN ('completed', 'failed', 'canceled')
 				AND COALESCE(rp.has_queued_or_claimed, 0) = 0 THEN t.status
-			WHEN lt.status = 'completed'
+			WHEN lt.status IN ('completed', 'canceled')
 				AND lt.run_kind = 'coordinator'
 				AND COALESCE(rp.has_queued_or_claimed, 0) = 0 THEN 'in_progress'
 			WHEN lt.status = 'completed' AND COALESCE(rp.has_queued_or_claimed, 0) = 0 THEN 'completed'

--- a/internal/store/globaldb/global_db_task_test.go
+++ b/internal/store/globaldb/global_db_task_test.go
@@ -1716,7 +1716,7 @@ func TestGlobalDBListTasksSearchAndActivityOrdering(t *testing.T) {
 }
 
 // Invariant: the catalog SQL derivation mirrors taskStatusFromPolicySnapshot —
-// a completed coordinator pulse keeps the umbrella task in_progress, and an
+// completed and canceled coordinator pulses keep the umbrella task in_progress, and an
 // explicitly closed task keeps its persisted terminal status.
 func TestGlobalDBTaskCatalogCoordinatorPulseStaysInProgress(t *testing.T) {
 	t.Parallel()
@@ -1753,7 +1753,7 @@ func TestGlobalDBTaskCatalogCoordinatorPulseStaysInProgress(t *testing.T) {
 		}
 	}
 
-	t.Run("Should keep the umbrella task in progress after a completed coordinator pulse", func(t *testing.T) {
+	t.Run("Should keep the umbrella task in progress after coordinator pulses", func(t *testing.T) {
 		t.Parallel()
 
 		globalDB := openTestGlobalDB(t)
@@ -1770,12 +1770,38 @@ func TestGlobalDBTaskCatalogCoordinatorPulseStaysInProgress(t *testing.T) {
 			ctx, t, globalDB, "run-pulse-2", umbrella.ID, "coordinator", "completed", 2, now.Add(time.Minute),
 		)
 
+		canceledUmbrella := taskRecordForTest("task-catalog-coordinator-canceled")
+		canceledUmbrella.Status = taskpkg.TaskStatusInProgress
+		if err := globalDB.CreateTask(ctx, canceledUmbrella); err != nil {
+			t.Fatalf("CreateTask(canceled umbrella) error = %v", err)
+		}
+		insertCatalogRun(
+			ctx,
+			t,
+			globalDB,
+			"run-pulse-canceled",
+			canceledUmbrella.ID,
+			"coordinator",
+			"canceled",
+			3,
+			now.Add(2*time.Minute),
+		)
+
 		worker := taskRecordForTest("task-catalog-worker")
 		worker.Status = taskpkg.TaskStatusInProgress
 		if err := globalDB.CreateTask(ctx, worker); err != nil {
 			t.Fatalf("CreateTask(worker) error = %v", err)
 		}
 		insertCatalogRun(ctx, t, globalDB, "run-worker-1", worker.ID, "worker", "completed", 1, now)
+
+		canceledWorker := taskRecordForTest("task-catalog-worker-canceled")
+		canceledWorker.Status = taskpkg.TaskStatusInProgress
+		if err := globalDB.CreateTask(ctx, canceledWorker); err != nil {
+			t.Fatalf("CreateTask(canceled worker) error = %v", err)
+		}
+		insertCatalogRun(
+			ctx, t, globalDB, "run-worker-canceled", canceledWorker.ID, "worker", "canceled", 1, now,
+		)
 
 		closed := taskRecordForTest("task-catalog-closed")
 		closed.Status = taskpkg.TaskStatusCompleted
@@ -1798,8 +1824,14 @@ func TestGlobalDBTaskCatalogCoordinatorPulseStaysInProgress(t *testing.T) {
 		if got := statusByID[umbrella.ID]; got != taskpkg.TaskStatusInProgress {
 			t.Fatalf("coordinator umbrella status = %q, want in_progress from a completed pulse", got)
 		}
+		if got := statusByID[canceledUmbrella.ID]; got != taskpkg.TaskStatusInProgress {
+			t.Fatalf("canceled coordinator umbrella status = %q, want in_progress from a canceled pulse", got)
+		}
 		if got := statusByID[worker.ID]; got != taskpkg.TaskStatusCompleted {
 			t.Fatalf("worker status = %q, want completed from its terminal run", got)
+		}
+		if got := statusByID[canceledWorker.ID]; got != taskpkg.TaskStatusCanceled {
+			t.Fatalf("canceled worker status = %q, want canceled from its terminal run", got)
 		}
 		if got := statusByID[closed.ID]; got != taskpkg.TaskStatusCompleted {
 			t.Fatalf("closed umbrella status = %q, want persisted completed", got)

--- a/internal/store/globaldb/queries/loop_runtime.sql
+++ b/internal/store/globaldb/queries/loop_runtime.sql
@@ -78,6 +78,11 @@ SELECT task_id FROM task_runs
 WHERE loop_run_id = sqlc.arg(loop_run_id) AND run_kind = 'coordinator'
 ORDER BY queued_at DESC, id DESC LIMIT 1;
 
+-- name: GetLastCoordinatorRunIDForLoopRun :one
+SELECT id FROM task_runs
+WHERE loop_run_id = sqlc.arg(loop_run_id) AND run_kind = 'coordinator'
+ORDER BY queued_at DESC, id DESC LIMIT 1;
+
 -- name: GetLastLoopTokenTick :one
 SELECT payload_json, at FROM loop_run_events
 WHERE loop_run_id = sqlc.arg(loop_run_id) AND kind = sqlc.arg(kind)

--- a/internal/store/globaldb/sqlcgen/loop_runtime.sql.go
+++ b/internal/store/globaldb/sqlcgen/loop_runtime.sql.go
@@ -90,6 +90,19 @@ func (q *Queries) CompareAndSwapLoopRunStatus(ctx context.Context, arg CompareAn
 	return result.RowsAffected()
 }
 
+const getLastCoordinatorRunIDForLoopRun = `-- name: GetLastCoordinatorRunIDForLoopRun :one
+SELECT id FROM task_runs
+WHERE loop_run_id = ?1 AND run_kind = 'coordinator'
+ORDER BY queued_at DESC, id DESC LIMIT 1
+`
+
+func (q *Queries) GetLastCoordinatorRunIDForLoopRun(ctx context.Context, loopRunID sql.NullString) (string, error) {
+	row := q.db.QueryRowContext(ctx, getLastCoordinatorRunIDForLoopRun, loopRunID)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getLastCoordinatorTaskIDForLoopRun = `-- name: GetLastCoordinatorTaskIDForLoopRun :one
 SELECT task_id FROM task_runs
 WHERE loop_run_id = ?1 AND run_kind = 'coordinator'

--- a/internal/task/manager_reconcile_status.go
+++ b/internal/task/manager_reconcile_status.go
@@ -300,7 +300,7 @@ func taskRunPolicyState(runs []Run) taskRunPolicySnapshot {
 func taskStatusFromTerminalRun(run Run, attemptsExhausted bool) (Status, bool) {
 	switch run.Status.Normalize() {
 	case TaskRunStatusCompleted:
-		// A completed coordinator pulse is loop progress between boundaries, not
+		// A terminal coordinator pulse is loop progress between boundaries, not
 		// task completion; only the loop terminal closes the umbrella task.
 		if run.RunKind.Normalize() == RunKindCoordinator {
 			return TaskStatusInProgress, true
@@ -309,6 +309,9 @@ func taskStatusFromTerminalRun(run Run, attemptsExhausted bool) (Status, bool) {
 	case TaskRunStatusFailed:
 		return TaskStatusFailed, attemptsExhausted
 	case TaskRunStatusCanceled:
+		if run.RunKind.Normalize() == RunKindCoordinator {
+			return TaskStatusInProgress, true
+		}
 		return TaskStatusCanceled, true
 	default:
 		return "", false

--- a/internal/task/manager_test.go
+++ b/internal/task/manager_test.go
@@ -7221,6 +7221,18 @@ func TestTaskStatusFromPolicySnapshotPrecedence(t *testing.T) {
 			want: TaskStatusInProgress,
 		},
 		{
+			name:          "Should keep the umbrella task in progress after a canceled coordinator pulse",
+			currentStatus: TaskStatusInProgress,
+			runs: []Run{{
+				ID:       "run-coordinator-canceled-pulse",
+				RunKind:  RunKindCoordinator,
+				Status:   TaskRunStatusCanceled,
+				Attempt:  4,
+				QueuedAt: base,
+			}},
+			want: TaskStatusInProgress,
+		},
+		{
 			name:          "Should keep an explicitly closed coordinator task completed",
 			currentStatus: TaskStatusCompleted,
 			runs: []Run{{
@@ -7243,6 +7255,18 @@ func TestTaskStatusFromPolicySnapshotPrecedence(t *testing.T) {
 				QueuedAt: base,
 			}},
 			want: TaskStatusCompleted,
+		},
+		{
+			name:          "Should cancel a worker task from its canceled terminal run",
+			currentStatus: TaskStatusInProgress,
+			runs: []Run{{
+				ID:       "run-worker-canceled",
+				RunKind:  RunKindWorker,
+				Status:   TaskRunStatusCanceled,
+				Attempt:  1,
+				QueuedAt: base,
+			}},
+			want: TaskStatusCanceled,
 		},
 		{
 			name:              "Should keep exhausted failed terminal run above needs attention",

--- a/packages/site/content/docs/loops/running.mdx
+++ b/packages/site/content/docs/loops/running.mdx
@@ -84,7 +84,9 @@ paused` only at the boundary. Pause is hidden or disabled outside `running`.
 - **Resume** continues a paused (or pause-requested) run.
 - **Cancel run** cooperatively moves through request, delivery, and drain before ending `canceled`
   with cause `operator_cancel`. The request is durable: boot recovery and scheduler sweeps retry
-  interrupted delivery until the active worker acknowledges it and the run drains.
+  interrupted delivery until the active worker acknowledges it or its session is already absent,
+  then the run drains. If a canceled coordinator task belongs to a nonterminal Loop, recovery
+  reopens that task and reserves one replacement coordinator run.
 - **Kill run** immediately fences stale work and ends `canceled` with cause `operator_kill`. It is
   destructive and never happens as a hidden escalation from Cancel.
 

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -221,7 +221,9 @@ find workspace-scoped cells. Pages default to 50 and cap at 200; narrow with Loo
 the exact run/node/item identity with node pause (`drain|cancel`), resume
 (`plain|reset_attempts|immediate`, optional manual-wait payload), cancel, kill, or requeue. Requeue is
 quarantine-only and creates a bounded successor generation. Cancel is cooperative; Kill fences
-immediately. Run cancel/kill both end `canceled` with distinct operator causes.
+immediately. A missing managed session is already stopped for cancellation delivery. Recovery
+reopens a canceled coordinator task only while its Loop remains nonterminal, then reserves one
+replacement coordinator run. Run cancel/kill both end `canceled` with distinct operator causes.
 
 Silence raises attention and never auto-kills or auto-pauses. Confirmed process/transport death may
 resume from progress through the bounded death-streak authority; parked nodes are never


### PR DESCRIPTION
## Summary

- Restarts no longer fail when a nonterminal Loop owns a canceled coordinator task or when cancellation reaches an already-removed managed session.
- Recovery reopens only the Loop-owned coordinator task, creates one causal replacement run, and remains idempotent across repeated boot and scheduler reconciliation.
- Public Loop guidance and the official Compozy skill now describe the missing-session and restart-recovery boundaries.

## Root cause

Cancellation could leave three durable facts out of agreement: the Loop remained nonterminal, its reusable coordinator task was `canceled`, and one or more managed sessions had already disappeared. Boot reconciliation correctly detected that the Loop still needed a coordinator, but reservation reused the closed task and failed with `task: invalid status transition` before daemon readiness. The daemon adapter also treated `session.ErrSessionNotFound` as failed delivery, so the cancellation backstop kept revisiting a stop that had already happened.

## Changes

- **Task projection:** canceled coordinator pulses now keep the Loop umbrella task `in_progress`, matching completed coordinator pulses; canceled worker runs still cancel their tasks.
- **Coordinator recovery:** the shared reservation boundary atomically reopens a canceled coordinator task only for a nonterminal Loop, clears `closed_at`, records the normal `task.status_changed` event, and reserves one replacement run.
- **Idempotency:** recovery identities include the previous coordinator run, so replay reserves nothing while canceling that recovered pulse permits one causally new recovery.
- **Cancellation delivery:** a named daemon adapter treats only `session.ErrSessionNotFound` as already stopped and propagates every other cancel or kill error.
- **Documentation:** the Loop operations guide and `skills/compozy/references/loops.md` document absent-session delivery and restart repair.
- **QA:** adds a targeted restart charter, scenario tracker, and dated report covering repeated cancellation, four daemon starts, CLI/HTTP agreement, and a foreign-workspace isolation canary.

## Release Notes

### 🐛 Bug Fixes

- Recover canceled Loop coordinator tasks during daemon restart and treat already-absent managed sessions as stopped, preventing one damaged Loop from blocking daemon readiness.

## QA

**Final Status:** PASS — missing-session cancellation and repeated restart recovery passed; teardown is clean and the full automated suite is green.

**Coverage:** Bruno completed one Interrupt Tour across `J-recover-loop-node-failure`, including affected and foreign workspace reads through CLI, HTTP, UDS, runtime, scheduler, task, session, Loop, and deterministic ACP subprocess surfaces.

**Issues:** 0 new issues (Blocks-Completion: 0, Data-Loss: 0, Trust-Damage: 0, Friction: 0, Cosmetic: 0).

**Blocked / needs human:** None.

**Full report:** [`2026-08-12-issue-348-loop-cancel-restart.md`](docs/qa/reports/2026-08-12-issue-348-loop-cancel-restart.md)

## Compozy Impact Audit

- **Native tools:** no tool IDs, toolsets, descriptors, schemas, digests, risk flags, availability diagnostics, or capability gates changed. Existing Loop cancel and kill tools use the corrected backend behavior.
- **Extensibility and hooks:** no extension, bridge SDK, MCP sidecar, registry, resource, or config lifecycle changed. Repair uses the existing `task.status_changed` hook path, and Loop terminal delivery remains unchanged.
- **Workspace data isolation:** Loop, task, run, event, and cancellation data remain workspace-scoped. Recovery preserves the stored `workspace_id`; canonical store tests and the public foreign-workspace QA read prove no cross-workspace result is exposed through CLI, HTTP/UDS, or SSE-backed state.
- **Official Compozy skill:** `skills/compozy/references/loops.md` now tells agents that an absent managed session is already stopped and that only a nonterminal Loop can recover its canceled coordinator task.

## Web / Docs / Config impact

- No Web route, component, hook, DTO, OpenAPI contract, generated TypeScript contract, or settings surface changes.
- No `config.toml` key, default, apply lifecycle, schema migration, or storage migration changes.
- The public Loop guide changes because restart recovery is operator-visible. Historical release artifacts remain unchanged.

## Review remediation

- **CodeRabbit round 1:** one minor testing finding. Commit `2873ffa` now asserts the exact stop cause and detail forwarded by the daemon cancellation adapter; the focused race test and the full iteration gate passed.
- **CodeRabbit round 2:** approved on `2873ffa` with no new findings; the round 1 thread is resolved.

## Test plan

- [x] Task policy regression: `CGO_ENABLED=1 go test -race ./internal/task -run '^TestTaskStatusFromPolicySnapshotPrecedence$'`
- [x] Store regressions: race-enabled canonical Loop cancellation/recovery and task-catalog suites.
- [x] Daemon adapter regression: `CGO_ENABLED=1 go test -race ./internal/daemon -run '^TestLoopCancellationSessionControllerShouldTreatMissingSessionsAsStopped$'`
- [x] Goal-managed runtime integration: race-enabled `TestLoopGoalManagedRuntimeIntegration` cancellation paths.
- [x] Historical migration timeout canary passed alone in 22 seconds.
- [x] Iteration gates escalated to the full `make verify`: 21,511 tests passed, 2 expected skips, Web/Bun gates, Go lint, Go build, codegen checks, and package boundaries passed. The authoritative final content fingerprint is recorded by `make gate-status` after the closing gate.
- [x] Isolated public-interface QA passed; strict evidence audit has no blockers or warnings; `teardown.json` reports `clean: true` with no survivors.

Closes #348
