### PR TITLE
fix: bound session prompt payloads

### DIFF
--- a/web/src/systems/session/lib/__tests__/session-prompt-chat-transport.test.ts
+++ b/web/src/systems/session/lib/__tests__/session-prompt-chat-transport.test.ts
@@ -8,6 +8,12 @@ const userMessage = (id: string, text = "Continue the durable transcript") => ({
   role: "user" as const,
 });
 
+const assistantMessage = (id: string, text: string) => ({
+  id,
+  parts: [{ text, type: "text" as const }],
+  role: "assistant" as const,
+});
+
 function streamResponse() {
   return new Response(
     [
@@ -22,6 +28,31 @@ function streamResponse() {
 }
 
 describe("session prompt chat transport", () => {
+  it("sends only the latest user message when the durable transcript exceeds the API body limit", async () => {
+    const fetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () => streamResponse()
+    );
+    const transport = createSessionPromptChatTransport({ api: "/prompt", fetch });
+    const latest = userMessage("message-latest", "Continue with the next task.");
+
+    await transport.sendMessages({
+      abortSignal: undefined,
+      chatId: "session-001",
+      messageId: undefined,
+      messages: [
+        userMessage("message-old"),
+        assistantMessage("message-large", "x".repeat(4 * 1024 * 1024)),
+        latest,
+      ],
+      trigger: "submit-message",
+    });
+
+    const serializedBody = String(fetch.mock.calls[0]?.[1]?.body);
+    const body = JSON.parse(serializedBody) as Record<string, unknown>;
+    expect(body).toMatchObject({ message_id: "message-latest", messages: [latest] });
+    expect(serializedBody.length).toBeLessThan(1024);
+  });
+
   it("sends the optimistic user id as message_id and retains one idempotency key for retries", async () => {
     const fetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
       async () => streamResponse()

--- a/web/src/systems/session/lib/session-prompt-chat-transport.ts
+++ b/web/src/systems/session/lib/session-prompt-chat-transport.ts
@@ -52,7 +52,7 @@ export function createSessionPromptChatTransport({
       const body: SessionPromptRequestBody = {
         idempotency_key: idempotencyKey,
         message_id: messageId,
-        messages,
+        messages: [message],
         ...(runtime ? { runtime } : {}),
       };
       return { body };


### PR DESCRIPTION
## Summary

- send only the newest authored user message from the Web session transport
- keep the durable `message_id`, runtime snapshot, and retry idempotency behavior unchanged
- add a regression test with a historical transcript larger than the daemon's 4 MiB API body limit

## Root cause

The session chat transport selected the latest user message for identity, but serialized the entire `messages` transcript into every prompt request. Once the transcript crossed the daemon's fixed API request-body limit, even a tiny follow-up was rejected with HTTP 413 before reaching the ACP provider.

Session history is already durable and the prompt endpoint extracts one newly authored user message, so resending historical UI messages is unnecessary.

## Validation

- `bun run --cwd web test:raw src/systems/session/lib/__tests__/session-prompt-chat-transport.test.ts` — 5 passed
- `bun run --cwd web typecheck:raw` — passed
- `bunx oxfmt --check web/src/systems/session/lib/session-prompt-chat-transport.ts web/src/systems/session/lib/__tests__/session-prompt-chat-transport.test.ts` — passed
- `bunx oxlint --deny-warnings web/src/systems/session/lib/session-prompt-chat-transport.ts web/src/systems/session/lib/__tests__/session-prompt-chat-transport.test.ts` — passed
- `git diff --check` — passed

The full Web test run was also attempted. It reported two unrelated existing failures in `e2e/fixtures/__tests__/runtime.test.ts` and then did not terminate, so it was interrupted. No files involved in those failures are changed here.

Fixes #399
