### PR TITLE
fix: preserve awaited child loop state

### DIFF
--- a/docs/qa/charters/CH-await-child-loop-restart.md
+++ b/docs/qa/charters/CH-await-child-loop-restart.md
@@ -1,0 +1,27 @@
+# CH-await-child-loop-restart: Does an awaited child survive interruption without reordering work?
+
+```yaml
+charter:
+  id: CH-await-child-loop-restart
+  mission: "As Bruno, run two ordered child Loops and interrupt the daemon while the first is live to prove the parent resumes the same work before advancing."
+  mode: charter-with-tour
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-await-child-loop
+  scenarios: [LP-run-loop-await-child-ordering]
+  tour: Interrupt Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Read the live parent through structured CLI and HTTP/UDS surfaces before and after restart."
+      - "Compare the exact first-child identity across restart and count child runs before releasing it."
+      - "Release each durable wait separately and confirm the second child begins only after the first is terminal."
+      - "Re-read the terminal parent and both children through an independent public surface."
+    must_avoid:
+      - "Extensions, agents, providers, native tools, or application-specific orchestration."
+```
+
+<!-- The charter is durable and immutable; run debriefs belong in dated reports. -->

--- a/docs/qa/journeys/J-await-child-loop.md
+++ b/docs/qa/journeys/J-await-child-loop.md
@@ -1,0 +1,55 @@
+# J-await-child-loop — Run ordered child Loops to completion
+
+```mermaid
+flowchart TD
+    A[Entry: run an authored parent Loop] --> B[Parent starts the first child in await mode]
+    B --> C{First child terminal?}
+    C -->|No| D[Parent reports awaiting_child and keeps later nodes pending]
+    D --> E[Operator restarts the daemon]
+    E --> F[Parent restores the same child without duplication]
+    F --> C
+    C -->|Yes| G[Parent starts the second child]
+    G --> H{Second child terminal?}
+    H -->|No| I[Parent remains awaiting_child]
+    I --> H
+    H -->|Yes| J[Side effect: both child runs are terminal]
+    J --> K[True end: parent is done with exactly two ordered children]
+    D -.->|operator stops the parent| X[Abandon: parent closes according to on_parent_close]
+```
+
+```yaml
+journey:
+  id: J-await-child-loop
+  name: "Run ordered child Loops to completion"
+  value_statement: "A Loop author can compose durable child work without the parent skipping ahead or duplicating work after restart."
+  personas: [Bruno, Ada]
+  entry_points:
+    - url: "CLI: compozy loop run --workspace <workspace-id> --name <parent>"
+      origin: direct
+    - url: "HTTP/UDS Loop run and run-detail routes"
+      origin: direct
+  actions:
+    - step: 1
+      verb: "Start a parent Loop with ordered run-loop nodes in await mode"
+      expected_observable: "The first parent node reports awaiting_child and exactly one child run exists"
+    - step: 2
+      verb: "Restart the daemon while the first child is live"
+      expected_observable: "The same child id remains attached, no duplicate child appears, and the second parent node stays pending"
+    - step: 3
+      verb: "Resume the first child"
+      expected_observable: "The first parent node succeeds and the second child starts only afterward"
+    - step: 4
+      verb: "Resume the second child"
+      expected_observable: "Both child runs and the parent reach done"
+  goal:
+    observable: "The parent reaches done only after both ordered child runs reach terminal success"
+    side_effects: [two-child-runs-created, parent-child-identities-persisted]
+  true_end_state: "Fresh CLI and HTTP/UDS reads agree that the parent is done, both child runs are terminal, and exactly two child identities were created in order."
+  exit:
+    natural: "The operator sees a terminal parent run whose child history matches the authored order."
+  abandonment:
+    - at_step: 2
+      how: "The operator stops the parent while its child is live."
+      resume: "The child follows the authored on_parent_close policy and the parent does not report false success."
+  crosses: [loop-coordinator, durable-run-state, daemon-restart, cli-http-uds-parity]
+```

--- a/docs/qa/reports/2026-08-13-run-loop-await-child.md
+++ b/docs/qa/reports/2026-08-13-run-loop-await-child.md
@@ -1,0 +1,99 @@
+# QA Run Report — 2026-08-13 — run-loop-await-child
+
+- **Scope:** Preserve an awaited child Loop's identity and blocking state across task completion and daemon restart.
+- **Cadence tier:** targeted
+- **Build:** `compozy v0.3.0-beta.15-15-gea7c17e4-dirty` · **Environment:** fresh isolated QA labs using the branch-built daemon; the primary ordering walk has no extension, agent, provider, or mock dependency, followed by a separate Batuta compatibility canary
+- **Started:** 2026-08-13T17:16:07-03:00 · **Status:** BLOCKED (upstream gate baseline)
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-await-child-loop-restart |
+
+## Flows in Scope
+
+- `J-await-child-loop` — compose durable child work without skipping or duplicating it after restart (`../journeys/J-await-child-loop.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-await-child-loop-restart | J-await-child-loop / LP-run-loop-await-child-ordering | Bruno | Interrupt Tour | Pass | [#386](https://github.com/compozy/compozy/issues/386) | this PR |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-await-child-loop-restart — Bruno
+
+- **Ran:** 2026-08-13T17:18:48-03:00 → 2026-08-13T17:20:23-03:00 (box respected: yes)
+- **Findings:** The parent stayed `running`; `first_child` stayed `awaiting_child`; `second_child` stayed `pending`; and exactly one child id survived the daemon restart. Releasing the first wait moved only that child to `done` before the second child was created. Releasing the second wait then moved the parent and both children to `done`. CLI/UDS and HTTP terminal reads matched.
+- **Bugs filed/updated:** Upstream issue [#386](https://github.com/compozy/compozy/issues/386) documents the fixed defect; no new runtime bug was found.
+- **Scenarios settled:** LP-run-loop-await-child-ordering → pass.
+- **Paper cuts:** A timed wait requires `--payload '{}'` to select the manual-wait resume path; omitting it attempts a paused-node transition and returns `node_not_paused` (dull, outside this fix).
+- **Surprises:** The CLI enters through UDS, so an authored reproduction intended for CLI use must declare `start: uds`; the generic design reproduction now declares manual, HTTP, and UDS starts explicitly.
+- **Suggested next charter:** Re-run this charter after merge as a smoke canary against the packaged release binary.
+
+## What Was Fixed
+
+### Issue #386: awaited run-loop output lost its child identity
+
+- **Symptom:** A parent could report `done` and start later nodes while awaited child Loops were still live.
+- **Root cause:** Completed mechanical task output was collapsed to generic success before the coordinator reconstructed the reserved `run-loop` await result.
+- **Fix:** Decode and validate the persisted result, restore `awaiting_child` plus the exact child id, and reuse the existing child-terminal refresh path; fail closed on malformed or foreign child identities.
+- **Regression test:** `internal/loop/coordinator_test.go` failed before the fix because the restored parent did not yield while its child was live; focused unit and restart E2E now pass.
+- **Retested:** J-await-child-loop through public CLI/UDS, HTTP, daemon restart, and durable wait resume in a fresh isolated lab.
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Bruno | J-await-child-loop step 3 | "I need to know that an empty payload selects wait-resume; otherwise the error talks about a paused node." | dull | watching |
+
+## Runtime Errors Observed
+
+- `node_not_paused` was returned when `loop node resume` omitted `--payload`; adding the documented payload selected manual-wait resume and succeeded. This did not affect the runtime-ordering verdict.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- Public CLI starts are transported over UDS; generic reproduction definitions must allow the actual ingress kind.
+- Persisted child identity is independently observable through CLI/UDS and HTTP, so no database or internal test seam is needed for the production diagnosis.
+
+## Compozy Impact Audit
+
+- **Runtime contract:** Awaited `run-loop` task results now restore `awaiting_child` plus the exact persisted child id before the coordinator considers dependents. Existing detach behavior remains immediate success.
+- **Terminal mapping:** `done` and `no-op` children settle the parent node as succeeded; failed and canceled children settle it as failed. Live children continue yielding through the existing coordinator path.
+- **Recovery:** Restart E2E proves the first child id survives daemon restart, no duplicate child is submitted, and the second child remains pending until the first is terminal.
+- **Workspace and ownership fence:** Unit coverage rejects a child from another workspace or another parent and clears the untrusted child id instead of normalizing or retaining it.
+- **Malformed durable state:** Empty, malformed, incomplete, padded, or contradictory awaited results fail closed with the stable existing `action_schema_invalid` reason and operator-safe diagnostic.
+- **Missing authored owner:** A completed action whose graph node is absent now fails closed as `action_schema_invalid` instead of being promoted to success.
+- **Public surfaces:** The isolated walk compared CLI/UDS and HTTP before and after restart and again at terminal state. Native-tool IDs, HTTP/UDS schemas, hooks, config, extension formats, and Web behavior are unchanged.
+- **Generated contracts:** No public enum or schema shape changes in this fix. `make codegen-check` remains part of the final gate; no generated TypeScript update is expected.
+- **Documentation:** Issue #386 and the checked-in design use a standalone authored-Loop reproduction with the actual manual/HTTP/UDS ingress allowlist. The official Loop skill and site guardrails describe ordering, restart, and terminal mapping. Batuta remains discovery evidence only.
+
+## Prior Review Learnings Applied
+
+- Regression fixtures assert the precondition that made the old implementation fail, not only the final success state.
+- New Go test cases use named `Should...` subtests, parallel execution, specific stable diagnostics, and outcome assertions rather than call-count-only checks.
+- The E2E waits on durable observable state instead of a fixed quiet window and verifies both children terminal, not only the parent.
+- Production logic lives in a focused file below the 500-line cap; new helpers have concise Go doc comments and share one failure-construction path.
+- Error handling distinguishes authored detach, valid await, malformed state, and ownership violations without permissive fallback or silent normalization.
+
+## Final Status
+
+- **Focused verification:** 21 new regression cases passed under race; the complete `internal/loop` package passed 807 tests under race; focused daemon restart E2E passed; canonical `test-e2e-runtime` passed daemon, HTTP, UDS, harness, and CLI lanes.
+- **Coverage:** `internal/loop` statement coverage is 78.1%.
+- **Build and Batuta compatibility:** `make build` passed; the branch binary has SHA-256 `8875c04907b9e40d54b8e9cc693361c10a1c8b1439ec4ddac27c28dfcdf316ad`. A separately isolated Batuta canary opened the exact `auto_commit=false` gate, preserved `todo 1.0.0`, created one task, ran one `batuta-deliver`, and finished the `implement-tasks` and `review-and-fix` children `done`. An intentional daemon crash while the parent awaited review recovered the same child run and recorded one requeue with no duplicate child. The origin agent session was terminated by that deliberate crash, so its terminal conversational wake was not part of the recovery verdict.
+- **Exit gate (full automated suite):** BLOCKED by failures reproduced on clean `upstream/main` at `a0761a0f`, outside this branch: one CLI config-validation expectation, one uppercase agent fixture rejected by the accepted agent-name contract, and release tag tests affected by the local signed-tag environment. The relevant changed packages and lint lanes passed. Evidence: `/home/franciscpd/dev/qa-labs/compozy-run-loop-await-child-20260813-201607-890089-lab/qa-artifacts/qa/final-make-verify.log`
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 1 · Friction 0 · Cosmetic 0
+- **Journey coverage:** 1/1 journeys walked; browser and provider were intentionally out of scope for this targeted non-agent runtime journey.
+- **Verdict:** BLOCKED — the isolated behavior-first walk, automated recovery coverage, and Batuta compatibility canary pass the changed behavior, but the repository-wide exit gate cannot be reported green until the independently reproduced upstream baseline failures are resolved.

--- a/docs/qa/scenarios/LP-run-loop-await-child-ordering.md
+++ b/docs/qa/scenarios/LP-run-loop-await-child-ordering.md
@@ -1,0 +1,24 @@
+---
+id: LP-run-loop-await-child-ordering
+area: LP
+title: Keep ordered run-loop children blocked until terminal
+persona: Bruno
+journey: J-await-child-loop
+expected: A parent Loop with two ordered run-loop nodes in mode await keeps the first node in awaiting_child while its child is live, starts no second child before the first terminates, restores the same child after daemon restart without duplication, and reaches done only after both children succeed.
+entry_points: compozy loop run; compozy loop status; compozy loop runs; HTTP and UDS Loop run detail
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /home/franciscpd/dev/qa-labs/compozy-run-loop-await-child-20260813-201607-890089-lab/qa-artifacts/qa/parent-after-restart.json; /home/franciscpd/dev/qa-labs/compozy-run-loop-await-child-20260813-201607-890089-lab/qa-artifacts/qa/final-summary.json
+last_report: docs/qa/reports/2026-08-13-run-loop-await-child.md
+overlaps:
+---
+
+Use two workspace-authored Loops with no extension, agent, provider, skill, or task dependency. The
+child parks on a durable wait. The parent invokes it twice through an authored edge and `mode:
+await`. Restart after the first child identity is durable, then release each child through the
+public node-resume surface and verify the exact run ordering.
+
+Issue: https://github.com/compozy/compozy/issues/386

--- a/docs/superpowers/specs/2026-08-13-run-loop-await-child-design.md
+++ b/docs/superpowers/specs/2026-08-13-run-loop-await-child-design.md
@@ -33,7 +33,7 @@ graph:
       kind: wait
       params: { for: 10m }
   edges: []
-start: [{ kind: manual }]
+start: [{ kind: manual }, { kind: http }, { kind: uds }]
 ```
 
 The parent starts that child twice, with an authored edge requiring strict order:
@@ -66,7 +66,7 @@ graph:
       params: { loop: await-child-hold, mode: await }
   edges:
     - { from: first_child, to: second_child }
-start: [{ kind: manual }]
+start: [{ kind: manual }, { kind: http }, { kind: uds }]
 ```
 
 After saving the files as `await-child-hold.yaml` and `await-parent-probe.yaml`, validate, publish, run, and inspect them:
@@ -232,7 +232,9 @@ Tests use conditions and durable reads, never sleeps as synchronization.
 
 Issue #386 leads with the standalone authored-Loop reproduction and keeps the real extension-driven sequence as secondary discovery evidence. It carries the run IDs, executed graph, observed output, expected contract, and impact. The PR will link that issue and include the executable regression commands.
 
-The official Compozy Loop skill will be checked against the corrected behavior. It already states that `awaiting_child` is node-level and live; it needs no wording change unless implementation review finds a mismatch.
+The official Compozy Loop skill and site documentation will state that an awaited child keeps the
+parent and dependents nonterminal, survives restart with the same child identity, and maps child
+terminal outcomes without coercion.
 
 A fresh isolated QA lab will first reproduce the standalone two-Loop flow with unique `COMPOZY_HOME`, ports, and UDS path, then use an installed extension as a compatibility canary. Evidence will include the ordered run timeline, exact parent/child IDs, restart boundary, absence of duplicate children, terminal states, and clean teardown.
 
@@ -241,11 +243,13 @@ A fresh isolated QA lab will first reproduce the standalone two-Loop flow with u
 - **Native tools:** No ToolID, descriptor, schema, risk, capability, or reason-code change. `compozy__loop_status` exposes corrected existing state.
 - **Extensibility and hooks:** Corrects generic nested Loop behavior for every extension and authored Loop. No manifest, resource, hook, capability, registry, MCP, or config lifecycle change.
 - **Workspace data isolation:** Child lookup and parent validation remain bound to the parent run's workspace. Tests must reject a child from another workspace.
-- **Official Compozy skill:** Checked `skills/compozy/references/loops.md`; its current live-state contract already matches the intended behavior.
+- **Official Compozy skill:** Update `skills/compozy/references/loops.md` with ordering, restart, and child-terminal mapping.
 
 ## Web And Docs Impact
 
-No Web component or route changes. Existing Loop run inspectors consume the same status fields and will display corrected runtime truth. No public documentation change is required beyond issue and QA/PR evidence because the documented `mode: await` contract is already correct.
+No Web component or route changes. Existing Loop run inspectors consume the same status fields and
+will display corrected runtime truth. The Loop guardrails documentation is updated with ordering,
+restart, and terminal-mapping behavior; no API or schema documentation changes.
 
 ## Rollout And Rollback
 

--- a/docs/superpowers/specs/2026-08-13-run-loop-await-child-design.md
+++ b/docs/superpowers/specs/2026-08-13-run-loop-await-child-design.md
@@ -4,9 +4,100 @@
 
 **Issue:** [#386](https://github.com/compozy/compozy/issues/386)
 
-## Confirmed Reproduction
+## Minimal Generic Reproduction
 
-At 2026-08-13 15:06 America/Sao_Paulo, an installed resource extension started a delivery Loop from an extension-published agent session. The executed graph was:
+The defect requires no extension, agent session, provider, skill, or imported task. It can be reproduced with two workspace-authored Loops and the public CLI.
+
+The child Loop contains only a durable wait, keeping it live long enough to inspect the parent:
+
+```yaml
+apiVersion: compozy.loop/v1
+kind: Loop
+meta:
+  name: await-child-hold
+  description: Generic child Loop that stays live long enough to inspect its parent.
+concurrency: allow
+contract:
+  goal: Hold a child run in a live state.
+  definition_of_done: The durable wait finishes.
+  stop_when: "nodes.hold.status == 'succeeded'"
+  verification: []
+  terminal_states: [done, failed, blocked, exhausted, stalled]
+  iteration_cap: 1
+  no_progress: { window: 2, hash_fields: ["nodes.hold.status"] }
+  budget: { tokens: 0, wall_clock_sec: 0, on_exceeded: halt }
+graph:
+  nodes:
+    - id: hold
+      class: control
+      kind: wait
+      params: { for: 10m }
+  edges: []
+start: [{ kind: manual }]
+```
+
+The parent starts that child twice, with an authored edge requiring strict order:
+
+```yaml
+apiVersion: compozy.loop/v1
+kind: Loop
+meta:
+  name: await-parent-probe
+  description: Generic parent with two sequential awaited child Loops.
+concurrency: allow
+contract:
+  goal: Run two child Loops in strict sequence.
+  definition_of_done: Both awaited child Loops finish in authored order.
+  stop_when: "nodes.second_child.status == 'succeeded'"
+  verification: []
+  terminal_states: [done, failed, blocked, exhausted, stalled]
+  iteration_cap: 1
+  no_progress: { window: 2, hash_fields: ["nodes.first_child.status", "nodes.second_child.status"] }
+  budget: { tokens: 0, wall_clock_sec: 0, on_exceeded: halt }
+graph:
+  nodes:
+    - id: first_child
+      class: action
+      kind: run-loop
+      params: { loop: await-child-hold, mode: await }
+    - id: second_child
+      class: action
+      kind: run-loop
+      params: { loop: await-child-hold, mode: await }
+  edges:
+    - { from: first_child, to: second_child }
+start: [{ kind: manual }]
+```
+
+After saving the files as `await-child-hold.yaml` and `await-parent-probe.yaml`, validate, publish, run, and inspect them:
+
+```bash
+WORKSPACE=/path/to/workspace
+
+compozy loop validate --workspace "$WORKSPACE" --file await-child-hold.yaml -o json
+compozy loop validate --workspace "$WORKSPACE" --file await-parent-probe.yaml -o json
+compozy loop create --workspace "$WORKSPACE" --file await-child-hold.yaml -o json
+compozy loop create --workspace "$WORKSPACE" --file await-parent-probe.yaml -o json
+
+PARENT_RUN_ID="$(compozy loop run \
+  --workspace "$WORKSPACE" \
+  --name await-parent-probe \
+  -o json | jq -r '.run.id')"
+
+compozy loop status --workspace "$WORKSPACE" --run-id "$PARENT_RUN_ID" -o json
+compozy loop runs --workspace "$WORKSPACE" -o json \
+  | jq '.runs[] | select(.loop_name == "await-child-hold")'
+```
+
+On the affected runtime, both child runs start and remain live while the parent becomes `done`. Its generation records `first_child` and `second_child` as `succeeded`, even though each structured output says `status: "awaiting_child"`. The second child therefore starts before the first child terminates.
+
+The corrected behavior is one live child, a live parent whose `first_child` node is `awaiting_child`, and no `second_child` run until the first child reaches an accepted terminal outcome.
+
+Both standalone definitions were checked with `compozy loop validate` before publication of the reproduction.
+
+## Real-World Discovery Evidence
+
+The generic defect was originally exposed at 2026-08-13 15:06 America/Sao_Paulo by an installed resource extension. An extension-published agent session started this delivery graph:
 
 ```text
 input -> import_tasks -> implement(run-loop, await) -> review(run-loop, await)
@@ -28,7 +119,7 @@ compozy loop status --run-id looprun-9205fd25577f44e2 -o json
 compozy loop runs --workspace /home/franciscpd/Projects/batuta-smoke-lab -o json
 ```
 
-The promoted build and its predecessor have no diff under `internal/loop`, so the smoke exposed a pre-existing runtime defect rather than a regression from the extension-session changes.
+The extension is discovery evidence, not a reproduction dependency. The promoted build and its predecessor have no diff under `internal/loop`, so the smoke exposed a pre-existing runtime defect rather than a regression from the extension-session changes.
 
 ## Root Cause
 
@@ -46,7 +137,7 @@ The existing `refreshAwaitingChildOutput` logic is correct once a snapshot alrea
 4. Restore the wait from durable task and generation state after daemon restart without submitting another child.
 5. Propagate accepted child terminal outcomes before scheduling dependents.
 6. Fail closed when the completed `run-loop` result is malformed or inconsistent with the authored mode.
-7. Document a reproducible extension-driven flow without making the fix specific to Batuta.
+7. Keep the primary reproduction independent of any extension while preserving the extension-driven discovery evidence.
 
 ## Non-Goals
 
@@ -139,11 +230,11 @@ Tests use conditions and durable reads, never sleeps as synchronization.
 
 ## Documentation And QA
 
-Issue #386 carries the real extension-driven sequence, run IDs, executed graph, observed output, expected contract, and impact. The PR will link that issue and include the executable regression commands.
+Issue #386 leads with the standalone authored-Loop reproduction and keeps the real extension-driven sequence as secondary discovery evidence. It carries the run IDs, executed graph, observed output, expected contract, and impact. The PR will link that issue and include the executable regression commands.
 
 The official Compozy Loop skill will be checked against the corrected behavior. It already states that `awaiting_child` is node-level and live; it needs no wording change unless implementation review finds a mismatch.
 
-A fresh isolated QA lab will reproduce the extension flow with unique `COMPOZY_HOME`, ports, and UDS path. Evidence will include the ordered run timeline, exact parent/child IDs, restart boundary, absence of duplicate children, terminal states, and clean teardown.
+A fresh isolated QA lab will first reproduce the standalone two-Loop flow with unique `COMPOZY_HOME`, ports, and UDS path, then use an installed extension as a compatibility canary. Evidence will include the ordered run timeline, exact parent/child IDs, restart boundary, absence of duplicate children, terminal states, and clean teardown.
 
 ## Compozy Impact Audit
 

--- a/docs/superpowers/specs/2026-08-13-run-loop-await-child-design.md
+++ b/docs/superpowers/specs/2026-08-13-run-loop-await-child-design.md
@@ -1,0 +1,175 @@
+# Durable `run-loop` Await Semantics
+
+**Status:** Approved
+
+**Issue:** [#386](https://github.com/compozy/compozy/issues/386)
+
+## Confirmed Reproduction
+
+At 2026-08-13 15:06 America/Sao_Paulo, an installed resource extension started a delivery Loop from an extension-published agent session. The executed graph was:
+
+```text
+input -> import_tasks -> implement(run-loop, await) -> review(run-loop, await)
+```
+
+The parent run `looprun-ae54eccd8e6a361b` reached `done` while both child runs were still live:
+
+- implementation: `looprun-8458a0aea51bca58`
+- review: `looprun-9205fd25577f44e2`
+
+The parent generation reported both nodes as `succeeded`, but each structured output contained `status: "awaiting_child"`. Review started before implementation completed and inspected an unimplemented repository.
+
+The evidence was read through public structured surfaces:
+
+```bash
+compozy loop status --run-id looprun-ae54eccd8e6a361b -o json
+compozy loop status --run-id looprun-8458a0aea51bca58 -o json
+compozy loop status --run-id looprun-9205fd25577f44e2 -o json
+compozy loop runs --workspace /home/franciscpd/Projects/batuta-smoke-lab -o json
+```
+
+The promoted build and its predecessor have no diff under `internal/loop`, so the smoke exposed a pre-existing runtime defect rather than a regression from the extension-session changes.
+
+## Root Cause
+
+`RunLoopActionExecutor.Execute` starts the child and returns a structured result containing the child run ID and `awaiting_child`. `executeActionTaskRun` persists that value as the completed worker task result.
+
+When the coordinator later refreshes the generation, `refreshCompletedTaskRunOutput` treats every successful mechanical action task as terminal success. It does not interpret the reserved `run-loop` result. The generation snapshot therefore records `succeeded` without copying the child run ID into `GenerationOutput.ChildLoopRunID`.
+
+The existing `refreshAwaitingChildOutput` logic is correct once a snapshot already contains `status: awaiting_child` and `child_loop_run_id`. Existing tests begin at that later state, so they do not cover the broken completed-task-to-generation-output transition.
+
+## Goals
+
+1. Preserve the live `awaiting_child` state when an awaited child has started but has not terminated.
+2. Preserve the child run ID in the parent generation snapshot.
+3. Prevent downstream nodes and parent terminal settlement while an awaited child is live.
+4. Restore the wait from durable task and generation state after daemon restart without submitting another child.
+5. Propagate accepted child terminal outcomes before scheduling dependents.
+6. Fail closed when the completed `run-loop` result is malformed or inconsistent with the authored mode.
+7. Document a reproducible extension-driven flow without making the fix specific to Batuta.
+
+## Non-Goals
+
+- Changing `detach` semantics.
+- Changing Loop, extension, native-tool, HTTP, UDS, or CLI schemas.
+- Adding polling, sleeps, or extension-specific behavior.
+- Fixing transcript assembly that drops whitespace-only message chunks.
+- Fixing provider/model routing diagnostics found during the same smoke.
+- Claiming atomic recovery from a process crash between child creation and durable completion of the action task. That is a separate transaction-boundary problem and requires separate evidence and design.
+
+## Design
+
+### Typed reserved-action result
+
+Introduce an internal typed decoder for the completed `run-loop` action result. It consumes the persisted task result and validates:
+
+- the owning graph node exists and is `kind: run-loop`;
+- the authored or defaulted mode is `await`;
+- `status` is exactly `awaiting_child`;
+- `loop_run_id` is non-empty.
+
+After decoding, the coordinator immediately resolves the referenced child through the existing `refreshAwaitingChildOutput` path. That lookup validates that the child belongs to the same workspace and names the current parent run before any dependent can be scheduled.
+
+This decoder is internal to `internal/loop`; it does not alter the public result shape.
+
+### Coordinator transition
+
+Before generic mechanical-action success handling, the coordinator recognizes a completed awaited `run-loop` action and transforms the parent output candidate to:
+
+```text
+Status         = awaiting_child
+ChildLoopRunID = <persisted child run ID>
+OutputRef      = <persisted structured action result>
+```
+
+The same refresh then passes the candidate through `refreshAwaitingChildOutput`. A live child makes the refresh report the output as live. The graph scheduler therefore cannot reserve dependents and the parent cannot settle terminally.
+
+On later coordinator passes, the existing `refreshAwaitingChildOutput` path remains the sole owner of child terminal interpretation:
+
+- `done` or `no-op` -> parent node `succeeded`;
+- every other child terminal outcome -> parent node `failed` with the existing classified child reference;
+- live child -> keep `awaiting_child` and yield;
+- timeout -> fail and request the existing child stop behavior.
+
+### Restart recovery
+
+The recovery test will stop runtime components only after the child ID is durable in either the completed action task result or the generation snapshot, then reopen the same database and rebuild the coordinator/runtime composition.
+
+On recovery:
+
+1. The completed action task is not executed again.
+2. The coordinator reconstructs or reads the same `awaiting_child` output.
+3. The same child run ID remains attached to the parent cell.
+4. No second child run exists for that cell.
+5. The next graph node remains unscheduled until the original child terminates.
+
+This is deterministic state recovery, not time-based polling.
+
+### Invalid results
+
+An awaited `run-loop` completed task with missing, empty, malformed, or contradictory child identity must not become `succeeded`. The coordinator records a classified failure with a stable internal reason and does not schedule dependents.
+
+A `detach` result remains ordinary successful action output and never enters the wait path.
+
+## Test Ownership
+
+The invariant belongs to the Loop coordinator because it maps durable action task results into generation state.
+
+The canonical coordinator suite will add RED coverage for:
+
+1. completed awaited result -> `awaiting_child` with exact child ID;
+2. live child -> yield and no dependent reservation;
+3. child `done` and `no-op` -> dependent becomes eligible;
+4. child failure/cancellation -> fail closed;
+5. malformed awaited result -> fail closed;
+6. detached child -> immediate success.
+
+The canonical daemon Loop integration suite will add a real-store restart case:
+
+1. start an ordered parent with two child Loop nodes;
+2. hold the first child live;
+3. persist the completed action result and observed wait state;
+4. rebuild the runtime against the same database;
+5. assert one original child, parent still live, and second child absent;
+6. complete the first child and assert the second starts exactly once;
+7. hold the second child and assert the parent remains live;
+8. complete the second child and assert the parent reaches the correct terminal outcome.
+
+Tests use conditions and durable reads, never sleeps as synchronization.
+
+## Documentation And QA
+
+Issue #386 carries the real extension-driven sequence, run IDs, executed graph, observed output, expected contract, and impact. The PR will link that issue and include the executable regression commands.
+
+The official Compozy Loop skill will be checked against the corrected behavior. It already states that `awaiting_child` is node-level and live; it needs no wording change unless implementation review finds a mismatch.
+
+A fresh isolated QA lab will reproduce the extension flow with unique `COMPOZY_HOME`, ports, and UDS path. Evidence will include the ordered run timeline, exact parent/child IDs, restart boundary, absence of duplicate children, terminal states, and clean teardown.
+
+## Compozy Impact Audit
+
+- **Native tools:** No ToolID, descriptor, schema, risk, capability, or reason-code change. `compozy__loop_status` exposes corrected existing state.
+- **Extensibility and hooks:** Corrects generic nested Loop behavior for every extension and authored Loop. No manifest, resource, hook, capability, registry, MCP, or config lifecycle change.
+- **Workspace data isolation:** Child lookup and parent validation remain bound to the parent run's workspace. Tests must reject a child from another workspace.
+- **Official Compozy skill:** Checked `skills/compozy/references/loops.md`; its current live-state contract already matches the intended behavior.
+
+## Web And Docs Impact
+
+No Web component or route changes. Existing Loop run inspectors consume the same status fields and will display corrected runtime truth. No public documentation change is required beyond issue and QA/PR evidence because the documented `mode: await` contract is already correct.
+
+## Rollout And Rollback
+
+The change is internal runtime behavior with no migration or config change. Rollout uses the normal daemon binary replacement and a fresh nested-Loop smoke. Rollback restores the prior binary; persisted runs retain existing schema compatibility.
+
+## Alternatives Rejected
+
+### Extend `ActionControl`
+
+`ActionControl` currently owns Goal pause and terminal dispositions. Expanding it for child-loop liveness would broaden an unrelated protocol and duplicate the existing generation-level `awaiting_child` state.
+
+### Keep the worker task open until the child terminates
+
+This would consume a long-lived lease and process, complicate cancellation and restart, and move graph coordination into the action worker. The coordinator already owns durable waiting and should remain the authority.
+
+### Special-case the extension
+
+The failure is in the generic `run-loop` contract. Extension-specific ordering or prompt rules would hide the runtime defect and leave every other caller exposed.

--- a/internal/config/agent_workspace_discovery_test.go
+++ b/internal/config/agent_workspace_discovery_test.go
@@ -101,17 +101,6 @@ func TestLoadWorkspaceAgentDefsReturnsLexicalDirectoryOrder(t *testing.T) {
 	t.Run("Should return valid same-root agents in lexical directory order", func(t *testing.T) {
 		t.Parallel()
 
-		caseProbe := t.TempDir()
-		if err := os.Mkdir(filepath.Join(caseProbe, "probe"), 0o700); err != nil {
-			t.Fatalf("os.Mkdir(lowercase probe) error = %v", err)
-		}
-		if err := os.Mkdir(filepath.Join(caseProbe, "PROBE"), 0o700); err != nil {
-			if os.IsExist(err) {
-				t.Skip("case-distinct directory names cannot coexist on this filesystem")
-			}
-			t.Fatalf("os.Mkdir(uppercase probe) error = %v", err)
-		}
-
 		homePaths, err := ResolveHomePathsFrom(filepath.Join(t.TempDir(), "home"))
 		if err != nil {
 			t.Fatalf("ResolveHomePathsFrom() error = %v", err)
@@ -123,15 +112,15 @@ func TestLoadWorkspaceAgentDefsReturnsLexicalDirectoryOrder(t *testing.T) {
 		root := t.TempDir()
 		writeAgentDefinition(
 			t,
-			filepath.Join(root, DirName, AgentsDirName, "worker", agentDefName),
-			"worker",
+			filepath.Join(root, DirName, AgentsDirName, "worker-z", agentDefName),
+			"worker-z",
 			"claude",
 			"created-first",
 		)
 		writeAgentDefinition(
 			t,
-			filepath.Join(root, DirName, AgentsDirName, "Worker", agentDefName),
-			"Worker",
+			filepath.Join(root, DirName, AgentsDirName, "worker-a", agentDefName),
+			"worker-a",
 			"claude",
 			"lexical-first",
 		)
@@ -143,13 +132,13 @@ func TestLoadWorkspaceAgentDefsReturnsLexicalDirectoryOrder(t *testing.T) {
 		if got, want := len(agents), 2; got != want {
 			t.Fatalf("len(LoadWorkspaceAgentDefs()) = %d, want %d", got, want)
 		}
-		if got, want := agents[0].Name, "Worker"; got != want {
+		if got, want := agents[0].Name, "worker-a"; got != want {
 			t.Fatalf("LoadWorkspaceAgentDefs()[0].Name = %q, want %q", got, want)
 		}
 		if got, want := agents[0].Model, "lexical-first"; got != want {
 			t.Fatalf("LoadWorkspaceAgentDefs()[0].Model = %q, want %q", got, want)
 		}
-		if got, want := agents[1].Name, "worker"; got != want {
+		if got, want := agents[1].Name, "worker-z"; got != want {
 			t.Fatalf("LoadWorkspaceAgentDefs()[1].Name = %q, want %q", got, want)
 		}
 	})

--- a/internal/config/bootstrap_test.go
+++ b/internal/config/bootstrap_test.go
@@ -27,13 +27,21 @@ func TestResolveAgentNameFallsBackToDefaults(t *testing.T) {
 func TestDefaultsAgentNameValidation(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should allow an empty default agent as no override", func(t *testing.T) {
+	t.Run("Should reject an empty default agent", func(t *testing.T) {
 		t.Parallel()
 
-		if err := (DefaultsConfig{}).Validate(); err != nil {
-			t.Fatalf("DefaultsConfig.Validate() error = %v, want nil", err)
+		err := (DefaultsConfig{}).Validate()
+		var validationErr ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("DefaultsConfig.Validate() error = %T, want ValidationError", err)
 		}
-		_, err := ResolveAgentName("", DefaultsConfig{})
+		if got, want := validationErr.Path, "defaults.agent"; got != want {
+			t.Fatalf("DefaultsConfig.Validate() path = %q, want %q", got, want)
+		}
+		if got, want := validationErr.Message, "is required"; got != want {
+			t.Fatalf("DefaultsConfig.Validate() message = %q, want %q", got, want)
+		}
+		_, err = ResolveAgentName("", DefaultsConfig{})
 		const wantErr = "agent name is required; run `compozy install` or set defaults.agent"
 		if err == nil || err.Error() != wantErr {
 			t.Fatalf("ResolveAgentName() error = %v, want %q", err, wantErr)

--- a/internal/config/bootstrap_test.go
+++ b/internal/config/bootstrap_test.go
@@ -27,26 +27,35 @@ func TestResolveAgentNameFallsBackToDefaults(t *testing.T) {
 func TestDefaultsAgentNameValidation(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should reject an empty default agent", func(t *testing.T) {
-		t.Parallel()
+	for _, test := range []struct {
+		name  string
+		agent string
+	}{
+		{name: "Should reject an empty default agent"},
+		{name: "Should reject a whitespace-only default agent", agent: " \t\n"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-		err := (DefaultsConfig{}).Validate()
-		var validationErr ValidationError
-		if !errors.As(err, &validationErr) {
-			t.Fatalf("DefaultsConfig.Validate() error = %T, want ValidationError", err)
-		}
-		if got, want := validationErr.Path, "defaults.agent"; got != want {
-			t.Fatalf("DefaultsConfig.Validate() path = %q, want %q", got, want)
-		}
-		if got, want := validationErr.Message, "is required"; got != want {
-			t.Fatalf("DefaultsConfig.Validate() message = %q, want %q", got, want)
-		}
-		_, err = ResolveAgentName("", DefaultsConfig{})
-		const wantErr = "agent name is required; run `compozy install` or set defaults.agent"
-		if err == nil || err.Error() != wantErr {
-			t.Fatalf("ResolveAgentName() error = %v, want %q", err, wantErr)
-		}
-	})
+			defaults := DefaultsConfig{Agent: test.agent}
+			err := defaults.Validate()
+			var validationErr ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("DefaultsConfig.Validate() error = %T, want ValidationError", err)
+			}
+			if got, want := validationErr.Path, "defaults.agent"; got != want {
+				t.Fatalf("DefaultsConfig.Validate() path = %q, want %q", got, want)
+			}
+			if got, want := validationErr.Message, "is required"; got != want {
+				t.Fatalf("DefaultsConfig.Validate() message = %q, want %q", got, want)
+			}
+			_, err = ResolveAgentName("", defaults)
+			const wantErr = "agent name is required; run `compozy install` or set defaults.agent"
+			if err == nil || err.Error() != wantErr {
+				t.Fatalf("ResolveAgentName() error = %v, want %q", err, wantErr)
+			}
+		})
+	}
 
 	t.Run("Should reject an invalid explicit or default agent name", func(t *testing.T) {
 		t.Parallel()

--- a/internal/config/config_validation.go
+++ b/internal/config/config_validation.go
@@ -263,10 +263,10 @@ func (p DaytonaProfile) Resolve() sandbox.DaytonaConfig {
 	return resolved
 }
 
-// Validate ensures a configured default agent name is valid.
+// Validate ensures the default agent setting is present and valid.
 func (c DefaultsConfig) Validate() error {
 	if strings.TrimSpace(c.Agent) == "" {
-		return nil
+		return ValidationError{Path: configDefaultsAgentPath, Message: "is required"}
 	}
 	return validateAgentNameAtPath(c.Agent, configDefaultsAgentPath)
 }

--- a/internal/daemon/loop_run_events_e2e_integration_test.go
+++ b/internal/daemon/loop_run_events_e2e_integration_test.go
@@ -147,6 +147,79 @@ func TestDaemonE2ELoopRunEventsShouldStreamRichFramesAndResume(t *testing.T) {
 			t.Fatalf("resumed loop generation = %d, want 2", detail.Run.Generation)
 		}
 	})
+
+	t.Run("Should restore ordered awaited children after restart", func(t *testing.T) {
+		t.Parallel()
+
+		homePaths := e2etest.NewHomePaths(t)
+		harnessOptions := e2etest.RuntimeHarnessOptions{
+			HomePaths: homePaths,
+			Workspace: e2etest.WorkspaceSeedOptions{Root: homePaths.HomeDir},
+		}
+		harness := e2etest.StartRuntimeHarness(t, &harnessOptions)
+		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		defer cancel()
+
+		createLoopViaHTTP(t, ctx, harness, awaitedChildHoldDefinition())
+		createLoopViaHTTP(t, ctx, harness, awaitedParentProbeDefinition())
+		parent := runLoopViaHTTP(t, ctx, harness, "await-parent-probe")
+		beforeRestart, firstChildID := waitForAwaitedChildNode(
+			t,
+			ctx,
+			harness,
+			parent.ID,
+			"first_child",
+			1,
+		)
+		assertAwaitedParentNodeStatus(t, beforeRestart, "second_child", "pending")
+
+		stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := harness.Stop(stopCtx); err != nil {
+			stopCancel()
+			t.Fatalf("Stop runtime harness error = %v", err)
+		}
+		stopCancel()
+
+		restarted := e2etest.StartRuntimeHarness(t, &harnessOptions)
+		afterRestart, restartedChildID := waitForAwaitedChildNode(
+			t,
+			ctx,
+			restarted,
+			parent.ID,
+			"first_child",
+			1,
+		)
+		if restartedChildID != firstChildID {
+			t.Fatalf("restarted child id = %q, want original %q", restartedChildID, firstChildID)
+		}
+		assertAwaitedParentNodeStatus(t, afterRestart, "second_child", "pending")
+
+		resumeLoopWaitViaHTTP(t, ctx, restarted, firstChildID, "hold")
+		withSecondChild, secondChildID := waitForAwaitedChildNode(
+			t,
+			ctx,
+			restarted,
+			parent.ID,
+			"second_child",
+			2,
+		)
+		if secondChildID == firstChildID {
+			t.Fatalf("second child id = first child id %q, want distinct run", secondChildID)
+		}
+		assertAwaitedParentNodeStatus(t, withSecondChild, "first_child", "succeeded")
+
+		resumeLoopWaitViaHTTP(t, ctx, restarted, secondChildID, "hold")
+		waitForLoopRunStatus(t, ctx, restarted, parent.ID, compozycontract.LoopRunStatusDone)
+		children := awaitedChildRunsViaHTTP(t, ctx, restarted)
+		if len(children) != 2 {
+			t.Fatalf("terminal child runs = %d, want 2", len(children))
+		}
+		for _, child := range children {
+			if child.Status != compozycontract.LoopRunStatusDone {
+				t.Fatalf("terminal child %q status = %q, want done", child.ID, child.Status)
+			}
+		}
+	})
 }
 
 func TestDaemonE2ELoopWatchEventsShouldWakeAndRecover(t *testing.T) {
@@ -334,6 +407,179 @@ func loopEventsDefinition() compozycontract.LoopDefinitionDocument {
 			{Kind: "http"},
 			{Kind: "uds"},
 		},
+	}
+}
+
+func awaitedChildHoldDefinition() compozycontract.LoopDefinitionDocument {
+	return compozycontract.LoopDefinitionDocument{
+		APIVersion:  "compozy.loop/v1",
+		Kind:        "Loop",
+		Concurrency: "allow",
+		Meta: compozycontract.LoopDefinitionMeta{
+			Name:        "await-child-hold",
+			Description: "Generic child Loop held by a durable wait.",
+		},
+		Contract: compozycontract.LoopContract{
+			Goal:             "Hold a child run in a live state.",
+			DefinitionOfDone: "The durable wait is released.",
+			StopWhen:         "nodes.hold.status == 'succeeded'",
+			IterationCap:     1,
+			NoProgress: compozycontract.LoopNoProgress{
+				Window:     2,
+				HashFields: []string{"nodes.hold.status"},
+			},
+			Budget: compozycontract.LoopBudget{
+				OnExceeded: compozycontract.LoopBudgetExceededHalt,
+			},
+			TerminalStates: []string{"done", "failed", "blocked", "exhausted", "stalled"},
+		},
+		Graph: compozycontract.LoopGraph{
+			Nodes: []compozycontract.LoopGraphNode{{
+				ID:     "hold",
+				Class:  compozycontract.LoopNodeClassControl,
+				Kind:   "wait",
+				Params: map[string]any{"for": "10m"},
+			}},
+		},
+		Start: []compozycontract.LoopStartBinding{{Kind: "manual"}, {Kind: "http"}},
+	}
+}
+
+func awaitedParentProbeDefinition() compozycontract.LoopDefinitionDocument {
+	return compozycontract.LoopDefinitionDocument{
+		APIVersion:  "compozy.loop/v1",
+		Kind:        "Loop",
+		Concurrency: "allow",
+		Meta: compozycontract.LoopDefinitionMeta{
+			Name:        "await-parent-probe",
+			Description: "Generic parent with two sequential awaited child Loops.",
+		},
+		Contract: compozycontract.LoopContract{
+			Goal:             "Run two child Loops in strict sequence.",
+			DefinitionOfDone: "Both awaited child Loops finish in authored order.",
+			StopWhen:         "nodes.second_child.status == 'succeeded'",
+			IterationCap:     1,
+			NoProgress: compozycontract.LoopNoProgress{
+				Window:     2,
+				HashFields: []string{"nodes.first_child.status", "nodes.second_child.status"},
+			},
+			Budget: compozycontract.LoopBudget{
+				OnExceeded: compozycontract.LoopBudgetExceededHalt,
+			},
+			TerminalStates: []string{"done", "failed", "blocked", "exhausted", "stalled"},
+		},
+		Graph: compozycontract.LoopGraph{
+			Nodes: []compozycontract.LoopGraphNode{
+				{
+					ID:    "first_child",
+					Class: compozycontract.LoopNodeClassAction,
+					Kind:  "run-loop",
+					Params: map[string]any{
+						"loop": "await-child-hold",
+						"mode": "await",
+					},
+				},
+				{
+					ID:    "second_child",
+					Class: compozycontract.LoopNodeClassAction,
+					Kind:  "run-loop",
+					Params: map[string]any{
+						"loop": "await-child-hold",
+						"mode": "await",
+					},
+				},
+			},
+			Edges: []compozycontract.LoopGraphEdge{{From: "first_child", To: "second_child"}},
+		},
+		Start: []compozycontract.LoopStartBinding{{Kind: "manual"}, {Kind: "http"}},
+	}
+}
+
+func waitForAwaitedChildNode(
+	t testing.TB,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	parentRunID string,
+	nodeID string,
+	wantChildRuns int,
+) (compozycontract.LoopRunResponse, string) {
+	t.Helper()
+	var detail compozycontract.LoopRunResponse
+	var childRunID string
+	waitForRuntimeCondition(t, "awaited child node "+nodeID, 20*time.Second, func() bool {
+		detail = readLoopRunDetailViaHTTP(t, ctx, harness, parentRunID)
+		if detail.Run.Status != compozycontract.LoopRunStatusRunning {
+			return false
+		}
+		for _, generation := range detail.Generations {
+			for _, output := range generation.Outputs {
+				if output.NodeID == nodeID && output.Status == "awaiting_child" {
+					childRunID = output.ChildLoopRunID
+				}
+			}
+		}
+		return childRunID != "" && len(awaitedChildRunsViaHTTP(t, ctx, harness)) == wantChildRuns
+	})
+	return detail, childRunID
+}
+
+func awaitedChildRunsViaHTTP(
+	t testing.TB,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+) []compozycontract.LoopRunPayload {
+	t.Helper()
+	var response compozycontract.LoopRunsResponse
+	path := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/loop-runs"
+	if err := harness.HTTPJSON(ctx, http.MethodGet, path, nil, &response); err != nil {
+		t.Fatalf("HTTP list loop runs error = %v", err)
+	}
+	children := make([]compozycontract.LoopRunPayload, 0, len(response.Runs))
+	for _, run := range response.Runs {
+		if run.LoopName == "await-child-hold" {
+			children = append(children, run)
+		}
+	}
+	return children
+}
+
+func assertAwaitedParentNodeStatus(
+	t testing.TB,
+	detail compozycontract.LoopRunResponse,
+	nodeID string,
+	want string,
+) {
+	t.Helper()
+	for _, generation := range detail.Generations {
+		for _, output := range generation.Outputs {
+			if output.NodeID == nodeID {
+				if output.Status != want {
+					t.Fatalf("%s status = %q, want %q", nodeID, output.Status, want)
+				}
+				return
+			}
+		}
+	}
+	t.Fatalf("node %q missing from parent detail", nodeID)
+}
+
+func resumeLoopWaitViaHTTP(
+	t testing.TB,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	runID string,
+	nodeID string,
+) {
+	t.Helper()
+	var response compozycontract.LoopMutationResponse
+	path := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) +
+		"/loop-runs/" + url.PathEscape(runID) + "/nodes/" + url.PathEscape(nodeID) + "/resume"
+	request := compozycontract.LoopNodeResumeRequest{Payload: json.RawMessage(`{}`)}
+	if err := harness.HTTPJSON(ctx, http.MethodPost, path, request, &response); err != nil {
+		t.Fatalf("HTTP resume loop wait error = %v", err)
+	}
+	if !response.OK {
+		t.Fatalf("HTTP resume loop wait response = %#v, want ok", response)
 	}
 }
 

--- a/internal/daemon/loop_run_events_e2e_integration_test.go
+++ b/internal/daemon/loop_run_events_e2e_integration_test.go
@@ -507,6 +507,7 @@ func waitForAwaitedChildNode(
 	var detail compozycontract.LoopRunResponse
 	var childRunID string
 	waitForRuntimeCondition(t, "awaited child node "+nodeID, 20*time.Second, func() bool {
+		childRunID = ""
 		detail = readLoopRunDetailViaHTTP(t, ctx, harness, parentRunID)
 		if detail.Run.Status != compozycontract.LoopRunStatusRunning {
 			return false

--- a/internal/loop/coordinator_outputs.go
+++ b/internal/loop/coordinator_outputs.go
@@ -154,7 +154,12 @@ func (r *CoordinatorRunner) refreshGenerationOutputFromTaskRun(
 	if err != nil {
 		return GenerationOutput{}, false, nil, nil, err
 	}
-	return refreshGenerationOutputFromTaskStatus(parent, graph, output, run)
+	refreshed, live, stops, terminal, err := refreshGenerationOutputFromTaskStatus(parent, graph, output, run)
+	if err != nil || refreshed.Status != generationOutputAwaitingChild {
+		return refreshed, live, stops, terminal, err
+	}
+	refreshed, childLive, childStops, err := r.refreshAwaitingChildOutput(ctx, parent, graph, refreshed)
+	return refreshed, live || childLive, append(stops, childStops...), terminal, err
 }
 
 func (r *CoordinatorRunner) refreshRetryingGenerationOutput(
@@ -258,15 +263,19 @@ func refreshCompletedTaskRunOutput(
 		payload = json.RawMessage(runtimeRef)
 	}
 	node, found := graphNode(graph, dsl.NodeID(output.NodeID))
-	if found {
-		inspection := InspectPayloadFailure(payload, nodeResultContract(node))
-		if inspection.Failure != nil {
-			output.Status = generationOutputFailed
-			if failureRef, ok := ActionFailureOutputRef(*inspection.Failure); ok {
-				setGenerationOutputRef(&output, failureRef)
-			}
-			return output, false, nil, nil, nil
+	if !found {
+		return invalidCompletedActionOwnerOutput(output), false, nil, nil, nil
+	}
+	inspection := InspectPayloadFailure(payload, nodeResultContract(node))
+	if inspection.Failure != nil {
+		output.Status = generationOutputFailed
+		if failureRef, ok := ActionFailureOutputRef(*inspection.Failure); ok {
+			setGenerationOutputRef(&output, failureRef)
 		}
+		return output, false, nil, nil, nil
+	}
+	if refreshed, handled := refreshCompletedRunLoopOutput(node, output, payload); handled {
+		return refreshed, false, nil, nil, nil
 	}
 	output.Status = generationOutputSucceeded
 	return output, false, nil, nil, nil
@@ -300,15 +309,21 @@ func (r *CoordinatorRunner) refreshAwaitingChildOutput(
 	graph dsl.Graph,
 	output GenerationOutput,
 ) (GenerationOutput, bool, []task.CoordinatorStopSpec, error) {
-	childRunID := strings.TrimSpace(output.ChildLoopRunID)
+	childRunID := output.ChildLoopRunID
 	if childRunID == "" {
 		output.Status = generationOutputFailed
 		setGenerationOutputRef(&output, "child_loop_missing")
 		return output, false, nil, nil
 	}
+	if strings.TrimSpace(childRunID) != childRunID {
+		return invalidAwaitedChildIdentityOutput(output), false, nil, nil
+	}
 	child, err := r.store.GetLoopRunByID(ctx, RunID(childRunID))
 	if err != nil {
 		return GenerationOutput{}, false, nil, err
+	}
+	if child.WorkspaceID != parent.WorkspaceID || child.ParentLoopRunID != parent.ID {
+		return invalidAwaitedChildBoundaryOutput(output, child.ID), false, nil, nil
 	}
 	if child.Status.Terminal() {
 		switch child.Status {

--- a/internal/loop/coordinator_run_loop_output.go
+++ b/internal/loop/coordinator_run_loop_output.go
@@ -1,0 +1,115 @@
+package loop
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+
+	"github.com/compozy/compozy/internal/loop/dsl"
+)
+
+// completedRunLoopResult is the durable result emitted by the reserved run-loop action.
+type completedRunLoopResult struct {
+	LoopRunID string `json:"loop_run_id"`
+	Status    string `json:"status"`
+}
+
+// refreshCompletedRunLoopOutput restores durable await state from a completed run-loop task.
+func refreshCompletedRunLoopOutput(
+	node dsl.Node,
+	output GenerationOutput,
+	payload json.RawMessage,
+) (GenerationOutput, bool) {
+	if node.Kind != string(dsl.ActionRunLoop) {
+		return output, false
+	}
+	if node.Class != dsl.NodeClassAction {
+		return invalidCompletedRunLoopOutput(output), true
+	}
+	var params dsl.RunLoopParams
+	if err := node.Params.Decode(&params); err != nil {
+		return invalidCompletedRunLoopOutput(output), true
+	}
+	if params.Mode == "" {
+		params.Mode = dsl.RunLoopAwait
+	}
+	if params.Mode == dsl.RunLoopDetach {
+		return output, false
+	}
+	if params.Mode != dsl.RunLoopAwait {
+		return invalidCompletedRunLoopOutput(output), true
+	}
+
+	var result completedRunLoopResult
+	if len(bytes.TrimSpace(payload)) == 0 {
+		return invalidCompletedRunLoopOutput(output), true
+	}
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return invalidCompletedRunLoopOutput(output), true
+	}
+	if result.Status != generationOutputAwaitingChild || result.LoopRunID == "" ||
+		strings.TrimSpace(result.LoopRunID) != result.LoopRunID {
+		return invalidCompletedRunLoopOutput(output), true
+	}
+
+	output.Status = generationOutputAwaitingChild
+	output.ChildLoopRunID = result.LoopRunID
+	setGenerationOutputRef(&output, string(payload))
+	return output, true
+}
+
+// invalidCompletedRunLoopOutput rejects a completed await result that cannot identify its child.
+func invalidCompletedRunLoopOutput(output GenerationOutput) GenerationOutput {
+	return invalidActionOutput(
+		output,
+		output.NodeID,
+		"completed run-loop await result is invalid",
+		"Inspect the completed run-loop result before retrying the parent Loop.",
+	)
+}
+
+// invalidCompletedActionOwnerOutput rejects a result whose authored graph node disappeared.
+func invalidCompletedActionOwnerOutput(output GenerationOutput) GenerationOutput {
+	return invalidActionOutput(
+		output,
+		output.NodeID,
+		"completed action owner node is missing",
+		"Restore the authored graph node before retrying the parent Loop.",
+	)
+}
+
+// invalidAwaitedChildBoundaryOutput rejects a child owned by another parent or workspace.
+func invalidAwaitedChildBoundaryOutput(output GenerationOutput, childRunID RunID) GenerationOutput {
+	return invalidActionOutput(
+		output,
+		string(childRunID),
+		"awaited child Loop is outside the parent boundary",
+		"Inspect the child workspace and parent Loop identity before retrying.",
+	)
+}
+
+// invalidAwaitedChildIdentityOutput rejects a persisted child ID that requires normalization.
+func invalidAwaitedChildIdentityOutput(output GenerationOutput) GenerationOutput {
+	return invalidActionOutput(
+		output,
+		output.NodeID,
+		"awaited child Loop identity is invalid",
+		"Inspect the persisted child Loop identity before retrying.",
+	)
+}
+
+// invalidActionOutput records a stable authoring failure and drops any untrusted child ID.
+func invalidActionOutput(output GenerationOutput, target, cause, hint string) GenerationOutput {
+	failure := NewActionFailure(
+		string(ReasonCodeActionSchemaInvalid),
+		cause,
+		hint,
+	)
+	failure.Target = target
+	output.Status = generationOutputFailed
+	output.ChildLoopRunID = ""
+	if ref, ok := ActionFailureOutputRef(failure); ok {
+		setGenerationOutputRef(&output, ref)
+	}
+	return output
+}

--- a/internal/loop/coordinator_test.go
+++ b/internal/loop/coordinator_test.go
@@ -691,12 +691,13 @@ func TestCoordinatorRunnerShouldYieldWhileAwaitingChildLoop(t *testing.T) {
 			Generation:  1,
 		}
 		childRun := Run{
-			ID:          "looprun-awaiting-child-live-child",
-			WorkspaceID: "ws-1",
-			LoopName:    "child",
-			Status:      StatusRunning,
-			Generation:  1,
-			CreatedAt:   time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC),
+			ID:              "looprun-awaiting-child-live-child",
+			WorkspaceID:     "ws-1",
+			LoopName:        "child",
+			Status:          StatusRunning,
+			Generation:      1,
+			ParentLoopRunID: loopRun.ID,
+			CreatedAt:       time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC),
 		}
 		coordinatorRun := task.Run{
 			ID:        "run-coordinator-awaiting-child-live",
@@ -731,6 +732,306 @@ func TestCoordinatorRunnerShouldYieldWhileAwaitingChildLoop(t *testing.T) {
 	})
 }
 
+func TestCoordinatorRunnerShouldRestoreAwaitedChildFromCompletedActionResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should keep dependent blocked while completed action child is live", func(t *testing.T) {
+		t.Parallel()
+
+		parent := Run{
+			ID:          "looprun-await-result-parent",
+			WorkspaceID: "ws-1",
+			LoopName:    "parent",
+			Status:      StatusRunning,
+			Generation:  1,
+		}
+		child := Run{
+			ID:              "looprun-await-result-child",
+			WorkspaceID:     parent.WorkspaceID,
+			LoopName:        "child",
+			Status:          StatusRunning,
+			Generation:      1,
+			ParentLoopRunID: parent.ID,
+		}
+		coordinatorRun := task.Run{
+			ID:        "run-coordinator-await-result",
+			TaskID:    "task-coordinator-await-result",
+			RunKind:   task.RunKindCoordinator,
+			LoopRunID: string(parent.ID),
+			Status:    task.TaskRunStatusClaimed,
+		}
+		completedRun := task.Run{
+			ID:        coordinatorNodeRunID(parent.ID, 1, "first_child", 0),
+			TaskID:    coordinatorNodeTaskID(parent.ID, 1, "first_child", 0),
+			RunKind:   task.RunKindWorker,
+			LoopRunID: string(parent.ID),
+			Status:    task.TaskRunStatusCompleted,
+			Result: json.RawMessage(
+				`{"loop_run_id":"looprun-await-result-child","status":"awaiting_child"}`,
+			),
+		}
+		graph := dsl.Graph{
+			Nodes: []dsl.Node{
+				{
+					ID:    "first_child",
+					Class: dsl.NodeClassAction,
+					Kind:  string(dsl.ActionRunLoop),
+					Params: dsl.NodeParams{
+						"loop": "child",
+						"mode": string(dsl.RunLoopAwait),
+					},
+				},
+				{
+					ID:    "second_child",
+					Class: dsl.NodeClassAction,
+					Kind:  string(dsl.ActionRunLoop),
+					Params: dsl.NodeParams{
+						"loop": "child",
+						"mode": string(dsl.RunLoopAwait),
+					},
+				},
+			},
+			Edges: []dsl.Edge{{From: "first_child", To: "second_child"}},
+		}
+		runner := newCoordinatorRunnerForTestWithGraph(
+			t,
+			parent,
+			coordinatorRun,
+			map[string]task.Run{
+				coordinatorRun.ID: coordinatorRun,
+				completedRun.ID:   completedRun,
+			},
+			coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{1: {
+				{
+					Generation: 1,
+					NodeID:     "first_child",
+					Status:     generationOutputEnqueued,
+					TaskRunID:  completedRun.ID,
+				},
+				{
+					Generation: 1,
+					NodeID:     "second_child",
+					Status:     generationOutputPending,
+				},
+			}}},
+			graph,
+		)
+		setCoordinatorRunnerRunsForTest(t, runner, map[RunID]Run{
+			parent.ID: parent,
+			child.ID:  child,
+		})
+
+		plan, err := runner.Run(context.Background(), task.RunID(coordinatorRun.ID))
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if !plan.Yield {
+			t.Fatal("Yield = false, want true while restored child wait is live")
+		}
+		if len(plan.NodeRuns) != 0 || plan.Terminal != nil {
+			t.Fatalf("NodeRuns/Terminal = %#v/%#v, want no dependent or terminal", plan.NodeRuns, plan.Terminal)
+		}
+		outputs := outputsByNodeForTest(coordinatorSnapshotPayloadForTest(t, plan).Outputs)
+		first := outputs["first_child"]
+		if got, want := first.Status, generationOutputAwaitingChild; got != want {
+			t.Fatalf("first_child status = %q, want %q", got, want)
+		}
+		if got, want := first.ChildLoopRunID, string(child.ID); got != want {
+			t.Fatalf("first_child child_loop_run_id = %q, want %q", got, want)
+		}
+		if got, want := outputs["second_child"].Status, generationOutputPending; got != want {
+			t.Fatalf("second_child status = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestRefreshCompletedTaskRunOutputShouldValidateRunLoopAwaitResult(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name      string
+		graph     dsl.Graph
+		result    json.RawMessage
+		wantCause string
+	}{
+		{name: "Should reject an empty result"},
+		{name: "Should reject malformed JSON", result: json.RawMessage(`{"loop_run_id":`)},
+		{name: "Should reject a missing child id", result: json.RawMessage(`{"status":"awaiting_child"}`)},
+		{name: "Should reject a whitespace child id", result: json.RawMessage(`{"loop_run_id":" ","status":"awaiting_child"}`)},
+		{name: "Should reject a contradictory status", result: json.RawMessage(`{"loop_run_id":"looprun-child","status":"completed"}`)},
+		{
+			name:      "Should reject a missing owner node",
+			graph:     dsl.Graph{Nodes: []dsl.Node{}},
+			result:    json.RawMessage(`{"loop_run_id":"looprun-child","status":"awaiting_child"}`),
+			wantCause: "completed action owner node is missing",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			wantCause := testCase.wantCause
+			if wantCause == "" {
+				wantCause = "completed run-loop await result is invalid"
+			}
+
+			graph := testCase.graph
+			if graph.Nodes == nil {
+				graph = dsl.Graph{Nodes: []dsl.Node{{
+					ID:    "child",
+					Class: dsl.NodeClassAction,
+					Kind:  string(dsl.ActionRunLoop),
+					Params: dsl.NodeParams{
+						"loop": "child-loop",
+						"mode": string(dsl.RunLoopAwait),
+					},
+				}}}
+			}
+			output, live, stops, terminal, err := refreshCompletedTaskRunOutput(
+				Run{ID: "looprun-parent", WorkspaceID: "ws-1"},
+				graph,
+				GenerationOutput{NodeID: "child", Status: generationOutputEnqueued},
+				task.Run{Status: task.TaskRunStatusCompleted, Result: testCase.result},
+			)
+			if err != nil {
+				t.Fatalf("refreshCompletedTaskRunOutput() error = %v", err)
+			}
+			if live || len(stops) != 0 || terminal != nil || output.Status != generationOutputFailed {
+				t.Fatalf(
+					"completed output = %#v live=%t stops=%#v terminal=%#v",
+					output,
+					live,
+					stops,
+					terminal,
+				)
+			}
+			failure := classifyGenerationOutputFailure(output, task.Run{})
+			if failure.Class != FailureAuthoring || failure.Code != string(ReasonCodeActionSchemaInvalid) ||
+				failure.Cause != wantCause || failure.Target != "child" {
+				t.Fatalf("classified invalid result = %#v", failure)
+			}
+		})
+	}
+}
+
+func TestRefreshCompletedTaskRunOutputShouldPreserveRunLoopDetachSuccess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should keep detached child as immediate success", func(t *testing.T) {
+		t.Parallel()
+
+		graph := dsl.Graph{Nodes: []dsl.Node{{
+			ID:    "child",
+			Class: dsl.NodeClassAction,
+			Kind:  string(dsl.ActionRunLoop),
+			Params: dsl.NodeParams{
+				"loop": "child-loop",
+				"mode": string(dsl.RunLoopDetach),
+			},
+		}}}
+		output, live, stops, terminal, err := refreshCompletedTaskRunOutput(
+			Run{ID: "looprun-parent", WorkspaceID: "ws-1"},
+			graph,
+			GenerationOutput{NodeID: "child", Status: generationOutputEnqueued},
+			task.Run{
+				Status: task.TaskRunStatusCompleted,
+				Result: json.RawMessage(`{"loop_run_id":"looprun-detached-child"}`),
+			},
+		)
+		if err != nil {
+			t.Fatalf("refreshCompletedTaskRunOutput() error = %v", err)
+		}
+		if live || len(stops) != 0 || terminal != nil {
+			t.Fatalf("live/stops/terminal = %t/%#v/%#v, want none", live, stops, terminal)
+		}
+		if got, want := output.Status, generationOutputSucceeded; got != want {
+			t.Fatalf("detached status = %q, want %q", got, want)
+		}
+		if output.ChildLoopRunID != "" {
+			t.Fatalf("detached child_loop_run_id = %q, want no parent wait ownership", output.ChildLoopRunID)
+		}
+	})
+}
+
+func TestCoordinatorRunnerShouldResolveCompletedAwaitedChildTerminal(t *testing.T) {
+	t.Parallel()
+
+	for _, testCase := range []struct {
+		name       string
+		status     Status
+		wantStatus string
+	}{
+		{name: "Should resolve a done child", status: StatusDone, wantStatus: generationOutputSucceeded},
+		{name: "Should resolve a no-op child", status: StatusNoOp, wantStatus: generationOutputSucceeded},
+		{name: "Should resolve a failed child", status: StatusFailed, wantStatus: generationOutputFailed},
+		{name: "Should resolve a canceled child", status: StatusCanceled, wantStatus: generationOutputFailed},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			parent := Run{
+				ID: "looprun-completed-child-parent", WorkspaceID: "ws-1", LoopName: "parent",
+				Status: StatusRunning, Generation: 1,
+			}
+			child := Run{
+				ID: "looprun-completed-child", WorkspaceID: parent.WorkspaceID, LoopName: "child",
+				Status: testCase.status, Generation: 1, ParentLoopRunID: parent.ID,
+			}
+			completedRun := task.Run{
+				ID: "run-completed-child", RunKind: task.RunKindWorker,
+				LoopRunID: string(parent.ID), Status: task.TaskRunStatusCompleted,
+				Result: json.RawMessage(
+					`{"loop_run_id":"looprun-completed-child","status":"awaiting_child"}`,
+				),
+			}
+			graph := dsl.Graph{Nodes: []dsl.Node{{
+				ID:    "child",
+				Class: dsl.NodeClassAction,
+				Kind:  string(dsl.ActionRunLoop),
+				Params: dsl.NodeParams{
+					"loop": "child-loop",
+					"mode": string(dsl.RunLoopAwait),
+				},
+			}}}
+			coordinatorRun := task.Run{
+				ID: "run-coordinator-completed-child", TaskID: "task-coordinator-completed-child",
+				RunKind: task.RunKindCoordinator, LoopRunID: string(parent.ID), Status: task.TaskRunStatusClaimed,
+			}
+			runner := newCoordinatorRunnerForTestWithGraph(
+				t,
+				parent,
+				coordinatorRun,
+				map[string]task.Run{
+					coordinatorRun.ID: coordinatorRun,
+					completedRun.ID:   completedRun,
+				},
+				coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{}},
+				graph,
+			)
+			setCoordinatorRunnerRunsForTest(t, runner, map[RunID]Run{parent.ID: parent, child.ID: child})
+
+			output, live, stops, terminal, err := runner.refreshGenerationOutputFromTaskRun(
+				context.Background(),
+				parent,
+				graph,
+				GenerationOutput{
+					NodeID: "child", Status: generationOutputEnqueued, TaskRunID: completedRun.ID,
+				},
+			)
+			if err != nil {
+				t.Fatalf("refreshGenerationOutputFromTaskRun() error = %v", err)
+			}
+			if live || len(stops) != 0 || terminal != nil {
+				t.Fatalf("live/stops/terminal = %t/%#v/%#v, want none", live, stops, terminal)
+			}
+			if got := output.Status; got != testCase.wantStatus {
+				t.Fatalf("output status = %q, want %q", got, testCase.wantStatus)
+			}
+			if got, want := output.ChildLoopRunID, string(child.ID); got != want {
+				t.Fatalf("child_loop_run_id = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 func TestCoordinatorRunnerShouldResolveAwaitingChildCoordinatorTerminal(t *testing.T) {
 	t.Run("Should resolve awaiting child loop terminal", func(t *testing.T) {
 		t.Parallel()
@@ -743,11 +1044,12 @@ func TestCoordinatorRunnerShouldResolveAwaitingChildCoordinatorTerminal(t *testi
 			Generation:  1,
 		}
 		childRun := Run{
-			ID:          "looprun-awaiting-child-terminal-child",
-			WorkspaceID: "ws-1",
-			LoopName:    "child",
-			Status:      StatusDone,
-			Generation:  1,
+			ID:              "looprun-awaiting-child-terminal-child",
+			WorkspaceID:     "ws-1",
+			LoopName:        "child",
+			Status:          StatusDone,
+			Generation:      1,
+			ParentLoopRunID: loopRun.ID,
 		}
 		coordinatorRun := task.Run{
 			ID:        "run-coordinator-awaiting-child-terminal",
@@ -867,6 +1169,132 @@ func TestCoordinatorRunnerShouldClassifyAwaitedChildTerminalFailClosed(t *testin
 	}
 }
 
+func TestCoordinatorRunnerShouldRejectAwaitedChildOutsideParentBoundary(t *testing.T) {
+	t.Parallel()
+
+	parent := Run{
+		ID: "looprun-parent-boundary", WorkspaceID: "ws-1", LoopName: "parent",
+		Status: StatusRunning, Generation: 1,
+	}
+	for _, testCase := range []struct {
+		name  string
+		child Run
+	}{
+		{
+			name: "Should reject a child from another workspace",
+			child: Run{
+				ID: "looprun-child-other-workspace", WorkspaceID: "ws-2", LoopName: "child",
+				Status: StatusRunning, Generation: 1, ParentLoopRunID: parent.ID,
+			},
+		},
+		{
+			name: "Should reject a child owned by another parent",
+			child: Run{
+				ID: "looprun-child-other-parent", WorkspaceID: parent.WorkspaceID, LoopName: "child",
+				Status: StatusRunning, Generation: 1, ParentLoopRunID: "looprun-another-parent",
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			coordinatorRun := task.Run{
+				ID: "run-coordinator-child-boundary", TaskID: "task-coordinator-child-boundary",
+				RunKind: task.RunKindCoordinator, LoopRunID: string(parent.ID), Status: task.TaskRunStatusClaimed,
+			}
+			runner := newCoordinatorRunnerForTestWithGraph(
+				t,
+				parent,
+				coordinatorRun,
+				map[string]task.Run{coordinatorRun.ID: coordinatorRun},
+				coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{}},
+				dsl.Graph{Nodes: []dsl.Node{{
+					ID: "child", Class: dsl.NodeClassAction, Kind: string(dsl.ActionRunLoop),
+				}}},
+			)
+			setCoordinatorRunnerRunsForTest(t, runner, map[RunID]Run{
+				parent.ID:         parent,
+				testCase.child.ID: testCase.child,
+			})
+
+			output, live, stops, err := runner.refreshAwaitingChildOutput(
+				context.Background(), parent, dsl.Graph{}, GenerationOutput{
+					Generation: 1, NodeID: "child", Status: generationOutputAwaitingChild,
+					ChildLoopRunID: string(testCase.child.ID),
+				},
+			)
+			if err != nil {
+				t.Fatalf("refreshAwaitingChildOutput() error = %v", err)
+			}
+			if live || len(stops) != 0 || output.Status != generationOutputFailed {
+				t.Fatalf("awaited child output = %#v live=%t stops=%#v", output, live, stops)
+			}
+			if output.ChildLoopRunID != "" {
+				t.Fatalf("failed boundary child_loop_run_id = %q, want cleared", output.ChildLoopRunID)
+			}
+			failure := classifyGenerationOutputFailure(output, task.Run{})
+			if failure.Class != FailureAuthoring || failure.Target != string(testCase.child.ID) ||
+				failure.Code != string(ReasonCodeActionSchemaInvalid) ||
+				failure.Cause != "awaited child Loop is outside the parent boundary" {
+				t.Fatalf("classified boundary failure = %#v", failure)
+			}
+		})
+	}
+}
+
+func TestCoordinatorRunnerShouldRejectMalformedAwaitedChildIdentity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should reject child id that would require normalization", func(t *testing.T) {
+		t.Parallel()
+
+		parent := Run{
+			ID: "looprun-parent-identity", WorkspaceID: "ws-1", LoopName: "parent",
+			Status: StatusRunning, Generation: 1,
+		}
+		child := Run{
+			ID: "looprun-child-identity", WorkspaceID: parent.WorkspaceID, LoopName: "child",
+			Status: StatusRunning, Generation: 1, ParentLoopRunID: parent.ID,
+		}
+		coordinatorRun := task.Run{
+			ID: "run-coordinator-child-identity", TaskID: "task-coordinator-child-identity",
+			RunKind: task.RunKindCoordinator, LoopRunID: string(parent.ID), Status: task.TaskRunStatusClaimed,
+		}
+		runner := newCoordinatorRunnerForTestWithGraph(
+			t,
+			parent,
+			coordinatorRun,
+			map[string]task.Run{coordinatorRun.ID: coordinatorRun},
+			coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{}},
+			dsl.Graph{Nodes: []dsl.Node{{
+				ID: "child", Class: dsl.NodeClassAction, Kind: string(dsl.ActionRunLoop),
+			}}},
+		)
+		setCoordinatorRunnerRunsForTest(t, runner, map[RunID]Run{parent.ID: parent, child.ID: child})
+
+		output, live, stops, err := runner.refreshAwaitingChildOutput(
+			context.Background(), parent, dsl.Graph{}, GenerationOutput{
+				Generation: 1, NodeID: "child", Status: generationOutputAwaitingChild,
+				ChildLoopRunID: " " + string(child.ID),
+			},
+		)
+		if err != nil {
+			t.Fatalf("refreshAwaitingChildOutput() error = %v", err)
+		}
+		if live || len(stops) != 0 || output.Status != generationOutputFailed {
+			t.Fatalf("awaited child output = %#v live=%t stops=%#v", output, live, stops)
+		}
+		if output.ChildLoopRunID != "" {
+			t.Fatalf("malformed child_loop_run_id = %q, want cleared", output.ChildLoopRunID)
+		}
+		failure := classifyGenerationOutputFailure(output, task.Run{})
+		if failure.Class != FailureAuthoring || failure.Code != string(ReasonCodeActionSchemaInvalid) ||
+			failure.Cause != "awaited child Loop identity is invalid" {
+			t.Fatalf("classified malformed child identity = %#v", failure)
+		}
+	})
+}
+
 // Invariant: a terminal parent plan carries only owned terminate/cancel children; abandon is
 // intentionally absent, and an omitted policy defaults to terminate. The coordinator suite
 // owns authored parent-close selection.
@@ -932,12 +1360,13 @@ func TestCoordinatorRunnerShouldRetryAwaitingChildLoopOnTimeout(t *testing.T) {
 			LastProgressAt: now,
 		}
 		childRun := Run{
-			ID:          "looprun-awaiting-child-timeout-child",
-			WorkspaceID: "ws-1",
-			LoopName:    "child",
-			Status:      StatusRunning,
-			Generation:  1,
-			CreatedAt:   now,
+			ID:              "looprun-awaiting-child-timeout-child",
+			WorkspaceID:     "ws-1",
+			LoopName:        "child",
+			Status:          StatusRunning,
+			Generation:      1,
+			ParentLoopRunID: loopRun.ID,
+			CreatedAt:       now,
 		}
 		coordinatorRun := task.Run{
 			ID:        "run-coordinator-awaiting-child-timeout",

--- a/packages/site/content/docs/loops/guardrails.mdx
+++ b/packages/site/content/docs/loops/guardrails.mdx
@@ -50,6 +50,11 @@ resume. `paused` is operator-initiated; `needs-approval` is system-initiated by 
 generation) — they are never run states. `awaiting_child` marks a `run-loop` node in `await` mode
 parked until its child Loop terminates.
 
+While that child is live, the parent remains live, dependent nodes remain pending, and a daemon
+restart restores the same `child_loop_run_id` without submitting another child. A child ending
+`done` or `no-op` settles the node as `succeeded`; every other terminal child outcome settles it as
+`failed`. `mode: detach` remains immediate success and does not establish parent wait ownership.
+
 ## No-progress checks
 
 "Making progress" is measured from committed work, not elapsed wall time.

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -194,6 +194,12 @@ healthy waiting ticks remain `watching`.
 watch tick), `needs-approval` (parked on a human gate — a live pause, not terminal), `paused`
 (operator paused at a boundary). `ready` and `awaiting_child` are node-level, never run states.
 
+A `run-loop` node in `await` mode remains `awaiting_child` with its exact `child_loop_run_id` while
+the child is live. The parent remains live, dependents stay pending, and daemon restart restores the
+same child identity without submitting another child. Child `done` or `no-op` settles the node as
+`succeeded`; every other child terminal outcome settles it as `failed`. `detach` remains immediate
+success and does not establish parent wait ownership.
+
 Native control rejections are `tool_invalid_input`: `invalid_status_transition` for an unsupported
 live state, or `terminal_loop_run` after termination. `schema_invalid` is reserved for malformed input.
 


### PR DESCRIPTION
## What & why

Fixes #386.

`run-loop` tasks using `mode: await` could be collapsed into ordinary task success as soon as the mechanical action completed. That allowed the parent node and its dependents to advance while the child Loop was still live.

This change restores the durable awaited-child state from the completed action result before dependency evaluation. It preserves the exact child run identity across daemon restart, prevents duplicate child submission, and maps child terminal outcomes without coercing live or failed children to success. `mode: detach` remains immediate success.

Release notes:

- 🐛 Bug Fixes: Preserve awaited child Loop state until child termination.
- 🐛 Bug Fixes: Reject an empty `defaults.agent` with the canonical config-validation error.
- 📚 Documentation: Generalize the `run-loop` await reproduction and specify durable await semantics.

Agent: Codex implemented and co-authored this change. Maintainer follow-ups were verified against head `6924c197`.

## How you verified it

- `go test -race ./internal/loop -count=1` passed for the contributor implementation before the maintainer follow-ups.
- `go test -race -tags=integration -count=1 -run '^TestDaemonE2ELoopRunEventsShouldStreamRichFramesAndResume$' ./internal/daemon` passed on the final head, proving the same child ID is restored, no duplicate child is created, and dependents remain pending until the child terminates.
- `go test -race -p 2 -parallel=4 -count=1 ./internal/config ./internal/cli` passed on the final head.
- `golangci-lint run --timeout=10m --concurrency=4 ./internal/config/... ./internal/daemon/...` reported no issues.
- Fresh isolated QA exercised the authored two-Loop flow through CLI/UDS and HTTP, restarted the daemon while awaiting the child, verified ordering and identity, and completed with clean teardown. Evidence is checked in at `docs/qa/reports/2026-08-13-run-loop-await-child.md`.
- Per maintainer direction, the full local gate was not rerun after the final follow-ups; GitHub CI is the authoritative full verification and is running on this head.

## Impact

- Runtime: awaited child results restore `awaiting_child` and the exact persisted child ID before the coordinator evaluates dependents. `done` and `no-op` settle the parent node as succeeded; other terminal child states settle it as failed; live children keep the parent live.
- Recovery: daemon restart reuses the persisted child ID and does not submit another child.
- Isolation: validation rejects child runs from another workspace or parent boundary and fails malformed durable state closed with the existing `action_schema_invalid` reason.
- Config lifecycle: no key or default changed; validation now enforces the existing required `defaults.agent` contract and reports the canonical `defaults.agent` path.
- Public surfaces: no new CLI command, HTTP/UDS schema, native ToolID, hook, extension format, generated contract, or Web route. Existing CLI config validation now rejects an empty default agent consistently.
- Documentation: the official Compozy Loop skill and site guardrails now describe ordering, restart identity, detach behavior, and terminal mapping.
- CI/release: no workflow or release artifact changes.

---

- [ ] `make gate` passes locally (`make gate-full` before review on larger changes)
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restoration of awaited child runs after daemon restarts.
  - Added validation for invalid, malformed, or out-of-scope child-run references.
  - Correctly handles completed, detached, pending, and failed child-run outcomes.
  - Ensures invalid or missing run data fails safely.
  - Requires the default agent setting to contain a non-whitespace value.

- **Tests**
  - Added coverage for restart recovery, sequential child runs, completion, retries, ownership boundaries, malformed results, and default-agent validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
