### PR TITLE
fix: clarify missing config path errors

### DIFF
--- a/docs/superpowers/plans/2026-08-13-config-path-error-message.md
+++ b/docs/superpowers/plans/2026-08-13-config-path-error-message.md
@@ -56,9 +56,9 @@ Expected: both new assertions fail with `tool not found` in the actual message.
 
 - [ ] **Step 3: Implement the minimal reason-aware selector**
 
-Pass `ToolError.ReasonCodes` into `safeToolErrorMessage`. Before the existing code switch, return
-`config path not found` when the reasons contain `ReasonConfigPathNotFound`. Pass `nil` reasons for
-code-only fallback paths. Do not change any other message.
+Pass `ToolError.ReasonCodes` into `safeToolErrorMessage`. Within the `ErrorCodeNotFound` case, return
+`config path not found` when the reasons contain `ReasonConfigPathNotFound`; otherwise retain
+`tool not found`. Pass `nil` reasons for code-only fallback paths. Do not change any other message.
 
 - [ ] **Step 4: Run tests to verify GREEN**
 

--- a/docs/superpowers/plans/2026-08-13-config-path-error-message.md
+++ b/docs/superpowers/plans/2026-08-13-config-path-error-message.md
@@ -1,0 +1,145 @@
+# Config Path Error Message Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every managed agent receive an unambiguous provider-visible message when `compozy__config_get` reads an absent path.
+
+**Architecture:** Fix the safe public message at the HTTP/UDS tool-error serialization boundary by allowing the existing selector to inspect deterministic reasons. Keep the hosted MCP formatter generic and verify that it projects the corrected transport payload without an extension-specific branch.
+
+**Tech Stack:** Go 1.26, Gin HTTP/UDS handlers, Compozy tool contracts, Go MCP SDK, daemon integration tests.
+
+## Global Constraints
+
+- Preserve `tool_not_found`, `config_path_not_found`, HTTP 404, ToolIDs, and all schemas.
+- Never expose internal error text.
+- Do not add an extension-specific or Batuta-specific fallback.
+- Use named `Should...` subtests and run changed Go behavior under the race detector.
+- Open the English issue before the first commit; issue #394 satisfies this requirement.
+
+---
+
+### Task 1: Reason-aware public tool error
+
+**Files:**
+- Modify: `internal/api/core/tools_test.go`
+- Modify: `internal/mcp/hosted_proxy_test.go`
+- Modify: `internal/api/core/tool_errors.go`
+
+**Interfaces:**
+- Consumes: `tools.ToolError{Code, ReasonCodes}` and `core.ToolErrorResponseForError(error, int, bool)`.
+- Produces: `safeToolErrorMessage(status int, code tools.ErrorCode, reasons []tools.ReasonCode) string` behavior consumed by HTTP/UDS serialization and the existing hosted MCP proxy.
+
+- [ ] **Step 1: Write the failing transport tests**
+
+Add a `TestToolErrorResponses/Should describe a missing config path without reporting the tool missing`
+case that constructs a `ToolError` with `ErrorCodeNotFound` and
+`ReasonConfigPathNotFound`. Assert HTTP 404, unchanged code/reason, message
+`config path not found`, and absence of `tool not found`.
+
+Add a hosted proxy case that builds the response through `core.ToolErrorResponseForError`, wraps it
+in the existing `hostedToolResponseError`, and expects exactly
+`config_path_not_found: config path not found`.
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+mise exec -- go test ./internal/api/core ./internal/mcp -run 'Test(ToolErrorResponses|HostedProxy)' -count=1
+```
+
+Expected: both new assertions fail with `tool not found` in the actual message.
+
+- [ ] **Step 3: Implement the minimal reason-aware selector**
+
+Pass `ToolError.ReasonCodes` into `safeToolErrorMessage`. Before the existing code switch, return
+`config path not found` when the reasons contain `ReasonConfigPathNotFound`. Pass `nil` reasons for
+code-only fallback paths. Do not change any other message.
+
+- [ ] **Step 4: Run tests to verify GREEN**
+
+Run:
+
+```bash
+mise exec -- env CGO_ENABLED=1 go test -race ./internal/api/core ./internal/mcp -run 'Test(ToolErrorResponses|HostedProxy)' -count=1
+```
+
+Expected: PASS with no warnings.
+
+### Task 2: Managed extension-session regression
+
+**Files:**
+- Modify: `internal/daemon/daemon_extension_agent_fixture_e2e_integration_test.go`
+- Modify: `skills/compozy/references/configuration.md`
+
+**Interfaces:**
+- Consumes: the real hosted MCP client bound to an extension-published managed agent.
+- Produces: an end-to-end assertion that the provider sees the exact reason/message pair for a neutral absent config path.
+
+- [ ] **Step 1: Strengthen the existing E2E assertion**
+
+Replace the Batuta-named absent path with `loops.inputs.extension-probe.preference`. Extend the
+helper assertion so the config call requires the exact text
+`config_path_not_found: config path not found` and rejects `tool not found`; keep the existing
+reason-only behavior for unrelated workspace-fence assertions.
+
+- [ ] **Step 2: Verify the E2E would fail without Task 1**
+
+Use the pre-fix commit or the recorded Task 1 RED output to establish that the real hosted result is
+`config_path_not_found: tool not found`. Do not revert production code only to manufacture a second
+RED run.
+
+- [ ] **Step 3: Run the real hosted MCP E2E**
+
+Run:
+
+```bash
+mise exec -- env CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EExtensionPublishedAgentSessionCommandsAndPrompt$' -count=1 -v
+```
+
+Expected: PASS; the extension-published agent session lists and invokes the real config tool and
+receives the exact non-contradictory message.
+
+- [ ] **Step 4: Update the official skill**
+
+Document that an absent key yields `config_path_not_found` with `config path not found`, after which
+the caller may set and structurally reread the same path. Use no extension or workflow name.
+
+### Task 3: Final verification and review preparation
+
+**Files:**
+- Verify all files changed by Tasks 1 and 2.
+
+**Interfaces:**
+- Consumes: final branch diff.
+- Produces: reviewable local commits and evidence for a future PR closing #394.
+
+- [ ] **Step 1: Run formatting, focused race, and contract checks**
+
+```bash
+make fmt-check
+mise exec -- env CGO_ENABLED=1 go test -race ./internal/api/core ./internal/mcp -count=1
+make codegen-check
+git diff --check
+```
+
+- [ ] **Step 2: Run deslop and inspect the full diff**
+
+Confirm no duplicated formatter, prompt workaround, generated contract churn, or unrelated refactor
+entered the branch.
+
+- [ ] **Step 3: Build and run the repository gate**
+
+```bash
+mise exec -- make build
+mise exec -- make gate-full
+make gate-status
+```
+
+Record exact failures without weakening tests; compare suspected baseline failures against a clean
+`upstream/main` worktree.
+
+- [ ] **Step 4: Commit using repository conventions**
+
+Stage only intended paths and create unscoped English conventional commits. Do not push or open a PR
+until the user asks after reviewing the final evidence.

--- a/docs/superpowers/plans/2026-08-13-config-path-error-message.md
+++ b/docs/superpowers/plans/2026-08-13-config-path-error-message.md
@@ -29,6 +29,10 @@
 - Consumes: `tools.ToolError{Code, ReasonCodes}` and `core.ToolErrorResponseForError(error, int, bool)`.
 - Produces: `safeToolErrorMessage(status int, code tools.ErrorCode, reasons []tools.ReasonCode) string` behavior consumed by HTTP/UDS serialization and the existing hosted MCP proxy.
 
+**Web/Docs Impact:**
+- Web: no route, component, hook, or generated client change; the existing HTTP/UDS error envelope keeps its schema and only corrects the safe message for an existing reason.
+- Docs: no `packages/site` change; the operator-facing configuration surface is unchanged, while managed-agent guidance is updated in the official skill in Task 2.
+
 - [ ] **Step 1: Write the failing transport tests**
 
 Add a `TestToolErrorResponses/Should describe a missing config path without reporting the tool missing`
@@ -36,8 +40,8 @@ case that constructs a `ToolError` with `ErrorCodeNotFound` and
 `ReasonConfigPathNotFound`. Assert HTTP 404, unchanged code/reason, message
 `config path not found`, and absence of `tool not found`.
 
-Add a hosted proxy case that builds the response through `core.ToolErrorResponseForError`, wraps it
-in the existing `hostedToolResponseError`, and expects exactly
+Add a hosted proxy case that constructs the serialized `contract.ToolErrorResponse` fixture at the
+MCP boundary, wraps it in the existing `hostedToolResponseError`, and expects exactly
 `config_path_not_found: config path not found`.
 
 - [ ] **Step 2: Run tests to verify RED**
@@ -75,6 +79,10 @@ Expected: PASS with no warnings.
 **Interfaces:**
 - Consumes: the real hosted MCP client bound to an extension-published managed agent.
 - Produces: an end-to-end assertion that the provider sees the exact reason/message pair for a neutral absent config path.
+
+**Web/Docs Impact:**
+- Web: no route, component, or hook change; the existing managed-session flow is exercised through the hosted MCP transport.
+- Docs: update `skills/compozy/references/configuration.md`; no `packages/site` change because no operator workflow, configuration key, or schema changes.
 
 - [ ] **Step 1: Strengthen the existing E2E assertion**
 

--- a/docs/superpowers/specs/2026-08-13-config-path-error-message-design.md
+++ b/docs/superpowers/specs/2026-08-13-config-path-error-message-design.md
@@ -29,13 +29,15 @@ own explicitly reviewed mapping in a future change. Internal error strings remai
 ## Implementation
 
 Extend the existing safe-message selector in `internal/api/core/tool_errors.go` to receive reason
-codes. It checks for the one public reason-specific mapping before falling back to the existing
-error-code switch. This fixes the source transport envelope; the hosted MCP proxy already combines
-the primary reason with that public message and needs no production special case.
+codes. The error-code switch remains authoritative, and its `ErrorCodeNotFound` case uses the one
+public reason-specific mapping before falling back to `tool not found`. This fixes the source
+transport envelope; the hosted MCP proxy already combines the primary reason with that public
+message and needs no production special case.
 
 ## Verification
 
 - A core API test proves the stable code, reason, status, and reason-aware message.
+- A core API test proves that a mismatched reason cannot override another error code.
 - A hosted MCP proxy test passes the real serialized response through the existing projection and
   asserts the exact provider-visible text.
 - The existing extension-agent daemon E2E uses a neutral absent Loop-input path, asserts the exact

--- a/docs/superpowers/specs/2026-08-13-config-path-error-message-design.md
+++ b/docs/superpowers/specs/2026-08-13-config-path-error-message-design.md
@@ -1,0 +1,57 @@
+# Config Path Error Message Design
+
+## Problem
+
+`compozy__config_get` correctly classifies an absent configuration entry with the public
+`config_path_not_found` reason, but the HTTP/UDS tool-error serializer chooses its safe message only
+from the broader `tool_not_found` code. The hosted MCP proxy then exposes the contradictory text
+`config_path_not_found: tool not found` to managed agents. Any authored, packaged, or
+extension-published agent can therefore mistake an absent value for a missing tool.
+
+Issue: [#394](https://github.com/compozy/compozy/issues/394).
+
+## Contract
+
+An absent path keeps the existing envelope:
+
+- error code: `tool_not_found`;
+- reason code: `config_path_not_found`;
+- HTTP status: `404`;
+- ToolID and HTTP/UDS/MCP schemas: unchanged.
+
+Only the safe public message becomes reason-aware. For `config_path_not_found`, transports expose
+`config path not found`; the hosted MCP result therefore becomes
+`config_path_not_found: config path not found`. It must not contain `tool not found`.
+
+Every other reason continues to use the existing code-derived safe message unless it receives its
+own explicitly reviewed mapping in a future change. Internal error strings remain masked.
+
+## Implementation
+
+Extend the existing safe-message selector in `internal/api/core/tool_errors.go` to receive reason
+codes. It checks for the one public reason-specific mapping before falling back to the existing
+error-code switch. This fixes the source transport envelope; the hosted MCP proxy already combines
+the primary reason with that public message and needs no production special case.
+
+## Verification
+
+- A core API test proves the stable code, reason, status, and reason-aware message.
+- A hosted MCP proxy test passes the real serialized response through the existing projection and
+  asserts the exact provider-visible text.
+- The existing extension-agent daemon E2E uses a neutral absent Loop-input path, asserts the exact
+  hosted MCP result, and forbids `tool not found`.
+- Existing tool-error tests prove unrelated codes retain their current messages.
+
+## Impact
+
+- Native tools: no ToolID, descriptor, schema, risk, capability, or reason-code change.
+- Extensibility: every installed extension receives the same corrected hosted error; no
+  extension-specific behavior is introduced.
+- Workspace isolation: unchanged; the existing session workspace binding remains authoritative.
+- Config lifecycle: no configuration value is written or renamed.
+- Web and generated contracts: unchanged.
+
+## Out of Scope
+
+No new public code or reason, no prompt workaround, no Batuta-specific fallback, and no general
+rewrite of tool-error messages.

--- a/internal/api/core/tool_errors.go
+++ b/internal/api/core/tool_errors.go
@@ -111,9 +111,9 @@ func ToolErrorResponseForError(err error, status int, maskInternal bool) contrac
 		payload.Message = http.StatusText(status)
 	} else if toolErr, ok := errors.AsType[*toolspkg.ToolError](err); ok {
 		payload.Code = toolErr.Code
-		payload.Message = safeToolErrorMessage(status, toolErr.Code)
 		payload.ToolID = toolErr.ToolID
 		payload.ReasonCodes = append([]toolspkg.ReasonCode(nil), toolErr.ReasonCodes...)
+		payload.Message = safeToolErrorMessage(status, toolErr.Code, payload.ReasonCodes)
 		payload.Layer = toolErrorLayer(toolErr.ReasonCodes)
 		payload.Details = contract.ToolOperatorFailureDetails(toolErr.Operator)
 		if toolErr.PartialResult != nil {
@@ -122,11 +122,11 @@ func ToolErrorResponseForError(err error, status int, maskInternal bool) contrac
 		}
 	} else {
 		payload.Code = toolErrorCodeForStatus(status)
-		payload.Message = safeToolErrorMessage(status, payload.Code)
 		if reason, ok := toolspkg.ReasonOf(err); ok {
 			payload.ReasonCodes = []toolspkg.ReasonCode{reason}
 			payload.Layer = toolErrorLayer(payload.ReasonCodes)
 		}
+		payload.Message = safeToolErrorMessage(status, payload.Code, payload.ReasonCodes)
 	}
 	if maskInternal && status >= http.StatusInternalServerError &&
 		payload.Code != toolspkg.ErrorCodeResultPersistenceFailed {
@@ -138,7 +138,10 @@ func ToolErrorResponseForError(err error, status int, maskInternal bool) contrac
 	return contract.ToolErrorResponse{Error: payload}
 }
 
-func safeToolErrorMessage(status int, code toolspkg.ErrorCode) string {
+func safeToolErrorMessage(status int, code toolspkg.ErrorCode, reasons []toolspkg.ReasonCode) string {
+	if slices.Contains(reasons, toolspkg.ReasonConfigPathNotFound) {
+		return "config path not found"
+	}
 	switch code {
 	case toolspkg.ErrorCodeNotFound:
 		return "tool not found"

--- a/internal/api/core/tool_errors.go
+++ b/internal/api/core/tool_errors.go
@@ -139,11 +139,11 @@ func ToolErrorResponseForError(err error, status int, maskInternal bool) contrac
 }
 
 func safeToolErrorMessage(status int, code toolspkg.ErrorCode, reasons []toolspkg.ReasonCode) string {
-	if slices.Contains(reasons, toolspkg.ReasonConfigPathNotFound) {
-		return "config path not found"
-	}
 	switch code {
 	case toolspkg.ErrorCodeNotFound:
+		if slices.Contains(reasons, toolspkg.ReasonConfigPathNotFound) {
+			return "config path not found"
+		}
 		return "tool not found"
 	case toolspkg.ErrorCodeConflict:
 		return "tool conflict"

--- a/internal/api/core/tools_test.go
+++ b/internal/api/core/tools_test.go
@@ -321,6 +321,28 @@ func TestToolErrorResponses(t *testing.T) {
 		}
 	})
 
+	t.Run("Should let the error code control the message before a mismatched reason", func(t *testing.T) {
+		t.Parallel()
+
+		err := toolspkg.NewToolError(
+			toolspkg.ErrorCodeBackendFailed,
+			toolspkg.ToolIDConfigGet,
+			"backend failed",
+			toolspkg.ErrToolBackendFailed,
+			toolspkg.ReasonConfigPathNotFound,
+		)
+		status := core.StatusForToolError(err)
+		payload := core.ToolErrorResponseForError(err, status, false)
+
+		if status != http.StatusBadGateway || payload.Error.Message != "tool backend failed" {
+			t.Fatalf(
+				"mismatched reason payload = %#v status=%d, want code-specific backend failure",
+				payload.Error,
+				status,
+			)
+		}
+	})
+
 	t.Run("Should sanitize cross workspace denial details", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/api/core/tools_test.go
+++ b/internal/api/core/tools_test.go
@@ -311,6 +311,7 @@ func TestToolErrorResponses(t *testing.T) {
 
 		if status != http.StatusNotFound ||
 			payload.Error.Code != toolspkg.ErrorCodeNotFound ||
+			payload.Error.ToolID != toolspkg.ToolIDConfigGet ||
 			payload.Error.Message != "config path not found" ||
 			!slices.Equal(payload.Error.ReasonCodes, []toolspkg.ReasonCode{toolspkg.ReasonConfigPathNotFound}) {
 			t.Fatalf("missing config payload = %#v status=%d, want reason-aware 404", payload.Error, status)

--- a/internal/api/core/tools_test.go
+++ b/internal/api/core/tools_test.go
@@ -296,6 +296,30 @@ func TestToolArtifactHandlersPreserveWorkspaceScopeAndExactPages(t *testing.T) {
 func TestToolErrorResponses(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should describe a missing config path without reporting the tool missing", func(t *testing.T) {
+		t.Parallel()
+
+		err := toolspkg.NewToolError(
+			toolspkg.ErrorCodeNotFound,
+			toolspkg.ToolIDConfigGet,
+			`config path "loops.inputs.extension-probe.preference" not found`,
+			toolspkg.ErrToolNotFound,
+			toolspkg.ReasonConfigPathNotFound,
+		)
+		status := core.StatusForToolError(err)
+		payload := core.ToolErrorResponseForError(err, status, true)
+
+		if status != http.StatusNotFound ||
+			payload.Error.Code != toolspkg.ErrorCodeNotFound ||
+			payload.Error.Message != "config path not found" ||
+			!slices.Equal(payload.Error.ReasonCodes, []toolspkg.ReasonCode{toolspkg.ReasonConfigPathNotFound}) {
+			t.Fatalf("missing config payload = %#v status=%d, want reason-aware 404", payload.Error, status)
+		}
+		if strings.Contains(payload.Error.Message, "tool not found") {
+			t.Fatalf("missing config message = %q, must not identify the tool as missing", payload.Error.Message)
+		}
+	})
+
 	t.Run("Should sanitize cross workspace denial details", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/daemon_extension_agent_fixture_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_agent_fixture_e2e_integration_test.go
@@ -247,17 +247,23 @@ func assertExtensionHostedMCPTools(
 	if !ok {
 		t.Fatal("extension commands missing cy-review-round after exact-set assertion")
 	}
-	assertExtensionHostedToolReason(
+	missingConfigMessage := assertExtensionHostedToolReason(
 		t,
 		ctx,
 		client,
 		toolspkg.ToolIDConfigGet,
 		map[string]any{
-			"path":      "loops.inputs.batuta-deliver.auto_commit",
+			"path":      "loops.inputs.extension-probe.preference",
 			"workspace": harness.WorkspaceRoot,
 		},
 		toolspkg.ReasonConfigPathNotFound,
 	)
+	if want := "config_path_not_found: config path not found"; missingConfigMessage != want {
+		t.Fatalf("extension hosted config_get missing path message = %q, want %q", missingConfigMessage, want)
+	}
+	if strings.Contains(missingConfigMessage, "tool not found") {
+		t.Fatalf("extension hosted config_get missing path message = %q, must not identify the tool as missing", missingConfigMessage)
+	}
 
 	var foreign compozycontract.WorkspaceResponse
 	if err := harness.UDSJSON(
@@ -409,7 +415,7 @@ func assertExtensionHostedToolReason(
 	toolID toolspkg.ToolID,
 	arguments map[string]any,
 	want toolspkg.ReasonCode,
-) {
+) string {
 	t.Helper()
 	result, err := client.CallTool(ctx, &sdkmcp.CallToolParams{Name: toolID.String(), Arguments: arguments})
 	if err != nil {
@@ -425,6 +431,13 @@ func assertExtensionHostedToolReason(
 	if !strings.Contains(string(payload), string(want)) {
 		t.Fatalf("CallTool(%s) error result = %s, want reason %q", toolID, payload, want)
 	}
+	for _, content := range result.Content {
+		if text, ok := content.(*sdkmcp.TextContent); ok {
+			return text.Text
+		}
+	}
+	t.Fatalf("CallTool(%s) error result = %s, want text content", toolID, payload)
+	return ""
 }
 
 func assertPersistedExtensionSkillInvocation(

--- a/internal/mcp/hosted_proxy_test.go
+++ b/internal/mcp/hosted_proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/compozy/compozy/internal/api/contract"
+	core "github.com/compozy/compozy/internal/api/core"
 	"github.com/compozy/compozy/internal/tools"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -505,6 +506,20 @@ func TestHostedProxyHelpers(t *testing.T) {
 		want := "workspace_access_denied: workspace denied: operator hint"
 		if got := hostedToolErrorMessage(transportErr); got != want {
 			t.Fatalf("hostedToolErrorMessage(transport) = %q, want reason and public message", got)
+		}
+
+		missingPathErr := tools.NewToolError(
+			tools.ErrorCodeNotFound,
+			tools.ToolIDConfigGet,
+			`config path "loops.inputs.extension-probe.preference" not found`,
+			tools.ErrToolNotFound,
+			tools.ReasonConfigPathNotFound,
+		)
+		status := core.StatusForToolError(missingPathErr)
+		missingPathResponse := core.ToolErrorResponseForError(missingPathErr, status, true)
+		got := hostedToolErrorMessage(hostedToolResponseError{response: missingPathResponse})
+		if want := "config_path_not_found: config path not found"; got != want {
+			t.Fatalf("hostedToolErrorMessage(missing config path) = %q, want %q", got, want)
 		}
 	})
 }

--- a/internal/mcp/hosted_proxy_test.go
+++ b/internal/mcp/hosted_proxy_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/compozy/compozy/internal/api/contract"
-	core "github.com/compozy/compozy/internal/api/core"
 	"github.com/compozy/compozy/internal/tools"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -508,15 +507,12 @@ func TestHostedProxyHelpers(t *testing.T) {
 			t.Fatalf("hostedToolErrorMessage(transport) = %q, want reason and public message", got)
 		}
 
-		missingPathErr := tools.NewToolError(
-			tools.ErrorCodeNotFound,
-			tools.ToolIDConfigGet,
-			`config path "loops.inputs.extension-probe.preference" not found`,
-			tools.ErrToolNotFound,
-			tools.ReasonConfigPathNotFound,
-		)
-		status := core.StatusForToolError(missingPathErr)
-		missingPathResponse := core.ToolErrorResponseForError(missingPathErr, status, true)
+		missingPathResponse := contract.ToolErrorResponse{Error: contract.ToolErrorPayload{
+			Code:        tools.ErrorCodeNotFound,
+			ToolID:      tools.ToolIDConfigGet,
+			Message:     "config path not found",
+			ReasonCodes: []tools.ReasonCode{tools.ReasonConfigPathNotFound},
+		}}
 		got := hostedToolErrorMessage(hostedToolResponseError{response: missingPathResponse})
 		if want := "config_path_not_found: config path not found"; got != want {
 			t.Fatalf("hostedToolErrorMessage(missing config path) = %q, want %q", got, want)

--- a/skills/compozy/references/configuration.md
+++ b/skills/compozy/references/configuration.md
@@ -28,7 +28,7 @@ Settings changes surface lifecycle status, not just file writes. The public cont
 Use `compozy config reload -o json` to reconcile edited desired state with the active generation. Use `compozy config apply-history -o json` or `GET /api/settings/apply` to inspect persisted apply records. A settings write is incomplete until you can see whether it applied live, requires a daemon restart, affects only new sessions, or failed with retryable diagnostics.
 
 Read and write scalar keys with `compozy config show|list|get|set|unset|diff|path` or the `compozy__config_*` native tools. Resolve the live `compozy__config_set` descriptor before mutating: it names the key's scope, lifecycle, and validation. Structured values (arrays, route tables) are edited through `config.toml` or the typed Settings APIs, never guessed into a scalar write.
-`compozy__config_get` reports an absent key as `config_path_not_found`; after `compozy__config_set`, read the same path again and confirm its structured value.
+`compozy__config_get` reports an absent key as `config_path_not_found: config path not found`; after `compozy__config_set`, read the same path again and confirm its structured value.
 
 ## Gateway
 


### PR DESCRIPTION
## What & why

Fixes #394.

Managed sessions calling `compozy__config_get` for an absent allowed path currently receive the contradictory hosted MCP text `config_path_not_found: tool not found`. This change makes the safe public message reason-aware so HTTP/UDS expose `config path not found` and hosted MCP exposes `config_path_not_found: config path not found`.

- Preserve the existing `tool_not_found` code, `config_path_not_found` reason, HTTP 404 status, ToolID, and schemas.
- Correct the source transport envelope while keeping the hosted proxy generic for every installed extension.
- Document the deterministic result in the official Compozy skill.

### Release notes

#### 🐛 Bug Fixes

- Clarify missing configuration-path errors delivered to managed agents.

#### 📚 Documentation

- Document the reason-aware configuration error contract and implementation plan.

## How you verified it

- `mise exec -- env CGO_ENABLED=1 go test -race ./internal/api/core ./internal/mcp -count=1`
- `mise exec -- env CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EExtensionPublishedAgentSessionCommandsAndPrompt$' -count=1 -v`
- `mise exec -- env GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=commit.gpgSign GIT_CONFIG_VALUE_1=false make build`
- `mise exec -- env GIT_CONFIG_COUNT=2 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false GIT_CONFIG_KEY_1=commit.gpgSign GIT_CONFIG_VALUE_1=false make gate-full` (command-scoped Git signing isolation matches CI because this workstation globally signs tags and commits)
- `make gate-status`: full pass, current fingerprint `d7b255725bf041d7686b979e009d524435c4e751`
- Visual QA is not applicable because this change does not alter the Web UI.

Codex co-authored the implementation; I independently reviewed the diff and verified the result locally.

## Impact

- HTTP/UDS tool-error messages and the hosted MCP projection are corrected for the existing `config_path_not_found` reason.
- CLI commands, configuration keys and values, ToolIDs, native-tool schemas, generated OpenAPI/TypeScript contracts, hooks, and the Web UI are unchanged.
- All installed extensions benefit from the generic transport correction; there is no extension-specific path or fallback.
- Workspace isolation remains unchanged and is covered by the managed extension-session E2E.
- The official Compozy skill documents the corrected deterministic result.

### Compozy Impact Audit

- **Native tools:** No ToolID, descriptor, input/output schema, risk, capability, or reason-code changes. Only the safe message associated with the existing config-path reason is corrected.
- **Extensibility and hooks:** Managed sessions from every installed extension receive the corrected hosted MCP message. No hook, resource, manifest, or extension format changes.
- **Workspace data isolation:** Unchanged. Configuration access remains bound to the session workspace, with the existing workspace fence covered by integration tests.
- **Official Compozy skill:** Updated `skills/compozy/references/configuration.md` with the stable missing-path result.

---

- [x] `make gate` passes locally (`make gate-full` before review on larger changes)
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing configuration paths.
  * Missing paths now return the stable message “config path not found.”
  * Errors correctly identify a missing path rather than a missing tool.
  * Hosted tool responses consistently include the `config_path_not_found` reason and `not_found` status.

* **Tests**
  * Added coverage for API and hosted transport responses involving missing configuration paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->