### PR TITLE
fix: preserve dead session history

### DIFF
--- a/docs/qa/charters/CH-dead-session-history-recovery.md
+++ b/docs/qa/charters/CH-dead-session-history-recovery.md
@@ -1,0 +1,28 @@
+# CH-dead-session-history-recovery: Return to an interrupted session safely
+
+```yaml
+charter:
+  id: CH-dead-session-history-recovery
+  mission: "As Théo, return to an interrupted session, confirm its history stays readable, and deliberately fork follow-up work without losing the failure evidence."
+  mode: scenario-based
+  persona:
+    name: Théo
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-dead-session-history-recovery
+  scenarios: [RT-acp-stream-disconnect-recovery]
+  tour: Back-Button Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Open the terminal session through the normal web route and read its partial transcript and failure detail."
+      - "Refresh and revisit the original session before choosing recovery."
+      - "Use the fork action and verify the child points back to the original while the original stays readable."
+      - "Read recap from the CLI or HTTP after the web recovery action to confirm the original evidence remains available."
+    must_avoid:
+      - "Do not retry the interrupted prompt; its provider-side effects are unknown."
+      - "Do not use internal storage or test helpers as user-facing evidence."
+```
+
+<!-- Immutable charter: write each run's outcome only in that run report. -->

--- a/docs/qa/journeys/J-15-operate-session-via-cli-api.md
+++ b/docs/qa/journeys/J-15-operate-session-via-cli-api.md
@@ -11,8 +11,10 @@ flowchart TD
     C --> STRM[Subscribe SSE: frames=transcript + after_sequence + epoch + generation]
     C -->|ACP process disconnects mid-response| PFAIL[Persist delivered chunks + emit terminal error]
     PFAIL --> DIAG[Read process_exit diagnostics + preserved transcript]
-    DIAG -->|new explicit prompt| RECOVER[Restart provider process without replaying the failed prompt]
-    RECOVER --> C
+    DIAG -->|normal prompt| REFUSED[Reject before session/load]
+    REFUSED --> RECAP[Read recap and transcript again]
+    RECAP --> FORK[Fork child session with parent provenance]
+    FORK --> C
     STRM -->|no cursor| SNAP[Bounded snapshot, reset=false]
     STRM -->|missing/stale fence or reset cursor| RESET[Reset snapshot + explicit reason]
     STRM -->|empty delta with newer cursor| ADV[Advance safe cursor without adding an entry]
@@ -59,7 +61,7 @@ journey:
   goal:
     observable: "The agent reads a complete, gap-free transcript and drives the session to a terminal outcome deterministically, with lifecycle state consistent across every surface"
     side_effects: [session-created, prompt-streamed, partial-output-persisted, session-stopped]
-  true_end_state: "Older REST pages remain loaded; reconnect after killing the client resumes from `after_sequence` with matching `epoch`/`generation`, or replaces the bounded tail only on an explicit reset; empty deltas still advance the cursor; an ACP process disconnect retains delivered chunks and requires one new explicit prompt; list/detail/status agree after a daemon restart; HTTP and UDS return identical structured output."
+  true_end_state: "Older REST pages remain loaded; reconnect after killing the client resumes from `after_sequence` with matching `epoch`/`generation`, or replaces the bounded tail only on an explicit reset; empty deltas still advance the cursor; an ACP process disconnect retains delivered chunks and diagnostics, refuses a normal prompt before `session/load`, and continues only in an explicit child session with parent provenance; list/detail/status agree after a daemon restart; HTTP and UDS return identical structured output."
   exit:
     natural: "The agent has a terminal outcome + a complete transcript and hands off / records the result."
   abandonment:
@@ -68,7 +70,7 @@ journey:
       resume: "Reconnect with `after_sequence`, `epoch`, and `generation`; matching fences resume with bounded deltas, while a reset snapshot names why the cached tail must be replaced; an empty delta still advances the safe cursor."
     - at_step: 3
       how: "The ACP provider process disconnects after delivering part of the final response."
-      resume: "Inspect the persisted transcript and `process_exit` diagnostics, then send a new explicit prompt to restart the provider process in the same Compozy session; Compozy never replays the failed prompt automatically because it may already have caused side effects."
+      resume: "Inspect the persisted transcript and `process_exit` diagnostics. A normal prompt is refused before ACP `session/load`; fork a child session with the original as parent when work must continue. Compozy never replays the failed prompt automatically because it may already have caused side effects."
     - at_step: 4
       how: "A read races the stop and hits a recorder-unavailable error, so the agent aborts."
       resume: "Reads during stop/finalize must degrade to the persisted transcript; the finding is any recorder error surfaced to the caller."
@@ -83,7 +85,7 @@ design_reference:
     - "Reconnects carry `after_sequence`, `epoch`, and `generation`; reset snapshots name `fence_missing`, `epoch_mismatch`, `generation_mismatch`, or `sequence_reset`."
     - "An empty `transcript_delta` may advance the safe cursor without adding a visible entry."
     - "Reads during stop/finalize return the persisted transcript, never a recorder error (task 21)."
-    - "An ACP process disconnect preserves delivered chunks, emits a terminal error, fails `compozy__session_prompt` with `backend_dead`, records `process_exit` diagnostics, and permits only an explicit next-prompt recovery — never automatic replay."
+    - "An ACP process disconnect preserves delivered chunks, emits a terminal error, fails `compozy__session_prompt` with `backend_dead`, records `process_exit` diagnostics, refuses another normal prompt before `session/load`, and permits an explicit child-session fork — never automatic replay."
     - "List/detail/status agree through spawn→background→stop→restart (task 22); HTTP↔UDS byte parity (RT-042)."
 
 e2e_backbone:
@@ -91,7 +93,7 @@ e2e_backbone:
     - "E2E-runtime 1: long-session bounded REST pagination under lane latency (task 14)."
     - "E2E-runtime 3: reconnect with matching and stale transcript fences, including explicit reset reasons and empty-delta cursor advancement (task 17)."
     - "E2E-runtime 4: consistent state across list and detail through spawn → background → stop (task 22)."
-    - "E2E-runtime fault path: a real ACP subprocess disconnect after a partial response is projected through HTTP, UDS, CLI JSONL, `compozy__session_prompt`, persisted transcript, crash diagnostics, and same-session explicit recovery."
+    - "E2E-runtime fault path: a real ACP subprocess disconnect after a partial response is projected through HTTP, UDS, CLI JSONL, `compozy__session_prompt`, persisted transcript, crash diagnostics, read-only rejection before `session/load`, and explicit child-session recovery."
   manual:
     - "Manual §9.6: raw-stream contiguity — `compozy session events --follow` against a busy session, disconnect during a large output burst, reconnect; the printed sequence is contiguous with no skipped `sequence` (tasks 42/43)."
   telemetry:

--- a/docs/qa/journeys/J-dead-session-history-recovery.md
+++ b/docs/qa/journeys/J-dead-session-history-recovery.md
@@ -1,0 +1,51 @@
+# J-dead-session-history-recovery — Read and fork a dead session
+
+A returning session user opens a session after its ACP provider process has ended unexpectedly. The
+session must remain a truthful record of what happened, not a failing resume loop. The user reads the
+preserved transcript and diagnostics, then forks a new child only if they choose to continue.
+
+```mermaid
+flowchart TD
+    E[Entry: session deep link or session list] --> H[Read persisted transcript and diagnostics]
+    H --> P{Is the runtime terminal process_exit?}
+    P -->|yes| RO[Show read-only history and disable prompt]
+    RO --> R[Refresh and read the same transcript again]
+    R --> F[Fork into a new session]
+    F --> C[Open child session with parent provenance]
+    RO -.->|leave now| L[Original history remains available]
+    C --> T[True end: original remains intact; child is ready for new work]
+```
+
+```yaml
+journey:
+  id: J-dead-session-history-recovery
+  name: "Read and fork a dead session"
+  value_statement: "I can understand an interrupted agent session without losing its history or triggering another hidden runtime retry."
+  personas: [Théo]
+  entry_points:
+    - url: "web session deep link or session list"
+      origin: return-visit
+    - url: "CLI: compozy session recap <session-id>"
+      origin: direct
+  actions:
+    - step: 1
+      verb: "Open the stopped session after a provider process exit"
+      expected_observable: "Persisted transcript, process_exit summary, and diagnostic path remain readable; the prompt composer is unavailable."
+    - step: 2
+      verb: "Refresh and re-read the session"
+      expected_observable: "The same transcript remains available and no session/load retry or generic server error appears."
+    - step: 3
+      verb: "Fork into a new session"
+      expected_observable: "A child opens in the same workspace with parent_session_id pointing to the original; the original remains unchanged and readable."
+  goal:
+    observable: "The user can safely inspect the original failure and start separate follow-up work without rewriting history."
+    side_effects: [child-session-created]
+  true_end_state: "The original transcript and diagnostics survive refresh; the child is a distinct session linked to its parent."
+  exit:
+    natural: "The user either leaves with the original history intact or continues in the child session."
+  abandonment:
+    - at_step: 1
+      how: "The user closes the tab after seeing the runtime unavailable notice."
+      resume: "Reopen the same deep link; persisted history remains readable without attaching to ACP."
+  crosses: [web, CLI, HTTP, UDS, session-store, transcript-projection, workspace-isolation]
+```

--- a/docs/qa/reports/2026-08-13-issue-365-dead-session.md
+++ b/docs/qa/reports/2026-08-13-issue-365-dead-session.md
@@ -1,0 +1,77 @@
+# QA Run Report — 2026-08-13 — issue 365 dead session
+
+- **Scope:** Issue #365: a terminal ACP session remains readable and can be forked from the web UI.
+- **Cadence tier:** targeted
+- **Build:** `codex/issue-365-dead-session` working tree · **Environment:** isolated targeted lab `compozy-issue-365-dead-session-attach-20260813-220424-298966-lab`
+- **Started:** 2026-08-13T21:22:02-03:00 · **Status:** pass
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Théo | Power User | desktop / wifi-fast / en-US | CH-dead-session-history-recovery |
+
+## Flows in Scope
+
+- `J-dead-session-history-recovery` — read persisted failure history and deliberately fork follow-up work (`../journeys/J-dead-session-history-recovery.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-dead-session-history-recovery | J-dead-session-history-recovery / RT-acp-stream-disconnect-recovery | Théo | Back-Button Tour | Pass | #365 | local working tree |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+The deterministic ACP fixture streamed `partial before crash`, then exited with code 23. The
+original session became `stopped`, `dead`, not attachable, and not eligible for wake.
+
+Repeated CLI recap reads returned the same persisted history; only the recap snapshot's generated-at
+timestamp changed. Explicit HTTP attach and prompt both returned 409, while UDS `session resume`
+and `session prompt` were recoverably refused as not attachable. The ACP diagnostics recorded zero
+subsequent `session/load` calls.
+
+The web session window displayed the original transcript, `process_exit` failure details, a
+disabled prompt, and the read-only recovery action. Agent-browser forked a child session; the child
+was in the same workspace and retained the original session as `parent_session_id`. It then opened
+a fresh direct link to the original session and reloaded it; its history and fork action remained
+available and the `session/load` count stayed zero.
+
+## What Was Fixed
+
+The runtime now rejects terminal `process_exit` sessions before an ACP resume attempt. Session
+projection reads remain independent of runtime attachment, and the session window makes the
+history-only state explicit while offering an intentional child-session fork.
+
+## Paper Cuts
+
+The new targeted lab initially lacked its ACP fixture executable and standard log/evidence
+directories. Building the fixture from the current worktree and creating those lab directories
+corrected the envelope only; no product code was changed for the QA setup.
+
+## Runtime Errors Observed
+
+The intended ACP fixture process exit was observed. No unexpected runtime errors were found.
+
+## Human Verifications Needed
+
+None recorded yet.
+
+## Decisions for a Human
+
+None recorded yet.
+
+## Learnings
+
+Persisted session projection is sufficient for history and recap after a provider dies; runtime
+attachment is neither needed nor safe for those reads. Recovery should create an explicit child
+session rather than replaying the failed turn in the original.
+
+## Final Status
+
+PASS — the targeted runtime, CLI, HTTP, UDS, and web journey completed with a deterministic ACP
+subprocess fixture. No credentialed provider was required for this provider-process failure path.
+The final automated exit gate is collected after this report's last tracked update; its current
+evidence is recorded in the isolated QA lab journey log during completion.

--- a/docs/qa/scenarios/RT-acp-stream-disconnect-recovery.md
+++ b/docs/qa/scenarios/RT-acp-stream-disconnect-recovery.md
@@ -2,32 +2,41 @@
 id: RT-acp-stream-disconnect-recovery
 area: RT
 title: Recover after an ACP stream disconnect
-persona: Ada
-journey: J-15
-expected: When an ACP process disconnects after streaming partial output, Compozy preserves the delivered chunks, emits a terminal error through HTTP and UDS, makes CLI JSONL exit nonzero after printing those frames, returns backend_dead from compozy__session_prompt, records process_exit diagnostics, and restarts the same session only after a new explicit prompt without replaying the failed prompt.
-entry_points: POST /api/sessions/:id/prompt; UDS session prompt; compozy session prompt -o jsonl; compozy__session_prompt; session events; session status
+persona: Théo
+journey: J-dead-session-history-recovery
+expected: When an ACP process disconnects after streaming partial output, Compozy preserves delivered chunks and process_exit diagnostics. Status, transcript, history, and recap remain readable without ACP session/load. Explicit attach/resume and a normal prompt are rejected as not attachable before another load attempt; the web UI keeps the original history read-only and can fork a child session in the same workspace with parent_session_id preserved.
+entry_points: web session window; POST /api/workspaces/:workspace_id/sessions/:session_id/attach; POST /api/workspaces/:workspace_id/sessions/:session_id/prompt; UDS session resume; UDS session prompt; compozy session prompt -o jsonl; compozy session resume; compozy session recap; compozy session new --parent; compozy__session_prompt; session events; session status
 qa_status: pass
 bug_ids: 315
-fix_status: fixed
-retest_status: pass
+fix_status:
+retest_status:
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-pr319-acp-stream-remediation-20260805-220911-045783-lab/qa-artifacts/qa/evidence/acp-stream-remediation/runtime-public-surfaces.log; /Users/pedronauck/dev/qa-labs/compozy-pr319-acp-stream-remediation-20260805-220911-045783-lab/qa-artifacts/qa/journey-log.jsonl
-last_report: docs/qa/reports/2026-08-05-pr319-acp-stream-remediation.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/dead-session-web-readonly.png; /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/dead-session-web-after-reload.png; /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/dead-attach-http.json; /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/dead-retry-http.json; /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/dead-attach-uds.stderr; /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/dead-retry-uds.stderr; /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/session-load-count-after-retries.json; /Users/pedronauck/dev/qa-labs/compozy-issue-365-dead-session-attach-20260813-220424-298966-lab/qa-artifacts/qa/evidence/session-list-after-fork.json
+last_report: docs/qa/reports/2026-08-13-issue-365-dead-session.md
 overlaps: RT-050; RT-051; RT-session-context-rebuild
 ---
 
 Issue #315 exposed a provider-side disconnect while the final response was still streaming. This
 scenario owns the boundary between a completed stream, a disconnected ACP peer, and a later
-`process_exit`. Recovery is deliberately a new explicit prompt: automatic replay is unsafe because
-the failed turn may already have performed external side effects.
+`process_exit`. The original session becomes durable read-only history: automatic replay is unsafe,
+and a new prompt must not keep retrying `session/load` after the peer has died.
 
-The deterministic walk uses the real daemon, SQLite store, HTTP server, UDS server, CLI binary, and
-an ACP subprocess fixture that exits with code 23 after one partial assistant chunk. It then proves
-the same session accepts a separate continuation prompt and retains both outputs.
+The deterministic walk uses the real daemon, SQLite store, HTTP server, UDS server, CLI binary, web
+UI, and an ACP subprocess fixture that exits with code 23 after one partial assistant chunk. It then
+proves repeated transcript reads remain projection-only, the normal prompt is recoverably refused,
+and a forked child preserves the original as durable provenance.
 
-QA retest 2026-08-05: the HTTP stream retained `partial before crash` and then emitted one typed
+Historical QA retest 2026-08-05: the HTTP stream retained `partial before crash` and then emitted one typed
 `process_exit` terminal for exit code 23. At the instant that event became observable, its crash
 bundle already contained the exit code and captured stderr. CLI JSONL printed the retained frames
 and exited nonzero, while `compozy__session_prompt` returned `tool_backend_failed` with
 `backend_dead`. The session stopped within the scenario bound, and a new explicit prompt recovered
-the same session without replaying the failed turn.
+the same session without replaying the failed turn. Issue #365 changes that final recovery behavior;
+the prior verdict is intentionally reset until the new read-only and fork path is walked.
+
+Issue #365 retest 2026-08-13: the deterministic ACP fixture emitted `partial before crash` then exited
+with code 23. Repeated recap reads preserved the same durable history (apart from each read's
+generated-at timestamp). HTTP attach and prompt returned 409, and UDS resume and prompt were
+refused as not attachable. The ACP diagnostics recorded no later `session/load` calls. The web
+session window preserved the original transcript and failure details after a fresh direct link and
+reload, then forked a child in the same workspace with the original `parent_session_id`.

--- a/internal/api/udsapi/transport_parity_integration_test.go
+++ b/internal/api/udsapi/transport_parity_integration_test.go
@@ -2050,70 +2050,74 @@ func TestUDSTransportTerminalProcessFailureRejectsAttachAndPromptBeforeACPResume
 	acpmock.RequireDriver(t)
 	t.Parallel()
 
-	runtimeHarness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
-		MockAgents: []e2etest.MockAgentSpec{{
-			FixturePath:  transportMockFixturePath(t, "driver_fault_fixture.json"),
-			FixtureAgent: "faulty",
-			AgentName:    transportUDSFaultyAgent,
-		}},
-	})
+	t.Run("Should reject attach and prompt before ACP resume after a terminal process failure", func(t *testing.T) {
+		t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
+		runtimeHarness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+			MockAgents: []e2etest.MockAgentSpec{{
+				FixturePath:  transportMockFixturePath(t, "driver_fault_fixture.json"),
+				FixtureAgent: "faulty",
+				AgentName:    transportUDSFaultyAgent,
+			}},
+		})
 
-	created, err := runtimeHarness.CreateSession(ctx, compozycontract.CreateSessionRequest{
-		AgentName:     transportUDSFaultyAgent,
-		WorkspacePath: runtimeHarness.WorkspaceRoot,
-	})
-	if err != nil {
-		t.Fatalf("CreateSession() error = %v", err)
-	}
-	created = waitForTransportSessionActive(t, ctx, runtimeHarness, created)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
 
-	stream, err := runtimeHarness.PromptSession(ctx, created.ID, "trigger crash mid-stream")
-	if err != nil {
-		t.Fatalf("PromptSession() error = %v", err)
-	}
-	if !udsSSEContainsEvent(stream, "error") {
-		t.Fatalf("UDS prompt stream = %#v, want error event", stream)
-	}
-	waitForTransportDeadSession(t, ctx, runtimeHarness, created.ID)
-
-	clients, err := runtimeHarness.TransportClients()
-	if err != nil {
-		t.Fatalf("TransportClients() error = %v", err)
-	}
-	path := transportHarnessSessionPath(t, runtimeHarness, created.ID, "/attach")
-	assertTransportDeadSessionRejection(t, clients.HTTPClient, runtimeHarness.HTTPURL(path), nil)
-	assertTransportDeadSessionRejection(t, clients.UDSClient, runtimeHarness.UDSURL(path), nil)
-
-	promptBody, err := json.Marshal(compozycontract.SendPromptRequest{
-		Message:        "retry a dead session",
-		MessageID:      "message-dead-session-retry",
-		IdempotencyKey: "idempotency-dead-session-retry",
-	})
-	if err != nil {
-		t.Fatalf("json.Marshal(dead session prompt) error = %v", err)
-	}
-	promptPath := transportHarnessSessionPath(t, runtimeHarness, created.ID, "/prompt")
-	assertTransportDeadSessionRejection(t, clients.HTTPClient, runtimeHarness.HTTPURL(promptPath), promptBody)
-	assertTransportDeadSessionRejection(t, clients.UDSClient, runtimeHarness.UDSURL(promptPath), promptBody)
-
-	registration, ok := runtimeHarness.MockAgentRegistration(transportUDSFaultyAgent)
-	if !ok {
-		t.Fatalf("MockAgentRegistration(%q) not found", transportUDSFaultyAgent)
-	}
-	diagnostics, err := acpmock.ReadDiagnostics(registration.DiagnosticsPath)
-	if err != nil {
-		t.Fatalf("ReadDiagnostics(%q) error = %v", registration.DiagnosticsPath, err)
-	}
-	for _, diagnostic := range acpmock.ProtocolDiagnostics(
-		acpmock.DiagnosticsForCompozySession(diagnostics, created.ID),
-	) {
-		if diagnostic.ProtocolMethod == "session/load" {
-			t.Fatalf("terminal session diagnostics = %#v, want no session/load", diagnostics)
+		created, err := runtimeHarness.CreateSession(ctx, compozycontract.CreateSessionRequest{
+			AgentName:     transportUDSFaultyAgent,
+			WorkspacePath: runtimeHarness.WorkspaceRoot,
+		})
+		if err != nil {
+			t.Fatalf("CreateSession() error = %v", err)
 		}
-	}
+		created = waitForTransportSessionActive(t, ctx, runtimeHarness, created)
+
+		stream, err := runtimeHarness.PromptSession(ctx, created.ID, "trigger crash mid-stream")
+		if err != nil {
+			t.Fatalf("PromptSession() error = %v", err)
+		}
+		if !udsSSEContainsEvent(stream, "error") {
+			t.Fatalf("UDS prompt stream = %#v, want error event", stream)
+		}
+		waitForTransportDeadSession(t, ctx, runtimeHarness, created.ID)
+
+		clients, err := runtimeHarness.TransportClients()
+		if err != nil {
+			t.Fatalf("TransportClients() error = %v", err)
+		}
+		path := transportHarnessSessionPath(t, runtimeHarness, created.ID, "/attach")
+		assertTransportDeadSessionRejection(t, clients.HTTPClient, runtimeHarness.HTTPURL(path), nil)
+		assertTransportDeadSessionRejection(t, clients.UDSClient, runtimeHarness.UDSURL(path), nil)
+
+		promptBody, err := json.Marshal(compozycontract.SendPromptRequest{
+			Message:        "retry a dead session",
+			MessageID:      "message-dead-session-retry",
+			IdempotencyKey: "idempotency-dead-session-retry",
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal(dead session prompt) error = %v", err)
+		}
+		promptPath := transportHarnessSessionPath(t, runtimeHarness, created.ID, "/prompt")
+		assertTransportDeadSessionRejection(t, clients.HTTPClient, runtimeHarness.HTTPURL(promptPath), promptBody)
+		assertTransportDeadSessionRejection(t, clients.UDSClient, runtimeHarness.UDSURL(promptPath), promptBody)
+
+		registration, ok := runtimeHarness.MockAgentRegistration(transportUDSFaultyAgent)
+		if !ok {
+			t.Fatalf("MockAgentRegistration(%q) not found", transportUDSFaultyAgent)
+		}
+		diagnostics, err := acpmock.ReadDiagnostics(registration.DiagnosticsPath)
+		if err != nil {
+			t.Fatalf("ReadDiagnostics(%q) error = %v", registration.DiagnosticsPath, err)
+		}
+		for _, diagnostic := range acpmock.ProtocolDiagnostics(
+			acpmock.DiagnosticsForCompozySession(diagnostics, created.ID),
+		) {
+			if diagnostic.ProtocolMethod == "session/load" {
+				t.Fatalf("terminal session diagnostics = %#v, want no session/load", diagnostics)
+			}
+		}
+	})
 }
 
 func TestUDSTransportObserveHarnessLifecycleParityMatchesHTTP(t *testing.T) {

--- a/internal/api/udsapi/transport_parity_integration_test.go
+++ b/internal/api/udsapi/transport_parity_integration_test.go
@@ -2044,6 +2044,78 @@ func TestUDSTransportPromptFailureProjectionUsesSharedRuntimeHarness(t *testing.
 	}
 }
 
+// Invariant: terminal process-exited sessions reject every attachment path before ACP session/load.
+// Owning layer: HTTP/UDS session transport parity.
+func TestUDSTransportTerminalProcessFailureRejectsAttachAndPromptBeforeACPResume(t *testing.T) {
+	acpmock.RequireDriver(t)
+	t.Parallel()
+
+	runtimeHarness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+		MockAgents: []e2etest.MockAgentSpec{{
+			FixturePath:  transportMockFixturePath(t, "driver_fault_fixture.json"),
+			FixtureAgent: "faulty",
+			AgentName:    transportUDSFaultyAgent,
+		}},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	created, err := runtimeHarness.CreateSession(ctx, compozycontract.CreateSessionRequest{
+		AgentName:     transportUDSFaultyAgent,
+		WorkspacePath: runtimeHarness.WorkspaceRoot,
+	})
+	if err != nil {
+		t.Fatalf("CreateSession() error = %v", err)
+	}
+	created = waitForTransportSessionActive(t, ctx, runtimeHarness, created)
+
+	stream, err := runtimeHarness.PromptSession(ctx, created.ID, "trigger crash mid-stream")
+	if err != nil {
+		t.Fatalf("PromptSession() error = %v", err)
+	}
+	if !udsSSEContainsEvent(stream, "error") {
+		t.Fatalf("UDS prompt stream = %#v, want error event", stream)
+	}
+	waitForTransportDeadSession(t, ctx, runtimeHarness, created.ID)
+
+	clients, err := runtimeHarness.TransportClients()
+	if err != nil {
+		t.Fatalf("TransportClients() error = %v", err)
+	}
+	path := transportHarnessSessionPath(t, runtimeHarness, created.ID, "/attach")
+	assertTransportDeadSessionRejection(t, clients.HTTPClient, runtimeHarness.HTTPURL(path), nil)
+	assertTransportDeadSessionRejection(t, clients.UDSClient, runtimeHarness.UDSURL(path), nil)
+
+	promptBody, err := json.Marshal(compozycontract.SendPromptRequest{
+		Message:        "retry a dead session",
+		MessageID:      "message-dead-session-retry",
+		IdempotencyKey: "idempotency-dead-session-retry",
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(dead session prompt) error = %v", err)
+	}
+	promptPath := transportHarnessSessionPath(t, runtimeHarness, created.ID, "/prompt")
+	assertTransportDeadSessionRejection(t, clients.HTTPClient, runtimeHarness.HTTPURL(promptPath), promptBody)
+	assertTransportDeadSessionRejection(t, clients.UDSClient, runtimeHarness.UDSURL(promptPath), promptBody)
+
+	registration, ok := runtimeHarness.MockAgentRegistration(transportUDSFaultyAgent)
+	if !ok {
+		t.Fatalf("MockAgentRegistration(%q) not found", transportUDSFaultyAgent)
+	}
+	diagnostics, err := acpmock.ReadDiagnostics(registration.DiagnosticsPath)
+	if err != nil {
+		t.Fatalf("ReadDiagnostics(%q) error = %v", registration.DiagnosticsPath, err)
+	}
+	for _, diagnostic := range acpmock.ProtocolDiagnostics(
+		acpmock.DiagnosticsForCompozySession(diagnostics, created.ID),
+	) {
+		if diagnostic.ProtocolMethod == "session/load" {
+			t.Fatalf("terminal session diagnostics = %#v, want no session/load", diagnostics)
+		}
+	}
+}
+
 func TestUDSTransportObserveHarnessLifecycleParityMatchesHTTP(t *testing.T) {
 	acpmock.RequireDriver(t)
 	t.Parallel()
@@ -2772,6 +2844,70 @@ func waitForTransportSessionActive(
 		t.Fatalf("WaitForSessionActive(%q) error = %v; accepted=%#v", accepted.ID, err, accepted)
 	}
 	return active
+}
+
+func waitForTransportDeadSession(
+	t testing.TB,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	sessionID string,
+) {
+	t.Helper()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	path := transportHarnessSessionPath(t, harness, sessionID, "?include_health=true")
+	var last compozycontract.SessionPayload
+	var lastErr error
+	for {
+		var response compozycontract.SessionResponse
+		if err := harness.UDSJSON(waitCtx, http.MethodGet, path, nil, &response); err == nil {
+			last = response.Session
+			if last.State == session.StateStopped &&
+				last.Failure != nil && last.Failure.Kind == store.FailureProcess &&
+				last.Health != nil && last.Health.Health == compozycontract.SessionHealthDead &&
+				!last.Health.Attachable && !last.Health.EligibleForWake {
+				return
+			}
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-waitCtx.Done():
+			t.Fatalf(
+				"terminal session %q did not become dead and non-attachable: %v; last=%#v",
+				sessionID,
+				lastErr,
+				last,
+			)
+		case <-ticker.C:
+		}
+	}
+}
+
+func assertTransportDeadSessionRejection(
+	t *testing.T,
+	client *http.Client,
+	targetURL string,
+	body []byte,
+) {
+	t.Helper()
+
+	response := mustUnixRequest(t, client, http.MethodPost, targetURL, body, nil)
+	payload := readAndCloseHTTPBody(t, response)
+	if response.StatusCode != http.StatusConflict {
+		t.Fatalf("POST %s status = %d, want %d; body=%s", targetURL, response.StatusCode, http.StatusConflict, payload)
+	}
+	var failure compozycontract.ErrorPayload
+	if err := json.Unmarshal(payload, &failure); err != nil {
+		t.Fatalf("json.Unmarshal(%s) error = %v; body=%s", targetURL, err, payload)
+	}
+	if !strings.Contains(failure.Error, "not attachable") {
+		t.Fatalf("POST %s error = %q, want attachability context", targetURL, failure.Error)
+	}
 }
 
 func transportCatalogHasSingleTitle(

--- a/internal/session/manager_attach.go
+++ b/internal/session/manager_attach.go
@@ -26,6 +26,13 @@ func (m *Manager) AttachSession(
 	if m.sessionCatalog == nil {
 		return store.SessionAttach{}, errors.New("session: attach catalog is required")
 	}
+	meta, err := m.readMetaWithContext(ctx, normalized.SessionID)
+	if err != nil {
+		return store.SessionAttach{}, err
+	}
+	if err := m.rejectDeadSessionAttachment(ctx, normalized.SessionID, meta); err != nil {
+		return store.SessionAttach{}, err
+	}
 	attach, err := m.sessionCatalog.AttachSession(ctx, normalized)
 	if err != nil {
 		return store.SessionAttach{}, fmt.Errorf("session: attach %q: %w", normalized.SessionID, err)

--- a/internal/session/manager_prompt_admission.go
+++ b/internal/session/manager_prompt_admission.go
@@ -144,6 +144,9 @@ func (m *Manager) resolvePromptAdmissionTarget(
 	if err != nil {
 		return promptAdmissionTarget{}, err
 	}
+	if err := m.rejectDeadSessionAttachment(ctx, target, meta); err != nil {
+		return promptAdmissionTarget{}, err
+	}
 	resolved, err := normalizePromptRuntimeSelectionFromMeta(meta, requested)
 	if err != nil {
 		return promptAdmissionTarget{}, err

--- a/internal/session/manager_prompt_contract_test.go
+++ b/internal/session/manager_prompt_contract_test.go
@@ -3,7 +3,6 @@ package session
 import (
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -12,7 +11,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	acpsdk "github.com/coder/acp-go-sdk"
 	"github.com/compozy/compozy/internal/acp"
 	commandpkg "github.com/compozy/compozy/internal/command"
 	compozyconfig "github.com/compozy/compozy/internal/config"
@@ -369,8 +367,8 @@ func TestPromptDeadlineDeliversRuntimeWarningBeforeError(t *testing.T) {
 	}
 }
 
-func TestPromptFatalProcessFailureStopsSessionAndAllowsFreshResumeFallback(t *testing.T) {
-	t.Run("Should stop after a fatal process failure and recover with an explicit prompt", func(t *testing.T) {
+func TestPromptFatalProcessFailureStopsSessionAndPreservesReadOnlyHistory(t *testing.T) {
+	t.Run("Should stop after a fatal process failure without resuming the original session", func(t *testing.T) {
 		t.Parallel()
 
 		h := newHarness(t)
@@ -490,57 +488,17 @@ func TestPromptFatalProcessFailureStopsSessionAndAllowsFreshResumeFallback(t *te
 			t.Fatalf("stored agent message = %s, want persisted partial chunk", partial.Content)
 		}
 
-		h.driver.startHook = func(opts acp.StartOpts, sequence int) (*fakeProcess, error) {
-			if opts.ResumeSessionID != "" {
-				return nil, fmt.Errorf(
-					"%w: load session %q for %q: %w",
-					acp.ErrLoadSessionFailed,
-					opts.ResumeSessionID,
-					opts.AgentName,
-					&acpsdk.RequestError{
-						Code:    -32002,
-						Message: "Resource not found: " + opts.ResumeSessionID,
-					},
-				)
-			}
-			return newFakeProcess(opts.AgentName, opts.Command, opts.Cwd, fmt.Sprintf("acp-new-%d", sequence)), nil
-		}
-
-		resumed, err := h.manager.Resume(testutil.Context(t), session.ID)
-		if err != nil {
-			t.Fatalf("Resume() error = %v", err)
-		}
-		t.Cleanup(func() {
-			reportSessionStop(t, h, resumed.ID)
+		startsBeforeRejectedPrompt := len(h.driver.startCalls)
+		_, err = h.manager.SendPrompt(testutil.Context(t), session.ID, SendPromptOpts{
+			Message:        "retry the dead session",
+			MessageID:      "message-dead-session-retry",
+			IdempotencyKey: "idempotency-dead-session-retry",
 		})
-
-		if got := h.driver.startCalls[1].ResumeSessionID; got != originalACP {
-			t.Fatalf("first resume start ResumeSessionID = %q, want %q", got, originalACP)
+		if !errors.Is(err, store.ErrSessionNotAttachable) {
+			t.Fatalf("SendPrompt(dead session) error = %v, want ErrSessionNotAttachable", err)
 		}
-		if got := h.driver.startCalls[2].ResumeSessionID; got != "" {
-			t.Fatalf("fallback resume start ResumeSessionID = %q, want empty", got)
-		}
-		if got := resumed.Info().ACPSessionID; got == "" || got == originalACP {
-			t.Fatalf("resumed ACPSessionID = %q, want fresh ACP session id distinct from %q", got, originalACP)
-		}
-
-		h.driver.mu.Lock()
-		h.driver.promptHook = nil
-		h.driver.stopHook = nil
-		h.driver.mu.Unlock()
-		recoveryEventsCh, err := h.manager.Prompt(testutil.Context(t), resumed.ID, "continue after disconnect")
-		if err != nil {
-			t.Fatalf("Prompt(recovered session) error = %v", err)
-		}
-		recoveryEvents := collectEvents(t, recoveryEventsCh)
-		if got, want := len(recoveryEvents), 2; got != want {
-			t.Fatalf("Prompt(recovered session) events = %d, want %d", got, want)
-		}
-		if recoveryEvents[0].Type != acp.EventTypeAgentMessage || recoveryEvents[1].Type != acp.EventTypeDone {
-			t.Fatalf("Prompt(recovered session) events = %#v, want agent message then done", recoveryEvents)
-		}
-		if got, want := len(h.driver.promptCalls), 2; got != want {
-			t.Fatalf("driver prompt calls = %d, want failed prompt plus one explicit recovery prompt", got)
+		if got := len(h.driver.startCalls); got != startsBeforeRejectedPrompt {
+			t.Fatalf("dead-session Prompt() start calls = %d, want %d", got, startsBeforeRejectedPrompt)
 		}
 	})
 }

--- a/internal/session/manager_resume.go
+++ b/internal/session/manager_resume.go
@@ -128,6 +128,9 @@ func resumeTarget(id string) (string, error) {
 
 // rejectDeadSessionAttachment keeps terminal process failures out of runtime attachment paths.
 func (m *Manager) rejectDeadSessionAttachment(ctx context.Context, target string, meta store.SessionMeta) error {
+	if isUnboundLogicalResume(meta) {
+		return nil
+	}
 	if meta.Failure == nil || meta.Failure.Kind != store.FailureProcess {
 		return nil
 	}

--- a/internal/session/manager_resume.go
+++ b/internal/session/manager_resume.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/compozy/compozy/internal/acp"
+	"github.com/compozy/compozy/internal/heartbeat"
 	"github.com/compozy/compozy/internal/store"
 )
 
@@ -45,6 +46,9 @@ func (m *Manager) Resume(ctx context.Context, id string) (resumed *Session, err 
 		return nil, err
 	}
 	if err := m.requireSessionUnarchived(ctx, meta.WorkspaceID, target); err != nil {
+		return nil, err
+	}
+	if err := m.rejectDeadSessionAttachment(ctx, target, meta); err != nil {
 		return nil, err
 	}
 	return m.resumeSession(ctx, target)
@@ -120,6 +124,21 @@ func resumeTarget(id string) (string, error) {
 		return "", errors.New("session: session id is required")
 	}
 	return target, nil
+}
+
+// rejectDeadSessionAttachment keeps terminal process failures out of runtime attachment paths.
+func (m *Manager) rejectDeadSessionAttachment(ctx context.Context, target string, meta store.SessionMeta) error {
+	if meta.Failure == nil || meta.Failure.Kind != store.FailureProcess {
+		return nil
+	}
+	health, err := m.GetSessionHealth(ctx, target)
+	if err != nil {
+		return fmt.Errorf("session: read health before attachment %q: %w", target, err)
+	}
+	if health.Health != heartbeat.SessionHealthDead || health.Attachable || health.EligibleForWake {
+		return nil
+	}
+	return fmt.Errorf("%w: session %q has a dead runtime", store.ErrSessionNotAttachable, target)
 }
 
 func isUnboundLogicalResume(meta store.SessionMeta) bool {

--- a/internal/session/manager_resume_test.go
+++ b/internal/session/manager_resume_test.go
@@ -73,6 +73,34 @@ func TestResumeLoadsMetaAndPassesStoredACPSessionID(t *testing.T) {
 	})
 }
 
+func TestResumeRejectsTerminalProcessFailureBeforeStartingACP(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should keep a dead process-exited session read-only", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		const sessionID = "dead-session-resume"
+		writeStoppedSessionArtifacts(t, h, sessionID, true)
+		metaPath := store.SessionMetaFile(filepath.Join(h.homePaths.SessionsDir, sessionID))
+		meta := readMeta(t, metaPath)
+		meta.Failure = &store.SessionFailure{
+			Kind:    store.FailureProcess,
+			Summary: "Codex exited before the response completed",
+		}
+		if err := store.WriteSessionMeta(metaPath, meta); err != nil {
+			t.Fatalf("WriteSessionMeta(%q) error = %v", metaPath, err)
+		}
+
+		if _, err := h.manager.Resume(testutil.Context(t), sessionID); !errors.Is(err, store.ErrSessionNotAttachable) {
+			t.Fatalf("Resume(dead session) error = %v, want ErrSessionNotAttachable", err)
+		}
+		if got := len(h.driver.startCalls); got != 0 {
+			t.Fatalf("Resume(dead session) started ACP %d times, want 0", got)
+		}
+	})
+}
+
 func TestCreateAndResumePreserveNetworkParticipation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/session/transcript_test.go
+++ b/internal/session/transcript_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"sync"
@@ -194,6 +195,51 @@ func TestManagerTranscriptPageLogsCleanupErrorsWithoutFailingSuccessfulRead(t *t
 
 func TestManagerTranscriptProjectionReads(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Should read dead-session history repeatedly without starting ACP", func(t *testing.T) {
+		t.Parallel()
+
+		recorder := &filteringTranscriptRecorder{}
+		h := newHarness(
+			t,
+			WithStore(func(_ context.Context, _ store.SessionDBOwner, _ string) (EventRecorder, error) {
+				return recorder, nil
+			}),
+		)
+		const sessionID = "dead-session-history"
+		writeStoppedSessionArtifacts(t, h, sessionID, true)
+		metaPath := store.SessionMetaFile(filepath.Join(h.homePaths.SessionsDir, sessionID))
+		meta := readMeta(t, metaPath)
+		meta.Failure = &store.SessionFailure{
+			Kind:    store.FailureProcess,
+			Summary: "Codex exited before the response completed",
+		}
+		if err := store.WriteSessionMeta(metaPath, meta); err != nil {
+			t.Fatalf("WriteSessionMeta(%q) error = %v", metaPath, err)
+		}
+		recorder.Append(transcriptProjectionEvent(
+			t,
+			sessionID,
+			1,
+			"turn-dead",
+			acp.EventTypeAgentMessage,
+			"partial response preserved",
+		))
+
+		for range 2 {
+			page, err := h.manager.TranscriptPage(testutil.Context(t), sessionID, transcript.PageQuery{})
+			if err != nil {
+				t.Fatalf("TranscriptPage(%q) error = %v", sessionID, err)
+			}
+			messages := transcript.MessagesFromEntries(page.Entries)
+			if got := transcript.JoinUIMessageText(messages); got != "partial response preserved" {
+				t.Fatalf("TranscriptPage(%q) = %q, want preserved history", sessionID, got)
+			}
+		}
+		if got := len(h.driver.startCalls); got != 0 {
+			t.Fatalf("dead-session transcript reads started ACP %d times, want 0", got)
+		}
+	})
 
 	t.Run("Should read materialized pages without querying raw events", func(t *testing.T) {
 		t.Parallel()

--- a/packages/site/content/docs/getting-started/quick-start.mdx
+++ b/packages/site/content/docs/getting-started/quick-start.mdx
@@ -135,8 +135,9 @@ compozy session history sess_1234
 
 Stopping ends the live provider process and moves the session to `stopped`. It preserves the session
 directory, catalog record, runtime choice, and history. A later `compozy session resume sess_1234`
-is expected to fail because stopped sessions are not attachable. Send a normal prompt to restart the
-provider with the same history, or create a new session when you want a clean slate.
+is expected to fail because stopped sessions are not attachable. Send a normal prompt to restart an
+eligible stopped session with the same history. If status reports a terminal `process_exit`, keep the
+original as history, inspect its recap, and fork a new session with `compozy session new --parent sess_1234`.
 
 ## What you just proved
 

--- a/packages/site/content/docs/getting-started/web-ui.mdx
+++ b/packages/site/content/docs/getting-started/web-ui.mdx
@@ -76,8 +76,9 @@ compozy session stop sess_1234
 compozy session history sess_1234
 ```
 
-The stopped session remains visible and promptable, but it is no longer attachable until a normal
-prompt restarts its agent process.
+The stopped session remains visible. An eligible stopped session is promptable even though it is no
+longer attachable. A session with terminal `process_exit` stays readable instead; the web UI offers a
+fork that starts a new child session while keeping the original transcript and diagnostics available.
 
 ## Change the HTTP address if needed
 

--- a/packages/site/content/docs/guides/debug-a-failed-session.mdx
+++ b/packages/site/content/docs/guides/debug-a-failed-session.mdx
@@ -132,16 +132,16 @@ compozy session resume sess_1234
 ```
 
 If a user session stopped after `process_exit`, use recap, history, events, and the crash bundle to
-decide what already happened. A new explicit prompt restarts the provider under the same session ID
-and retained transcript:
+decide what already happened. The original session remains readable, but a new prompt is rejected so
+CompozyOS does not retry ACP `session/load`. Create a child session with the original as provenance:
 
 ```bash
-compozy session prompt sess_1234 "Continue from the persisted output. Do not repeat completed actions."
+compozy session new --parent sess_1234 --agent <agent-name> --workspace <workspace>
 ```
 
 CompozyOS does not automatically replay the interrupted prompt because its external effects may be
-indeterminate. Create another session only when you intentionally want a separate history or the
-stopped session is archived or not a user session.
+indeterminate. The child leaves the original transcript and diagnostics intact; use recap to carry
+the relevant context forward.
 Read [Resume Attach and Replay](/docs/sessions/resume) before treating attach refusal as a
 data-loss problem.
 

--- a/packages/site/content/docs/sessions/lifecycle.mdx
+++ b/packages/site/content/docs/sessions/lifecycle.mdx
@@ -33,12 +33,12 @@ stopping --> stopped: finalization complete`}
   caption="CompozyOS creates an active logical session without starting ACP. Its first prompt binds a runtime; stopping normally finalizes the session through `stopping`."
 />
 
-| State      | Meaning                                                                                                                                                                              | Valid live transition |
-| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- |
-| `starting` | A prompt to a stopped session is restoring the ACP process and durable provider history.                                                                                             | `starting -> active`  |
-| `active`   | CompozyOS has durably allocated the session ID, prepared its storage, and accepts prompts. Before the first prompt, its runtime is `unbound`; after binding, it can emit ACP events. | `active -> stopping`  |
-| `stopping` | CompozyOS has accepted a stop request and is draining the session toward a stopped state.                                                                                            | `stopping -> stopped` |
-| `stopped`  | Final metadata is written and the recorder is closed. Reads remain available, and a normal user prompt can restore the runtime against the same session ID and transcript.           | `stopped -> starting` |
+| State      | Meaning                                                                                                                                                                                                                                     | Valid live transition |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- |
+| `starting` | A prompt to a stopped session is restoring the ACP process and durable provider history.                                                                                                                                                    | `starting -> active`  |
+| `active`   | CompozyOS has durably allocated the session ID, prepared its storage, and accepts prompts. Before the first prompt, its runtime is `unbound`; after binding, it can emit ACP events.                                                        | `active -> stopping`  |
+| `stopping` | CompozyOS has accepted a stop request and is draining the session toward a stopped state.                                                                                                                                                   | `stopping -> stopped` |
+| `stopped`  | Final metadata is written and the recorder is closed. Reads remain available. A normal user prompt can restore an eligible stopped user session; a terminal `process_exit` remains read-only history and must be forked into a new session. | `stopped -> starting` |
 
 ## Creating a session
 

--- a/packages/site/content/docs/sessions/resume.mdx
+++ b/packages/site/content/docs/sessions/resume.mdx
@@ -27,7 +27,8 @@ eligible for an explicit holder:
 
 Use a new session when you want a clean slate. Use history, repair, and recap when the session is
 stopped and you need to understand what happened before either sending a normal prompt to continue
-it or creating new work.
+an eligible session or creating new work. A terminal `process_exit` is not eligible for a normal
+prompt; keep its durable history and create a child with `compozy session new --parent <session-id>`.
 
 ## Finding an attachable session
 
@@ -203,9 +204,10 @@ lease on the same CompozyOS session ID.
 
 ### Attach after a terminal stop
 
-Attach is intentionally refused. Inspect recap, history, status, and repair output, then send a
-normal prompt when you want CompozyOS to restore the provider history and continue the same session.
-Only normal prompt dispatch triggers that restart.
+Attach is intentionally refused. Inspect recap, history, status, and repair output. A normal prompt
+can restore an eligible stopped session. For a terminal `process_exit`, CompozyOS keeps the original
+session read-only and rejects another prompt before it can try ACP `session/load`. Create a child
+session with `compozy session new --parent <session-id>` when you need to continue separately.
 
 ### Resume does not rewrite history
 

--- a/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
+++ b/web/src/hooks/routes/__tests__/use-session-page-controls.test.tsx
@@ -187,6 +187,27 @@ describe("useSessionPageControls", () => {
     expect(result.current.isSessionRunning).toBe(false);
   });
 
+  it("Should keep a dead stopped session readable without allowing another prompt", () => {
+    const { result } = renderControls({
+      ...makeSession("stopped"),
+      failure: { kind: "process_exit", summary: "Codex exited" },
+      health: {
+        active_prompt: false,
+        agent_name: "codex-agent",
+        attachable: false,
+        eligible_for_wake: false,
+        health: "dead",
+        session_id: "sess-1",
+        state: "stopped",
+        updated_at: "2026-04-17T10:00:00Z",
+        workspace_id: WORKSPACE_ID,
+      },
+    });
+
+    expect(result.current.canPrompt).toBe(false);
+    expect(result.current.isSessionRunning).toBe(false);
+  });
+
   it("Should block clear while work is running and allow durable transcript content when idle", () => {
     routeHookMocks.auiState.thread.isRunning = true;
     routeHookMocks.transcriptMessages = [{ id: "message-1" }];

--- a/web/src/systems/os/apps/session/__tests__/session-window-content.test.tsx
+++ b/web/src/systems/os/apps/session/__tests__/session-window-content.test.tsx
@@ -1,0 +1,141 @@
+// Suite: OS session-window content
+// Invariant: a terminal process-exited session forks a child in the same workspace
+// and preserves the original as the child's durable parent.
+// Owning layer: the session-window recovery action.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Suspense } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionPayload } from "@/systems/session";
+
+const mocks = vi.hoisted(() => ({
+  forkMutation: { isPending: false, mutate: vi.fn() },
+  selectSession: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("../session-window-module-loader", () => ({
+  loadSessionThread: async () => ({ SessionThread: () => null }),
+}));
+
+vi.mock("../use-session-window-controller", () => ({
+  useSessionWindowController: () => ({
+    clearDialog: { open: false },
+    commandCatalog: [],
+    commandCatalogStatus: "ready",
+    controls: {
+      canPrompt: false,
+      isBusyInputPending: false,
+      isResuming: false,
+      isSessionRunning: false,
+      queuedPrompts: [],
+      resumeFailure: null,
+    },
+    deleteDialog: { open: false },
+    inspector: { open: false },
+    inspectorMemory: {},
+    inspectorUsage: null,
+    refreshCommandCatalog: vi.fn(),
+    renameDialog: { open: false },
+    sessionVault: { data: [], error: null, isLoading: false },
+    sidebar: {
+      collapsedAgentIds: [],
+      collapsedThreadIds: [],
+      disconnected: false,
+      onNewSession: vi.fn(),
+      onSelectSession: mocks.selectSession,
+      onToggleGroup: vi.fn(),
+      onToggleThread: vi.fn(),
+      open: false,
+      rowDeleteDialog: { open: false },
+      rowRenameDialog: { open: false },
+      sessionActions: {},
+      sessions: [],
+      toggle: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("@/systems/session", () => ({
+  hasUnrecoverableRuntime: (session: SessionPayload) =>
+    session.failure?.kind === "process_exit" && session.health?.health === "dead",
+  SessionPromptRuntimeSelector: () => null,
+  SessionResumeFailure: ({ onRetry, retryLabel }: { onRetry: () => void; retryLabel?: string }) => (
+    <button type="button" onClick={onRetry}>
+      {retryLabel}
+    </button>
+  ),
+  SessionSidebar: () => null,
+  useCreateSession: () => mocks.forkMutation,
+}));
+
+vi.mock("sonner", () => ({ toast: { error: mocks.toastError } }));
+
+import { SessionWindowContent } from "../session-window-content";
+
+const deadSession: SessionPayload = {
+  agent_name: "codex-agent",
+  archived_at: null,
+  attachable: false,
+  available_commands: [],
+  badge: "stopped",
+  created_at: "2026-08-13T12:00:00Z",
+  failure: { kind: "process_exit", summary: "Codex exited" },
+  health: {
+    active_prompt: false,
+    agent_name: "codex-agent",
+    attachable: false,
+    eligible_for_wake: false,
+    health: "dead",
+    session_id: "sess-dead",
+    state: "stopped",
+    updated_at: "2026-08-13T12:01:00Z",
+    workspace_id: "ws-alpha",
+  },
+  id: "sess-dead",
+  runtime: { selection_revision: 0, status: "unbound" },
+  state: "stopped",
+  updated_at: "2026-08-13T12:01:00Z",
+  workspace_id: "ws-alpha",
+};
+
+describe("SessionWindowContent", () => {
+  beforeEach(() => {
+    mocks.forkMutation.isPending = false;
+    mocks.forkMutation.mutate.mockReset();
+    mocks.selectSession.mockReset();
+    mocks.toastError.mockReset();
+  });
+
+  it("Should fork a dead session into its workspace and select the child", async () => {
+    render(
+      <Suspense fallback={null}>
+        <SessionWindowContent
+          agentName="codex-agent"
+          liveDataEnabled={false}
+          onDeleteSuccess={vi.fn()}
+          session={deadSession}
+          sessionId="sess-dead"
+          windowId="session:sess-dead"
+          workspaceId="ws-alpha"
+        />
+      </Suspense>
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Fork into a new session" }));
+
+    expect(mocks.forkMutation.mutate).toHaveBeenCalledWith(
+      {
+        agent_name: "codex-agent",
+        parent_session_id: "sess-dead",
+        workspace: "ws-alpha",
+      },
+      expect.objectContaining({ onError: expect.any(Function), onSuccess: expect.any(Function) })
+    );
+    const callbacks = mocks.forkMutation.mutate.mock.calls[0]?.[1];
+    const child = { ...deadSession, failure: undefined, health: undefined, id: "sess-child" };
+    callbacks?.onSuccess(child);
+
+    expect(mocks.selectSession).toHaveBeenCalledWith(child);
+  });
+});

--- a/web/src/systems/os/apps/session/session-window-content.tsx
+++ b/web/src/systems/os/apps/session/session-window-content.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense } from "react";
+import { toast } from "sonner";
 
 import { loadSessionThread } from "./session-window-module-loader";
 import { useSessionWindowController } from "./use-session-window-controller";
@@ -7,6 +8,8 @@ import {
   SessionPromptRuntimeSelector,
   SessionResumeFailure,
   SessionSidebar,
+  hasUnrecoverableRuntime,
+  useCreateSession,
 } from "@/systems/session";
 
 const SessionThread = lazy(() =>
@@ -76,6 +79,23 @@ export function SessionWindowContent({
     commandCatalogStatus,
     refreshCommandCatalog,
   } = page;
+  const forkSession = useCreateSession();
+
+  const handleForkDeadSession = () => {
+    forkSession.mutate(
+      {
+        agent_name: session.agent_name,
+        parent_session_id: sessionId,
+        workspace: workspaceId,
+      },
+      {
+        onError: error => {
+          toast.error(error instanceof Error ? error.message : "Failed to fork session.");
+        },
+        onSuccess: sidebar.onSelectSession,
+      }
+    );
+  };
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
@@ -102,6 +122,19 @@ export function SessionWindowContent({
             onDismiss={controls.handleDismissResumeFailure}
             onRetry={controls.handleResume}
             sessionId={sessionId}
+          />
+        ) : hasUnrecoverableRuntime(session) ? (
+          <SessionResumeFailure
+            agentName={agentName}
+            isRetrying={forkSession.isPending}
+            message="This provider runtime cannot be resumed. Its original transcript and failure details remain available here."
+            missingProvider={null}
+            onDismiss={() => undefined}
+            onRetry={handleForkDeadSession}
+            retryLabel="Fork into a new session"
+            sessionId={sessionId}
+            showDismiss={false}
+            title="Runtime unavailable"
           />
         ) : null}
         <SessionThread

--- a/web/src/systems/session/adapters/__tests__/session-api.test.ts
+++ b/web/src/systems/session/adapters/__tests__/session-api.test.ts
@@ -257,6 +257,26 @@ describe("createSession", () => {
     });
   });
 
+  it("preserves parent session provenance when creating a recovery fork", async () => {
+    mockJsonResponse({ session: mockSession });
+
+    await createSession({
+      agent_name: "codex-agent",
+      parent_session_id: "sess-dead",
+      workspace: "ws_alpha",
+    });
+
+    await expectFetchRequest({
+      body: {
+        agent_name: "codex-agent",
+        parent_session_id: "sess-dead",
+        workspace: "ws_alpha",
+      },
+      method: "POST",
+      path: "/api/sessions",
+    });
+  });
+
   it("sends workspace_path when creating from an explicit path", async () => {
     mockJsonResponse({ session: mockSession });
 
@@ -299,7 +319,9 @@ describe("fetchSession", () => {
     const result = await fetchSession(WORKSPACE_ID, "sess-001");
 
     expect(result).toEqual(mockSession);
-    await expectFetchRequest({ path: "/api/workspaces/ws_alpha/sessions/sess-001" });
+    await expectFetchRequest({
+      path: "/api/workspaces/ws_alpha/sessions/sess-001?include_health=true",
+    });
   });
 
   it("throws 404 error for unknown session", async () => {
@@ -315,7 +337,9 @@ describe("fetchSession", () => {
 
     await fetchSession(WORKSPACE_ID, "id with spaces");
 
-    await expectFetchRequest({ path: "/api/workspaces/ws_alpha/sessions/id%20with%20spaces" });
+    await expectFetchRequest({
+      path: "/api/workspaces/ws_alpha/sessions/id%20with%20spaces?include_health=true",
+    });
   });
 });
 

--- a/web/src/systems/session/adapters/session-api.ts
+++ b/web/src/systems/session/adapters/session-api.ts
@@ -79,7 +79,10 @@ export async function fetchSession(
   const { data, error, response } = await apiClient.GET(
     "/api/workspaces/{workspace_id}/sessions/{session_id}",
     {
-      params: { path: { workspace_id: workspaceId, session_id: id } },
+      params: {
+        path: { workspace_id: workspaceId, session_id: id },
+        query: { include_health: true },
+      },
       signal,
     }
   );

--- a/web/src/systems/session/components/__tests__/session-resume-failure.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-resume-failure.test.tsx
@@ -51,6 +51,33 @@ describe("SessionResumeFailure", () => {
     expect(screen.queryByTestId("session-resume-failure-provider")).not.toBeInTheDocument();
   });
 
+  it("renders a dead runtime as read-only history with a fork action", () => {
+    render(
+      <SessionResumeFailure
+        isRetrying={false}
+        message="This provider runtime cannot be resumed. Its original transcript and failure details remain available here."
+        missingProvider={null}
+        onDismiss={vi.fn()}
+        onRetry={vi.fn()}
+        retryLabel="Fork into a new session"
+        sessionId="sess_dead"
+        showDismiss={false}
+        title="Runtime unavailable"
+      />
+    );
+
+    expect(screen.getByTestId("session-resume-failure-title")).toHaveTextContent(
+      "Runtime unavailable"
+    );
+    expect(screen.getByTestId("session-resume-failure-message")).toHaveTextContent(
+      "original transcript and failure details remain available here"
+    );
+    expect(screen.getByTestId("session-resume-failure-retry")).toHaveTextContent(
+      "Fork into a new session"
+    );
+    expect(screen.queryByTestId("session-resume-failure-dismiss")).not.toBeInTheDocument();
+  });
+
   it("falls back to the raw message when the provider detail is only whitespace", () => {
     render(
       <SessionResumeFailure

--- a/web/src/systems/session/components/session-resume-failure.tsx
+++ b/web/src/systems/session/components/session-resume-failure.tsx
@@ -13,13 +13,16 @@ export interface SessionResumeFailureProps {
   isRetrying: boolean;
   onRetry: () => void;
   onDismiss: () => void;
+  title?: string;
+  retryLabel?: string;
+  showDismiss?: boolean;
 }
 
 /**
  * The ONE banner the transcript budget allows — a session-level failure above
  * the transcript: 28% danger hairline on a 4% wash, plain body sentences (the
  * session id, provider, and agent read as text, never id pills), and the
- * retry/dismiss pair on the right.
+ * recovery actions on the right.
  */
 export function SessionResumeFailure({
   sessionId,
@@ -29,11 +32,15 @@ export function SessionResumeFailure({
   isRetrying,
   onRetry,
   onDismiss,
+  title,
+  retryLabel = "Retry attach",
+  showDismiss = true,
 }: SessionResumeFailureProps) {
   const normalizedMissingProvider = missingProvider?.trim() ?? "";
   const normalizedAgentName = agentName?.trim() ?? "";
   const hasProviderDetail = normalizedMissingProvider.length > 0;
-  const title = hasProviderDetail ? "Attach failed: provider no longer available" : "Attach failed";
+  const resolvedTitle =
+    title ?? (hasProviderDetail ? "Attach failed: provider no longer available" : "Attach failed");
 
   const handleEscape = useEffectEvent((event: KeyboardEvent) => {
     if (event.key !== "Escape" || event.defaultPrevented) return;
@@ -49,7 +56,7 @@ export function SessionResumeFailure({
     <SessionDangerBanner
       data-testid="session-resume-failure"
       className="mt-3 mb-1 w-full"
-      title={<span data-testid="session-resume-failure-title">{title}</span>}
+      title={<span data-testid="session-resume-failure-title">{resolvedTitle}</span>}
     >
       <p data-testid="session-resume-failure-message" className="text-transcript-body text-muted">
         {hasProviderDetail
@@ -74,18 +81,20 @@ export function SessionResumeFailure({
           ) : (
             <RefreshCw aria-hidden="true" className="size-3" />
           )}
-          Retry attach
+          {retryLabel}
         </Button>
-        <Button
-          data-testid="session-resume-failure-dismiss"
-          onClick={onDismiss}
-          size="sm"
-          type="button"
-          variant="ghost"
-        >
-          <X aria-hidden="true" className="size-3" />
-          Dismiss
-        </Button>
+        {showDismiss ? (
+          <Button
+            data-testid="session-resume-failure-dismiss"
+            onClick={onDismiss}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            <X aria-hidden="true" className="size-3" />
+            Dismiss
+          </Button>
+        ) : null}
       </div>
     </SessionDangerBanner>
   );

--- a/web/src/systems/session/index.ts
+++ b/web/src/systems/session/index.ts
@@ -189,6 +189,7 @@ export {
 } from "./hooks/use-session-inputs";
 export {
   canPromptSession,
+  hasUnrecoverableRuntime,
   hasRunningSession,
   idleAttachableAgentNames,
   isSessionRunning,

--- a/web/src/systems/session/lib/session-running.ts
+++ b/web/src/systems/session/lib/session-running.ts
@@ -66,7 +66,26 @@ export function isUserControllableSession(session: SessionPayload): boolean {
   return (session.type ?? "user") === "user";
 }
 
+/**
+ * A process-exited session has durable history but no ACP peer to resume.
+ * Health alone cannot identify this state: intentionally stopped sessions are
+ * also reported as dead until they are resumed.
+ */
+export function hasUnrecoverableRuntime(session: SessionPayload): boolean {
+  const health = session.health;
+  return (
+    session.state === "stopped" &&
+    session.failure?.kind === "process_exit" &&
+    health?.health === "dead" &&
+    !health.attachable &&
+    !health.eligible_for_wake
+  );
+}
+
 export function canPromptSession(session: SessionPayload): boolean {
+  if (hasUnrecoverableRuntime(session)) {
+    return false;
+  }
   return (
     isUserControllableSession(session) &&
     session.archived_at === null &&


### PR DESCRIPTION
## Root cause

A terminal ACP process failure left the persisted transcript intact, but resume paths still attempted runtime attachment. Prompt admission and explicit attach could reach ACP `session/load`, turning a recoverable dead runtime into an internal error. Repeated transcript reads also risked coupling history access to runtime recovery.

## Solution

- Centralized dead-runtime admission in the shared resume/attach owner, before ACP startup or `session/load`.
- Kept persisted transcript projection independent from runtime attachment; dead sessions remain readable.
- Returned the existing not-attachable conflict contract for HTTP and UDS prompt/attach operations.
- Preserved unbound logical resumes, which do not require an ACP attachment.
- Made the session UI truthful: durable history remains visible, sending is disabled, and users can fork a new child session.
- Added the missing default-agent configuration validation baseline from `fc11be1f` as `cd342a33`.

## Verification

- `go test -race -count=1 ./internal/config ./internal/cli`
- `go test -race -count=1 ./internal/session -run 'TestResumeRejectsTerminalProcessFailureBeforeStartingACP|TestPromptFatalProcessFailureStopsSessionAndPreservesReadOnlyHistory|TestManagerTranscriptProjectionReads'` — 9 passed.
- `go test -race -count=1 -tags=integration ./internal/api/udsapi -run TestUDSTransportTerminalProcessFailureRejectsAttachAndPromptBeforeACPResume` — 1 passed.

The final local `make gate-full` was intentionally not rerun after the corrected baseline, per execution direction; CI owns the full gate for this PR.

## QA

- Scenario: `docs/qa/scenarios/RT-acp-stream-disconnect-recovery.md`
- Journey: `docs/qa/journeys/J-dead-session-history-recovery.md`
- Report: `docs/qa/reports/2026-08-13-issue-365-dead-session.md`
- Isolated lab teardown: `qa-artifacts/qa/teardown.json` reports `clean: true` with no survivors.

## Compozy Impact Audit

- Native tools: no `compozy__*` IDs, toolsets, descriptors, schemas, digests, or capability gates changed; checked CLI, HTTP, UDS, and diagnostics error surfaces.
- Extensibility and hooks: no extensions, hooks, skills/capabilities, registries, bridge SDKs, MCP sidecars, or config.toml keys changed. The baseline only tightens invalid default-agent validation.
- Workspace data isolation: session-scoped behavior remains workspace-bound; HTTP/UDS attach and prompt keep existing workspace validation, and UI fork creation retains the workspace and parent-session lineage.
- Official Compozy skill: no update required; public tools, hooks, capabilities, memory, and network semantics are unchanged.

Closes #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the option to fork an unrecoverable session into a new session, preserving its agent, workspace, and history context.
  - Added clearer recovery messaging and customizable recovery actions.
- **Bug Fixes**
  - Dead sessions now remain readable as history while preventing new prompts, attachments, or automatic recovery attempts.
  - Improved handling of terminal process failures across session transports.
- **Tests**
  - Added coverage for dead-session behavior, transcript preservation, transport rejection, and recovery forks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->