### PR TITLE
fix: prevent resolved clarification render loops

### DIFF
--- a/docs/design/opendesign/_done/session/SESSION-REDESIGN-SPEC.md
+++ b/docs/design/opendesign/_done/session/SESSION-REDESIGN-SPEC.md
@@ -122,7 +122,7 @@ From `UIMessagePart` / `SessionTimelineToolPart` / `ToolUseResult`:
 5. **Receipts are persistent rows** — permission/clarification outcomes stay outside turn
    folds (`isPersistentTurnRow` already does this — keep).
 6. Update `web/src/components/assistant-ui/timeline-row-estimates.ts` (trow ≈ 26px, marker ≈ 24px) and keep
-   `isRowUnchanged` in sync with new row fields.
+   `sessionRowEqual` in sync with new row fields.
 
 ## 6. Behaviors
 
@@ -270,7 +270,7 @@ repos are **visual-grammar references only** — Compozy's data layer (`UIMessag
 
 | Path | What it carries | Port? |
 |---|---|---|
-| `.resources/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts` | `MAX_VISIBLE_WORK_LOG_ENTRIES = 1` (:12) — t3code shows only the last live entry; `TIMELINE_CONTENT_MAX_WIDTH = 768` (:16) — the one-column premise; `computeMessageDurationStart` (:185); "Worked for ${duration}" derivation (:391); `deriveMessagesTimelineRows` (:405) with the hidden/visible slice for the "+N previous" overflow (:482–493); `computeStableMessagesTimelineRows` (:577) — the stable-row identity pattern our `isRowUnchanged` mirrors | pattern yes; our tail limit is `ACTIVE_WORK_VISIBLE_LIMIT = 4`, not 1 |
+| `.resources/t3code/apps/web/src/components/chat/MessagesTimeline.logic.ts` | `MAX_VISIBLE_WORK_LOG_ENTRIES = 1` (:12) — t3code shows only the last live entry; `TIMELINE_CONTENT_MAX_WIDTH = 768` (:16) — the one-column premise; `computeMessageDurationStart` (:185); "Worked for ${duration}" derivation (:391); `deriveMessagesTimelineRows` (:405) with the hidden/visible slice for the "+N previous" overflow (:482–493); `computeStableMessagesTimelineRows` (:577) — the semantic row-equality pattern our `sessionRowEqual` mirrors | pattern yes; our tail limit is `ACTIVE_WORK_VISIBLE_LIMIT = 4`, not 1 |
 | `.resources/t3code/apps/web/src/components/chat/MessagesTimeline.tsx` | fold row anchoring, `WorkingTimer`/`LiveElapsed` ticker components (comment :121 — elapsed handled outside React commits) | ticker discipline yes; minimap no |
 | `.resources/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts` + `MessagesTimeline.test.tsx` | test shapes for row derivation and folding | mirror the cases in `session-timeline.logic` suites |
 | `.resources/synara/apps/web/src/components/chat/MessagesTimeline.logic.ts` | `MAX_VISIBLE_WORK_LOG_ENTRIES = 6` (:23); `chunkCollapsedTurnItems` (:43) + `chunkWorkEntries` (:77) — consecutive-kind chunking; `planWorkEntryRenderChunks` (:103) / `capOpenWorkEntryRenderChunks` (:128) — live-tail capping; `findLastLiveWorkGroupId` (:174) — only the last live run stays open; live-turn header mirroring the settled fold (:244); `collapseSettledTurns` post-pass (:634, contract comment :691) — **collapse on settle, even mid-turn** | yes — this is the §5 grouping engine |
@@ -340,7 +340,7 @@ is `session.css` (class contracts in §2); token authority stays `packages/ui/sr
    `SessionTimelineToolPart`, `MIN_COLLAPSIBLE_TOOL_GROUP_SIZE = 2`. Add collapse-on-settle
    (synara `collapseSettledTurns` post-pass) and marker clustering (×N). Delete
    `SETTLED_WORK_VISIBLE_LIMIT`; keep `ACTIVE_WORK_VISIBLE_LIMIT = 4`. Update
-   `timeline-row-estimates.ts` (trow ≈ 26px, marker ≈ 24px) and `isRowUnchanged`.
+   `timeline-row-estimates.ts` (trow ≈ 26px, marker ≈ 24px) and `sessionRowEqual`.
    Extend the existing logic test suite with the reference cases (§10.1 test files).
 2. **Primitives — `packages/ui`** (story + test each, per reuse-before-create):
    retoned `tool-call-row` (`.trow` grammar), new `marker`, `receipt`, `dock` (incl.

--- a/docs/qa/automation-backlog/tool-call-a11y.md
+++ b/docs/qa/automation-backlog/tool-call-a11y.md
@@ -2,7 +2,7 @@
 
 - Legacy ID: AB-007
 - Source: J-14 / RT-048, RT-049, RT-055..RT-057, RT-060 / `_tests.md` §8.2–§8.9 visual; `_qa.md` §6 J-D flag
-- Why automate: the transcript derive layer (grouping, `+N previous tool calls`, settled-turn collapse, structural sharing) is stable enough to pin; row accessibility is unit-owned with no axe pass over the assembled thread.
+- Why automate: the transcript derive layer (grouping, `+N previous tool calls`, settled-turn collapse, semantic row equality) is stable enough to pin; row accessibility is unit-owned with no axe pass over the assembled thread.
 - Suggested layer: unit (pure-logic timeline) + an axe/accessibility sweep of the redesigned thread.
-- Spec sketch: assert grouping folds consecutive tool calls, the `+N` toggle reveals prior calls, settled turns collapse to `Worked for Xs`, and structural sharing preserves row identity across refetch; axe-check status-not-color-only, labelled toggles, and reduced motion. True end state: the visual-language invariants and accessibility floor hold as the derive layer evolves.
+- Spec sketch: assert grouping folds consecutive tool calls, the `+N` toggle reveals prior calls, settled turns collapse to `Worked for Xs`, and stream updates preserve mounted settled rows while changed rows refresh; axe-check status-not-color-only, labelled toggles, and reduced motion. True end state: the visual-language invariants and accessibility floor hold as the derive layer evolves.
 - Status: proposed

--- a/docs/qa/journeys/J-14-read-a-finished-transcript.md
+++ b/docs/qa/journeys/J-14-read-a-finished-transcript.md
@@ -68,7 +68,7 @@ design_reference:
     - ".resources/t3code/apps/web/src/components/chat/MessagesTimeline.tsx:1900-2036 (SimpleWorkEntryRow visual baseline)"
     - ".resources/synara/apps/web/src/components/chat/MessagesTimeline.tsx:2942-3374 (Synara row baseline)"
     - ".resources/synara/apps/web/src/components/chat/MessagesTimeline.logic.ts:226-590 (+N previous tool calls, settled-turn collapse)"
-    - ".resources/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts (grouping/folds/structural-sharing invariants to spot-check)"
+    - ".resources/t3code/apps/web/src/components/chat/MessagesTimeline.logic.test.ts (grouping/folds/semantic-row-equality invariants to spot-check)"
   truthful_ui_checks:
     - "Tool call = one ~24–28px line, never a 44px filled card; consecutive calls fold with '+N previous tool calls' (tasks 25/26)."
     - "Any tool kind's Input + Output is inspectable inline (structured, not a lossy blob) (task 27)."
@@ -88,5 +88,5 @@ e2e_backbone:
   telemetry:
     - "None specific — read-path perf rides the transcript assembly-duration counter (task 40) via J-12."
   followups:
-    - "AB-007 — pure-logic grouping/fold regression (mirror MessagesTimeline.logic.test.ts: +N previous, settled-turn collapse, structural sharing) + an axe/a11y pass over the redesigned thread (row a11y unit-owned today, task 25)."
+    - "AB-007 — pure-logic grouping/fold regression (mirror MessagesTimeline.logic.test.ts: +N previous, settled-turn collapse, semantic row equality) + an axe/a11y pass over the redesigned thread (row a11y unit-owned today, task 25)."
 ```

--- a/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
+++ b/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
@@ -278,6 +278,87 @@ describe("SessionThread transcript states", () => {
     expect(retry).toHaveBeenCalledTimes(1);
   });
 
+  it("Should render past a resolved clarification with an unstable structured payload", async () => {
+    const transcript: SessionMessage[] = [
+      {
+        id: "assistant-resolved-clarification",
+        role: "assistant",
+        parts: [
+          {
+            type: "data-compozy-event",
+            data: {
+              type: "clarify",
+              session_id: primarySessionFixture.id,
+              turn_id: "clarify:req-render-loop",
+              raw: {
+                status: "resolved",
+                request: {
+                  request_id: "req-render-loop",
+                  workspace_id: primarySessionFixture.workspace_id,
+                  session_id: primarySessionFixture.id,
+                  agent_name: primarySessionFixture.agent_name,
+                  question: "Which environment should deploy?",
+                  choices: ["staging", "production"],
+                  asked_at: "2026-08-12T12:00:00Z",
+                  deadline: "2026-08-12T12:05:00Z",
+                },
+                answer: { choice: 1, text: "", fallback: false },
+                at: "2026-08-12T12:00:10Z",
+              },
+            },
+          },
+        ],
+      },
+      {
+        id: "assistant-after-resolved-clarification",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "Deployment checks completed after the clarification.",
+            state: "done",
+          },
+        ],
+      },
+    ];
+
+    const messages = toReadonlyThreadMessages(transcript);
+    const clarificationMessage = messages[0];
+    expect.assert(clarificationMessage);
+    const clarificationPart = clarificationMessage.content[0];
+    expect.assert(clarificationPart);
+    const volatilePart = new Proxy(clarificationPart, {
+      get(target, property, receiver) {
+        const value = Reflect.get(target, property, receiver);
+        return property === "data" ? structuredClone(value) : value;
+      },
+    });
+    const volatileContent = [volatilePart, ...clarificationMessage.content.slice(1)];
+    const volatileClarification = new Proxy(clarificationMessage, {
+      get(target, property, receiver) {
+        if (property === "content") {
+          return volatileContent;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    renderThreadState({
+      status: "success",
+      messages: [volatileClarification, ...messages.slice(1)],
+    });
+
+    expect(await screen.findByTestId("clarification-receipt")).toHaveAttribute(
+      "data-status",
+      "resolved"
+    );
+    expect(screen.getByTestId("clarification-receipt-answer")).toHaveTextContent("production");
+    expect(
+      screen.getByText("Deployment checks completed after the clarification.")
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("session-thread-error-boundary")).not.toBeInTheDocument();
+  });
+
   it("Should render ThreadEmpty only for success with zero messages", async () => {
     renderThreadState({ status: "success" });
 
@@ -1461,10 +1542,9 @@ describe("SessionThread transcript states", () => {
 });
 
 // Suite: streaming render-count probe (task 39).
-// Invariant: derive-layer structural sharing + compiler-stabilized `TimelineRowContent` mean
-// streaming N chunk updates change only the live row's visible subtree; settled
-// rows keep both their data reference and mounted DOM subtree.
-// Boundary IN: `computeStableSessionRows` row identity + the compiler-managed row renderer.
+// Invariant: semantic row equality + compiler-stabilized `TimelineRowContent` mean streaming N
+// chunk updates change only the live row's visible subtree; settled rows keep their mounted DOM.
+// Boundary IN: `sessionRowEqual` + the compiler-managed row renderer.
 // Boundary OUT: SSE/query wiring (owned by use-session-live-tail.test.tsx).
 describe("SessionThread streaming render-count", () => {
   function streamingTranscript(liveText: string): readonly ThreadMessage[] {

--- a/web/src/components/assistant-ui/__tests__/session-timeline.logic.test.ts
+++ b/web/src/components/assistant-ui/__tests__/session-timeline.logic.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  computeStableSessionRows,
   deriveSessionRows,
-  EMPTY_STABLE_SESSION_ROWS,
   visibleWorkEntries,
   type SessionTimelinePart,
   type SessionTimelineToolPart,
@@ -203,49 +201,6 @@ describe("session timeline derivation", () => {
     );
   });
 
-  it("Should keep unchanged row references across passes and leave prior rows intact on append", () => {
-    const first = deriveSessionRows([text("stable-text", "Stable"), tool(1)]);
-    const firstStable = computeStableSessionRows(first, EMPTY_STABLE_SESSION_ROWS);
-
-    // Re-parse with fresh part objects of identical content (simulates the hook's
-    // per-message re-parse): unchanged rows must keep referential identity.
-    const second = deriveSessionRows([text("stable-text", "Stable"), tool(1)]);
-    const secondStable = computeStableSessionRows(second, firstStable);
-    expect(secondStable).toBe(firstStable);
-    expect(secondStable.result[0]).toBe(firstStable.result[0]);
-    expect(secondStable.result[1]).toBe(firstStable.result[1]);
-
-    const third = deriveSessionRows([
-      text("stable-text", "Stable"),
-      tool(1),
-      text("appended", "New", "turn-1", "2026-07-07T12:00:12Z"),
-    ]);
-    const thirdStable = computeStableSessionRows(third, secondStable);
-    expect(thirdStable).not.toBe(secondStable);
-    expect(thirdStable.result[0]).toBe(secondStable.result[0]);
-    expect(thirdStable.result[1]).toBe(secondStable.result[1]);
-    expect(thirdStable.result[2]?.kind).toBe("text");
-  });
-
-  it("Should give only the mutated row a new reference while sibling rows keep identity", () => {
-    const first = deriveSessionRows([text("stable-a", "Alpha"), text("mutating-b", "Bravo")]);
-    const firstStable = computeStableSessionRows(first, EMPTY_STABLE_SESSION_ROWS);
-
-    // Re-derive with fresh part objects where only the second row's visible text
-    // changed (simulates a streaming chunk landing on the live row).
-    const second = deriveSessionRows([
-      text("stable-a", "Alpha"),
-      text("mutating-b", "Bravo, revised"),
-    ]);
-    const secondStable = computeStableSessionRows(second, firstStable);
-
-    expect(secondStable).not.toBe(firstStable);
-    // The unchanged sibling keeps its reference; only the mutated row is fresh.
-    expect(secondStable.result[0]).toBe(firstStable.result[0]);
-    expect(secondStable.result[1]).not.toBe(firstStable.result[1]);
-    expect(secondStable.result[1]).toBe(second[1]);
-  });
-
   it("Should treat the derivation as a pure view that never mutates the message parts", () => {
     const parts = Object.freeze([tool(1), tool(2), tool(3)]) as readonly SessionTimelinePart[];
     const snapshot = parts.map(part => ({ ...part }));
@@ -258,20 +213,6 @@ describe("session timeline derivation", () => {
     parts.forEach((part, index) => {
       expect(part).toEqual(snapshot[index]);
     });
-  });
-
-  it("Should return the previous stable state when a re-derivation reorders rows to a new result", () => {
-    const rows = deriveSessionRows([
-      text("first", "First", undefined, "2026-07-07T12:00:00Z"),
-      text("second", "Second", undefined, "2026-07-07T12:00:10Z"),
-    ]);
-    const initial = computeStableSessionRows(rows, EMPTY_STABLE_SESSION_ROWS);
-
-    const reordered = computeStableSessionRows([rows[1]!, rows[0]!], initial);
-
-    expect(reordered).not.toBe(initial);
-    expect(reordered.result[0]).toBe(initial.result[1]);
-    expect(reordered.result[1]).toBe(initial.result[0]);
   });
 
   it("Should fold settled turns while leaving the terminal assistant text visible", () => {
@@ -525,19 +466,6 @@ describe("session timeline derivation", () => {
     // A still-streaming reasoning part keeps the row live so the turn stays open.
     expect(second.streaming).toBe(true);
   });
-
-  it("Should keep a grouped reasoning row referentially stable across an unchanged re-derive", () => {
-    const parts: SessionTimelinePart[] = [
-      { kind: "reasoning", id: "reason-x", text: "One", turnId: "turn-1", state: "done" },
-      { kind: "reasoning", id: "reason-y", text: "Two", turnId: "turn-1", state: "done" },
-    ];
-
-    const first = computeStableSessionRows(deriveSessionRows(parts), EMPTY_STABLE_SESSION_ROWS);
-    const second = computeStableSessionRows(deriveSessionRows(parts), first);
-
-    expect(second).toBe(first);
-    expect(second.result[0]).toBe(first.result[0]);
-  });
 });
 
 describe("changed-files roll-up derivation", () => {
@@ -632,27 +560,6 @@ describe("changed-files roll-up derivation", () => {
     );
 
     expect(rows.some(row => row.kind === "changed-files")).toBe(false);
-  });
-
-  it("Should keep the changed-files row referentially stable across an unchanged re-derive", () => {
-    const parts: SessionTimelinePart[] = [
-      tool(1, {
-        toolName: "Write",
-        turnId: "turn-1",
-        args: { file_path: "/src/a.ts", content: "a\nb\nc" },
-      }),
-      text("t1", "Wrote the file.", "turn-1"),
-    ];
-    const options = { foldSettledTurns: true };
-
-    const first = computeStableSessionRows(
-      deriveSessionRows(parts, options),
-      EMPTY_STABLE_SESSION_ROWS
-    );
-    const second = computeStableSessionRows(deriveSessionRows(parts, options), first);
-
-    expect(second).toBe(first);
-    expect(second.result.some(row => row.kind === "changed-files")).toBe(true);
   });
 });
 

--- a/web/src/components/assistant-ui/session-row-equality.ts
+++ b/web/src/components/assistant-ui/session-row-equality.ts
@@ -1,7 +1,6 @@
-// Structural sharing for the derived row list: reuses row references from the
-// previous pass when a freshly derived row is content-equal, so unchanged rows
-// stay referentially stable across derive passes (append leaves prior rows
-// intact) and the virtualizer plus memoized children avoid needless re-renders.
+// Semantic row equality for the memoized timeline renderer. Fresh derivations
+// may allocate new row objects; this comparator keeps unchanged row subtrees
+// from rendering again without feeding derived data back into React state.
 
 import type {
   ChangedFileEntry,
@@ -17,36 +16,6 @@ import type {
   SessionWorkRow,
   SessionWorkToggleRow,
 } from "./session-timeline.logic";
-
-export interface StableSessionRowsState {
-  byId: Map<string, SessionRow>;
-  result: SessionRow[];
-}
-
-export const EMPTY_STABLE_SESSION_ROWS: StableSessionRowsState = {
-  byId: new Map(),
-  result: [],
-};
-
-export function computeStableSessionRows(
-  rows: SessionRow[],
-  previous: StableSessionRowsState
-): StableSessionRowsState {
-  const next = new Map<string, SessionRow>();
-  let anyChanged = rows.length !== previous.byId.size;
-
-  const result = rows.map((row, index) => {
-    const previousRow = previous.byId.get(row.id);
-    const stableRow = previousRow && sessionRowEqual(previousRow, row) ? previousRow : row;
-    next.set(row.id, stableRow);
-    if (!anyChanged && previous.result[index] !== stableRow) {
-      anyChanged = true;
-    }
-    return stableRow;
-  });
-
-  return anyChanged ? { byId: next, result } : previous;
-}
 
 /** Shallow, per-variant content comparison — avoids serialization cost. */
 export function sessionRowEqual(a: SessionRow, b: SessionRow): boolean {

--- a/web/src/components/assistant-ui/session-timeline.logic.ts
+++ b/web/src/components/assistant-ui/session-timeline.logic.ts
@@ -9,8 +9,8 @@
 // Failed and interrupted calls never disappear into a summary. Consecutive
 // reasoning parts fold into one row; consecutive same-kind runtime markers merge
 // into one data row carrying a ×N count. The settled-turn "Worked for Xs" fold
-// layer lives in `./session-timeline-fold`; structural sharing lives in
-// `./session-timeline-stable`; the run summarizer in `./session-timeline-summary`.
+// layer lives in `./session-timeline-fold`; semantic row equality lives in
+// `./session-row-equality`; the run summarizer in `./session-timeline-summary`.
 
 import { foldSettledTurns } from "./session-timeline-fold";
 import { markerClusterKey } from "./session-timeline-markers";
@@ -22,12 +22,7 @@ import {
 
 export { markerClusterKey } from "./session-timeline-markers";
 
-export {
-  computeStableSessionRows,
-  EMPTY_STABLE_SESSION_ROWS,
-  sessionRowEqual,
-  type StableSessionRowsState,
-} from "./session-timeline-stable";
+export { sessionRowEqual } from "./session-row-equality";
 export {
   classifyToolSummaryCategory,
   isSummarizableToolPart,


### PR DESCRIPTION
## Summary

- Prevent session transcripts with resolved structured clarification events from entering React's infinite-render failure path.
- Keep timeline rows as a pure render derivation and restrict semantic row equality to memoized child rendering.
- Add a regression that reproduces the unstable payload identity reported in #360 and proves later transcript content still renders.

## Root cause

`v0.3.0-beta.13` stored derived timeline rows in local React state and called `setStableRows()` during render whenever `computeStableSessionRows()` returned a different state object. A resolved `data-compozy-event` clarification can expose a new structured payload identity on each read, so the comparison never converges. Every render scheduled another render until React stopped the loop with error #301.

Current `main` had already removed the render-phase setter incidentally in #354, but the stateful stabilization implementation, its implementation-detail tests, and stale documentation remained. That left the failure unguarded and made the unsafe mechanism easy to reintroduce.

## Changes

- **Regression coverage:** add a `SessionThread` integration case with a resolved clarification whose structured payload has deliberately unstable identity. The test asserts the receipt, answer, and following transcript message render without entering the thread error boundary.
- **Timeline architecture:** remove `StableSessionRowsState`, `EMPTY_STABLE_SESSION_ROWS`, and `computeStableSessionRows`; rename the remaining module to `session-row-equality.ts` and keep `sessionRowEqual` only as the memo comparator for row children.
- **Test ownership:** remove pure-logic tests that froze the deleted state container's reference behavior. The user-visible render invariant now lives in the canonical component integration suite.
- **Internal docs:** update the session redesign spec, QA journey, and automation backlog to describe semantic row equality and mounted-DOM stability instead of cross-render object identity.

## Compozy Impact Audit

- **Native tools:** no impact — checked `compozy__*` IDs, toolsets, descriptors, schemas, digests, risk flags, diagnostics, and capability gates; this is confined to the Web transcript renderer.
- **Extensibility and hooks:** no impact — no extension, hook, skill/capability, tool/resource, registry, bridge SDK, MCP sidecar, or config lifecycle contract changed.
- **Workspace data isolation:** no impact — session transcript ownership and `workspace_id` propagation through CLI/HTTP/UDS/core/store/Web/SSE/cache/events are unchanged; the change only removes local derived render state.
- **Official Compozy skill:** no impact — no public behavior, tool ID, CLI path, hook event, capability, extension resource, or memory/network/task semantic changed.
- **Web/Docs:** Web regression coverage and internal architecture references updated; no `packages/site` documentation impact.
- **Settings:** no impact — no `config.toml` key or settings attachment references the removed render-state implementation.

## Release Notes

### 🐛 Bug Fixes

- Prevent resolved clarification receipts from crashing the session timeline with React error #301.

## QA

No scenario was added or reset because the production behavior on current `main` already uses pure derivation; this PR locks that behavior with a regression and removes the obsolete state mechanism. The existing clarification round-trip remains owned by `docs/qa/scenarios/RT-session-clarification-roundtrip.md`.

## Test plan

- [x] Red/green mutation proof: the regression fails with the exact beta.13 render-phase state loop (`Too many re-renders`, `AssistantMessageTimeline`, thread error boundary) and passes after restoring pure derivation.
- [x] Focused component and timeline suites: 84 tests passed.
- [x] `make gate`: Web lint, typecheck, and full Web tests passed; fingerprint `85ba1fc2414f13df5fad9c4b912ed65be3570202`.
- [x] React Doctor changed-scope scan: 100/100, no issues.
- [ ] `make gate-full`: delegated to CI by maintainer direction; the local run was intentionally interrupted rather than reported as passing.

Closes #360


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeline rendering for resolved clarifications with changing structured data.
  * Ensured resolved receipts, selected answers, and subsequent assistant messages render correctly without triggering an error boundary.
* **Performance**
  * Refined row comparison for more reliable memoized rendering and live timeline updates.
* **Tests**
  * Added regression coverage for volatile clarification payloads.
  * Updated streaming rendering tests to validate semantic row equality and nested updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->