### PR TITLE
fix: include extension tools in hosted MCP bootstrap

### DIFF
--- a/docs/qa/reports/2026-08-13-hosted-extension-tool-bootstrap.md
+++ b/docs/qa/reports/2026-08-13-hosted-extension-tool-bootstrap.md
@@ -1,0 +1,51 @@
+# Hosted extension tool bootstrap QA
+
+- **Issue:** [compozy/compozy#371](https://github.com/compozy/compozy/issues/371)
+- **Branch:** `fix/hosted-extension-tool-bootstrap`
+- **Scenario:** `ET-048`
+- **Result:** PASS
+- **Lab manifest:** `/home/franciscpd/dev/qa-labs/compozy-hosted-extension-tool-bootstrap-20260813-151539-252959-lab/qa-artifacts/qa/bootstrap-manifest.json`
+
+## Result
+
+The daemon now includes extension-host tools in the initial hosted MCP projection. A workspace
+extension created from the official `tool-provider-go` template was active before a new managed
+session bound its hosted MCP server. The live Codex session resolved `ext__qa_hosted__search` as
+registered, available, authorized, executable, and callable, then called it with `query=alpha` and
+received `No results for alpha`.
+
+This proof is extension-generic: the fixture and live lab use `hello` and `qa-hosted`, respectively.
+Neither the implementation nor the tests refer to Batuta or dev-cycle. Vendor MCP providers keep
+their existing deferred discovery behavior.
+
+## Verification
+
+- `mise exec -- go test -race ./internal/daemon -count=1` — PASS
+- `mise exec -- go test -race -tags=integration ./internal/daemon -run TestDaemonE2EExtensionDistributionAcrossIsolatedHomes -count=1 -v` — PASS
+- `mise exec -- golangci-lint run ./internal/daemon/...` — PASS, zero issues
+- `mise exec -- make build` — PASS
+- Strict QA audit — PASS, no blockers or warnings
+- Teardown — `clean: true`, no survivors
+
+Live evidence:
+
+- Session: `sess-67821081fd92dcde`
+- Tool discovery: sequences 12–13
+- Tool call/result: sequences 15–16
+- Result: `No results for alpha`
+- Evidence: `/home/franciscpd/dev/qa-labs/compozy-hosted-extension-tool-bootstrap-20260813-151539-252959-lab/qa-artifacts/qa/hosted-extension-proof.json`
+
+## Compozy Impact Audit
+
+- **Native tools:** no `compozy__*` or extension ToolID, descriptor, schema, digest, risk flag, or
+  capability gate changed. The hosted MCP bootstrap now includes the already-callable
+  `ext__<extension>__<tool>` descriptors. Unit and live hosted-MCP tests cover discovery and call.
+- **Extensibility and hooks:** extension-host providers now participate in initial hosted MCP
+  discovery; external vendor MCP providers remain deferred. Extension manifests, capabilities,
+  subprocess protocol, hooks, resources, bridge SDKs, and config lifecycle are unchanged.
+- **Workspace data isolation:** extension discovery and calls keep the bound session workspace scope.
+  The E2E installs the extension in an isolated consumer home and invokes it only from its registered
+  workspace; no new global, workspace, session, or agent datum is introduced.
+- **Official Compozy skill:** no update required. Existing extension authoring and tool-discovery
+  guidance already describes extension ToolIDs and live descriptor resolution; this fix restores the
+  documented hosted MCP projection behavior without adding a command, schema, or operator workflow.

--- a/docs/qa/scenarios/ET-048.md
+++ b/docs/qa/scenarios/ET-048.md
@@ -7,12 +7,12 @@ journey: J-validate-compozy-hard-cut
 expected: UDS `/api/internal/hosted-mcp/{bind,projection,projection/stream,tools/call,release}` is gated on peer identity; the initial projection includes every callable local-provider tool without waiting on deferred providers; missing session/bind returns stable errors (`hosted_mcp_session_required`, `hosted_mcp_bind_required`).
 entry_points: UDS internal hosted-mcp routes
 qa_status: pass
-bug_ids:
+bug_ids: compozy/compozy#371
 fix_status: fixed
 retest_status: pass
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-critical-runtime-ui-fixes-20260807-225222-371495-lab/qa-artifacts/qa/codex-native-tools-evidence.md
-last_report: docs/qa/reports/2026-08-07-critical-runtime-ui-fixes.md
+evidence: /home/franciscpd/dev/qa-labs/compozy-hosted-extension-tool-bootstrap-20260813-151539-252959-lab/qa-artifacts/qa/hosted-extension-proof.json; /home/franciscpd/dev/qa-labs/compozy-hosted-extension-tool-bootstrap-20260813-151539-252959-lab/qa-artifacts/qa/qa-audit-report.json; /home/franciscpd/dev/qa-labs/compozy-hosted-extension-tool-bootstrap-20260813-151539-252959-lab/qa-artifacts/qa/teardown.json
+last_report: docs/qa/reports/2026-08-13-hosted-extension-tool-bootstrap.md
 overlaps:
 ---
 
@@ -30,3 +30,8 @@ QA impact 2026-07-30: the closeout gate found that the initial hosted projection
 non-bootstrap local tools. The focused hosted-stdio re-walk passed after the production projection
 fix: a real daemon with the ACP mock advertised `compozy__network_channel_create`, executed it through
 hosted MCP, and verified the persisted channel. Prior negative-route evidence remains valid.
+
+QA impact 2026-08-13: issue #371 exposed the same bootstrap boundary for installed extension-host
+tools. A fresh managed Codex session bound hosted MCP after the arbitrary `qa-hosted` extension was
+linked, resolved `ext__qa_hosted__search` as callable, invoked it with `query=alpha`, and received the
+extension-owned result. The strict QA audit passed and teardown reported no survivors.

--- a/docs/qa/scenarios/ET-048.md
+++ b/docs/qa/scenarios/ET-048.md
@@ -18,9 +18,9 @@ overlaps:
 
 story: As an ACP agent I bind to a daemon-hosted MCP projection and call its tools through the daemon.
 
-migrated-status: qa=Passed with route-limited coverage | retest=Passed
+migrated-status: historical route-limited coverage=Passed | live hosted-stdio retest=Passed
 
-UDS hosted-MCP route absence/missing-session/missing-bind errors are stable and HTTP route absence returns 404. Full bind/projection/call requires a session-issued nonce and peer executable match, so this pass covers the reachable operator-negative contract rather than a live hosted projection.
+Historical route coverage established stable UDS missing-session/missing-bind errors and HTTP route absence. It did not prove a live hosted projection because full bind/projection/call requires a session-issued nonce and peer executable match.
 
 src: docs/qa/_seeds/feature-stories/03_analysis_extensibility-tools.md
 

--- a/internal/daemon/daemon_extension_distribution_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_distribution_e2e_integration_test.go
@@ -21,8 +21,10 @@ import (
 	compozycontract "github.com/compozy/compozy/internal/api/contract"
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	extensionpkg "github.com/compozy/compozy/internal/extension"
+	"github.com/compozy/compozy/internal/testutil/acpmock"
 	e2etest "github.com/compozy/compozy/internal/testutil/e2e"
 	toolspkg "github.com/compozy/compozy/internal/tools"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestDaemonE2EExtensionDistributionAcrossIsolatedHomes(t *testing.T) {
@@ -84,6 +86,11 @@ func testDaemonE2EExtensionDistributionAcrossIsolatedHomes(t *testing.T) {
 	consumer := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
 		BinaryPath: binaryPath,
 		ConfigSeed: configSeed,
+		MockAgents: []e2etest.MockAgentSpec{{
+			FixturePath:  mockFixturePath(t, "hosted_native_tools_fixture.json"),
+			FixtureAgent: "hosted-native",
+			AgentName:    "mock-installed-extension",
+		}},
 	})
 	var installed compozycontract.ExtensionPayload
 	runExtensionAuthoringCLI(
@@ -114,6 +121,7 @@ func testDaemonE2EExtensionDistributionAcrossIsolatedHomes(t *testing.T) {
 	}
 	assertDistributionExtensionInventory(t, ctx, consumer, "hello", true, "daily", true)
 	assertDistributionExtensionInvocation(t, ctx, consumer, "published-v1:alpha")
+	assertDistributionHostedExtensionInvocation(t, ctx, consumer, "published-v1:alpha")
 
 	writeExtensionKitE2EAutomation(t, sourceDir, "hourly")
 	rewriteExtensionAuthoringGeneration(t, sourceDir, "published-v1:", "published-v2:", "published-v2")
@@ -193,6 +201,68 @@ func testDaemonE2EExtensionDistributionAcrossIsolatedHomes(t *testing.T) {
 		t.Fatal("GetExtension(after remove) error = nil, want not found")
 	}
 	githubServer.requireReleaseCount(t, 2)
+}
+
+func assertDistributionHostedExtensionInvocation(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	want string,
+) {
+	t.Helper()
+	registration, ok := harness.MockAgentRegistration("mock-installed-extension")
+	if !ok {
+		t.Fatal("MockAgentRegistration(mock-installed-extension) = missing")
+	}
+	active := createBoundFixtureBackedSession(
+		t,
+		ctx,
+		harness,
+		"mock-installed-extension",
+		"installed-extension-hosted-mcp",
+	)
+	diagnostics, err := acpmock.ReadDiagnostics(registration.DiagnosticsPath)
+	if err != nil {
+		t.Fatalf("ReadDiagnostics(mock-installed-extension) error = %v", err)
+	}
+	sessionDiagnostics := acpmock.DiagnosticsForCompozySession(diagnostics, active.ID)
+	client := startHostedMCPClient(
+		t,
+		ctx,
+		requireHostedMCPStdioServer(t, sessionDiagnostics, hostedMCPServerLatest),
+	)
+	defer func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("Close(installed extension hosted MCP client) error = %v", err)
+		}
+	}()
+
+	toolID, err := toolspkg.CanonicalToolID("ext", "hello", "search")
+	if err != nil {
+		t.Fatalf("CanonicalToolID(hello search) error = %v", err)
+	}
+	listed, err := client.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools(installed extension hosted MCP) error = %v", err)
+	}
+	if !sdkToolListContains(listed.Tools, toolID.String()) {
+		t.Fatalf("hosted MCP tools = %#v, want installed extension tool %s", sdkToolNames(listed.Tools), toolID)
+	}
+
+	result, err := client.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      toolID.String(),
+		Arguments: map[string]any{"query": "alpha"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool(%s) error = %v", toolID, err)
+	}
+	if result == nil || result.IsError || len(result.Content) != 1 {
+		t.Fatalf("CallTool(%s) result = %#v, want one successful text result", toolID, result)
+	}
+	textContent, ok := result.Content[0].(*sdkmcp.TextContent)
+	if !ok || textContent.Text != want {
+		t.Fatalf("CallTool(%s) content = %#v, want %q", toolID, result.Content, want)
+	}
 }
 
 func assertDistributionExtensionInvocation(

--- a/internal/daemon/native_extension_tool_provider.go
+++ b/internal/daemon/native_extension_tool_provider.go
@@ -25,11 +25,6 @@ type daemonExtensionToolProvider struct {
 var _ toolspkg.Provider = (*daemonExtensionToolProvider)(nil)
 var _ toolspkg.ProjectionGenerationProvider = (*daemonExtensionToolProvider)(nil)
 
-// DeferInitialDiscovery keeps extension subprocess discovery out of the hosted MCP handshake.
-func (*daemonExtensionToolProvider) DeferInitialDiscovery() bool {
-	return true
-}
-
 func newDaemonScopedExtensionToolProvider(
 	inner toolspkg.Provider,
 	workspaceResolver workspacepkg.RuntimeResolver,

--- a/internal/daemon/native_extension_tool_provider_test.go
+++ b/internal/daemon/native_extension_tool_provider_test.go
@@ -18,6 +18,34 @@ import (
 func TestDaemonExtensionToolProvider(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should project callable extension tools during the hosted session bootstrap", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &daemonExtensionProviderStub{handle: &daemonExtensionHandleStub{}}
+		provider := newDaemonScopedExtensionToolProvider(inner, &daemonExtensionWorkspaceResolverStub{})
+		registry, err := toolspkg.NewRegistry(
+			toolspkg.WithProviders(provider),
+			toolspkg.WithPolicyInputs(toolspkg.PolicyInputs{
+				SystemPermissionMode: toolspkg.PermissionModeApproveAll,
+				ExternalDefault:      toolspkg.ExternalDefaultEnabled,
+			}, toolspkg.ToolsetCatalog{}),
+		)
+		if err != nil {
+			t.Fatalf("NewRegistry() error = %v", err)
+		}
+
+		views, err := registry.BootstrapSessionProjection(t.Context(), toolspkg.Scope{})
+		if err != nil {
+			t.Fatalf("BootstrapSessionProjection() error = %v", err)
+		}
+		if got, want := len(views), 1; got != want {
+			t.Fatalf("len(bootstrap tools) = %d, want %d: %#v", got, want, views)
+		}
+		if got, want := views[0].Descriptor.ID, devCycleImportTasksToolID; got != want {
+			t.Fatalf("bootstrap tool = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("Should canonicalize workspace scope and attach authority to arbitrary extension tools", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/native_tools.go
+++ b/internal/daemon/native_tools.go
@@ -181,6 +181,7 @@ func newDaemonExtensionToolProvider(state *bootState) (toolspkg.Provider, error)
 			}
 			return toolRuntime
 		},
+		extensionpkg.WithToolProviderLogger(state.logger),
 	)
 	if err != nil {
 		return nil, err

--- a/internal/extension/manifest_load.go
+++ b/internal/extension/manifest_load.go
@@ -235,7 +235,10 @@ func loadManifestTOML(path string) (*Manifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("extension: read manifest %q: %w", path, err)
 	}
+	return loadManifestTOMLContent(path, data)
+}
 
+func loadManifestTOMLContent(path string, data []byte) (*Manifest, error) {
 	var doc manifestDocument
 	meta, err := toml.Decode(string(data), &doc)
 	if err != nil {
@@ -260,7 +263,10 @@ func loadManifestJSON(path string) (*Manifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("extension: read manifest %q: %w", path, err)
 	}
+	return loadManifestJSONContent(path, data)
+}
 
+func loadManifestJSONContent(path string, data []byte) (*Manifest, error) {
 	var doc manifestDocument
 	if err := rejectLegacyManifestJSON(data); err != nil {
 		return nil, err
@@ -280,6 +286,17 @@ func loadManifestJSON(path string) (*Manifest, error) {
 		return nil, err
 	}
 	return &manifest, nil
+}
+
+func loadManifestContentAtPath(path string, data []byte) (*Manifest, error) {
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(path))) {
+	case manifestFileExtTOML:
+		return loadManifestTOMLContent(path, data)
+	case manifestFileExtJSON:
+		return loadManifestJSONContent(path, data)
+	default:
+		return nil, fmt.Errorf("extension: unsupported manifest path %q", path)
+	}
 }
 
 func rejectUnsupportedManifestTOML(keys []toml.Key) error {

--- a/internal/extension/tool_projection_generation.go
+++ b/internal/extension/tool_projection_generation.go
@@ -1,7 +1,10 @@
 package extensionpkg
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"slices"
 	"strconv"
@@ -20,7 +23,7 @@ func (p *ExtensionToolProvider) ProjectionGeneration(
 	if err := extensionProviderContextErr(ctx); err != nil {
 		return "", false
 	}
-	manifestTools, err := p.manifestTools(scope)
+	manifestTools, manifestFingerprint, err := p.manifestToolsWithFingerprint(ctx, scope)
 	if err != nil {
 		return "", false
 	}
@@ -28,7 +31,7 @@ func (p *ExtensionToolProvider) ProjectionGeneration(
 	if !known {
 		return "", false
 	}
-	return p.updateProjectionGeneration(runtimeFingerprint), true
+	return extensionProjectionGenerationToken(manifestFingerprint, runtimeFingerprint), true
 }
 
 func (p *ExtensionToolProvider) runtimeProjectionFingerprint(
@@ -63,7 +66,11 @@ func (p *ExtensionToolProvider) runtimeProjectionFingerprint(
 		if err != nil {
 			return "", false
 		}
-		encoded, err := json.Marshal(descriptors)
+		canonicalDescriptors, err := canonicalProjectionRuntimeDescriptors(descriptors)
+		if err != nil {
+			return "", false
+		}
+		encoded, err := json.Marshal(canonicalDescriptors)
 		if err != nil {
 			return "", false
 		}
@@ -71,6 +78,66 @@ func (p *ExtensionToolProvider) runtimeProjectionFingerprint(
 		fingerprint.WriteByte(0)
 	}
 	return fingerprint.String(), true
+}
+
+func canonicalProjectionRuntimeDescriptors(
+	src []toolspkg.ExtensionToolRuntimeDescriptor,
+) ([]toolspkg.ExtensionToolRuntimeDescriptor, error) {
+	descriptors := cloneRuntimeToolDescriptors(src)
+	keyed := make([]canonicalProjectionRuntimeDescriptor, len(descriptors))
+	for i := range descriptors {
+		descriptors[i].Capabilities = canonicalProjectionCapabilities(descriptors[i].Capabilities)
+		inputSchema, err := canonicalProjectionSchema(descriptors[i].InputSchema)
+		if err != nil {
+			return nil, err
+		}
+		descriptors[i].InputSchema = inputSchema
+		outputSchema, err := canonicalProjectionSchema(descriptors[i].OutputSchema)
+		if err != nil {
+			return nil, err
+		}
+		descriptors[i].OutputSchema = outputSchema
+		key, err := json.Marshal(descriptors[i])
+		if err != nil {
+			return nil, err
+		}
+		keyed[i] = canonicalProjectionRuntimeDescriptor{
+			descriptor: descriptors[i],
+			key:        key,
+		}
+	}
+	slices.SortFunc(keyed, func(left, right canonicalProjectionRuntimeDescriptor) int {
+		return bytes.Compare(left.key, right.key)
+	})
+	for i := range keyed {
+		descriptors[i] = keyed[i].descriptor
+	}
+	return descriptors, nil
+}
+
+type canonicalProjectionRuntimeDescriptor struct {
+	descriptor toolspkg.ExtensionToolRuntimeDescriptor
+	key        []byte
+}
+
+func canonicalProjectionCapabilities(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	canonical := slices.Clone(values)
+	slices.Sort(canonical)
+	return slices.Compact(canonical)
+}
+
+func canonicalProjectionSchema(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+	canonical, err := toolspkg.CanonicalJSON(raw)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(canonical), nil
 }
 
 func extensionProjectionRuntimeDescriptors(
@@ -107,7 +174,9 @@ func appendExtensionProjectionFingerprint(
 		Healthy: snapshot.Status.Healthy,
 	}
 	if snapshot.InitializeResult != nil {
-		state.Capabilities = slices.Clone(snapshot.InitializeResult.AcceptedCapabilities.Provides)
+		state.Capabilities = canonicalProjectionCapabilities(
+			snapshot.InitializeResult.AcceptedCapabilities.Provides,
+		)
 	}
 	encoded, err := json.Marshal(state)
 	if err != nil {
@@ -118,15 +187,9 @@ func appendExtensionProjectionFingerprint(
 	dst.WriteByte(0)
 }
 
-func (p *ExtensionToolProvider) updateProjectionGeneration(runtimeFingerprint string) string {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.cache.runtimeFingerprint != runtimeFingerprint {
-		p.cache.runtimeFingerprint = runtimeFingerprint
-		p.cache.generation++
-	}
-	if p.cache.generation == 0 {
-		p.cache.generation = 1
-	}
-	return strconv.FormatUint(p.cache.generation, 10)
+func extensionProjectionGenerationToken(manifestFingerprint, runtimeFingerprint string) string {
+	payload := strconv.Itoa(len(manifestFingerprint)) + ":" + manifestFingerprint +
+		strconv.Itoa(len(runtimeFingerprint)) + ":" + runtimeFingerprint
+	digest := sha256.Sum256([]byte(payload))
+	return "sha256:" + hex.EncodeToString(digest[:])
 }

--- a/internal/extension/tool_provider.go
+++ b/internal/extension/tool_provider.go
@@ -334,6 +334,7 @@ func (p *ExtensionToolProvider) manifestTools(scope toolspkg.Scope) ([]extension
 	}
 
 	manifestTools := make([]extensionManifestTool, 0)
+	cacheComplete := true
 	for _, info := range infos {
 		if !info.Enabled {
 			continue
@@ -348,11 +349,13 @@ func (p *ExtensionToolProvider) manifestTools(scope toolspkg.Scope) ([]extension
 		manifest, err := loadManifestAtPath(info.ManifestPath)
 		if err != nil {
 			p.logInvalidToolManifest(info.Name, err)
+			cacheComplete = false
 			continue
 		}
 		descriptors, err := ResolveManifestToolDescriptors(manifest)
 		if err != nil {
 			p.logInvalidToolManifest(info.Name, err)
+			cacheComplete = false
 			continue
 		}
 		for i := range descriptors {
@@ -369,7 +372,9 @@ func (p *ExtensionToolProvider) manifestTools(scope toolspkg.Scope) ([]extension
 	slices.SortFunc(manifestTools, func(left, right extensionManifestTool) int {
 		return strings.Compare(left.descriptor.Tool.ID.String(), right.descriptor.Tool.ID.String())
 	})
-	p.storeManifestTools(fingerprint, manifestTools)
+	if cacheComplete {
+		p.storeManifestTools(fingerprint, manifestTools)
+	}
 	return cloneExtensionManifestTools(manifestTools), nil
 }
 

--- a/internal/extension/tool_provider.go
+++ b/internal/extension/tool_provider.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -39,12 +38,16 @@ type ExtensionToolProviderOption func(*ExtensionToolProvider)
 // ExtensionToolProvider lists manifest-authored extension tools and resolves
 // executable handles through the live subprocess runtime.
 type ExtensionToolProvider struct {
-	mu       sync.RWMutex
-	registry *Registry
-	runtime  ExtensionToolRuntimeResolver
-	logger   *slog.Logger
-	source   toolspkg.SourceRef
-	cache    extensionToolProviderCache
+	mu sync.RWMutex
+	// manifestRefresh serializes manifest observation through cache publication.
+	// The cache mutex stays unheld while this boundary performs filesystem I/O.
+	manifestRefresh  chan struct{}
+	manifestReadFile extensionManifestReadFile
+	registry         *Registry
+	runtime          ExtensionToolRuntimeResolver
+	logger           *slog.Logger
+	source           toolspkg.SourceRef
+	cache            extensionToolProviderCache
 }
 
 var _ toolspkg.Provider = (*ExtensionToolProvider)(nil)
@@ -74,9 +77,11 @@ func NewExtensionToolProvider(
 		)
 	}
 	provider := &ExtensionToolProvider{
-		registry: registry,
-		runtime:  runtime,
-		logger:   slog.Default(),
+		manifestRefresh:  make(chan struct{}, 1),
+		manifestReadFile: os.ReadFile,
+		registry:         registry,
+		runtime:          runtime,
+		logger:           slog.Default(),
 		source: toolspkg.SourceRef{
 			Kind:  toolspkg.SourceExtension,
 			Owner: extensionToolProviderOwner,
@@ -104,7 +109,7 @@ func (p *ExtensionToolProvider) List(ctx context.Context, scope toolspkg.Scope) 
 	if err := extensionProviderContextErr(ctx); err != nil {
 		return nil, err
 	}
-	manifestTools, err := p.manifestTools(scope)
+	manifestTools, err := p.manifestTools(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +133,7 @@ func (p *ExtensionToolProvider) Resolve(
 	if err := id.Validate(); err != nil {
 		return nil, false, err
 	}
-	manifestTool, found, err := p.manifestTool(scope, id)
+	manifestTool, found, err := p.manifestTool(ctx, scope, id)
 	if err != nil || !found {
 		return nil, found, err
 	}
@@ -137,19 +142,6 @@ func (p *ExtensionToolProvider) Resolve(
 		runtime:  p.runtime,
 		scope:    scope,
 	}, true, nil
-}
-
-type extensionManifestTool struct {
-	info       ExtensionInfo
-	key        InstanceKey
-	descriptor ManifestToolDescriptor
-}
-
-type extensionToolProviderCache struct {
-	fingerprint        string
-	runtimeFingerprint string
-	generation         uint64
-	tools              []extensionManifestTool
 }
 
 type extensionToolHandle struct {
@@ -290,165 +282,11 @@ func (h *extensionToolHandle) provideTools(
 	return runtime.ProvideTools(ctx, h.extensionID())
 }
 
-func (p *ExtensionToolProvider) manifestTool(
-	scope toolspkg.Scope,
-	id toolspkg.ToolID,
-) (extensionManifestTool, bool, error) {
-	manifestTools, err := p.manifestTools(scope)
-	if err != nil {
-		return extensionManifestTool{}, false, err
-	}
-	for i := range manifestTools {
-		if manifestTools[i].descriptor.Tool.ID == id {
-			return manifestTools[i], true, nil
-		}
-	}
-	return extensionManifestTool{}, false, nil
-}
-
-func (p *ExtensionToolProvider) manifestTools(scope toolspkg.Scope) ([]extensionManifestTool, error) {
-	if p == nil || p.registry == nil {
-		return nil, toolspkg.NewValidationError(
-			"provider",
-			toolspkg.ReasonDependencyMissing,
-			"extension tool provider is required",
-		)
-	}
-	workspaceID := strings.TrimSpace(scope.WorkspaceID)
-	var infos []ExtensionInfo
-	if runtime := p.runtimeInstance(); runtime != nil {
-		if scoped, ok := runtime.(extensionScopedToolRuntime); ok {
-			infos = scoped.ListForWorkspace(workspaceID)
-		}
-	}
-	if infos == nil {
-		var err error
-		infos, err = p.registry.List()
-		if err != nil {
-			return nil, fmt.Errorf("extension: list tool manifests: %w", err)
-		}
-	}
-	fingerprint := extensionToolManifestFingerprint(workspaceID, infos)
-	if tools, ok := p.cachedManifestTools(fingerprint); ok {
-		return tools, nil
-	}
-
-	manifestTools := make([]extensionManifestTool, 0)
-	cacheComplete := true
-	for _, info := range infos {
-		if !info.Enabled {
-			continue
-		}
-		key := GlobalInstanceKey(info.Name)
-		if workspaceID != "" {
-			if link, linkErr := p.registry.GetDevLink(info.Name, workspaceID); linkErr == nil &&
-				strings.TrimSpace(link.BundleGeneration) == strings.TrimSpace(info.Checksum) {
-				key.WorkspaceID = workspaceID
-			}
-		}
-		manifest, err := loadManifestAtPath(info.ManifestPath)
-		if err != nil {
-			p.logInvalidToolManifest(info.Name, err)
-			cacheComplete = false
-			continue
-		}
-		descriptors, err := ResolveManifestToolDescriptors(manifest)
-		if err != nil {
-			p.logInvalidToolManifest(info.Name, err)
-			cacheComplete = false
-			continue
-		}
-		for i := range descriptors {
-			if descriptors[i].Tool.Backend.Kind != toolspkg.BackendExtensionHost {
-				continue
-			}
-			manifestTools = append(manifestTools, extensionManifestTool{
-				info:       cloneExtensionInfo(info),
-				key:        key,
-				descriptor: cloneManifestToolDescriptor(&descriptors[i]),
-			})
-		}
-	}
-	slices.SortFunc(manifestTools, func(left, right extensionManifestTool) int {
-		return strings.Compare(left.descriptor.Tool.ID.String(), right.descriptor.Tool.ID.String())
-	})
-	if cacheComplete {
-		p.storeManifestTools(fingerprint, manifestTools)
-	}
-	return cloneExtensionManifestTools(manifestTools), nil
-}
-
-func (p *ExtensionToolProvider) logInvalidToolManifest(name string, err error) {
-	if p == nil || p.logger == nil || err == nil {
-		return
-	}
-	p.logger.Warn(
-		"extension: skip invalid extension tool manifest",
-		"extension_name", strings.TrimSpace(name),
-		"error", err,
-	)
-}
-
 func (p *ExtensionToolProvider) runtimeInstance() ExtensionToolRuntime {
 	if p == nil || p.runtime == nil {
 		return nil
 	}
 	return p.runtime()
-}
-
-func (p *ExtensionToolProvider) cachedManifestTools(fingerprint string) ([]extensionManifestTool, bool) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if p.cache.fingerprint != fingerprint {
-		return nil, false
-	}
-	return cloneExtensionManifestTools(p.cache.tools), true
-}
-
-func (p *ExtensionToolProvider) storeManifestTools(fingerprint string, tools []extensionManifestTool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.cache.fingerprint != fingerprint {
-		p.cache.generation++
-	}
-	p.cache.fingerprint = fingerprint
-	p.cache.tools = cloneExtensionManifestTools(tools)
-}
-
-func extensionToolManifestFingerprint(workspaceID string, infos []ExtensionInfo) string {
-	var builder strings.Builder
-	builder.WriteString(strings.TrimSpace(workspaceID))
-	builder.WriteByte(0)
-	for i := range infos {
-		info := infos[i]
-		builder.WriteString(info.Name)
-		builder.WriteByte(0)
-		builder.WriteString(info.Version)
-		builder.WriteByte(0)
-		builder.WriteString(info.Source.String())
-		builder.WriteByte(0)
-		if info.Enabled {
-			builder.WriteByte('1')
-		} else {
-			builder.WriteByte('0')
-		}
-		builder.WriteByte(0)
-		builder.WriteString(info.ManifestPath)
-		builder.WriteByte(0)
-		builder.WriteString(info.Checksum)
-		builder.WriteByte(0)
-		stat, err := os.Stat(info.ManifestPath)
-		if err != nil {
-			builder.WriteString("unavailable")
-			builder.WriteByte(0)
-			continue
-		}
-		builder.WriteString(strconv.FormatInt(stat.Size(), 10))
-		builder.WriteByte(':')
-		builder.WriteString(strconv.FormatInt(stat.ModTime().UnixNano(), 10))
-		builder.WriteByte(0)
-	}
-	return builder.String()
 }
 
 func runtimeDescriptorForTool(
@@ -469,26 +307,6 @@ func runtimeDescriptorForTool(
 		found = &descriptor
 	}
 	return found, false
-}
-
-func cloneManifestToolDescriptor(src *ManifestToolDescriptor) ManifestToolDescriptor {
-	cloned := *src
-	cloned.Tool = src.Tool.Descriptor().Tool()
-	cloned.RuntimeDescriptor.Capabilities = slices.Clone(src.RuntimeDescriptor.Capabilities)
-	cloned.RuntimeDescriptor.Command = cloneExtensionCommandSpec(src.RuntimeDescriptor.Command)
-	return cloned
-}
-
-func cloneExtensionManifestTools(src []extensionManifestTool) []extensionManifestTool {
-	cloned := make([]extensionManifestTool, len(src))
-	for i := range src {
-		cloned[i] = extensionManifestTool{
-			info:       cloneExtensionInfo(src[i].info),
-			key:        src[i].key,
-			descriptor: cloneManifestToolDescriptor(&src[i].descriptor),
-		}
-	}
-	return cloned
 }
 
 func extensionProviderContextErr(ctx context.Context) error {

--- a/internal/extension/tool_provider.go
+++ b/internal/extension/tool_provider.go
@@ -3,6 +3,7 @@ package extensionpkg
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"slices"
 	"strconv"
@@ -41,11 +42,22 @@ type ExtensionToolProvider struct {
 	mu       sync.RWMutex
 	registry *Registry
 	runtime  ExtensionToolRuntimeResolver
+	logger   *slog.Logger
 	source   toolspkg.SourceRef
 	cache    extensionToolProviderCache
 }
 
 var _ toolspkg.Provider = (*ExtensionToolProvider)(nil)
+
+// WithToolProviderLogger injects the logger used when one invalid extension is
+// isolated from the aggregate tool catalog.
+func WithToolProviderLogger(logger *slog.Logger) ExtensionToolProviderOption {
+	return func(provider *ExtensionToolProvider) {
+		if logger != nil {
+			provider.logger = logger
+		}
+	}
+}
 
 // NewExtensionToolProvider creates the extension_host provider for the central
 // tool registry.
@@ -64,6 +76,7 @@ func NewExtensionToolProvider(
 	provider := &ExtensionToolProvider{
 		registry: registry,
 		runtime:  runtime,
+		logger:   slog.Default(),
 		source: toolspkg.SourceRef{
 			Kind:  toolspkg.SourceExtension,
 			Owner: extensionToolProviderOwner,
@@ -315,10 +328,7 @@ func (p *ExtensionToolProvider) manifestTools(scope toolspkg.Scope) ([]extension
 			return nil, fmt.Errorf("extension: list tool manifests: %w", err)
 		}
 	}
-	fingerprint, err := extensionToolManifestFingerprint(workspaceID, infos)
-	if err != nil {
-		return nil, err
-	}
+	fingerprint := extensionToolManifestFingerprint(workspaceID, infos)
 	if tools, ok := p.cachedManifestTools(fingerprint); ok {
 		return tools, nil
 	}
@@ -337,11 +347,13 @@ func (p *ExtensionToolProvider) manifestTools(scope toolspkg.Scope) ([]extension
 		}
 		manifest, err := loadManifestAtPath(info.ManifestPath)
 		if err != nil {
-			return nil, fmt.Errorf("extension: load tool manifest %q: %w", info.Name, err)
+			p.logInvalidToolManifest(info.Name, err)
+			continue
 		}
 		descriptors, err := ResolveManifestToolDescriptors(manifest)
 		if err != nil {
-			return nil, fmt.Errorf("extension: resolve tool manifest %q: %w", info.Name, err)
+			p.logInvalidToolManifest(info.Name, err)
+			continue
 		}
 		for i := range descriptors {
 			if descriptors[i].Tool.Backend.Kind != toolspkg.BackendExtensionHost {
@@ -359,6 +371,17 @@ func (p *ExtensionToolProvider) manifestTools(scope toolspkg.Scope) ([]extension
 	})
 	p.storeManifestTools(fingerprint, manifestTools)
 	return cloneExtensionManifestTools(manifestTools), nil
+}
+
+func (p *ExtensionToolProvider) logInvalidToolManifest(name string, err error) {
+	if p == nil || p.logger == nil || err == nil {
+		return
+	}
+	p.logger.Warn(
+		"extension: skip invalid extension tool manifest",
+		"extension_name", strings.TrimSpace(name),
+		"error", err,
+	)
 }
 
 func (p *ExtensionToolProvider) runtimeInstance() ExtensionToolRuntime {
@@ -387,7 +410,7 @@ func (p *ExtensionToolProvider) storeManifestTools(fingerprint string, tools []e
 	p.cache.tools = cloneExtensionManifestTools(tools)
 }
 
-func extensionToolManifestFingerprint(workspaceID string, infos []ExtensionInfo) (string, error) {
+func extensionToolManifestFingerprint(workspaceID string, infos []ExtensionInfo) string {
 	var builder strings.Builder
 	builder.WriteString(strings.TrimSpace(workspaceID))
 	builder.WriteByte(0)
@@ -411,14 +434,16 @@ func extensionToolManifestFingerprint(workspaceID string, infos []ExtensionInfo)
 		builder.WriteByte(0)
 		stat, err := os.Stat(info.ManifestPath)
 		if err != nil {
-			return "", fmt.Errorf("extension: stat tool manifest %q: %w", info.Name, err)
+			builder.WriteString("unavailable")
+			builder.WriteByte(0)
+			continue
 		}
 		builder.WriteString(strconv.FormatInt(stat.Size(), 10))
 		builder.WriteByte(':')
 		builder.WriteString(strconv.FormatInt(stat.ModTime().UnixNano(), 10))
 		builder.WriteByte(0)
 	}
-	return builder.String(), nil
+	return builder.String()
 }
 
 func runtimeDescriptorForTool(

--- a/internal/extension/tool_provider_manifest_cache.go
+++ b/internal/extension/tool_provider_manifest_cache.go
@@ -1,0 +1,404 @@
+package extensionpkg
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	toolspkg "github.com/compozy/compozy/internal/tools"
+)
+
+type extensionManifestTool struct {
+	info       ExtensionInfo
+	key        InstanceKey
+	descriptor ManifestToolDescriptor
+}
+
+const extensionManifestDisabledFingerprint = "disabled"
+
+type extensionToolProviderCache struct {
+	fingerprint                  string
+	tools                        []extensionManifestTool
+	manifestSnapshots            map[string]extensionManifestSnapshot
+	manifestContentStates        map[extensionManifestContentKey]extensionManifestContentState
+	manifestWarnings             map[extensionManifestWarningKey]struct{}
+	manifestSnapshotPathsByScope map[string]map[string]struct{}
+}
+
+type extensionManifestToolSource struct {
+	info     ExtensionInfo
+	key      InstanceKey
+	snapshot extensionManifestSnapshot
+}
+
+type extensionManifestSnapshot struct {
+	content     []byte
+	fingerprint string
+	err         error
+	metadata    extensionManifestFileMetadata
+	reusable    bool
+}
+
+type extensionManifestReadFile func(string) ([]byte, error)
+
+func (p *ExtensionToolProvider) manifestTool(
+	ctx context.Context,
+	scope toolspkg.Scope,
+	id toolspkg.ToolID,
+) (extensionManifestTool, bool, error) {
+	manifestTools, err := p.manifestTools(ctx, scope)
+	if err != nil {
+		return extensionManifestTool{}, false, err
+	}
+	for i := range manifestTools {
+		if manifestTools[i].descriptor.Tool.ID == id {
+			return manifestTools[i], true, nil
+		}
+	}
+	return extensionManifestTool{}, false, nil
+}
+
+func (p *ExtensionToolProvider) manifestTools(
+	ctx context.Context,
+	scope toolspkg.Scope,
+) ([]extensionManifestTool, error) {
+	tools, _, err := p.manifestToolsWithFingerprint(ctx, scope)
+	return tools, err
+}
+
+func (p *ExtensionToolProvider) manifestToolsWithFingerprint(
+	ctx context.Context,
+	scope toolspkg.Scope,
+) ([]extensionManifestTool, string, error) {
+	if p == nil || p.registry == nil {
+		return nil, "", toolspkg.NewValidationError(
+			"provider",
+			toolspkg.ReasonDependencyMissing,
+			"extension tool provider is required",
+		)
+	}
+	if err := extensionProviderContextErr(ctx); err != nil {
+		return nil, "", err
+	}
+	release, err := p.acquireManifestRefresh(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	defer release()
+	if err := extensionProviderContextErr(ctx); err != nil {
+		return nil, "", err
+	}
+
+	workspaceID := strings.TrimSpace(scope.WorkspaceID)
+	infos, err := p.manifestToolInfos(workspaceID)
+	if err != nil {
+		return nil, "", err
+	}
+	sources := p.manifestToolSources(workspaceID, infos)
+	p.reconcileManifestSnapshots(workspaceID, sources)
+	if err := extensionProviderContextErr(ctx); err != nil {
+		return nil, "", err
+	}
+	fingerprint := extensionToolManifestFingerprint(workspaceID, sources)
+	if cached, ok := p.cachedManifestTools(fingerprint); ok {
+		return cached, fingerprint, nil
+	}
+
+	tools := p.resolveManifestTools(sources)
+	if err := extensionProviderContextErr(ctx); err != nil {
+		return nil, "", err
+	}
+	p.storeManifestTools(fingerprint, tools)
+	return tools, fingerprint, nil
+}
+
+func (p *ExtensionToolProvider) acquireManifestRefresh(ctx context.Context) (func(), error) {
+	select {
+	case p.manifestRefresh <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	if err := extensionProviderContextErr(ctx); err != nil {
+		<-p.manifestRefresh
+		return nil, err
+	}
+	return func() {
+		<-p.manifestRefresh
+	}, nil
+}
+
+func (p *ExtensionToolProvider) manifestToolInfos(workspaceID string) ([]ExtensionInfo, error) {
+	if runtime := p.runtimeInstance(); runtime != nil {
+		if scoped, ok := runtime.(extensionScopedToolRuntime); ok {
+			if infos := scoped.ListForWorkspace(workspaceID); infos != nil {
+				return infos, nil
+			}
+		}
+	}
+	infos, err := p.registry.List()
+	if err != nil {
+		return nil, fmt.Errorf("extension: list tool manifests: %w", err)
+	}
+	return infos, nil
+}
+
+func (p *ExtensionToolProvider) manifestToolSources(
+	workspaceID string,
+	infos []ExtensionInfo,
+) []extensionManifestToolSource {
+	sources := make([]extensionManifestToolSource, 0, len(infos))
+	for i := range infos {
+		info := infos[i]
+		source := extensionManifestToolSource{info: info}
+		if !info.Enabled {
+			source.snapshot.fingerprint = extensionManifestDisabledFingerprint
+			sources = append(sources, source)
+			continue
+		}
+
+		source.key = GlobalInstanceKey(info.Name)
+		if workspaceID != "" {
+			if link, err := p.registry.GetDevLink(info.Name, workspaceID); err == nil &&
+				strings.TrimSpace(link.BundleGeneration) == strings.TrimSpace(info.Checksum) {
+				source.key.WorkspaceID = workspaceID
+			}
+		}
+		source.snapshot = p.manifestSnapshot(info.ManifestPath)
+		sources = append(sources, source)
+	}
+	return sources
+}
+
+func (p *ExtensionToolProvider) manifestSnapshot(path string) extensionManifestSnapshot {
+	info, err := os.Stat(path)
+	if err != nil {
+		metadata := unavailableExtensionManifestFileMetadata(err)
+		if snapshot, ok := p.cachedManifestSnapshot(path, metadata); ok {
+			return snapshot
+		}
+		snapshot := extensionManifestSnapshot{
+			fingerprint: "unavailable:" + err.Error(),
+			err:         fmt.Errorf("extension: read manifest %q: %w", path, err),
+			metadata:    metadata,
+			reusable:    true,
+		}
+		p.storeManifestSnapshot(path, snapshot)
+		return snapshot
+	}
+	metadata := newExtensionManifestFileMetadata(info)
+	if metadata.reliable {
+		if snapshot, ok := p.cachedManifestSnapshot(path, metadata); ok {
+			return snapshot
+		}
+	}
+	// Platforms without a reliable change token must read and hash after each
+	// successful stat so same-size, same-mtime edits remain observable.
+	snapshot := p.readExtensionManifestSnapshot(path, metadata)
+	p.storeManifestSnapshot(path, snapshot)
+	return snapshot
+}
+
+func (p *ExtensionToolProvider) readExtensionManifestSnapshot(
+	path string,
+	metadata extensionManifestFileMetadata,
+) extensionManifestSnapshot {
+	content, err := p.manifestReadFile(path)
+	if err != nil {
+		return extensionManifestSnapshot{
+			fingerprint: "unavailable:" + err.Error(),
+			err:         fmt.Errorf("extension: read manifest %q: %w", path, err),
+			metadata:    metadata,
+			reusable:    false,
+		}
+	}
+	digest := sha256.Sum256(content)
+	return extensionManifestSnapshot{
+		content:     content,
+		fingerprint: "content:sha256:" + hex.EncodeToString(digest[:]),
+		metadata:    metadata,
+		reusable:    true,
+	}
+}
+
+func (p *ExtensionToolProvider) resolveManifestTools(
+	sources []extensionManifestToolSource,
+) []extensionManifestTool {
+	manifestTools := make([]extensionManifestTool, 0)
+	for i := range sources {
+		source := &sources[i]
+		if !source.info.Enabled {
+			continue
+		}
+
+		descriptors, err := p.manifestToolDescriptors(source)
+		if err != nil {
+			if p.claimManifestToolWarning(source) {
+				p.logInvalidToolManifest(source.info.Name, err)
+			}
+			continue
+		}
+		for j := range descriptors {
+			if descriptors[j].Tool.Backend.Kind != toolspkg.BackendExtensionHost {
+				continue
+			}
+			manifestTools = append(manifestTools, extensionManifestTool{
+				info:       cloneExtensionInfo(source.info),
+				key:        source.key,
+				descriptor: cloneManifestToolDescriptor(&descriptors[j]),
+			})
+		}
+	}
+	slices.SortFunc(manifestTools, func(left, right extensionManifestTool) int {
+		return strings.Compare(left.descriptor.Tool.ID.String(), right.descriptor.Tool.ID.String())
+	})
+	return manifestTools
+}
+
+func (p *ExtensionToolProvider) logInvalidToolManifest(name string, err error) {
+	if p == nil || p.logger == nil || err == nil {
+		return
+	}
+	p.logger.Warn(
+		"extension: skip invalid extension tool manifest",
+		"extension_name", strings.TrimSpace(name),
+		"error", err,
+	)
+}
+
+func (p *ExtensionToolProvider) cachedManifestTools(fingerprint string) ([]extensionManifestTool, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.cache.fingerprint != fingerprint {
+		return nil, false
+	}
+	return cloneExtensionManifestTools(p.cache.tools), true
+}
+
+func (p *ExtensionToolProvider) storeManifestTools(fingerprint string, tools []extensionManifestTool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.cache.fingerprint = fingerprint
+	p.cache.tools = cloneExtensionManifestTools(tools)
+}
+
+func (p *ExtensionToolProvider) cachedManifestSnapshot(
+	path string,
+	metadata extensionManifestFileMetadata,
+) (extensionManifestSnapshot, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	snapshot, ok := p.cache.manifestSnapshots[path]
+	if !ok || !snapshot.reusable || !snapshot.metadata.Equal(metadata) {
+		return extensionManifestSnapshot{}, false
+	}
+	return snapshot, true
+}
+
+func (p *ExtensionToolProvider) storeManifestSnapshot(path string, snapshot extensionManifestSnapshot) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cache.manifestSnapshots == nil {
+		p.cache.manifestSnapshots = make(map[string]extensionManifestSnapshot)
+	}
+	p.cache.manifestSnapshots[path] = snapshot
+	p.pruneManifestContentStatesLocked()
+}
+
+func (p *ExtensionToolProvider) reconcileManifestSnapshots(
+	workspaceID string,
+	sources []extensionManifestToolSource,
+) {
+	activeManifestPaths := make(map[string]struct{}, len(sources))
+	for i := range sources {
+		if path := strings.TrimSpace(sources[i].info.ManifestPath); path != "" {
+			activeManifestPaths[sources[i].info.ManifestPath] = struct{}{}
+		}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cache.manifestSnapshotPathsByScope == nil {
+		p.cache.manifestSnapshotPathsByScope = make(map[string]map[string]struct{})
+	}
+	scopeID := strings.TrimSpace(workspaceID)
+	if len(activeManifestPaths) == 0 {
+		delete(p.cache.manifestSnapshotPathsByScope, scopeID)
+	} else {
+		p.cache.manifestSnapshotPathsByScope[scopeID] = activeManifestPaths
+	}
+	// Each effective scope replaces only its own active-path ownership. A poll
+	// for one workspace cannot evict a global or peer-workspace snapshot; an
+	// empty observed view releases only that scope's paths.
+	ownedManifestPaths := make(map[string]struct{})
+	for _, paths := range p.cache.manifestSnapshotPathsByScope {
+		for path := range paths {
+			ownedManifestPaths[path] = struct{}{}
+		}
+	}
+	for path := range p.cache.manifestSnapshots {
+		if _, ok := ownedManifestPaths[path]; !ok {
+			delete(p.cache.manifestSnapshots, path)
+		}
+	}
+	p.pruneManifestContentStatesLocked()
+}
+
+func extensionToolManifestFingerprint(
+	workspaceID string,
+	sources []extensionManifestToolSource,
+) string {
+	var builder strings.Builder
+	builder.WriteString(strings.TrimSpace(workspaceID))
+	builder.WriteByte(0)
+	for i := range sources {
+		info := sources[i].info
+		builder.WriteString(info.Name)
+		builder.WriteByte(0)
+		builder.WriteString(info.Version)
+		builder.WriteByte(0)
+		builder.WriteString(info.Source.String())
+		builder.WriteByte(0)
+		if info.Enabled {
+			builder.WriteByte('1')
+		} else {
+			builder.WriteByte('0')
+		}
+		builder.WriteByte(0)
+		builder.WriteString(info.ManifestPath)
+		builder.WriteByte(0)
+		builder.WriteString(info.Checksum)
+		builder.WriteByte(0)
+		builder.WriteString(sources[i].snapshot.fingerprint)
+		builder.WriteByte(0)
+	}
+	return builder.String()
+}
+
+func cloneManifestToolDescriptor(src *ManifestToolDescriptor) ManifestToolDescriptor {
+	cloned := *src
+	cloned.Tool = src.Tool.Descriptor().Tool()
+	cloned.RuntimeDescriptor.Capabilities = slices.Clone(src.RuntimeDescriptor.Capabilities)
+	cloned.RuntimeDescriptor.Command = cloneExtensionCommandSpec(src.RuntimeDescriptor.Command)
+	return cloned
+}
+
+func cloneExtensionManifestTools(src []extensionManifestTool) []extensionManifestTool {
+	cloned := make([]extensionManifestTool, len(src))
+	for i := range src {
+		cloned[i] = extensionManifestTool{
+			info:       cloneExtensionInfo(src[i].info),
+			key:        src[i].key,
+			descriptor: cloneManifestToolDescriptor(&src[i].descriptor),
+		}
+	}
+	return cloned
+}

--- a/internal/extension/tool_provider_manifest_content.go
+++ b/internal/extension/tool_provider_manifest_content.go
@@ -1,0 +1,123 @@
+package extensionpkg
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type extensionManifestContentState struct {
+	descriptors []ManifestToolDescriptor
+	err         error
+}
+
+type extensionManifestContentKey struct {
+	path        string
+	fingerprint string
+}
+
+type extensionManifestWarningKey struct {
+	contentKey extensionManifestContentKey
+	name       string
+}
+
+func (p *ExtensionToolProvider) manifestToolDescriptors(
+	source *extensionManifestToolSource,
+) ([]ManifestToolDescriptor, error) {
+	contentKey := extensionManifestContentKeyForSource(source)
+	if state, ok := p.cachedManifestContentState(contentKey); ok {
+		return state.descriptors, state.err
+	}
+
+	state := extensionManifestContentState{err: source.snapshot.err}
+	if state.err == nil {
+		manifest, err := loadManifestContentAtPath(source.info.ManifestPath, source.snapshot.content)
+		if err != nil {
+			state.err = err
+		} else {
+			state.descriptors, state.err = ResolveManifestToolDescriptors(manifest)
+		}
+	}
+	p.storeManifestContentState(contentKey, state)
+	return cloneExtensionManifestContentState(state).descriptors, state.err
+}
+
+func (p *ExtensionToolProvider) claimManifestToolWarning(source *extensionManifestToolSource) bool {
+	warningKey := extensionManifestWarningKey{
+		contentKey: extensionManifestContentKeyForSource(source),
+		name:       strings.TrimSpace(source.info.Name),
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if _, ok := p.cache.manifestWarnings[warningKey]; ok {
+		return false
+	}
+	if p.cache.manifestWarnings == nil {
+		p.cache.manifestWarnings = make(map[extensionManifestWarningKey]struct{})
+	}
+	p.cache.manifestWarnings[warningKey] = struct{}{}
+	return true
+}
+
+func (p *ExtensionToolProvider) cachedManifestContentState(
+	contentKey extensionManifestContentKey,
+) (extensionManifestContentState, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	state, ok := p.cache.manifestContentStates[contentKey]
+	return cloneExtensionManifestContentState(state), ok
+}
+
+func (p *ExtensionToolProvider) storeManifestContentState(
+	contentKey extensionManifestContentKey,
+	state extensionManifestContentState,
+) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.cache.manifestContentStates == nil {
+		p.cache.manifestContentStates = make(map[extensionManifestContentKey]extensionManifestContentState)
+	}
+	p.cache.manifestContentStates[contentKey] = cloneExtensionManifestContentState(state)
+}
+
+func (p *ExtensionToolProvider) pruneManifestContentStatesLocked() {
+	activeContentKeys := make(map[extensionManifestContentKey]struct{}, len(p.cache.manifestSnapshots))
+	for path, snapshot := range p.cache.manifestSnapshots {
+		if snapshot.fingerprint != "" {
+			activeContentKeys[extensionManifestContentKey{
+				path:        filepath.Clean(path),
+				fingerprint: snapshot.fingerprint,
+			}] = struct{}{}
+		}
+	}
+	for contentKey := range p.cache.manifestContentStates {
+		if _, ok := activeContentKeys[contentKey]; !ok {
+			delete(p.cache.manifestContentStates, contentKey)
+		}
+	}
+	for warningKey := range p.cache.manifestWarnings {
+		if _, ok := activeContentKeys[warningKey.contentKey]; !ok {
+			delete(p.cache.manifestWarnings, warningKey)
+		}
+	}
+}
+
+func extensionManifestContentKeyForSource(source *extensionManifestToolSource) extensionManifestContentKey {
+	return extensionManifestContentKey{
+		path:        filepath.Clean(source.info.ManifestPath),
+		fingerprint: source.snapshot.fingerprint,
+	}
+}
+
+func cloneExtensionManifestContentState(
+	src extensionManifestContentState,
+) extensionManifestContentState {
+	cloned := extensionManifestContentState{err: src.err}
+	cloned.descriptors = make([]ManifestToolDescriptor, len(src.descriptors))
+	for i := range src.descriptors {
+		cloned.descriptors[i] = cloneManifestToolDescriptor(&src.descriptors[i])
+	}
+	return cloned
+}

--- a/internal/extension/tool_provider_manifest_metadata.go
+++ b/internal/extension/tool_provider_manifest_metadata.go
@@ -1,0 +1,47 @@
+package extensionpkg
+
+import (
+	"os"
+	"time"
+)
+
+type extensionManifestFileMetadata struct {
+	size        int64
+	modTime     time.Time
+	changeToken string
+	statError   string
+	reliable    bool
+}
+
+func newExtensionManifestFileMetadata(info os.FileInfo) extensionManifestFileMetadata {
+	changeToken, reliable := extensionManifestPlatformChangeToken(info)
+	return extensionManifestFileMetadata{
+		size:        info.Size(),
+		modTime:     info.ModTime(),
+		changeToken: changeToken,
+		reliable:    reliable,
+	}
+}
+
+func unavailableExtensionManifestFileMetadata(err error) extensionManifestFileMetadata {
+	if err == nil {
+		return extensionManifestFileMetadata{}
+	}
+	return extensionManifestFileMetadata{statError: err.Error(), reliable: true}
+}
+
+func (m extensionManifestFileMetadata) Equal(other extensionManifestFileMetadata) bool {
+	if m.reliable != other.reliable {
+		return false
+	}
+	if m.statError != other.statError {
+		return false
+	}
+	if m.statError != "" {
+		return true
+	}
+	return m.reliable &&
+		m.size == other.size &&
+		m.modTime.Equal(other.modTime) &&
+		m.changeToken == other.changeToken
+}

--- a/internal/extension/tool_provider_manifest_metadata_darwin.go
+++ b/internal/extension/tool_provider_manifest_metadata_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package extensionpkg
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func extensionManifestPlatformChangeToken(info os.FileInfo) (string, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat == nil {
+		return "", false
+	}
+	return fmt.Sprintf("%d:%d:%d:%d", stat.Dev, stat.Ino, stat.Ctimespec.Sec, stat.Ctimespec.Nsec), true
+}

--- a/internal/extension/tool_provider_manifest_metadata_linux.go
+++ b/internal/extension/tool_provider_manifest_metadata_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package extensionpkg
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func extensionManifestPlatformChangeToken(info os.FileInfo) (string, bool) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || stat == nil {
+		return "", false
+	}
+	return fmt.Sprintf("%d:%d:%d:%d", stat.Dev, stat.Ino, stat.Ctim.Sec, stat.Ctim.Nsec), true
+}

--- a/internal/extension/tool_provider_manifest_metadata_other.go
+++ b/internal/extension/tool_provider_manifest_metadata_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin
+
+package extensionpkg
+
+import "os"
+
+// Platforms without an OS change token rehash a manifest after every successful stat.
+func extensionManifestPlatformChangeToken(os.FileInfo) (string, bool) {
+	return "", false
+}

--- a/internal/extension/tool_provider_test.go
+++ b/internal/extension/tool_provider_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -94,6 +95,76 @@ func TestExtensionToolProviderAvailability(t *testing.T) {
 func TestExtensionToolProviderProjectionGeneration(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should keep projection tokens stable for equivalent runtime projection sets", func(t *testing.T) {
+		t.Parallel()
+
+		env, fixture, descriptor := createExtensionToolProviderFixture(t, "ext-generation-ordering", true)
+		primary := descriptor.RuntimeDescriptor
+		primary.Capabilities = []string{"capability.beta", "capability.alpha", "capability.beta"}
+		primary.InputSchema = json.RawMessage(`{
+			"type": "object",
+			"properties": {"query": {"type": "string"}}
+		}`)
+		primary.OutputSchema = json.RawMessage(`{
+			"properties": {"result": {"type": "string"}},
+			"type": "object"
+		}`)
+		secondary := primary
+		secondary.Handler = "secondary-handler"
+		secondary.Capabilities = []string{"capability.gamma", "capability.alpha", "capability.gamma"}
+		secondary.InputSchema = json.RawMessage(`{
+			"type": "object",
+			"properties": {"limit": {"type": "integer"}}
+		}`)
+		secondary.OutputSchema = json.RawMessage(`{
+			"properties": {"items": {"type": "array"}},
+			"type": "object"
+		}`)
+		runtime := newFakeExtensionToolRuntime(
+			t,
+			env.registry,
+			fixture.manifest.Name,
+			[]toolspkg.ExtensionToolRuntimeDescriptor{primary, secondary},
+		)
+		runtime.extension.InitializeResult.AcceptedCapabilities.Provides = []string{
+			extensionprotocol.CapabilityToolProvider,
+			"capability.bridge",
+			extensionprotocol.CapabilityToolProvider,
+		}
+		provider, err := NewExtensionToolProvider(env.registry, func() ExtensionToolRuntime {
+			return runtime
+		})
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+
+		first, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || first == "" {
+			t.Fatalf("ProjectionGeneration(first) = %q, %t, want authoritative token", first, known)
+		}
+
+		primary.Capabilities = []string{"capability.alpha", "capability.beta"}
+		primary.InputSchema = json.RawMessage(`{"properties":{"query":{"type":"string"}},"type":"object"}`)
+		primary.OutputSchema = json.RawMessage(`{"type":"object","properties":{"result":{"type":"string"}}}`)
+		secondary.Capabilities = []string{"capability.alpha", "capability.gamma"}
+		secondary.InputSchema = json.RawMessage(`{"properties":{"limit":{"type":"integer"}},"type":"object"}`)
+		secondary.OutputSchema = json.RawMessage(`{"type":"object","properties":{"items":{"type":"array"}}}`)
+		runtime.descriptors = []toolspkg.ExtensionToolRuntimeDescriptor{secondary, primary}
+		runtime.extension.InitializeResult.AcceptedCapabilities.Provides = []string{
+			"capability.bridge",
+			extensionprotocol.CapabilityToolProvider,
+		}
+		second, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || second != first {
+			t.Fatalf(
+				"ProjectionGeneration(reordered equivalent runtime state) = %q, %t, want %q",
+				second,
+				known,
+				first,
+			)
+		}
+	})
+
 	t.Run("Should change when runtime descriptors change", func(t *testing.T) {
 		t.Parallel()
 
@@ -123,6 +194,304 @@ func TestExtensionToolProviderProjectionGeneration(t *testing.T) {
 				second,
 				known,
 				first,
+			)
+		}
+	})
+
+	t.Run("Should reflect manifest byte changes with preserved metadata", func(t *testing.T) {
+		t.Parallel()
+
+		env, fixture, descriptor := createExtensionToolProviderFixture(t, "ext-generation-manifest", true)
+		info, err := env.registry.Get(fixture.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", fixture.manifest.Name, err)
+		}
+		original, stat := readManifestContentAndMetadata(t, info.ManifestPath)
+		malformed := malformedManifestContent(original)
+		runtime := newFakeExtensionToolRuntime(
+			t,
+			env.registry,
+			fixture.manifest.Name,
+			[]toolspkg.ExtensionToolRuntimeDescriptor{descriptor.RuntimeDescriptor},
+		)
+		provider, err := NewExtensionToolProvider(env.registry, func() ExtensionToolRuntime {
+			return runtime
+		})
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+
+		validGeneration, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || validGeneration == "" {
+			t.Fatalf("ProjectionGeneration(valid) = %q, %t, want authoritative token", validGeneration, known)
+		}
+		replaceManifestContentPreservingMetadata(t, info.ManifestPath, malformed, stat)
+		invalidGeneration, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || invalidGeneration == validGeneration {
+			t.Fatalf(
+				"ProjectionGeneration(valid to invalid) = %q, %t, want token different from %q",
+				invalidGeneration,
+				known,
+				validGeneration,
+			)
+		}
+
+		replaceManifestContentPreservingMetadata(t, info.ManifestPath, original, stat)
+		repairedGeneration, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || repairedGeneration == invalidGeneration {
+			t.Fatalf(
+				"ProjectionGeneration(invalid to valid) = %q, %t, want token different from %q",
+				repairedGeneration,
+				known,
+				invalidGeneration,
+			)
+		}
+	})
+
+	t.Run("Should keep healthy partial projections for unchanged invalid manifests", func(t *testing.T) {
+		t.Parallel()
+
+		env := newRegistryTestEnv(t)
+		healthy := createExtensionToolTestExtension(t, "healthy-generation", "fake-extension", nil, nil, true)
+		broken := createExtensionToolTestExtension(t, "broken-generation", "fake-extension", nil, nil, true)
+		installManagerFixture(t, env.registry, healthy, SourceUser, true)
+		installManagerFixture(t, env.registry, broken, SourceUser, true)
+		brokenInfo, err := env.registry.Get(broken.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", broken.manifest.Name, err)
+		}
+		original, stat := readManifestContentAndMetadata(t, brokenInfo.ManifestPath)
+		replaceManifestContentPreservingMetadata(
+			t,
+			brokenInfo.ManifestPath,
+			malformedManifestContent(original),
+			stat,
+		)
+		descriptors, err := ResolveManifestToolDescriptors(healthy.manifest)
+		if err != nil || len(descriptors) != 1 {
+			t.Fatalf("ResolveManifestToolDescriptors(healthy) = %#v, %v, want one descriptor", descriptors, err)
+		}
+		runtime := newFakeExtensionToolRuntime(
+			t,
+			env.registry,
+			healthy.manifest.Name,
+			[]toolspkg.ExtensionToolRuntimeDescriptor{descriptors[0].RuntimeDescriptor},
+		)
+		var logs bytes.Buffer
+		provider, err := NewExtensionToolProvider(
+			env.registry,
+			func() ExtensionToolRuntime { return runtime },
+			WithToolProviderLogger(slog.New(slog.NewTextHandler(&logs, nil))),
+		)
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+
+		first, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || first == "" {
+			t.Fatalf("ProjectionGeneration(first) = %q, %t, want authoritative token", first, known)
+		}
+		second, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || second != first {
+			t.Fatalf("ProjectionGeneration(repeated) = %q, %t, want unchanged token %q", second, known, first)
+		}
+		if got := strings.Count(logs.String(), "extension_name=broken-generation"); got != 1 {
+			t.Fatalf("invalid manifest warning count = %d, want 1; logs = %q", got, logs.String())
+		}
+	})
+
+	t.Run("Should keep deterministic projection tokens stable across workspace alternation", func(t *testing.T) {
+		t.Parallel()
+
+		env := newRegistryTestEnv(t)
+		fixtureA := createExtensionToolTestExtension(t, "projection-workspace-a", "fake-extension", nil, nil, true)
+		fixtureB := createExtensionToolTestExtension(t, "projection-workspace-b", "fake-extension", nil, nil, true)
+		installManagerFixture(t, env.registry, fixtureA, SourceUser, true)
+		installManagerFixture(t, env.registry, fixtureB, SourceUser, true)
+		infoA, err := env.registry.Get(fixtureA.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", fixtureA.manifest.Name, err)
+		}
+		infoB, err := env.registry.Get(fixtureB.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", fixtureB.manifest.Name, err)
+		}
+		descriptorsA, err := ResolveManifestToolDescriptors(fixtureA.manifest)
+		if err != nil || len(descriptorsA) != 1 {
+			t.Fatalf("ResolveManifestToolDescriptors(workspace A) = %#v, %v, want one descriptor", descriptorsA, err)
+		}
+		descriptorsB, err := ResolveManifestToolDescriptors(fixtureB.manifest)
+		if err != nil || len(descriptorsB) != 1 {
+			t.Fatalf("ResolveManifestToolDescriptors(workspace B) = %#v, %v, want one descriptor", descriptorsB, err)
+		}
+		fakeA := newFakeExtensionToolRuntime(
+			t,
+			env.registry,
+			fixtureA.manifest.Name,
+			[]toolspkg.ExtensionToolRuntimeDescriptor{descriptorsA[0].RuntimeDescriptor},
+		)
+		fakeB := newFakeExtensionToolRuntime(
+			t,
+			env.registry,
+			fixtureB.manifest.Name,
+			[]toolspkg.ExtensionToolRuntimeDescriptor{descriptorsB[0].RuntimeDescriptor},
+		)
+		keyA := GlobalInstanceKey(infoA.Name)
+		keyB := GlobalInstanceKey(infoB.Name)
+		runtime := &fakeScopedExtensionToolRuntime{
+			fakeExtensionToolRuntime: fakeA,
+			infosByWorkspace: map[string][]ExtensionInfo{
+				"workspace-a": {*infoA},
+				"workspace-b": {*infoB},
+			},
+			extensionsByInstance: map[InstanceKey]*Extension{
+				keyA: fakeA.extension,
+				keyB: fakeB.extension,
+			},
+			descriptorsByInstance: map[InstanceKey][]toolspkg.ExtensionToolRuntimeDescriptor{
+				keyA: fakeA.descriptors,
+				keyB: fakeB.descriptors,
+			},
+		}
+		provider, err := NewExtensionToolProvider(env.registry, func() ExtensionToolRuntime { return runtime })
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+		generationFor := func(workspaceID string) string {
+			t.Helper()
+			generation, known := provider.ProjectionGeneration(
+				t.Context(),
+				toolspkg.Scope{WorkspaceID: workspaceID},
+			)
+			if !known || generation == "" {
+				t.Fatalf("ProjectionGeneration(%q) = %q, %t, want token", workspaceID, generation, known)
+			}
+			return generation
+		}
+
+		aFirst := generationFor("workspace-a")
+		bFirst := generationFor("workspace-b")
+		if aRepeated := generationFor("workspace-a"); aRepeated != aFirst {
+			t.Fatalf("ProjectionGeneration(A/B/A) = %q, want %q", aRepeated, aFirst)
+		}
+		if bRepeated := generationFor("workspace-b"); bRepeated != bFirst {
+			t.Fatalf("ProjectionGeneration(B/A/B) = %q, want %q", bRepeated, bFirst)
+		}
+
+		originalA, statA := readManifestContentAndMetadata(t, infoA.ManifestPath)
+		replaceManifestContentPreservingMetadata(t, infoA.ManifestPath, malformedManifestContent(originalA), statA)
+		if aChanged := generationFor("workspace-a"); aChanged == aFirst {
+			t.Fatalf("ProjectionGeneration(A manifest change) = %q, want token different from %q", aChanged, aFirst)
+		}
+		if bAfterManifestChange := generationFor("workspace-b"); bAfterManifestChange != bFirst {
+			t.Fatalf("ProjectionGeneration(B after A manifest change) = %q, want %q", bAfterManifestChange, bFirst)
+		}
+
+		replaceManifestContentPreservingMetadata(t, infoA.ManifestPath, originalA, statA)
+		if aRestored := generationFor("workspace-a"); aRestored != aFirst {
+			t.Fatalf("ProjectionGeneration(A manifest restored) = %q, want %q", aRestored, aFirst)
+		}
+		fakeB.extension.Status.Healthy = false
+		if bRuntimeChanged := generationFor("workspace-b"); bRuntimeChanged == bFirst {
+			t.Fatalf(
+				"ProjectionGeneration(B runtime change) = %q, want token different from %q",
+				bRuntimeChanged,
+				bFirst,
+			)
+		}
+		if aAfterRuntimeChange := generationFor("workspace-a"); aAfterRuntimeChange != aFirst {
+			t.Fatalf("ProjectionGeneration(A after B runtime change) = %q, want %q", aAfterRuntimeChange, aFirst)
+		}
+	})
+
+	t.Run("Should serialize manifest refreshes before publishing cached content", func(t *testing.T) {
+		t.Parallel()
+
+		env, fixture, _ := createExtensionToolProviderFixture(t, "ext-generation-order", true)
+		info, err := env.registry.Get(fixture.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", fixture.manifest.Name, err)
+		}
+		original, stat := readManifestContentAndMetadata(t, info.ManifestPath)
+		releaseWarning := make(chan struct{})
+		logger := &blockingExtensionToolLogHandler{
+			started: make(chan struct{}),
+			release: releaseWarning,
+		}
+		t.Cleanup(logger.Release)
+		provider, err := NewExtensionToolProvider(
+			env.registry,
+			func() ExtensionToolRuntime { return nil },
+			WithToolProviderLogger(slog.New(logger)),
+		)
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+
+		replaceManifestContentPreservingMetadata(
+			t,
+			info.ManifestPath,
+			malformedManifestContent(original),
+			stat,
+		)
+		firstResult := make(chan extensionToolProviderListResult, 1)
+		go func() {
+			tools, listErr := provider.List(t.Context(), toolspkg.Scope{})
+			firstResult <- extensionToolProviderListResult{tools: tools, err: listErr}
+		}()
+		select {
+		case <-logger.started:
+		case first := <-firstResult:
+			t.Fatalf("Provider.List(earlier invalid content) completed before blocking warning: %#v", first)
+		}
+
+		replaceManifestContentPreservingMetadata(t, info.ManifestPath, original, stat)
+		waitBase, cancelWait := context.WithCancel(t.Context())
+		t.Cleanup(cancelWait)
+		waitContext := &manifestRefreshWaitContext{
+			Context: waitBase,
+			waiting: make(chan struct{}),
+		}
+		secondResult := make(chan extensionToolProviderListResult, 1)
+		go func() {
+			tools, listErr := provider.List(waitContext, toolspkg.Scope{})
+			secondResult <- extensionToolProviderListResult{tools: tools, err: listErr}
+		}()
+		select {
+		case <-waitContext.waiting:
+			cancelWait()
+		case second := <-secondResult:
+			t.Fatalf("Provider.List(newer content) completed before waiting for refresh: %#v", second)
+		}
+		second := <-secondResult
+		if !errors.Is(second.err, context.Canceled) {
+			t.Fatalf("Provider.List(waiting refresh) error = %v, want context canceled", second.err)
+		}
+
+		logger.Release()
+		first := <-firstResult
+		if first.err != nil {
+			t.Fatalf("Provider.List(earlier invalid content) error = %v", first.err)
+		}
+		if len(first.tools) != 0 {
+			t.Fatalf("Provider.List(earlier invalid content) = %#v, want invalid extension isolated", first.tools)
+		}
+
+		currentGeneration, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || currentGeneration == "" {
+			t.Fatalf(
+				"ProjectionGeneration(newer content) = %q, %t, want authoritative token",
+				currentGeneration,
+				known,
+			)
+		}
+		stableGeneration, known := provider.ProjectionGeneration(t.Context(), toolspkg.Scope{})
+		if !known || stableGeneration != currentGeneration {
+			t.Fatalf(
+				"ProjectionGeneration(unchanged newer content) = %q, %t, want %q",
+				stableGeneration,
+				known,
+				currentGeneration,
 			)
 		}
 	})
@@ -213,6 +582,8 @@ func TestExtensionToolProviderCatalog(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			env := newRegistryTestEnv(t)
 			healthy := createExtensionToolTestExtension(t, "healthy-tool", "fake-extension", nil, nil, true)
 			broken := createExtensionToolTestExtension(t, tc.logKey, "fake-extension", nil, nil, true)
@@ -267,7 +638,305 @@ func TestExtensionToolProviderCatalog(t *testing.T) {
 		})
 	}
 
-	t.Run("Should rediscover a repaired manifest with unchanged file metadata", func(t *testing.T) {
+	t.Run("Should cache healthy partial catalogs for unchanged invalid manifests", func(t *testing.T) {
+		t.Parallel()
+
+		env := newRegistryTestEnv(t)
+		healthy := createExtensionToolTestExtension(t, "healthy-catalog", "fake-extension", nil, nil, true)
+		broken := createExtensionToolTestExtension(t, "broken-catalog", "fake-extension", nil, nil, true)
+		installManagerFixture(t, env.registry, healthy, SourceUser, true)
+		installManagerFixture(t, env.registry, broken, SourceUser, true)
+		brokenInfo, err := env.registry.Get(broken.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", broken.manifest.Name, err)
+		}
+		original, stat := readManifestContentAndMetadata(t, brokenInfo.ManifestPath)
+		malformed := malformedManifestContent(original)
+		replaceManifestContentPreservingMetadata(t, brokenInfo.ManifestPath, malformed, stat)
+		healthyDescriptors, err := ResolveManifestToolDescriptors(healthy.manifest)
+		if err != nil || len(healthyDescriptors) != 1 {
+			t.Fatalf(
+				"ResolveManifestToolDescriptors(healthy) = %#v, %v, want one descriptor",
+				healthyDescriptors,
+				err,
+			)
+		}
+		var logs bytes.Buffer
+		provider, err := NewExtensionToolProvider(
+			env.registry,
+			func() ExtensionToolRuntime { return nil },
+			WithToolProviderLogger(slog.New(slog.NewTextHandler(&logs, nil))),
+		)
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+
+		for _, name := range []string{"first", "repeated"} {
+			catalog, listErr := provider.List(testutil.Context(t), toolspkg.Scope{})
+			if listErr != nil {
+				t.Fatalf("Provider.List(%s) error = %v", name, listErr)
+			}
+			if len(catalog) != 1 || catalog[0].ID != healthyDescriptors[0].Tool.ID {
+				t.Fatalf("Provider.List(%s) = %#v, want healthy tool %q", name, catalog, healthyDescriptors[0].Tool.ID)
+			}
+		}
+		if got := strings.Count(logs.String(), "extension_name=broken-catalog"); got != 1 {
+			t.Fatalf("unchanged invalid manifest warning count = %d, want 1; logs = %q", got, logs.String())
+		}
+
+		changedMalformed := slices.Clone(malformed)
+		changedMalformed[0] = '['
+		replaceManifestContentPreservingMetadata(t, brokenInfo.ManifestPath, changedMalformed, stat)
+		catalog, err := provider.List(testutil.Context(t), toolspkg.Scope{})
+		if err != nil {
+			t.Fatalf("Provider.List(changed invalid) error = %v", err)
+		}
+		if len(catalog) != 1 || catalog[0].ID != healthyDescriptors[0].Tool.ID {
+			t.Fatalf(
+				"Provider.List(changed invalid) = %#v, want healthy tool %q",
+				catalog,
+				healthyDescriptors[0].Tool.ID,
+			)
+		}
+		if got := strings.Count(logs.String(), "extension_name=broken-catalog"); got != 2 {
+			t.Fatalf("changed invalid manifest warning count = %d, want 2; logs = %q", got, logs.String())
+		}
+	})
+
+	t.Run("Should recover from a transient manifest read error without metadata changes", func(t *testing.T) {
+		t.Parallel()
+
+		env, fixture, descriptor := createExtensionToolProviderFixture(t, "transient-read-error", true)
+		info, err := env.registry.Get(fixture.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", fixture.manifest.Name, err)
+		}
+		var logs bytes.Buffer
+		provider, err := NewExtensionToolProvider(
+			env.registry,
+			func() ExtensionToolRuntime { return nil },
+			WithToolProviderLogger(slog.New(slog.NewTextHandler(&logs, nil))),
+		)
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+		readFile := provider.manifestReadFile
+		firstRead := true
+		provider.manifestReadFile = func(path string) ([]byte, error) {
+			if path == info.ManifestPath && firstRead {
+				firstRead = false
+				return nil, errors.New("transient manifest read error")
+			}
+			return readFile(path)
+		}
+
+		first, err := provider.List(testutil.Context(t), toolspkg.Scope{})
+		if err != nil {
+			t.Fatalf("Provider.List(transient read error) error = %v", err)
+		}
+		if len(first) != 0 {
+			t.Fatalf("Provider.List(transient read error) = %#v, want invalid extension isolated", first)
+		}
+		second, err := provider.List(testutil.Context(t), toolspkg.Scope{})
+		if err != nil {
+			t.Fatalf("Provider.List(recovered read) error = %v", err)
+		}
+		if len(second) != 1 || second[0].ID != descriptor.Tool.ID {
+			t.Fatalf("Provider.List(recovered read) = %#v, want healthy tool %q", second, descriptor.Tool.ID)
+		}
+		if got := strings.Count(logs.String(), "extension_name=transient-read-error"); got != 1 {
+			t.Fatalf("transient read error warning count = %d, want 1; logs = %q", got, logs.String())
+		}
+	})
+
+	t.Run("Should retain global snapshots behind workspace development overrides", func(t *testing.T) {
+		t.Parallel()
+
+		env := newRegistryTestEnv(t)
+		healthyA := createExtensionToolTestExtension(t, "workspace-healthy-a", "fake-extension", nil, nil, true)
+		healthyB := createExtensionToolTestExtension(t, "workspace-healthy-b", "fake-extension", nil, nil, true)
+		broken := createExtensionToolTestExtension(t, "workspace-broken", "fake-extension", nil, nil, true)
+		installManagerFixture(t, env.registry, healthyA, SourceUser, true)
+		installManagerFixture(t, env.registry, healthyB, SourceUser, true)
+		installManagerFixture(t, env.registry, broken, SourceUser, true)
+		healthyAInfo, err := env.registry.Get(healthyA.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", healthyA.manifest.Name, err)
+		}
+		healthyBInfo, err := env.registry.Get(healthyB.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", healthyB.manifest.Name, err)
+		}
+		brokenInfo, err := env.registry.Get(broken.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", broken.manifest.Name, err)
+		}
+		workspaceHealthyAInfo := cloneExtensionInfo(*healthyAInfo)
+		workspaceHealthyAInfo.Name = brokenInfo.Name
+		workspaceHealthyAInfo.Source = SourceWorkspace
+		workspaceHealthyBInfo := cloneExtensionInfo(*healthyBInfo)
+		workspaceHealthyBInfo.Name = brokenInfo.Name
+		workspaceHealthyBInfo.Source = SourceWorkspace
+		original, stat := readManifestContentAndMetadata(t, brokenInfo.ManifestPath)
+		replaceManifestContentPreservingMetadata(
+			t,
+			brokenInfo.ManifestPath,
+			malformedManifestContent(original),
+			stat,
+		)
+		healthyADescriptors, err := ResolveManifestToolDescriptors(healthyA.manifest)
+		if err != nil || len(healthyADescriptors) != 1 {
+			t.Fatalf(
+				"ResolveManifestToolDescriptors(workspace A) = %#v, %v, want one descriptor",
+				healthyADescriptors,
+				err,
+			)
+		}
+		healthyBDescriptors, err := ResolveManifestToolDescriptors(healthyB.manifest)
+		if err != nil || len(healthyBDescriptors) != 1 {
+			t.Fatalf(
+				"ResolveManifestToolDescriptors(workspace B) = %#v, %v, want one descriptor",
+				healthyBDescriptors,
+				err,
+			)
+		}
+		runtime := &fakeScopedExtensionToolRuntime{
+			fakeExtensionToolRuntime: newFakeExtensionToolRuntime(
+				t,
+				env.registry,
+				healthyA.manifest.Name,
+				nil,
+			),
+			infosByWorkspace: map[string][]ExtensionInfo{
+				"":            {*brokenInfo},
+				"workspace-a": {workspaceHealthyAInfo},
+				"workspace-b": {workspaceHealthyBInfo},
+			},
+		}
+		var logs bytes.Buffer
+		provider, err := NewExtensionToolProvider(
+			env.registry,
+			func() ExtensionToolRuntime { return runtime },
+			WithToolProviderLogger(slog.New(slog.NewTextHandler(&logs, nil))),
+		)
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+
+		for _, testCase := range []struct {
+			workspaceID string
+			wantID      toolspkg.ToolID
+			wantEmpty   bool
+		}{
+			{workspaceID: "", wantEmpty: true},
+			{workspaceID: "workspace-a", wantID: healthyADescriptors[0].Tool.ID},
+			{workspaceID: "workspace-b", wantID: healthyBDescriptors[0].Tool.ID},
+			{workspaceID: "", wantEmpty: true},
+		} {
+			catalog, listErr := provider.List(testutil.Context(t), toolspkg.Scope{WorkspaceID: testCase.workspaceID})
+			if listErr != nil {
+				t.Fatalf("Provider.List(%q) error = %v", testCase.workspaceID, listErr)
+			}
+			if testCase.wantEmpty {
+				if len(catalog) != 0 {
+					t.Fatalf("Provider.List(%q) = %#v, want overridden invalid catalog", testCase.workspaceID, catalog)
+				}
+				continue
+			}
+			if len(catalog) != 1 || catalog[0].ID != testCase.wantID {
+				t.Fatalf(
+					"Provider.List(%q) = %#v, want only healthy tool %q",
+					testCase.workspaceID,
+					catalog,
+					testCase.wantID,
+				)
+			}
+		}
+		if got := strings.Count(logs.String(), "extension_name=workspace-broken"); got != 1 {
+			t.Fatalf("global invalid manifest warning count = %d, want 1; logs = %q", got, logs.String())
+		}
+	})
+
+	t.Run("Should name each invalid extension with identical bytes once", func(t *testing.T) {
+		t.Parallel()
+
+		env, fixture, _ := createExtensionToolProviderFixture(t, "invalid-json", true)
+		jsonInfo, err := env.registry.Get(fixture.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", fixture.manifest.Name, err)
+		}
+		tomlDir := t.TempDir()
+		tomlPath := filepath.Join(tomlDir, manifestTOMLFileName)
+		const invalidManifest = "{"
+		writeFile(t, jsonInfo.ManifestPath, invalidManifest)
+		writeFile(t, tomlPath, invalidManifest)
+		_, jsonParseErr := loadManifestContentAtPath(jsonInfo.ManifestPath, []byte(invalidManifest))
+		if jsonParseErr == nil {
+			t.Fatal("loadManifestContentAtPath(JSON) error = nil, want invalid manifest error")
+		}
+		_, tomlParseErr := loadManifestContentAtPath(tomlPath, []byte(invalidManifest))
+		if tomlParseErr == nil {
+			t.Fatal("loadManifestContentAtPath(TOML) error = nil, want invalid manifest error")
+		}
+		if !strings.Contains(jsonParseErr.Error(), "JSON") || !strings.Contains(tomlParseErr.Error(), "toml:") {
+			t.Fatalf("parser errors = %q, %q, want JSON and TOML parser errors", jsonParseErr, tomlParseErr)
+		}
+		tomlInfo := cloneExtensionInfo(*jsonInfo)
+		tomlInfo.Name = "invalid-toml"
+		tomlInfo.ManifestPath = tomlPath
+		runtime := &fakeScopedExtensionToolRuntime{
+			fakeExtensionToolRuntime: newFakeExtensionToolRuntime(
+				t,
+				env.registry,
+				fixture.manifest.Name,
+				nil,
+			),
+			infosByWorkspace: map[string][]ExtensionInfo{
+				"workspace-invalid": {*jsonInfo, tomlInfo},
+			},
+		}
+		var logs bytes.Buffer
+		provider, err := NewExtensionToolProvider(
+			env.registry,
+			func() ExtensionToolRuntime { return runtime },
+			WithToolProviderLogger(slog.New(slog.NewTextHandler(&logs, nil))),
+		)
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+
+		for _, name := range []string{"first", "repeated"} {
+			catalog, listErr := provider.List(
+				testutil.Context(t),
+				toolspkg.Scope{WorkspaceID: "workspace-invalid"},
+			)
+			if listErr != nil {
+				t.Fatalf("Provider.List(%s) error = %v", name, listErr)
+			}
+			if len(catalog) != 0 {
+				t.Fatalf("Provider.List(%s) = %#v, want invalid extensions isolated", name, catalog)
+			}
+		}
+		for _, extensionName := range []string{"invalid-json", "invalid-toml"} {
+			if got := strings.Count(logs.String(), "extension_name="+extensionName); got != 1 {
+				t.Fatalf(
+					"warning count for %q = %d, want 1; logs = %q",
+					extensionName,
+					got,
+					logs.String(),
+				)
+			}
+		}
+		for _, parserMarker := range []string{"JSON", "toml:"} {
+			if !strings.Contains(logs.String(), parserMarker) {
+				t.Fatalf("provider logs = %q, want parser marker %q", logs.String(), parserMarker)
+			}
+		}
+	})
+
+	t.Run("Should reflect manifest byte changes with unchanged file metadata", func(t *testing.T) {
+		t.Parallel()
+
 		env := newRegistryTestEnv(t)
 		fixture := createExtensionToolTestExtension(t, "repaired-tool", "fake-extension", nil, nil, true)
 		installManagerFixture(t, env.registry, fixture, SourceUser, true)
@@ -275,22 +944,8 @@ func TestExtensionToolProviderCatalog(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Registry.Get(%q) error = %v", fixture.manifest.Name, err)
 		}
-		original, err := os.ReadFile(info.ManifestPath)
-		if err != nil {
-			t.Fatalf("os.ReadFile(%q) error = %v", info.ManifestPath, err)
-		}
-		stat, err := os.Stat(info.ManifestPath)
-		if err != nil {
-			t.Fatalf("os.Stat(%q) error = %v", info.ManifestPath, err)
-		}
-		malformed := bytes.Repeat([]byte{' '}, len(original))
-		malformed[0] = '{'
-		if err := os.WriteFile(info.ManifestPath, malformed, stat.Mode()); err != nil {
-			t.Fatalf("os.WriteFile(malformed) error = %v", err)
-		}
-		if err := os.Chtimes(info.ManifestPath, stat.ModTime(), stat.ModTime()); err != nil {
-			t.Fatalf("os.Chtimes(malformed) error = %v", err)
-		}
+		original, stat := readManifestContentAndMetadata(t, info.ManifestPath)
+		malformed := malformedManifestContent(original)
 
 		provider, err := NewExtensionToolProvider(env.registry, func() ExtensionToolRuntime { return nil })
 		if err != nil {
@@ -298,18 +953,22 @@ func TestExtensionToolProviderCatalog(t *testing.T) {
 		}
 		first, err := provider.List(testutil.Context(t), toolspkg.Scope{Operator: true})
 		if err != nil {
-			t.Fatalf("Provider.List(malformed) error = %v", err)
+			t.Fatalf("Provider.List(valid) error = %v", err)
 		}
-		if len(first) != 0 {
-			t.Fatalf("Provider.List(malformed) = %#v, want invalid extension isolated", first)
+		if len(first) != 1 {
+			t.Fatalf("Provider.List(valid) = %#v, want extension tool", first)
 		}
 
-		if err := os.WriteFile(info.ManifestPath, original, stat.Mode()); err != nil {
-			t.Fatalf("os.WriteFile(repaired) error = %v", err)
+		replaceManifestContentPreservingMetadata(t, info.ManifestPath, malformed, stat)
+		invalid, err := provider.List(testutil.Context(t), toolspkg.Scope{Operator: true})
+		if err != nil {
+			t.Fatalf("Provider.List(valid to invalid) error = %v", err)
 		}
-		if err := os.Chtimes(info.ManifestPath, stat.ModTime(), stat.ModTime()); err != nil {
-			t.Fatalf("os.Chtimes(repaired) error = %v", err)
+		if len(invalid) != 0 {
+			t.Fatalf("Provider.List(valid to invalid) = %#v, want invalid extension isolated", invalid)
 		}
+
+		replaceManifestContentPreservingMetadata(t, info.ManifestPath, original, stat)
 		repaired, err := provider.List(testutil.Context(t), toolspkg.Scope{Operator: true})
 		if err != nil {
 			t.Fatalf("Provider.List(repaired) error = %v", err)
@@ -566,7 +1225,109 @@ type fakeExtensionToolRuntime struct {
 	callErr     error
 }
 
+type fakeScopedExtensionToolRuntime struct {
+	*fakeExtensionToolRuntime
+	infosByWorkspace      map[string][]ExtensionInfo
+	extensionsByInstance  map[InstanceKey]*Extension
+	descriptorsByInstance map[InstanceKey][]toolspkg.ExtensionToolRuntimeDescriptor
+}
+
+type extensionToolProviderListResult struct {
+	tools []toolspkg.Descriptor
+	err   error
+}
+
+type manifestRefreshWaitContext struct {
+	context.Context
+	waiting  chan struct{}
+	waitOnce sync.Once
+}
+
+func (c *manifestRefreshWaitContext) Done() <-chan struct{} {
+	c.waitOnce.Do(func() {
+		close(c.waiting)
+	})
+	return c.Context.Done()
+}
+
+type blockingExtensionToolLogHandler struct {
+	started     chan struct{}
+	release     chan struct{}
+	startedOnce sync.Once
+	releaseOnce sync.Once
+}
+
+var _ slog.Handler = (*blockingExtensionToolLogHandler)(nil)
+
+func (h *blockingExtensionToolLogHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *blockingExtensionToolLogHandler) Handle(ctx context.Context, record slog.Record) error {
+	if record.Message != "extension: skip invalid extension tool manifest" {
+		return nil
+	}
+	h.startedOnce.Do(func() {
+		close(h.started)
+	})
+	select {
+	case <-h.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (h *blockingExtensionToolLogHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *blockingExtensionToolLogHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func (h *blockingExtensionToolLogHandler) Release() {
+	h.releaseOnce.Do(func() {
+		close(h.release)
+	})
+}
+
 var _ ExtensionToolRuntime = (*fakeExtensionToolRuntime)(nil)
+var _ extensionScopedToolRuntime = (*fakeScopedExtensionToolRuntime)(nil)
+
+func (f *fakeScopedExtensionToolRuntime) GetForInstance(key InstanceKey) (*Extension, error) {
+	if extension := f.extensionsByInstance[key.Normalize()]; extension != nil {
+		return extension, nil
+	}
+	return f.extension, nil
+}
+
+func (f *fakeScopedExtensionToolRuntime) ListForWorkspace(workspaceID string) []ExtensionInfo {
+	infos := f.infosByWorkspace[workspaceID]
+	cloned := make([]ExtensionInfo, len(infos))
+	for i := range infos {
+		cloned[i] = cloneExtensionInfo(infos[i])
+	}
+	return cloned
+}
+
+func (f *fakeScopedExtensionToolRuntime) ProvideToolsForInstance(
+	ctx context.Context,
+	key InstanceKey,
+) ([]toolspkg.ExtensionToolRuntimeDescriptor, error) {
+	if descriptors, ok := f.descriptorsByInstance[key.Normalize()]; ok {
+		return cloneRuntimeToolDescriptors(descriptors), nil
+	}
+	return f.ProvideTools(ctx, "")
+}
+
+func (f *fakeScopedExtensionToolRuntime) CallToolForInstance(
+	ctx context.Context,
+	_ InstanceKey,
+	req toolspkg.ExtensionToolCallRequest,
+) (toolspkg.ToolResult, error) {
+	return f.CallTool(ctx, "", req)
+}
 
 func (f *fakeExtensionToolRuntime) Get(string) (*Extension, error) {
 	return f.extension, nil
@@ -952,4 +1713,40 @@ func extensionToolManifestJSON(
 		panic(fmt.Sprintf("marshal extension tool manifest fixture: %v", err))
 	}
 	return string(data)
+}
+
+func readManifestContentAndMetadata(t *testing.T, path string) ([]byte, os.FileInfo) {
+	t.Helper()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile(%q) error = %v", path, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat(%q) error = %v", path, err)
+	}
+	return content, info
+}
+
+func malformedManifestContent(original []byte) []byte {
+	malformed := bytes.Repeat([]byte{' '}, len(original))
+	malformed[0] = '{'
+	return malformed
+}
+
+func replaceManifestContentPreservingMetadata(
+	t *testing.T,
+	path string,
+	content []byte,
+	info os.FileInfo,
+) {
+	t.Helper()
+
+	if err := os.WriteFile(path, content, info.Mode()); err != nil {
+		t.Fatalf("os.WriteFile(%q) error = %v", path, err)
+	}
+	if err := os.Chtimes(path, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatalf("os.Chtimes(%q) error = %v", path, err)
+	}
 }

--- a/internal/extension/tool_provider_test.go
+++ b/internal/extension/tool_provider_test.go
@@ -266,6 +266,58 @@ func TestExtensionToolProviderCatalog(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Should rediscover a repaired manifest with unchanged file metadata", func(t *testing.T) {
+		env := newRegistryTestEnv(t)
+		fixture := createExtensionToolTestExtension(t, "repaired-tool", "fake-extension", nil, nil, true)
+		installManagerFixture(t, env.registry, fixture, SourceUser, true)
+		info, err := env.registry.Get(fixture.manifest.Name)
+		if err != nil {
+			t.Fatalf("Registry.Get(%q) error = %v", fixture.manifest.Name, err)
+		}
+		original, err := os.ReadFile(info.ManifestPath)
+		if err != nil {
+			t.Fatalf("os.ReadFile(%q) error = %v", info.ManifestPath, err)
+		}
+		stat, err := os.Stat(info.ManifestPath)
+		if err != nil {
+			t.Fatalf("os.Stat(%q) error = %v", info.ManifestPath, err)
+		}
+		malformed := bytes.Repeat([]byte{' '}, len(original))
+		malformed[0] = '{'
+		if err := os.WriteFile(info.ManifestPath, malformed, stat.Mode()); err != nil {
+			t.Fatalf("os.WriteFile(malformed) error = %v", err)
+		}
+		if err := os.Chtimes(info.ManifestPath, stat.ModTime(), stat.ModTime()); err != nil {
+			t.Fatalf("os.Chtimes(malformed) error = %v", err)
+		}
+
+		provider, err := NewExtensionToolProvider(env.registry, func() ExtensionToolRuntime { return nil })
+		if err != nil {
+			t.Fatalf("NewExtensionToolProvider() error = %v", err)
+		}
+		first, err := provider.List(testutil.Context(t), toolspkg.Scope{Operator: true})
+		if err != nil {
+			t.Fatalf("Provider.List(malformed) error = %v", err)
+		}
+		if len(first) != 0 {
+			t.Fatalf("Provider.List(malformed) = %#v, want invalid extension isolated", first)
+		}
+
+		if err := os.WriteFile(info.ManifestPath, original, stat.Mode()); err != nil {
+			t.Fatalf("os.WriteFile(repaired) error = %v", err)
+		}
+		if err := os.Chtimes(info.ManifestPath, stat.ModTime(), stat.ModTime()); err != nil {
+			t.Fatalf("os.Chtimes(repaired) error = %v", err)
+		}
+		repaired, err := provider.List(testutil.Context(t), toolspkg.Scope{Operator: true})
+		if err != nil {
+			t.Fatalf("Provider.List(repaired) error = %v", err)
+		}
+		if len(repaired) != 1 {
+			t.Fatalf("Provider.List(repaired) = %#v, want repaired extension tool", repaired)
+		}
+	})
 }
 
 func TestExtensionToolProviderDispatch(t *testing.T) {

--- a/internal/extension/tool_provider_test.go
+++ b/internal/extension/tool_provider_test.go
@@ -1,10 +1,12 @@
 package extensionpkg
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -185,6 +187,85 @@ func TestExtensionToolProviderCatalog(t *testing.T) {
 			t.Fatalf("Registry.List(restored) omitted %q", descriptor.Tool.ID)
 		}
 	})
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*testing.T, string)
+		logKey string
+	}{
+		{
+			name: "Should isolate an extension with a missing manifest",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Remove(path); err != nil {
+					t.Fatalf("os.Remove(%q) error = %v", path, err)
+				}
+			},
+			logKey: "broken-missing",
+		},
+		{
+			name: "Should isolate an extension with a malformed manifest",
+			mutate: func(t *testing.T, path string) {
+				t.Helper()
+				writeFile(t, path, "{")
+			},
+			logKey: "broken-malformed",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newRegistryTestEnv(t)
+			healthy := createExtensionToolTestExtension(t, "healthy-tool", "fake-extension", nil, nil, true)
+			broken := createExtensionToolTestExtension(t, tc.logKey, "fake-extension", nil, nil, true)
+			installManagerFixture(t, env.registry, healthy, SourceUser, true)
+			installManagerFixture(t, env.registry, broken, SourceUser, true)
+			brokenInfo, err := env.registry.Get(broken.manifest.Name)
+			if err != nil {
+				t.Fatalf("Registry.Get(%q) error = %v", broken.manifest.Name, err)
+			}
+			tc.mutate(t, brokenInfo.ManifestPath)
+
+			descriptors, err := ResolveManifestToolDescriptors(healthy.manifest)
+			if err != nil || len(descriptors) != 1 {
+				t.Fatalf("ResolveManifestToolDescriptors(healthy) = %#v, %v, want one descriptor", descriptors, err)
+			}
+			runtime := newFakeExtensionToolRuntime(
+				t,
+				env.registry,
+				healthy.manifest.Name,
+				[]toolspkg.ExtensionToolRuntimeDescriptor{descriptors[0].RuntimeDescriptor},
+			)
+			var logs bytes.Buffer
+			registry := newExtensionToolRegistry(
+				t,
+				env.registry,
+				runtime,
+				extensionToolPolicyAllowAll(),
+				WithToolProviderLogger(slog.New(slog.NewTextHandler(&logs, nil))),
+			)
+
+			views, err := registry.List(testutil.Context(t), toolspkg.Scope{Operator: true})
+			if err != nil {
+				t.Fatalf("Registry.List() error = %v, want invalid extension isolated", err)
+			}
+			if !extensionToolViewsContain(views, descriptors[0].Tool.ID) {
+				t.Fatalf("Registry.List() omitted healthy tool %q", descriptors[0].Tool.ID)
+			}
+			_, err = registry.Call(
+				testutil.Context(t),
+				toolspkg.Scope{SessionID: "session-1"},
+				toolspkg.CallRequest{
+					ToolID: descriptors[0].Tool.ID,
+					Input:  json.RawMessage(`{"query":"alpha"}`),
+				},
+			)
+			if err != nil {
+				t.Fatalf("Registry.Call(healthy) error = %v, want invalid extension isolated", err)
+			}
+			if !strings.Contains(logs.String(), tc.logKey) {
+				t.Fatalf("provider logs = %q, want invalid extension name %q", logs.String(), tc.logKey)
+			}
+		})
+	}
 }
 
 func TestExtensionToolProviderDispatch(t *testing.T) {
@@ -518,12 +599,13 @@ func newExtensionToolRegistry(
 	extensionRegistry *Registry,
 	runtime ExtensionToolRuntime,
 	policyInputs toolspkg.PolicyInputs,
+	providerOpts ...ExtensionToolProviderOption,
 ) *toolspkg.RuntimeRegistry {
 	t.Helper()
 
 	provider, err := NewExtensionToolProvider(extensionRegistry, func() ExtensionToolRuntime {
 		return runtime
-	})
+	}, providerOpts...)
 	if err != nil {
 		t.Fatalf("NewExtensionToolProvider() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- include callable extension-host providers in the initial hosted MCP session projection
- preserve deferred discovery for external vendor MCP providers
- prove an arbitrary installed extension tool is listed and invoked from a fresh managed session
- record the `ET-048` live QA re-walk and strict teardown evidence

## Root cause

`daemonExtensionToolProvider` implemented `DeferInitialDiscovery`, so hosted MCP bound a session before collecting tools from active installed extensions. The daemon registry could report an extension tool as callable while the managed provider never received an invocable tool reference.

The extension provider already owns availability, workspace scope, policy, and generation tracking. Removing this incorrect deferral restores registry/projection parity. The external `MCPProvider` remains deferred because its discovery may start remote vendor servers during the handshake.

Closes #371.

## Verification

- `mise exec -- go test -race ./internal/daemon -count=1`
- `mise exec -- go test -race -tags=integration ./internal/daemon -run TestDaemonE2EExtensionDistributionAcrossIsolatedHomes -count=1 -v`
- `mise exec -- golangci-lint run ./internal/daemon/...`
- `mise exec -- make build`
- `make gate-full` — PASS, 21,620 tests with 3 platform skips; `tag.gpgSign=false` was scoped to the command so temporary fixture repositories could create unsigned test tags under an operator environment with global tag signing enabled
- `make gate-status` — full pass CURRENT, fingerprint `d134daebea34b5bbf2ca0b8b9a53c7f246cdda32`

## QA

Fresh isolated lab:

- manifest: `/home/franciscpd/dev/qa-labs/compozy-hosted-extension-tool-bootstrap-20260813-151539-252959-lab/qa-artifacts/qa/bootstrap-manifest.json`
- arbitrary extension: `qa-hosted`, created from the official `tool-provider-go` template
- managed session: `sess-67821081fd92dcde` with live Codex
- hosted tool: `ext__qa_hosted__search`
- result: `No results for alpha`
- strict audit: PASS, no blockers or warnings
- teardown: `clean: true`, no survivors
- durable report: `docs/qa/reports/2026-08-13-hosted-extension-tool-bootstrap.md`

No UI surface changed, so screenshots are not applicable.

## Compozy Impact Audit

- **Native tools:** no `compozy__*` or extension ToolID, descriptor, schema, digest, risk flag, or capability gate changed. Hosted MCP bootstrap now includes already-callable `ext__<extension>__<tool>` descriptors.
- **Extensibility and hooks:** active extension-host providers now participate in initial hosted MCP discovery. External vendor MCP providers remain deferred. Extension manifests, capabilities, subprocess protocol, hooks, resources, bridge SDKs, and config lifecycle are unchanged.
- **Workspace data isolation:** discovery and calls retain the bound session workspace scope. The E2E installs the extension in an isolated consumer home and invokes it only from its registered workspace. No new stored datum is introduced.
- **Official Compozy skill:** no update required. Existing extension authoring and live descriptor guidance already describes this behavior; the fix restores the documented hosted MCP projection contract without adding commands or schemas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosted MCP sessions now discover and expose installed extension tools during startup.
  * Extension tools can be discovered and invoked through hosted MCP connections.
  * Added structured logging for extension tool discovery.
  * Added support for reliable extension manifest refresh and workspace-specific tool discovery.

* **Bug Fixes**
  * Invalid or unavailable extension manifests no longer prevent healthy extension tools from being discovered.
  * Repaired manifests are rediscovered automatically, even when file metadata is unchanged.
  * Extension tool listings now remain consistent across equivalent configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->