### PR TITLE
fix: align update artifacts with release policy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -116,6 +116,13 @@ signs:
     artifacts: checksum
     output: true
 
+before_publish:
+  - ids:
+      - compozy-archive
+    artifacts: archive
+    cmd: go run github.com/magefile/mage@v1.17.2 updateArchiveCheck "{{ .ArtifactPath }}"
+    output: true
+
 snapshot:
   version_template: "0.0.0-{{ .Timestamp }}"
 

--- a/docs/qa/bugs/BUG-20260812-successful-update-recommends-retry.md
+++ b/docs/qa/bugs/BUG-20260812-successful-update-recommends-retry.md
@@ -1,0 +1,42 @@
+# BUG-20260812-successful-update-recommends-retry: Successful update still recommends another update
+
+- **Status:** verified
+- **Impact (user-side):** Trust-Damage
+- **Severity:** High · **Priority:** P1
+- **Persona Affected:** Dora
+- **Journey Step:** J-evaluate-compozy-beta, step 4
+- **Scenarios:** REL-beta-self-update
+- **Found:** 2026-08-12 · **Report:** docs/qa/reports/2026-08-12-issue-359-auto-update.md
+
+## Summary
+
+After CompozyOS reported that the isolated binary had updated to beta.13, the same structured result
+still told Dora to run `compozy update` again.
+
+## Reproduction
+
+- **Charter:** CH-beta-self-update-artifact-contract · **Tour:** Feature Tour
+- **Environment:** desktop / wifi-fast / en-US, isolated direct binary using the real beta.13 release
+
+1. Build the fixed candidate as beta.8 into the isolated QA lab.
+2. Run `compozy update -o json` from that candidate path.
+3. Read the successful structured result.
+
+**Expected:** The result reports beta.13 as installed and contains no further update recommendation.
+**Actual:** The result reports `status: updated` and also recommends `Run compozy update`.
+
+## Evidence
+
+- `/Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab/qa-artifacts/qa/update-apply.json`
+- `/Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab/qa-artifacts/qa/candidate-after-version.txt`
+
+## Fix
+
+- **Root cause:** The successful update paths reused the available-state record but changed only status, version, and message, leaving its pre-update recommendation intact.
+- **Fix commit:** working-tree
+- **Regression test:** `internal/cli/update_command_test.go` — the canonical successful local-update flow now starts with the available recommendation and requires it to be empty after completion; it failed before the fix and passed after it.
+
+## Verification
+
+- **Retested:** 2026-08-12, same persona/journey · **Report:** docs/qa/reports/2026-08-12-issue-359-auto-update.md
+- **Result:** A fresh isolated beta.8 candidate updated through the real beta.13 release; its successful JSON omitted `recommendation`, and the replaced binary reported beta.13.

--- a/docs/qa/charters/CH-beta-self-update-artifact-contract.md
+++ b/docs/qa/charters/CH-beta-self-update-artifact-contract.md
@@ -1,0 +1,26 @@
+# CH-beta-self-update-artifact-contract: Update an isolated beta through the real release archive
+
+```yaml
+charter:
+  id: CH-beta-self-update-artifact-contract
+  mission: "As Dora, update an isolated direct-binary beta through the real signed beta.13 archive and prove the executable reaches the reported version without touching the operator installation."
+  mode: scenario-based
+  persona:
+    name: Dora
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-evaluate-compozy-beta
+  scenarios: [REL-beta-self-update]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Build the candidate into the isolated lab as beta.8, record its path and digest, then run `update --check -o json` and `update -o json` from that exact path."
+      - "Confirm beta.13 selection, signed artifact verification, executable replacement, final version output, and no mutation of the operator binary."
+      - "Exercise abandonment with check-only mode and confirm it leaves the candidate executable unchanged."
+    must_avoid:
+      - "Do not run the candidate from an operator-managed install path or infer success from unit tests alone."
+```
+
+<!-- Immutable charter: write each run's outcome only in that run report. -->

--- a/docs/qa/charters/CH-release-update-archive-contract.md
+++ b/docs/qa/charters/CH-release-update-archive-contract.md
@@ -1,0 +1,26 @@
+# CH-release-update-archive-contract: Validate a published archive before release
+
+```yaml
+charter:
+  id: CH-release-update-archive-contract
+  mission: "As Dora, run the release archive hook against the real beta.13 artifact and confirm the same policy that accepts runtime extraction gates publication."
+  mode: scenario-based
+  persona:
+    name: Dora
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-publish-compozy-beta
+  scenarios: [REL-release-archive-update-contract]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Download a real Darwin or Linux beta.13 archive and invoke the exact GoReleaser `updateArchiveCheck` command against it."
+      - "Record the compressed archive size and extracted `compozy` size beside the hook verdict."
+      - "Confirm the GoReleaser configuration calls the hook for `compozy-archive` artifacts before publication."
+    must_avoid:
+      - "Do not publish, tag, or alter a GitHub release during this charter."
+```
+
+<!-- Immutable charter: write each run's outcome only in that run report. -->

--- a/docs/qa/journeys/J-publish-compozy-beta.md
+++ b/docs/qa/journeys/J-publish-compozy-beta.md
@@ -4,7 +4,9 @@
 flowchart TD
     A[Entry: approved candidate on main] --> B[Dispatch release workflow with exact version and beta channel]
     B --> C[Planner and preflight confirm the candidate]
-    C --> D0[Stage production release: annotated tag, GoReleaser draft GitHub release, both npm packages published, Homebrew formula published]
+    C --> C0[Build archives and prove every direct-update artifact satisfies the runtime artifact policy]
+    C0 --> D0[Stage production release: annotated tag, GoReleaser draft GitHub release, both npm packages published, Homebrew formula published]
+    C0 -.->|archive is incompatible| X0[Abandon: stop before publication with measured archive or binary details]
     D0 --> C1{Desktop signing material complete for every platform?}
     C1 -->|incomplete| X3[Abandon: desktop lane asserts signing material before building and hard-fails - nothing reaches the update feed]
     C1 -->|complete| C2[Build, sign, and notarize the three desktop platforms]
@@ -36,7 +38,7 @@ journey:
       expected_observable: "The release plan and preflight name the exact checked-out candidate before publication starts"
     - step: 2
       verb: "Observe the staged production release"
-      expected_observable: "GoReleaser stages a draft GitHub release while both npm packages and the Homebrew formula publish for the same version — the draft is not public yet"
+      expected_observable: "GoReleaser validates each direct-update archive against the runtime artifact policy before it stages a draft GitHub release or publishes packages"
     - step: 3
       verb: "Wait for the public npm channel policy"
       expected_observable: "Stale or missing dist-tags are re-read within a fixed deadline, while terminal query and policy errors stop immediately"
@@ -53,6 +55,9 @@ journey:
   exit:
     natural: "Hand the published version to the post-release install and provenance checks."
   abandonment:
+    - at_step: 2
+      how: "A built archive or extracted binary exceeds the runtime-owned artifact policy."
+      resume: "Reduce the artifact or deliberately revise the single shared policy before rerunning the release; publication remains stopped."
     - at_step: 3
       how: "The registry query fails, a beta moves latest, malformed policy data is returned, or the readiness deadline expires."
       resume: "Stop for incident review with the last observation; never overwrite tags or republish an immutable npm version."

--- a/docs/qa/reports/2026-08-12-issue-359-auto-update.md
+++ b/docs/qa/reports/2026-08-12-issue-359-auto-update.md
@@ -1,0 +1,102 @@
+# QA Run Report — 2026-08-12 — issue-359-auto-update
+
+- **Scope:** Issue #359 direct-binary extraction and release archive compatibility contract
+- **Cadence tier:** targeted
+- **Build:** 26f7b488 + working tree · **Environment:** isolated lab `/Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab`; real GitHub beta.13 release; no provider or Web surface required
+- **Started:** 2026-08-12T21:12:59Z · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Dora | Power User | desktop / wifi-fast / en-US | CH-beta-self-update-artifact-contract, CH-release-update-archive-contract |
+
+## Flows in Scope
+
+- `J-evaluate-compozy-beta` — update an isolated direct binary through the real beta channel (`../journeys/J-evaluate-compozy-beta.md`)
+- `J-publish-compozy-beta` — reject a direct-update archive before release publication when the runtime cannot consume it (`../journeys/J-publish-compozy-beta.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-beta-self-update-artifact-contract | J-evaluate-compozy-beta / REL-beta-self-update | Dora | Feature Tour | Fixed | BUG-20260812-successful-update-recommends-retry | working-tree |
+| 2 | CH-release-update-archive-contract | J-publish-compozy-beta / REL-release-archive-update-contract | Dora | Feature Tour | Pass | | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-beta-self-update-artifact-contract — Dora
+
+- **Ran:** 2026-08-12T21:15:00Z → 2026-08-12T21:20:00Z (box respected: yes)
+- **Findings:** The real beta.13 archive verified, extracted, and replaced the isolated beta.8 binary, but the successful JSON result retained the stale recommendation to run the update again (Trust-Damage).
+- **Bugs filed/updated:** BUG-20260812-successful-update-recommends-retry
+- **Scenarios settled:** REL-beta-self-update → pass after governed fix and retest
+- **Paper cuts:** The unsupported `--version` flag was a dull CLI convention surprise; the documented `version` verb remained clear and functional.
+- **Surprises:** The full signed beta.13 update completed in under three seconds after the release check cache was warm.
+- **Suggested next charter:** Exercise the next candidate across another supported platform.
+
+### CH-release-update-archive-contract — Dora
+
+- **Ran:** 2026-08-12T21:20:00Z → 2026-08-12T21:27:00Z (box respected: yes)
+- **Findings:** The exact `before_publish` Mage target accepted the real beta.13 archive and rejected a binary one MiB above policy with measured size and limit. No additional defect surfaced.
+- **Bugs filed/updated:** None.
+- **Scenarios settled:** REL-release-archive-update-contract → pass
+- **Paper cuts:** None.
+- **Surprises:** The 257 MiB rejection fixture compressed below 300 KiB, confirming that compressed size alone cannot protect extraction.
+- **Suggested next charter:** Exercise the next candidate's four Darwin/Linux archives during release rehearsal.
+
+## What Was Fixed
+
+### BUG-20260812-successful-update-recommends-retry: Successful update still recommends another update
+
+- **Symptom:** Successful structured output combined `status: updated` with a command to update again.
+- **Root cause:** Terminal success reused the available-state record without clearing its recommendation.
+- **Fix:** working-tree; both local and daemon-restart success paths clear the terminal recommendation.
+- **Regression test:** `internal/cli/update_command_test.go` — red before, green after.
+- **Retested:** `J-evaluate-compozy-beta` from a fresh isolated beta.8 candidate, plus the adjacent release archive journey.
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Dora | J-evaluate-compozy-beta step 4 | "The update says it finished and immediately tells me to update again." | sharp | fixed (working-tree) |
+| Dora | J-evaluate-compozy-beta step 4 | "I expected `--version`, but the help teaches the `version` verb." | dull | watching |
+
+## Runtime Errors Observed
+
+- Successful update output initially retained `Run compozy update`; fixed and absent from `qa/update-apply-final.json`.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- Taxonomy plan: the two CLI/release flows cover journey, functional, error recovery, and producer-consumer continuity. Browser responsiveness, form input, locale, and accessibility are deliberate skips because this diff exposes no browser or input surface.
+- The consumer walk uses the real GitHub archive, checksum catalog, and Sigstore bundle. Its only parity deviation is an isolated candidate executable and `COMPOZY_HOME`, required to protect the operator installation.
+- The release walk invokes the exact configured Mage target without publishing, tagging, or changing a release.
+- Edge probes covered check-only immutability, repeat current-state reads, operator-binary isolation, an unsupported file format, an extracted binary above policy, and a repeated real-archive hook run.
+
+## Experiential Lens Pass
+
+| Journey | Usability | Accessibility | Perceived performance | Compatibility | Error recoverability | Production parity |
+|---|---|---|---|---|---|---|
+| J-evaluate-compozy-beta | pass | pass | pass | pass | pass after fix | pass |
+| J-publish-compozy-beta | pass | pass | pass | pass | pass | pass |
+
+Compatibility is scoped to the live Darwin arm64 consumer walk; the producer hook is configured for
+every Darwin/Linux archive. Browser, viewport, form, and locale checks are not applicable to these
+text-only CLI and release-operator surfaces.
+
+## Final Status
+
+- **Exit gate (full automated suite):** `make gate-full` — PASS; exact fingerprint and log recorded in the lab verification report and `.cache/gate/`.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 1 fixed and verified · Friction 0 · Cosmetic 0
+- **Coverage:** 2/2 journeys walked; no skipped session rows
+- **Verdict:** ready — both journeys passed, the only QA finding was fixed and re-walked, and no user-impact issue remains open.

--- a/docs/qa/scenarios/REL-beta-self-update.md
+++ b/docs/qa/scenarios/REL-beta-self-update.md
@@ -4,15 +4,15 @@ area: REL
 title: Keep self-update on the running beta line
 persona: Dora
 journey: J-evaluate-compozy-beta
-expected: A v0.3 beta build offers only the newest non-draft v0.3 beta, ignores v0.2 stable, RC, future minor, and draft releases, keeps beta cache state separate from stable, and returns beta-safe npm, Go, or hosted-installer guidance without a Homebrew command.
+expected: A v0.3 beta direct binary selects the newest non-draft v0.3 beta, verifies and extracts its official archive within the runtime artifact policy, replaces only the isolated executable, and reports the installed beta version.
 entry_points: compozy update; compozy update --check -o json; GitHub releases API; managed install detection
-qa_status: blocked-verify
-bug_ids:
-fix_status:
-retest_status:
-fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-qa-gl-rel-wave1-20260730-045845-838751-lab/qa-artifacts/qa
-last_report: docs/qa/reports/2026-07-28-untested-full.md
+qa_status: pass
+bug_ids: BUG-20260812-successful-update-recommends-retry
+fix_status: fixed
+retest_status: pass
+fix_commits: working-tree
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab/qa-artifacts/qa/update-check-final.json; /Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab/qa-artifacts/qa/update-apply-final.json; /Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab/qa-artifacts/qa/candidate-final-version.txt
+last_report: docs/qa/reports/2026-08-12-issue-359-auto-update.md
 overlaps: REL-beta-install-paths
 ---
 
@@ -20,3 +20,11 @@ QA impact 2026-07-27: Compozy migration Task 10 made update selection channel-aw
 managed lifecycle guidance to the active beta distribution identities. Planning flag only; Task
 10's post-publish single-cut runbook owns real release/API behavior. Task 13 must not select or
 simulate this scenario.
+
+QA impact 2026-08-12: the updater now enforces the runtime-owned archive policy shared with the
+release producer. Reset for an isolated direct-binary walk from beta.8 to the real beta.13 archive,
+including structured output and executable replacement.
+
+QA verdict 2026-08-12: an isolated fixed-source beta.8 candidate selected the real beta.13 release,
+verified its signed checksum catalog, extracted the 135,516,530-byte binary, replaced only its lab
+executable, and reported beta.13. The final JSON cleared the completed update recommendation.

--- a/docs/qa/scenarios/REL-release-archive-update-contract.md
+++ b/docs/qa/scenarios/REL-release-archive-update-contract.md
@@ -1,0 +1,24 @@
+---
+id: REL-release-archive-update-contract
+area: REL
+title: Reject archives the self-updater cannot consume
+persona: Dora
+journey: J-publish-compozy-beta
+expected: Every Darwin and Linux archive passes the runtime-owned compressed-archive and extracted-binary policy after GoReleaser builds it and before the draft can be published; an incompatible archive stops publication with measured artifact details.
+entry_points: .goreleaser.yml before_publish; go run github.com/magefile/mage@v1.17.2 updateArchiveCheck <archive>
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab/qa-artifacts/qa/release-archive-contract-final.txt; /Users/pedronauck/dev/qa-labs/compozy-issue-359-auto-update-20260812-211235-947224-lab/qa-artifacts/qa/release-archive-oversized-rejection-final.txt
+last_report: docs/qa/reports/2026-08-12-issue-359-auto-update.md
+overlaps: REL-beta-self-update
+---
+
+Added for issue #359. The release producer and direct-binary updater consume the same Go policy;
+Windows ZIP remains outside the supported in-place update platforms.
+
+QA verdict 2026-08-12: the exact Mage hook accepted beta.13's 49,342,626-byte archive and
+135,516,530-byte binary, then rejected a 269,484,032-byte binary with the measured 268,435,456-byte
+policy limit before publication.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	goruntime "runtime"
 	"strings"
 	"time"
 
@@ -127,6 +128,13 @@ func applyAvailableUpdate(
 	if err != nil {
 		record.Status = string(compozyupdate.StatusFailed)
 		record.Message = err.Error()
+		var artifactSizeErr *compozyupdate.ArtifactSizeError
+		if errors.As(err, &artifactSizeErr) {
+			record.Recommendation = compozyupdate.ManualDirectBinaryRecommendation(
+				record.ReleaseURL,
+				goruntime.GOOS,
+			)
+		}
 		return writeUpdateFailure(cmd, record, err)
 	}
 	if !running {
@@ -161,6 +169,7 @@ func finishLocalUpdate(
 	}
 	record.Status = string(compozyupdate.StatusUpdated)
 	record.CurrentVersion = strings.TrimSpace(release.Version)
+	record.Recommendation = ""
 	record.Message = "Updated CompozyOS to " + strings.TrimSpace(release.Version) + "."
 	return writeCommandOutput(cmd, updateBundle(record))
 }
@@ -240,6 +249,7 @@ func restartDaemonAfterUpdate(
 	}
 	record.Status = string(compozyupdate.StatusUpdated)
 	record.CurrentVersion = strings.TrimSpace(release.Version)
+	record.Recommendation = ""
 	record.DaemonRestarted = true
 	record.Message = "Updated CompozyOS to " + strings.TrimSpace(release.Version) + " and restarted the daemon."
 	return writeCommandOutput(cmd, updateBundle(record))

--- a/internal/cli/update_command_test.go
+++ b/internal/cli/update_command_test.go
@@ -36,6 +36,7 @@ func TestUpdateCommandFlows(t *testing.T) {
 						LatestVersion:  "v1.1.0",
 						Available:      true,
 						Status:         compozyupdate.StatusAvailable,
+						Recommendation: "Run `compozy update`.",
 						Message:        "A newer stable CompozyOS release is available.",
 					}, &compozyupdate.Release{Version: "v1.1.0"}, nil
 				},
@@ -74,6 +75,9 @@ func TestUpdateCommandFlows(t *testing.T) {
 		}
 		if record.Status != string(compozyupdate.StatusUpdated) || record.DaemonRestarted {
 			t.Fatalf("record = %#v, want updated without daemon restart", record)
+		}
+		if record.Recommendation != "" {
+			t.Fatalf("record.Recommendation = %q, want no action after successful update", record.Recommendation)
 		}
 	})
 
@@ -221,6 +225,51 @@ func TestUpdateCommandFlows(t *testing.T) {
 		}
 		if record.Status != string(compozyupdate.StatusCurrent) || record.CurrentVersion != "v1.1.0" {
 			t.Fatalf("record = %#v, want current latest snapshot", record)
+		}
+	})
+
+	t.Run("Should recommend manual recovery when the release binary exceeds the artifact policy", func(t *testing.T) {
+		t.Parallel()
+
+		deps := newTestDeps(t, &stubClient{})
+		deps.newUpdateManager = func(compozyconfig.HomePaths) (updateManager, error) {
+			return stubUpdateManager{
+				checkFn: func(context.Context, compozyupdate.CheckOptions) (compozyupdate.State, *compozyupdate.Release, error) {
+					return compozyupdate.State{
+						Supported:      true,
+						InstallMethod:  string(compozyupdate.InstallMethodDirectBinary),
+						CurrentVersion: "v1.0.0",
+						LatestVersion:  "v1.1.0",
+						Available:      true,
+						Status:         compozyupdate.StatusAvailable,
+						Recommendation: "Run `compozy update`.",
+						ReleaseURL:     "https://github.com/compozy/compozy/releases/tag/v1.1.0",
+					}, &compozyupdate.Release{Version: "v1.1.0"}, nil
+				},
+				applyFn: func(context.Context, *compozyupdate.Release) (compozyupdate.AppliedBinary, error) {
+					policy := compozyupdate.DefaultArtifactPolicy()
+					return compozyupdate.AppliedBinary{}, &compozyupdate.ArtifactSizeError{
+						Kind:  compozyupdate.ArtifactKindBinary,
+						Size:  policy.MaxBinaryBytes + 1,
+						Limit: policy.MaxBinaryBytes,
+					}
+				},
+			}, nil
+		}
+
+		stdout, _, err := executeRootCommand(t, deps, "update", "-o", "json")
+		if err == nil {
+			t.Fatal("executeRootCommand() error = nil, want artifact policy failure")
+		}
+		var record updateRecord
+		if err := json.Unmarshal([]byte(stdout), &record); err != nil {
+			t.Fatalf("json.Unmarshal(update failure) error = %v", err)
+		}
+		if strings.Contains(record.Recommendation, "compozy update") {
+			t.Fatalf("record.Recommendation = %q, must not repeat the failed command", record.Recommendation)
+		}
+		if !strings.Contains(record.Recommendation, record.ReleaseURL) {
+			t.Fatalf("record.Recommendation = %q, want release URL %q", record.Recommendation, record.ReleaseURL)
 		}
 	})
 }

--- a/internal/config/release_config_test.go
+++ b/internal/config/release_config_test.go
@@ -85,6 +85,32 @@ func TestGoReleaserConfigPreservesTrustArtifactsAndPackageTargets(t *testing.T) 
 		}
 	})
 
+	t.Run("Should validate update archives with the runtime policy before publishing", func(t *testing.T) {
+		t.Parallel()
+
+		hooks := sliceAt(t, cfg, "before_publish")
+		if len(hooks) != 1 {
+			t.Fatalf("before_publish len = %d, want 1 update archive policy hook", len(hooks))
+		}
+		hook := asMap(t, hooks[0], "before_publish[0]")
+		if !stringSliceContains(sliceAt(t, hook, "ids"), "compozy-archive") {
+			t.Fatalf("before_publish[0].ids = %#v, want compozy-archive", hook["ids"])
+		}
+		if got, want := stringAt(t, hook, "artifacts"), "archive"; got != want {
+			t.Fatalf("before_publish[0].artifacts = %q, want %q", got, want)
+		}
+		command := stringAt(t, hook, "cmd")
+		for _, want := range []string{"updateArchiveCheck", "{{ .ArtifactPath }}"} {
+			if !strings.Contains(command, want) {
+				t.Fatalf("before_publish[0].cmd = %q, want %q", command, want)
+			}
+		}
+		output, ok := hook["output"].(bool)
+		if !ok || !output {
+			t.Fatalf("before_publish[0].output = %#v, want true", hook["output"])
+		}
+	})
+
 	t.Run("Should publish stable archives and curl installer asset", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/update/artifact_policy.go
+++ b/internal/update/artifact_policy.go
@@ -1,0 +1,82 @@
+package update
+
+import "fmt"
+
+const (
+	defaultMaxArchiveBytes = int64(128 << 20)
+	defaultMaxBinaryBytes  = int64(256 << 20)
+)
+
+// ArtifactKind identifies the release artifact constrained by the update policy.
+type ArtifactKind string
+
+const (
+	ArtifactKindArchive ArtifactKind = "archive"
+	ArtifactKindBinary  ArtifactKind = "binary"
+)
+
+// ArtifactPolicy defines the accepted size envelope for direct self-update artifacts.
+type ArtifactPolicy struct {
+	MaxArchiveBytes int64
+	MaxBinaryBytes  int64
+}
+
+// ArtifactSizeError reports a release artifact outside the accepted size envelope.
+type ArtifactSizeError struct {
+	Kind  ArtifactKind
+	Size  int64
+	Limit int64
+}
+
+type downloadSizeError struct {
+	Path  string
+	Size  int64
+	Limit int64
+}
+
+func (e *downloadSizeError) Error() string {
+	return fmt.Sprintf("update: download %q size %d exceeds limit %d", e.Path, e.Size, e.Limit)
+}
+
+func (e *ArtifactSizeError) Error() string {
+	return fmt.Sprintf(
+		"update: %s size %d exceeds the allowed limit of %d bytes",
+		e.Kind,
+		e.Size,
+		e.Limit,
+	)
+}
+
+// DefaultArtifactPolicy returns the size envelope enforced by runtime updates and release publication.
+func DefaultArtifactPolicy() ArtifactPolicy {
+	return ArtifactPolicy{
+		MaxArchiveBytes: defaultMaxArchiveBytes,
+		MaxBinaryBytes:  defaultMaxBinaryBytes,
+	}
+}
+
+func resolveArtifactPolicy(policy ArtifactPolicy) (ArtifactPolicy, error) {
+	if policy == (ArtifactPolicy{}) {
+		return DefaultArtifactPolicy(), nil
+	}
+	if policy.MaxArchiveBytes <= 0 {
+		return ArtifactPolicy{}, fmt.Errorf(
+			"update: artifact policy archive limit must be positive, got %d",
+			policy.MaxArchiveBytes,
+		)
+	}
+	if policy.MaxBinaryBytes <= 0 {
+		return ArtifactPolicy{}, fmt.Errorf(
+			"update: artifact policy binary limit must be positive, got %d",
+			policy.MaxBinaryBytes,
+		)
+	}
+	return policy, nil
+}
+
+func validateArtifactSize(kind ArtifactKind, size int64, limit int64) error {
+	if size <= limit {
+		return nil
+	}
+	return &ArtifactSizeError{Kind: kind, Size: size, Limit: limit}
+}

--- a/internal/update/github.go
+++ b/internal/update/github.go
@@ -155,12 +155,7 @@ func (m *Manager) downloadFile(ctx context.Context, url string, path string, max
 		return fmt.Errorf("update: download %q returned %s", url, resp.Status)
 	}
 	if resp.ContentLength > maxBytes {
-		return fmt.Errorf(
-			"update: download %q size %d exceeds limit %d",
-			url,
-			resp.ContentLength,
-			maxBytes,
-		)
+		return &downloadSizeError{Path: url, Size: resp.ContentLength, Limit: maxBytes}
 	}
 
 	file, err := os.Create(path)

--- a/internal/update/manager.go
+++ b/internal/update/manager.go
@@ -47,8 +47,7 @@ func NewManager(cfg Config) (*Manager, error) {
 	if runCommand == nil {
 		runCommand = defaultRunCommand
 	}
-
-	resolvedExecutable, err := resolveExecutablePath(executablePath, resolveSymlinks)
+	resolvedExecutable, artifactPolicy, err := resolveManagerInputs(cfg, executablePath, resolveSymlinks)
 	if err != nil {
 		return nil, err
 	}
@@ -74,6 +73,7 @@ func NewManager(cfg Config) (*Manager, error) {
 		lookPath:       lookPath,
 		runCommand:     runCommand,
 		binaryApplier:  cfg.BinaryApplier,
+		artifactPolicy: artifactPolicy,
 		releaseTrack:   releaseTrack,
 	}
 	if manager.runtimeOS == "" {
@@ -94,6 +94,22 @@ func NewManager(cfg Config) (*Manager, error) {
 		return nil, errors.New("update: CompozyOS home directory is required")
 	}
 	return manager, nil
+}
+
+func resolveManagerInputs(
+	cfg Config,
+	executablePath func() (string, error),
+	resolveSymlinks func(string) (string, error),
+) (string, ArtifactPolicy, error) {
+	artifactPolicy, err := resolveArtifactPolicy(cfg.ArtifactPolicy)
+	if err != nil {
+		return "", ArtifactPolicy{}, err
+	}
+	resolvedExecutable, err := resolveExecutablePath(executablePath, resolveSymlinks)
+	if err != nil {
+		return "", ArtifactPolicy{}, err
+	}
+	return resolvedExecutable, artifactPolicy, nil
 }
 
 func resolveExecutablePath(
@@ -208,6 +224,7 @@ func (m *Manager) ApplyRelease(ctx context.Context, release *Release) (applied A
 		downloaded.archivePath,
 		tmpDir,
 		m.archiveBinaryName(),
+		m.artifactPolicy,
 	)
 	if err != nil {
 		return AppliedBinary{}, err
@@ -291,8 +308,16 @@ func (m *Manager) downloadReleaseArtifacts(
 		ctx,
 		assets.archive.DownloadURL,
 		downloaded.archivePath,
-		maxArchiveDownloadBytes,
+		m.artifactPolicy.MaxArchiveBytes,
 	); err != nil {
+		var downloadErr *downloadSizeError
+		if errors.As(err, &downloadErr) {
+			return downloadedReleaseArtifacts{}, &ArtifactSizeError{
+				Kind:  ArtifactKindArchive,
+				Size:  downloadErr.Size,
+				Limit: downloadErr.Limit,
+			}
+		}
 		return downloadedReleaseArtifacts{}, err
 	}
 	if err := m.downloadFile(

--- a/internal/update/manager_apply_test.go
+++ b/internal/update/manager_apply_test.go
@@ -89,6 +89,46 @@ func TestManagerApplyRelease(t *testing.T) {
 		}
 	})
 
+	t.Run("Should reject a binary outside the configured artifact policy before applying it", func(t *testing.T) {
+		t.Parallel()
+
+		verifier := &stubBundleVerifier{}
+		applier := &recordingBinaryApplier{}
+		manager, _ := newManagerWithExecutable(t, Config{
+			RuntimeOS:      runtimeOSLinux,
+			RuntimeArch:    runtimeArchAMD64,
+			BundleVerifier: verifier,
+			BinaryApplier:  applier,
+			ArtifactPolicy: ArtifactPolicy{
+				MaxArchiveBytes: 1 << 20,
+				MaxBinaryBytes:  8,
+			},
+		})
+
+		archiveBody := createTarGzBinary(t, "compozy", []byte("123456789"), 0o755)
+		release, _, server := newReleaseFixtureServer(t, manager, assetFixture{
+			archiveBody: archiveBody,
+			bundleBody:  []byte(`{}`),
+		})
+		defer server.Close()
+		manager.httpClient = server.Client()
+
+		_, err := manager.ApplyRelease(t.Context(), release)
+		var sizeErr *ArtifactSizeError
+		if !errors.As(err, &sizeErr) {
+			t.Fatalf("ApplyRelease() error = %v, want ArtifactSizeError", err)
+		}
+		if sizeErr.Kind != ArtifactKindBinary || sizeErr.Size != 9 || sizeErr.Limit != 8 {
+			t.Fatalf("ArtifactSizeError = %#v, want binary size 9 limit 8", sizeErr)
+		}
+		if verifier.calls != 1 {
+			t.Fatalf("VerifyChecksums() calls = %d, want 1 before archive inspection", verifier.calls)
+		}
+		if applier.applyCalls != 0 {
+			t.Fatalf("ApplyBinary() calls = %d, want 0 after artifact policy failure", applier.applyCalls)
+		}
+	})
+
 	t.Run("Should reject oversized archive download before verification", func(t *testing.T) {
 		t.Parallel()
 
@@ -103,18 +143,19 @@ func TestManagerApplyRelease(t *testing.T) {
 
 		release, _, server := newReleaseFixtureServer(t, manager, assetFixture{
 			archiveBody:          []byte("unused"),
-			archiveContentLength: fmt.Sprintf("%d", maxArchiveDownloadBytes+1),
+			archiveContentLength: fmt.Sprintf("%d", DefaultArtifactPolicy().MaxArchiveBytes+1),
 			bundleBody:           []byte("{}"),
 		})
 		defer server.Close()
 		manager.httpClient = server.Client()
 
 		_, err := manager.ApplyRelease(context.Background(), release)
-		if err == nil {
-			t.Fatal("ApplyRelease() error = nil, want oversized archive failure")
+		var sizeErr *ArtifactSizeError
+		if !errors.As(err, &sizeErr) {
+			t.Fatalf("ApplyRelease() error = %v, want ArtifactSizeError", err)
 		}
-		if !strings.Contains(err.Error(), "exceeds limit") {
-			t.Fatalf("ApplyRelease() error = %v, want download limit failure", err)
+		if sizeErr.Kind != ArtifactKindArchive || sizeErr.Limit != DefaultArtifactPolicy().MaxArchiveBytes {
+			t.Fatalf("ArtifactSizeError = %#v, want archive policy failure", sizeErr)
 		}
 		if verifier.calls != 0 {
 			t.Fatalf("VerifyChecksums() calls = %d, want 0 after oversized archive", verifier.calls)

--- a/internal/update/manager_archive.go
+++ b/internal/update/manager_archive.go
@@ -64,10 +64,82 @@ func extractBinaryFromTarGz(
 	archivePath string,
 	tempDir string,
 	binaryName string,
-) (_ string, _ os.FileMode, err error) {
+	policy ArtifactPolicy,
+) (string, os.FileMode, error) {
+	resolvedPolicy, err := resolveArtifactPolicy(policy)
+	if err != nil {
+		return "", 0, err
+	}
+	targetPath := filepath.Join(tempDir, binaryName)
+	writeBinary := func(reader io.Reader, size int64) error {
+		target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
+		if err != nil {
+			return fmt.Errorf("update: create extracted binary %q: %w", targetPath, err)
+		}
+		if err := copyArchiveEntry(target, reader, size); err != nil {
+			return errors.Join(
+				fmt.Errorf("update: extract binary %q: %w", targetPath, err),
+				target.Close(),
+			)
+		}
+		if err := target.Close(); err != nil {
+			return fmt.Errorf("update: close extracted binary %q: %w", targetPath, err)
+		}
+		return nil
+	}
+	mode, err := inspectArchiveBinary(archivePath, binaryName, resolvedPolicy, writeBinary)
+	if err != nil {
+		return "", 0, err
+	}
+	if mode != 0 {
+		if err := os.Chmod(targetPath, mode); err != nil {
+			return "", 0, fmt.Errorf("update: chmod extracted binary %q: %w", targetPath, err)
+		}
+	}
+	return targetPath, mode, nil
+}
+
+// ValidateReleaseArchive checks one direct-update archive without applying its binary.
+func ValidateReleaseArchive(
+	archivePath string,
+	binaryName string,
+	policy ArtifactPolicy,
+) error {
+	resolvedPolicy, err := resolveArtifactPolicy(policy)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		return fmt.Errorf("update: stat archive %q: %w", archivePath, err)
+	}
+	if err := validateArtifactSize(
+		ArtifactKindArchive,
+		info.Size(),
+		resolvedPolicy.MaxArchiveBytes,
+	); err != nil {
+		return err
+	}
+
+	_, err = inspectArchiveBinary(archivePath, binaryName, resolvedPolicy, func(reader io.Reader, size int64) error {
+		return copyArchiveEntry(io.Discard, reader, size)
+	})
+	return err
+}
+
+func inspectArchiveBinary(
+	archivePath string,
+	binaryName string,
+	policy ArtifactPolicy,
+	consume func(io.Reader, int64) error,
+) (_ os.FileMode, err error) {
+	resolvedPolicy, err := resolveArtifactPolicy(policy)
+	if err != nil {
+		return 0, err
+	}
 	file, err := os.Open(archivePath)
 	if err != nil {
-		return "", 0, fmt.Errorf("update: open archive %q: %w", archivePath, err)
+		return 0, fmt.Errorf("update: open archive %q: %w", archivePath, err)
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
@@ -77,7 +149,7 @@ func extractBinaryFromTarGz(
 
 	gzipReader, err := gzip.NewReader(file)
 	if err != nil {
-		return "", 0, fmt.Errorf("update: open gzip archive %q: %w", archivePath, err)
+		return 0, fmt.Errorf("update: open gzip archive %q: %w", archivePath, err)
 	}
 	defer func() {
 		if closeErr := gzipReader.Close(); closeErr != nil {
@@ -90,9 +162,9 @@ func extractBinaryFromTarGz(
 		header, err := tarReader.Next()
 		switch {
 		case errors.Is(err, io.EOF):
-			return "", 0, fmt.Errorf("update: archive %q did not contain %s", archivePath, binaryName)
+			return 0, fmt.Errorf("update: archive %q did not contain %s", archivePath, binaryName)
 		case err != nil:
-			return "", 0, fmt.Errorf("update: read archive %q: %w", archivePath, err)
+			return 0, fmt.Errorf("update: read archive %q: %w", archivePath, err)
 		case header == nil:
 			continue
 		case !isRegularArchiveFile(header):
@@ -101,28 +173,18 @@ func extractBinaryFromTarGz(
 			continue
 		}
 
-		targetPath := filepath.Join(tempDir, binaryName)
-		target, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o755)
-		if err != nil {
-			return "", 0, fmt.Errorf("update: create extracted binary %q: %w", targetPath, err)
-		}
-		if err := copyArchiveEntry(target, tarReader, header.Size); err != nil {
-			return "", 0, errors.Join(
-				fmt.Errorf("update: extract binary %q: %w", targetPath, err),
-				target.Close(),
-			)
-		}
-		if err := target.Close(); err != nil {
-			return "", 0, fmt.Errorf("update: close extracted binary %q: %w", targetPath, err)
-		}
-
 		mode := header.FileInfo().Mode().Perm()
-		if mode != 0 {
-			if err := os.Chmod(targetPath, mode); err != nil {
-				return "", 0, fmt.Errorf("update: chmod extracted binary %q: %w", targetPath, err)
-			}
+		if err := validateArtifactSize(
+			ArtifactKindBinary,
+			header.Size,
+			resolvedPolicy.MaxBinaryBytes,
+		); err != nil {
+			return 0, err
 		}
-		return targetPath, mode, nil
+		if err := consume(tarReader, header.Size); err != nil {
+			return 0, err
+		}
+		return mode, nil
 	}
 }
 
@@ -148,16 +210,9 @@ func executableBinaryMode(candidate os.FileMode, fallback os.FileMode) os.FileMo
 	return 0o755
 }
 
-func copyArchiveEntry(target *os.File, reader io.Reader, size int64) error {
+func copyArchiveEntry(target io.Writer, reader io.Reader, size int64) error {
 	if size <= 0 {
 		return errors.New("archive entry size must be positive")
-	}
-	if size > maxExtractedBinaryBytes {
-		return fmt.Errorf(
-			"archive entry size %d exceeds the allowed limit of %d bytes",
-			size,
-			maxExtractedBinaryBytes,
-		)
 	}
 
 	limitedReader := io.LimitReader(reader, size)

--- a/internal/update/manager_state.go
+++ b/internal/update/manager_state.go
@@ -113,7 +113,7 @@ func (m *Manager) composeState(install installInfo, latest *Release, checkedAt *
 	}
 
 	if state.InstallMethod == string(InstallMethodDirectBinary) && !supportedPlatform {
-		state.Recommendation = manualDirectBinaryRecommendation(state.ReleaseURL, m.runtimeOS)
+		state.Recommendation = ManualDirectBinaryRecommendation(state.ReleaseURL, m.runtimeOS)
 	}
 	return state
 }
@@ -148,7 +148,7 @@ func (m *Manager) updateRecommendation(installMethod string, release *Release) s
 		case string(InstallMethodGoInstall):
 			return "Use `go install " + goInstallModulePath + "@" + releaseVersion + "`."
 		case string(InstallMethodDirectBinary):
-			return manualDirectBinaryRecommendation(releaseURL, m.runtimeOS)
+			return ManualDirectBinaryRecommendation(releaseURL, m.runtimeOS)
 		default:
 			return "Install the v0.3 beta with `curl -fsSL https://compozy.com/install.sh | sh`."
 		}
@@ -172,7 +172,7 @@ func (m *Manager) updateRecommendation(installMethod string, release *Release) s
 	case string(InstallMethodGoInstall):
 		return "Use `go install " + goInstallModulePath + "@latest`."
 	case string(InstallMethodDirectBinary):
-		return manualDirectBinaryRecommendation(releaseURL, m.runtimeOS)
+		return ManualDirectBinaryRecommendation(releaseURL, m.runtimeOS)
 	default:
 		if strings.TrimSpace(installMethod) == "" {
 			return ""
@@ -181,7 +181,8 @@ func (m *Manager) updateRecommendation(installMethod string, release *Release) s
 	}
 }
 
-func manualDirectBinaryRecommendation(releaseURL string, runtimeOS string) string {
+// ManualDirectBinaryRecommendation returns the recovery path when in-place update is unavailable.
+func ManualDirectBinaryRecommendation(releaseURL string, runtimeOS string) string {
 	if runtimeOS == runtimeOSWindows {
 		if strings.TrimSpace(releaseURL) == "" {
 			return "Download the latest CompozyOS Windows release archive and replace `compozy.exe` manually."

--- a/internal/update/resource_cleanup.go
+++ b/internal/update/resource_cleanup.go
@@ -49,7 +49,7 @@ func writeDownloadTarget(targetPath string, target io.WriteCloser, source io.Rea
 		return fmt.Errorf("update: write download %q: %w", targetPath, copyErr)
 	}
 	if written > maxBytes {
-		return fmt.Errorf("update: download %q exceeds limit %d", targetPath, maxBytes)
+		return &downloadSizeError{Path: targetPath, Size: written, Limit: maxBytes}
 	}
 	return closeTarget()
 }

--- a/internal/update/types.go
+++ b/internal/update/types.go
@@ -40,12 +40,10 @@ const (
 )
 
 const (
-	cacheTTL                = 24 * time.Hour
-	defaultHTTPTimeout      = 30 * time.Second
-	maxArchiveDownloadBytes = int64(128 << 20)
-	maxChecksumsBytes       = int64(1 << 20)
-	maxSigstoreBundleBytes  = int64(8 << 20)
-	maxExtractedBinaryBytes = int64(128 << 20)
+	cacheTTL               = 24 * time.Hour
+	defaultHTTPTimeout     = 30 * time.Second
+	maxChecksumsBytes      = int64(1 << 20)
+	maxSigstoreBundleBytes = int64(8 << 20)
 )
 
 var ErrNoCachedRelease = errors.New("update: cached release info not found")
@@ -150,6 +148,7 @@ type Config struct {
 	RunCommand      func(context.Context, string, ...string) (string, error)
 	BundleVerifier  BundleVerifier
 	BinaryApplier   BinaryApplier
+	ArtifactPolicy  ArtifactPolicy
 }
 
 type cacheEntry struct {
@@ -179,6 +178,7 @@ type Manager struct {
 	runCommand     func(context.Context, string, ...string) (string, error)
 	bundleVerifier BundleVerifier
 	binaryApplier  BinaryApplier
+	artifactPolicy ArtifactPolicy
 	releaseTrack   releaseTrack
 	installMu      sync.Mutex
 	installFlight  chan struct{}

--- a/magefiles/update_archive.go
+++ b/magefiles/update_archive.go
@@ -1,0 +1,30 @@
+//go:build mage
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	compozyupdate "github.com/compozy/compozy/internal/update"
+)
+
+// UpdateArchiveCheck validates one GoReleaser archive against the runtime self-update contract.
+func UpdateArchiveCheck(archivePath string) error {
+	lowerPath := strings.ToLower(strings.TrimSpace(archivePath))
+	if strings.HasSuffix(lowerPath, ".zip") {
+		return nil
+	}
+	if !strings.HasSuffix(lowerPath, ".tar.gz") {
+		return fmt.Errorf("update archive check: unsupported archive format %q", archivePath)
+	}
+
+	if err := compozyupdate.ValidateReleaseArchive(
+		archivePath,
+		"compozy",
+		compozyupdate.DefaultArtifactPolicy(),
+	); err != nil {
+		return fmt.Errorf("update archive check %q: %w", archivePath, err)
+	}
+	return nil
+}

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -25,6 +25,10 @@ Do not manage runtime state by editing SQLite databases, process internals, or g
 build tracks newer beta releases. For install channels and moving between lines, follow the
 compozy.com docs instead of package managers, which may lag the active line.
 
+When an artifact-policy failure prevents an in-place update, follow the command's release-specific
+manual replacement recommendation. The same release cannot succeed through another immediate
+`compozy update` attempt.
+
 ## Daemon Drain
 
 Use `compozy drain -o json` (or `POST /api/drain` over HTTP/UDS) to close daemon-global new-work admission while admitted prompts and claimed runs finish. The stable response is `{"state":"draining"}`; repeated calls are no-ops. New session/prompt, task-run enqueue, retry/recover, and run-claim attempts return 503 with `daemon is draining; new work admission is closed`, while cancellation, terminal transitions, and teardown remain available.


### PR DESCRIPTION
Closes #359.

## What broke

The direct-binary updater treated the compressed archive and the extracted executable as if they had the same 128 MiB safety envelope. The official beta.13 Darwin arm64 archive is 49,342,626 bytes, but its verified `compozy` entry is 135,516,530 bytes, so the runtime rejected an artifact produced by CompozyOS's own release pipeline.

This was a producer/consumer contract gap: the runtime enforced a private limit, while GoReleaser had no pre-publication check proving that a release archive was consumable. Retrying could never succeed, yet the failed command still recommended another `compozy update`.

## What changed

- Introduced one runtime-owned artifact policy: 128 MiB for the downloaded archive and 256 MiB for the extracted executable.
- Made runtime extraction and release validation use the same tar reader, size checks, and typed `ArtifactSizeError`.
- Added a GoReleaser Pro `before_publish` hook for the Darwin/Linux `compozy-archive` artifacts. The Mage target validates each built archive against the runtime policy before publication can begin.
- Kept Windows ZIP outside this hook because direct self-update is not supported on Windows; unsupported non-ZIP/non-tar formats fail closed.
- Replaced the impossible retry recommendation with the existing release-specific manual replacement path when an artifact is outside policy.
- Cleared stale recommendations after both successful local updates and successful daemon restart updates.
- Updated the official Compozy skill and the release/self-update QA contracts.

## Regression coverage

- `internal/update`: rejects an archive above policy as a typed archive error; rejects an extracted binary above a configurable policy before applying it.
- `internal/cli`: converts artifact policy failures to manual recovery and never repeats the failed update command; successful updates no longer retain the pre-update recommendation.
- `internal/config`: proves the release configuration invokes the archive contract for `compozy-archive` artifacts before publication.

Test placement follows the existing canonical suites: runtime policy belongs to `TestManagerApplyRelease`, command behavior belongs to `TestUpdateCommandFlows`, and release wiring belongs to `TestGoReleaserConfigPreservesTrustArtifactsAndPackageTargets`.

## Production-like QA

- Built an isolated candidate reporting beta.8 and updated it through the real beta.13 GitHub archive, checksum catalog, and Sigstore bundle.
- Verified that only the isolated candidate changed, the installed executable reported beta.13, and the successful JSON result contained no stale recommendation.
- Ran the exact release Mage hook against the official archive: 49,342,626-byte archive / 135,516,530-byte binary accepted.
- Ran the same hook against a fixture containing a 269,484,032-byte binary: rejected against the 268,435,456-byte policy before publication.
- Strict QA evidence audit: PASS, zero blockers and zero warnings.
- QA teardown: `clean: true`; no daemon, watcher, browser, or lab process remained.

## Verification

- `make gate-full`: PASS
- Fingerprint: `760d454386dbbe5262a5e4ce3ad886b6afc70b9b`
- `CGO_ENABLED=1 go test -race ./internal/update`: PASS
- `CGO_ENABLED=1 go test -race ./internal/cli ./internal/config -count=1`: PASS
- Scoped `golangci-lint` for `internal/update`: PASS

## Broader auto-update audit

The whole auto-update area was explored across artifact integrity, runtime surfaces, and release production. The following adjacent gaps are deliberately not bundled into this fix because they require separate contracts:

- update diagnostics lose some structured detail between runtime, CLI, HTTP/UDS, and UI surfaces;
- direct-binary replacement has no explicit cross-process update lock;
- Windows ZIP validation and a Windows in-place update contract remain absent;
- some beta managed-install fallback/configuration paths need their own lifecycle design.

None changes the root cause or safety of this patch; each should be handled independently rather than hidden behind compatibility or fallback code.

## Compozy Impact Audit

- **Native tools:** no impact. Checked `compozy__*` tool IDs, toolsets, descriptors, schemas, digests, risk flags, availability diagnostics, and capability gates; update is a CLI/runtime path and exposes no native tool contract.
- **Extensibility and hooks:** the GoReleaser `before_publish` hook now consumes the runtime-owned artifact policy. Checked extensions, runtime hooks, capabilities, tools/resources, registries, bridge SDKs, and MCP sidecars; none use or expose self-update artifacts. No `config.toml` key, default, or lifecycle changed.
- **Workspace data isolation:** no impact. Artifact policy and installation replacement are global process/install concerns and create no workspace/session/agent datum. Checked CLI, HTTP/UDS, core/store, Web cache, SSE, and event propagation; no `workspace_id` path changed.
- **Official Compozy skill:** updated `skills/compozy/references/runtime-operations.md` so agents use manual release replacement after a deterministic artifact-policy failure instead of retrying the same command.

## Web / docs impact

No Web route, component, hook, or site documentation contract changed. The user-visible CLI recovery behavior is covered in the official built-in skill and the tracked QA scenarios/report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added size safeguards for downloaded update archives and binaries.
  * Added archive validation before release publication.
  * Added direct-binary guidance when an update cannot be applied due to artifact limits.
* **Bug Fixes**
  * Update recommendations are now cleared after successful updates or daemon restarts.
  * Oversized or invalid update artifacts now produce clearer errors and safer failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->