### PR TITLE
fix: canonicalize desktop runtime manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -876,6 +876,12 @@ jobs:
         with:
           install-playwright: "false"
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri -> target
+
       - name: Install verification tools
         run: brew install minisign awscli
 
@@ -904,6 +910,7 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
           RELEASE_VERSION: ${{ needs.release-plan.outputs.release_version }}
         run: |
           set -euo pipefail
@@ -914,6 +921,15 @@ jobs:
             "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             .artifacts/feed
           scripts/sign-runtime-manifest.sh .artifacts/feed/runtime.json
+          cargo run --locked \
+            --manifest-path desktop/src-tauri/Cargo.toml \
+            --bin compozy-runtime-manifest-check -- \
+            .artifacts/feed/runtime.json \
+            .artifacts/feed/runtime.json.minisig \
+            "${RELEASE_VERSION}" \
+            darwin-aarch64 \
+            darwin-x86_64 \
+            linux-x86_64
 
       - name: Revalidate stapling and bundle version
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .cache/
 .turbo/
 .tanstack/
-bin/
+/bin/
 dist/
 desktop/src-tauri/target/
 desktop/src-tauri/gen/

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -68,3 +68,7 @@ strip = true
 [[bin]]
 name = "compozyos-desktop"
 path = "src/main.rs"
+
+[[bin]]
+name = "compozy-runtime-manifest-check"
+path = "src/bin/runtime_manifest_check.rs"

--- a/desktop/src-tauri/src/bin/runtime_manifest_check.rs
+++ b/desktop/src-tauri/src/bin/runtime_manifest_check.rs
@@ -1,0 +1,150 @@
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+
+use compozyos_desktop::runtime::artifacts::verify_manifest;
+use semver::Version;
+
+fn main() {
+    if let Err(error) = run(env::args_os(), env::var("TAURI_SIGNING_PUBLIC_KEY")) {
+        eprintln!("desktop release: runtime manifest verification failed: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn run(
+    mut args: impl Iterator<Item = OsString>,
+    public_key: Result<String, env::VarError>,
+) -> Result<(), String> {
+    let program = args
+        .next()
+        .and_then(|value| value.into_string().ok())
+        .unwrap_or_else(|| "compozy-runtime-manifest-check".to_owned());
+    let manifest_path = required_path(&mut args, &program, "manifest")?;
+    let signature_path = required_path(&mut args, &program, "signature")?;
+    let expected_version = required_text(&mut args, &program, "expected version")?;
+    let targets = args
+        .map(|target| {
+            target
+                .into_string()
+                .map_err(|_| "target must be valid UTF-8".to_owned())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if targets.is_empty() {
+        return Err(usage(&program));
+    }
+
+    let expected_version = Version::parse(&expected_version)
+        .map_err(|error| format!("parse expected version: {error}"))?;
+    let public_key = public_key.map_err(|_| "TAURI_SIGNING_PUBLIC_KEY is required".to_owned())?;
+    let manifest = fs::read(&manifest_path)
+        .map_err(|error| format!("read {}: {error}", manifest_path.display()))?;
+    let signature = fs::read_to_string(&signature_path)
+        .map_err(|error| format!("read {}: {error}", signature_path.display()))?;
+
+    for target in &targets {
+        let verified = verify_manifest(&manifest, &signature, &public_key, target, None)
+            .map_err(|error| format!("verify {target}: {error}"))?
+            .ok_or_else(|| {
+                format!("verify {target}: manifest unexpectedly selected no artifact")
+            })?;
+        if verified.version != expected_version {
+            return Err(format!(
+                "verify {target}: manifest version {} does not match {expected_version}",
+                verified.version
+            ));
+        }
+    }
+
+    println!(
+        "desktop release: runtime manifest verified for {} target(s)",
+        targets.len()
+    );
+    Ok(())
+}
+
+fn required_path(
+    args: &mut impl Iterator<Item = OsString>,
+    program: &str,
+    name: &str,
+) -> Result<PathBuf, String> {
+    args.next()
+        .map(PathBuf::from)
+        .ok_or_else(|| format!("{name} path is required\n{}", usage(program)))
+}
+
+fn required_text(
+    args: &mut impl Iterator<Item = OsString>,
+    program: &str,
+    name: &str,
+) -> Result<String, String> {
+    args.next()
+        .ok_or_else(|| format!("{name} is required\n{}", usage(program)))?
+        .into_string()
+        .map_err(|_| format!("{name} must be valid UTF-8"))
+}
+
+fn usage(program: &str) -> String {
+    format!(
+        "usage: {program} <runtime.json> <runtime.json.minisig> <version> <target> [<target> ...]"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::io::Cursor;
+
+    use base64::Engine;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use minisign::{KeyPair, sign};
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn should_verify_signed_canonical_manifest_for_requested_target() {
+        let temp = tempfile::tempdir().expect("temporary directory creates");
+        let manifest_path = temp.path().join("runtime.json");
+        let signature_path = temp.path().join("runtime.json.minisig");
+        let manifest = BTreeMap::from([
+            (
+                "platforms",
+                json!({
+                    "darwin-aarch64": {
+                        "sha256": "a".repeat(64),
+                        "size": 3,
+                        "url": "http://127.0.0.1:43119/runtime.tar.gz"
+                    }
+                }),
+            ),
+            ("schema_heads", json!({"global": 12})),
+            ("schema_version", json!(1)),
+            ("version", json!("0.4.0")),
+        ]);
+        let bytes = serde_json::to_vec(&manifest).expect("manifest serializes");
+        let pair = KeyPair::generate_unencrypted_keypair().expect("test key generates");
+        let signature = sign(
+            Some(&pair.pk),
+            &pair.sk,
+            Cursor::new(&bytes),
+            Some("timestamp:0"),
+            Some("test signature"),
+        )
+        .expect("manifest signs")
+        .to_string();
+        fs::write(&manifest_path, bytes).expect("manifest writes");
+        fs::write(&signature_path, signature).expect("signature writes");
+        let public_key = BASE64.encode(pair.pk.to_box().expect("public key boxes").to_string());
+        let args = [
+            OsString::from("checker"),
+            manifest_path.into_os_string(),
+            signature_path.into_os_string(),
+            OsString::from("0.4.0"),
+            OsString::from("darwin-aarch64"),
+        ];
+
+        run(args.into_iter(), Ok(public_key)).expect("candidate manifest verifies");
+    }
+}

--- a/desktop/src-tauri/src/runtime/artifacts.rs
+++ b/desktop/src-tauri/src/runtime/artifacts.rs
@@ -343,20 +343,7 @@ mod tests {
         public_key: String,
     }
 
-    fn signed_manifest(version: &str, schema_heads: Value) -> SignedManifest {
-        let value = json!({
-            "schema_version": 1,
-            "version": version,
-            "platforms": {
-                "darwin-aarch64": {
-                    "url": "http://127.0.0.1:43119/runtime.tar.gz",
-                    "sha256": "a".repeat(64),
-                    "size": 3
-                }
-            },
-            "schema_heads": schema_heads
-        });
-        let bytes = canonical_json(&value).expect("manifest canonicalizes");
+    fn sign_manifest_bytes(bytes: Vec<u8>) -> SignedManifest {
         let pair = KeyPair::generate_unencrypted_keypair().expect("test key generates");
         let signature = sign(
             Some(&pair.pk),
@@ -372,6 +359,27 @@ mod tests {
             signature,
             public_key: BASE64.encode(pair.pk.to_box().expect("public key boxes").to_string()),
         }
+    }
+
+    fn manifest_value(version: &str, schema_heads: Value) -> Value {
+        json!({
+            "schema_version": 1,
+            "version": version,
+            "platforms": {
+                "darwin-aarch64": {
+                    "url": "http://127.0.0.1:43119/runtime.tar.gz",
+                    "sha256": "a".repeat(64),
+                    "size": 3
+                }
+            },
+            "schema_heads": schema_heads
+        })
+    }
+
+    fn signed_manifest(version: &str, schema_heads: Value) -> SignedManifest {
+        let value = manifest_value(version, schema_heads);
+        let bytes = canonical_json(&value).expect("manifest canonicalizes");
+        sign_manifest_bytes(bytes)
     }
 
     #[test]
@@ -425,6 +433,30 @@ mod tests {
                 None,
             ),
             Err(ArtifactError::Signature)
+        ));
+    }
+
+    #[test]
+    fn should_refuse_signed_manifest_when_json_is_not_canonical() {
+        let value = manifest_value("0.4.0", json!({"global": 12}));
+        let bytes = serde_json::to_vec(&RuntimeManifest {
+            schema_version: 1,
+            version: Version::parse("0.4.0").expect("version parses"),
+            platforms: serde_json::from_value(value["platforms"].clone()).expect("platforms parse"),
+            schema_heads: BTreeMap::from([("global".to_owned(), 12)]),
+        })
+        .expect("noncanonical manifest serializes");
+        let signed = sign_manifest_bytes(bytes);
+
+        assert!(matches!(
+            verify_manifest(
+                &signed.bytes,
+                &signed.signature,
+                &signed.public_key,
+                "darwin-aarch64",
+                None,
+            ),
+            Err(ArtifactError::NonCanonical)
         ));
     }
 

--- a/docs/qa/reports/2026-08-12-runtime-manifest-verification.md
+++ b/docs/qa/reports/2026-08-12-runtime-manifest-verification.md
@@ -1,0 +1,83 @@
+# QA Run Report — 2026-08-12 — Runtime Manifest Verification
+
+- **Scope:** Issue #362 release fix: signed runtime-manifest verification before macOS and Linux installer publication
+- **Cadence tier:** targeted
+- **Build:** `5786c79589d214907f92b3630d1997d03e8eebac` + working tree · **Environment:** isolated local QA lab; signed candidate packages required for production parity
+- **Started:** 2026-08-13T00:43:14Z · **Status:** in-progress
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Lea | clean install | macOS and Linux laptop / wifi-fast / en-US | CH-desktop-first-run-macos, CH-desktop-first-run-linux |
+
+## Flows in Scope
+
+- `J-desktop-first-run` — install CompozyOS and reach a working product without terminal setup (`../journeys/J-desktop-first-run.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-desktop-first-run-macos | J-desktop-first-run / APP-install-first-run-provision | Lea | Feature Tour | Blocked (needs human verify) | No signed candidate DMG built from this change | working tree |
+| 2 | CH-desktop-first-run-linux | J-desktop-first-run / APP-install-first-run-provision | Lea | Feature Tour | Blocked (needs human verify) | No signed candidate AppImage built from this change | working tree |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-desktop-first-run-macos — Lea
+
+- **Ran:** 2026-08-13T00:43Z → 2026-08-13T00:45Z (box respected: yes)
+- **Findings:** The package precondition failed: the branch has no release run and local signing secrets are unavailable.
+- **Bugs filed/updated:** GitHub issue #362; no new product symptom was observed.
+- **Scenarios settled:** APP-install-first-run-provision → blocked-verify
+- **Paper cuts:** Not evaluated because the signed DMG entry point was unavailable.
+- **Surprises:** None.
+- **Suggested next charter:** Re-run CH-desktop-first-run-macos against the next signed candidate.
+
+### CH-desktop-first-run-linux — Lea
+
+- **Ran:** 2026-08-13T00:43Z → 2026-08-13T00:45Z (box respected: yes)
+- **Findings:** The package precondition failed: the branch has no release run and local signing secrets are unavailable.
+- **Bugs filed/updated:** GitHub issue #362; no new product symptom was observed.
+- **Scenarios settled:** APP-install-first-run-provision → blocked-verify
+- **Paper cuts:** Not evaluated because the signed AppImage entry point was unavailable.
+- **Surprises:** None.
+- **Suggested next charter:** Re-run CH-desktop-first-run-linux against the next signed candidate.
+
+## What Was Fixed
+
+### GitHub issue #362: Runtime package cannot be verified or installed
+
+- **Symptom:** A clean Linux AppImage launch cannot provision its runtime package.
+- **Root cause:** The Go release producer signed compact JSON in struct-field order while the desktop verifier requires recursively sorted object keys.
+- **Fix:** working tree; canonical producer output plus exact desktop-verifier enforcement before release upload.
+- **Regression test:** `internal/desktoprelease/release_test.go`, `desktop/src-tauri/src/runtime/artifacts.rs`, and `internal/config/release_config_test.go` failed before their owning production changes and pass afterward.
+- **Retested:** Exact producer and consumer contracts passed locally; signed candidate package walks are blocked.
+
+## Paper Cuts
+
+Not evaluated; package walks did not start.
+
+## Runtime Errors Observed
+
+No new runtime process was started. The published beta.13 remains the reported failing artifact and was not treated as evidence for the working-tree fix.
+
+## Human Verifications Needed
+
+- [ ] Download the next signed candidate DMG on a clean macOS machine, accept it through Gatekeeper, complete provisioning, relaunch, and confirm one daemon plus healthy `compozy status`. (row #1)
+- [ ] Install the next signed candidate AppImage on a clean Linux machine, complete provisioning, relaunch, and confirm one daemon plus healthy `compozy status`; retain the tauri-driver transcript. (row #2)
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- A release signature proves byte integrity, not that the desktop accepts the signed bytes; publication must execute the exact consumer contract.
+- The targeted evidence audit passed at `/Users/pedronauck/dev/qa-labs/compozy-issue-362-runtime-manifest-20260813-004336-922826-lab/qa-artifacts/qa/qa-audit-report.md`.
+
+## Final Status
+
+Pending.

--- a/docs/qa/scenarios/APP-install-first-run-provision.md
+++ b/docs/qa/scenarios/APP-install-first-run-provision.md
@@ -9,10 +9,10 @@ entry_points: CompozyOS installer (macOS dmg, Linux package); app first launch
 qa_status: blocked-verify
 bug_ids: BUG-20260810-desktop-dev-shell-crashes; BUG-20260810-desktop-runtime-stalls; BUG-20260810-initial-boot-window-absent; BUG-20260810-boot-controls-unavailable
 fix_status: fixed
-retest_status: blocked-verify
+retest_status: pending
 fix_commits: 01a45c49; b415f24b; b3aa3d27; bd610cfa; 02b55a46; f081a1e; working tree
-evidence: /Users/pedronauck/dev/qa-labs/compozy-coderabbit-desktop-remediation-20260810-153824-470714-lab/qa-artifacts/qa/boot-retry-blocked.jpeg; /Users/pedronauck/dev/qa-labs/compozy-coderabbit-desktop-remediation-20260810-153824-470714-lab/qa-artifacts/qa/boot-diagnostics-fixed.jpeg; /Users/pedronauck/dev/qa-labs/compozy-coderabbit-desktop-remediation-20260810-153824-470714-lab/qa-artifacts/qa/boot-retry-fixed.jpeg; /Users/pedronauck/dev/qa-labs/compozy-coderabbit-desktop-remediation-20260810-153824-470714-lab/qa-artifacts/qa/platform-capability-blockers.txt; /Users/pedronauck/dev/qa-labs/compozy-desktop-startup-diagnostics-20260811-200336-439901-lab/qa-artifacts/qa/runtime-cli-walk.md
-last_report: docs/qa/reports/2026-08-11-desktop-startup-diagnostics.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-362-runtime-manifest-20260813-004336-922826-lab/qa-artifacts/qa/candidate-preconditions.md; /Users/pedronauck/dev/qa-labs/compozy-issue-362-runtime-manifest-20260813-004336-922826-lab/qa-artifacts/qa/qa-audit-report.md
+last_report: docs/qa/reports/2026-08-12-runtime-manifest-verification.md
 overlaps:
 ---
 
@@ -28,8 +28,9 @@ tauri-driver script + package install/reinstall transcript. All OSes: process-ta
 proving exactly one daemon, and the offline-first-run retry walk (E2E-002) on at least one OS
 with the branch recorded.
 
-QA impact 2026-08-11: first-run now self-starts the verified app-owned runtime and keeps the boot
-window available after failure for a redacted report, local copy, and explicit local export.
-Historical evidence above is preserved. The working-tree macOS runtime path passed, but a signed
-candidate DMG and Linux AppImage were unavailable, so installer trust, packaged provisioning, and
-the boot-window recovery controls remain blocked for the mandatory pre-publish artifact smoke.
+QA impact 2026-08-12: release publication now requires the signed candidate runtime manifest to
+pass the desktop's exact verifier for every shipping target before upload. The scenario is reset
+because installer trust and packaged provisioning must be re-walked with signed candidate macOS
+and Linux packages. No signed candidate exists for this branch, so both package walks remain
+blocked; the dated report preserves the exact verification steps and prior reports retain their
+historical evidence.

--- a/internal/config/release_config_test.go
+++ b/internal/config/release_config_test.go
@@ -542,6 +542,34 @@ func TestDesktopReleaseWorkflowFailsClosedAndPublishesDraftLast(t *testing.T) {
 		assertNotContainsText(t, "desktop release workflow", workflow, "APPLE_API_ISSUER")
 		assertNotContainsText(t, "desktop release workflow", workflow, "APPLE_API_KEY")
 	})
+
+	t.Run("Should verify the signed runtime manifest with the desktop consumer before publication", func(t *testing.T) {
+		t.Parallel()
+
+		signManifest := strings.Index(workflow, "scripts/sign-runtime-manifest.sh")
+		verifyManifest := strings.Index(workflow, "--bin compozy-runtime-manifest-check")
+		publishFeed := strings.Index(workflow, "scripts/publish-desktop-release.sh")
+		if signManifest == -1 || verifyManifest == -1 || publishFeed == -1 {
+			t.Fatal(
+				"desktop release workflow is missing candidate manifest signing, " +
+					"consumer verification, or publication",
+			)
+		}
+		if signManifest > verifyManifest || verifyManifest > publishFeed {
+			t.Fatal("desktop release workflow must verify signed candidate manifest bytes before publication")
+		}
+		verification := workflow[signManifest:publishFeed]
+		for _, required := range []string{
+			"TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}",
+			".artifacts/feed/runtime.json.minisig",
+			`"${RELEASE_VERSION}"`,
+			"darwin-aarch64",
+			"darwin-x86_64",
+			"linux-x86_64",
+		} {
+			assertContainsText(t, "runtime manifest consumer verification", verification, required)
+		}
+	})
 }
 
 func TestDesktopReleaseScriptsRefuseUnsafeOperatorInputs(t *testing.T) {

--- a/internal/desktoprelease/canonical_json.go
+++ b/internal/desktoprelease/canonical_json.go
@@ -1,0 +1,34 @@
+package desktoprelease
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func writeCanonicalJSON(path string, value any) error {
+	contents, err := canonicalJSON(value)
+	if err != nil {
+		return fmt.Errorf("desktop release: encode canonical JSON: %w", err)
+	}
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		return fmt.Errorf("desktop release: write %s: %w", filepath.Base(path), err)
+	}
+	return nil
+}
+
+func canonicalJSON(value any) ([]byte, error) {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var document any
+	if err := decoder.Decode(&document); err != nil {
+		return nil, err
+	}
+	return json.Marshal(document)
+}

--- a/internal/desktoprelease/manifest.go
+++ b/internal/desktoprelease/manifest.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/url"
@@ -242,15 +241,4 @@ func digestFile(path string) (string, int64, error) {
 		return "", 0, fmt.Errorf("close artifact: %w", closeErr)
 	}
 	return hex.EncodeToString(digest.Sum(nil)), size, nil
-}
-
-func writeCanonicalJSON(path string, value any) error {
-	contents, err := json.Marshal(value)
-	if err != nil {
-		return fmt.Errorf("desktop release: encode canonical JSON: %w", err)
-	}
-	if err := os.WriteFile(path, contents, 0o600); err != nil {
-		return fmt.Errorf("desktop release: write %s: %w", filepath.Base(path), err)
-	}
-	return nil
 }

--- a/internal/desktoprelease/release_test.go
+++ b/internal/desktoprelease/release_test.go
@@ -1,6 +1,7 @@
 package desktoprelease
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"os"
@@ -178,6 +179,7 @@ func TestBuildFeeds(t *testing.T) {
 		if strings.HasSuffix(string(latestBytes), "\n") {
 			t.Fatal("latest.json has a trailing newline, want canonical JSON bytes")
 		}
+		assertCanonicalJSON(t, "latest.json", latestBytes)
 		var latest LatestManifest
 		if err := json.Unmarshal(latestBytes, &latest); err != nil {
 			t.Fatalf("json.Unmarshal(latest.json) error = %v", err)
@@ -189,8 +191,11 @@ func TestBuildFeeds(t *testing.T) {
 			t.Fatalf("universal Darwin URLs differ: arm64 = %q, x86_64 = %q", got, want)
 		}
 
+		runtimeBytes := readTestFile(t, filepath.Join(outputDir, "runtime.json"))
+		assertCanonicalJSON(t, "runtime.json", runtimeBytes)
+
 		var runtime RuntimeManifest
-		if err := json.Unmarshal(readTestFile(t, filepath.Join(outputDir, "runtime.json")), &runtime); err != nil {
+		if err := json.Unmarshal(runtimeBytes, &runtime); err != nil {
 			t.Fatalf("json.Unmarshal(runtime.json) error = %v", err)
 		}
 		if err := ValidateRuntimeManifest(runtime); err != nil {
@@ -390,4 +395,21 @@ func readTestFile(t *testing.T, path string) []byte {
 		t.Fatalf("os.ReadFile(%s) error = %v", path, err)
 	}
 	return contents
+}
+
+func assertCanonicalJSON(t *testing.T, name string, contents []byte) {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(contents))
+	decoder.UseNumber()
+	var document any
+	if err := decoder.Decode(&document); err != nil {
+		t.Fatalf("decode %s for canonical comparison: %v", name, err)
+	}
+	canonical, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("json.Marshal(canonical %s) error = %v", name, err)
+	}
+	if !bytes.Equal(contents, canonical) {
+		t.Fatalf("%s is not recursively key-sorted canonical JSON\ngot:  %s\nwant: %s", name, contents, canonical)
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes Linux AppImage runtime provisioning by making release manifests match the desktop verifier's canonical JSON contract.
- Requires signed candidate manifests to pass the desktop's exact verifier for every shipping runtime target before publication.
- Keeps signed candidate installer verification explicit: macOS and Linux package walks remain pending until a candidate is built from this branch.

Closes #362.

## Root cause

The Go release producer serialized `runtime.json` from structs. Go preserves struct-field order, while the Rust desktop verifier recursively sorts object keys and requires those canonical bytes to match the signed input exactly. Beta.13 therefore carried a valid signature and valid archive metadata but was rejected as non-canonical before provisioning could install the runtime.

## Changes

- **Manifest producer:** canonicalizes JSON through a number-preserving generic document before writing feeds, recursively sorting object keys while preserving compact bytes and exact numeric values.
- **Desktop verifier:** adds a regression proving that a correctly signed but non-canonical runtime manifest is rejected.
- **Release publication:** adds the tracked `compozy-runtime-manifest-check` CLI and invokes it after signing and before upload for `darwin-aarch64`, `darwin-x86_64`, and `linux-x86_64`.
- **Release contract tests:** assert signing → exact consumer verification → publication ordering and the complete shipping-target matrix.
- **CI checkout integrity:** anchors the root build-output ignore rule as `/bin/`, so Rust's standard `src/bin/` source directory is tracked. Commit `2c7499d7` fixes the missing-source failure from Actions job `94311211872`.
- **QA tracking:** records the absence of signed branch candidates and the exact macOS/Linux follow-up walks.

## Release notes

### 🐛 Bug Fixes

- Desktop releases now publish canonical signed runtime manifests that the macOS and Linux apps can verify during first-run provisioning.
- Release publication now stops before upload if the signed candidate manifest fails the desktop's exact verification contract for any shipping runtime target.

## QA

**Status:** ready with blocked items at the code-contract level; not ready for signed package acceptance.

**Coverage:** Lea's macOS and Linux first-run charters were evaluated through the package precondition boundary in an isolated targeted QA lab.

**Blocked / needs human:** build the next signed candidate from this branch, then walk the DMG on a clean macOS machine and the AppImage on a clean Linux machine through install, provisioning, relaunch, single-daemon verification, and healthy `compozy status`.

**Process hygiene:** the QA evidence audit passed, and teardown completed with `clean: true` and no survivors.

**Full report:** [`2026-08-12-runtime-manifest-verification.md`](docs/qa/reports/2026-08-12-runtime-manifest-verification.md)

## Test plan

- [x] `CGO_ENABLED=1 go test -race ./internal/desktoprelease ./internal/config`
- [x] `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- [x] `cargo test --manifest-path desktop/src-tauri/Cargo.toml runtime::artifacts::tests::`
- [x] `cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml --bin compozy-runtime-manifest-check`
- [x] `make desktop-lint`
- [x] `make desktop-test`
- [x] `git ls-tree -r --name-only HEAD -- desktop/src-tauri/src/bin/runtime_manifest_check.rs`
- [x] Targeted QA evidence audit and mandatory teardown (`clean: true`)
- [ ] `make gate-full` was not completed at the operator's request
- [ ] Signed candidate DMG and AppImage first-run walks require release signing infrastructure

## Compozy Impact Audit

- **Native tools:** No impact. Checked `compozy__*` tool IDs, descriptors, schemas, capability gates, and CLI/API fallbacks; this change is confined to offline desktop release metadata and publication.
- **Extensibility and hooks:** No impact. Checked extensions, hooks, skills/capabilities, tools/resources, registries, bridge SDKs, MCP sidecars, and `config.toml`; no runtime extension surface or configuration key changes.
- **Workspace data isolation:** No impact. The changed datum is global distribution metadata, not workspace/session/agent data; no CLI, HTTP, UDS, store, cache, SSE, or event path changes.
- **Official Compozy skill:** No impact. Checked `skills/compozy/`; public tools, CLI paths, hook events, capabilities, extension resources, and task/memory/network behavior are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of signed runtime manifests, including rejection of non-canonical JSON.
  * Release feeds now verify manifest signatures, versions, platform coverage, and expected publication ordering.
  * Generated release metadata is written in a consistent, canonical JSON format with restrictive file permissions.

* **Tests**
  * Expanded coverage for manifest signing, consumer verification, canonical feed output, and supported runtime platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->