### PR TITLE
fix: authorize daemon-owned loop effects

### DIFF
--- a/docs/qa/reports/2026-08-14-loop-effect-tool-policy.md
+++ b/docs/qa/reports/2026-08-14-loop-effect-tool-policy.md
@@ -1,0 +1,81 @@
+# QA Run Report — 2026-08-14 — loop-effect-tool-policy
+
+- **Scope:** Daemon-owned terminal Loop tool effects for compozy/compozy#403.
+- **Cadence tier:** targeted
+- **Build:** `5873aaea`, containing the patch-equivalent daemon fix `61f3bfc2` (`b3c0087f` after rebase) · **Environment:** fresh isolated lab; local production builds; system Chrome 151 fallback because the pinned Playwright browser download was unavailable
+- **Started:** 2026-08-14T22:00:58-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Lea | Loop author and operator | laptop / wifi-fast / en-US | CH-author-loop-failure-contract |
+
+## Flows in Scope
+
+- `J-recover-loop-node-failure` — Author, run, repair, and finish a Loop (`../journeys/J-recover-loop-node-failure.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-author-loop-failure-contract | J-recover-loop-node-failure / LP-terminal-outcome-notification | Lea | Feature Tour | Fixed | #403 | `b3c0087f` |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-author-loop-failure-contract — Lea
+
+- **Ran:** 2026-08-14T22:04:41-03:00 → 2026-08-14T22:17:05-03:00 (box respected: yes)
+- **Findings:**
+  - A same-workspace daemon-owned terminal effect completed after `Done` with a durable `outcome: ok` result and delivery ID.
+  - A foreign-workspace effect remained denied with `tool_denied`, while the committed Loop remained `Done`.
+  - The public agent catalog did not expose a synthetic `loop-effect` agent.
+  - Both durable results remained observable through the structured reads and the visual timeline after reload.
+- **Bugs filed/updated:** compozy/compozy#403
+- **Scenarios settled:** LP-terminal-outcome-notification → Fixed
+- **Paper cuts:** Closing the browser produced a development-console stream error during transport teardown; no error appeared while the page was mounted or after reload.
+- **Surprises:** The full verifier exposed an unrelated release-test dependency on the operator's global `tag.gpgSign=true`; the same two failures reproduced on clean `main`.
+- **Suggested next charter:** Run a real extension delivery canary and verify its terminal callback reaches the orchestrator without polling.
+
+## What Was Fixed
+
+### compozy/compozy#403: Loop tool effects fail under the daemon-owned execution scope
+
+- **Symptom:** A committed terminal tool effect failed before invocation because the synthetic `loop-effect` audit label was resolved as an authored agent.
+- **Root cause:** Native policy and workspace-input authorization did not preserve daemon-owned scope semantics.
+- **Fix:** `b3c0087f`
+- **Regression test:** `internal/daemon/loop_effect_relay_test.go`, `internal/daemon/native_tools_test.go`, and `internal/daemon/loop_node_lifecycle_e2e_integration_test.go`
+- **Retested:** Fresh isolated CLI, runtime, API/SSE, and visual journey; permitted and denied effects behaved as designed.
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Lea | Browser teardown after the visual journey | Development console briefly logged a stream failure only after the browser process closed | dull | disclosed; not user-visible during the run |
+
+## Runtime Errors Observed
+
+- A `Loop stream failed` message was emitted only while the browser process was closing. Mounted-page and post-reload console captures were empty, and no HTTP response was `>=400`.
+
+## Human Verifications Needed
+
+- None currently identified.
+
+## Decisions for a Human
+
+- None currently identified.
+
+## Learnings
+
+- The daemon-owned scope can authorize a terminal native effect without making its audit label a public or authored agent.
+- The visual read path used a separately stacked Web presentation fix. That code and compozy/compozy#405 are outside this branch.
+
+## Final Status
+
+- **Exit gate (full automated suite):** `mise exec -- make verify` — BLOCKED by two pre-existing `internal/config` release-fixture failures under global `tag.gpgSign=true`; the identical focused failures reproduce on clean `main`. All preceding frontend checks, 4,877 Bun tests, Web build, Go lint, and 22,266 other Go tests passed.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 targeted journey walked across CLI, runtime, API/SSE, and Web. The Web view was supplied by the separately stacked presentation branch; the daemon-owned tool policy and durable structured result are the verdict under test here.
+- **Evidence:** `docs/qa/evidence/2026-08-14-loop-effects-combined/success-reload.png`; `docs/qa/evidence/2026-08-14-loop-effects-combined/denied-reload.png`. The isolated audit verdict was `pass`; teardown recorded `clean: true` with no surviving processes.
+- **Verdict:** ready with blocked items — compozy/compozy#403 passed its targeted structured and visual acceptance checks; resolve the unrelated release-fixture signing isolation before claiming a fully green repository gate.

--- a/docs/qa/scenarios/LP-terminal-outcome-notification.md
+++ b/docs/qa/scenarios/LP-terminal-outcome-notification.md
@@ -6,14 +6,18 @@ persona: Lea
 journey: J-recover-loop-node-failure
 expected: Exactly the declared effect for the committed done, no-op, blocked, failed, exhausted, stalled, or canceled outcome is delivered once, and its result is observable without firing another lifecycle hook.
 entry_points: web /loops/:name/editor; web /loop-runs/:id; `compozy loop status --run-id <run-id> -o json`; HTTP/UDS Loop events; SSE
-qa_status: blocked-verify
-bug_ids:
-fix_status:
+qa_status: untested
+bug_ids: compozy/compozy#403
+fix_status: pending
 retest_status:
 fix_commits:
-evidence: done, failed, canceled, and routed outcomes observed; no public fixture path seeds all seven terminal outcomes with distinct effects in one real-user walk
-last_report: docs/qa/reports/2026-08-03-loop-node-lifecycle.md
+evidence:
+last_report:
 overlaps:
 ---
 
-acceptance-walk: Seed separate runs that commit done, no-op, blocked, failed, exhausted, stalled, and canceled, with distinct terminal effects. Confirm each run delivers only its committed terminal effect once and that refreshed Web, structured CLI, and HTTP event reads expose the same delivery result without recursive lifecycle effects.
+QA for compozy/compozy#403 remains pending. Capture isolated structured and visual evidence before
+changing the scenario status. Prior terminal outcome evidence is available in
+`docs/qa/reports/2026-08-03-loop-node-lifecycle.md`.
+
+acceptance-walk: Seed separate runs that commit done, no-op, blocked, failed, exhausted, stalled, and canceled, with distinct terminal effects. For the done run, declare a permitted read-only native tool effect that explicitly targets the run workspace. Confirm each run delivers only its committed terminal effect once; the done result is `outcome: ok` with no authored/public `loop-effect` agent; a foreign-workspace target is denied; and refreshed Web, structured CLI, and HTTP event reads expose the same delivery result without recursive lifecycle effects.

--- a/docs/qa/scenarios/LP-terminal-outcome-notification.md
+++ b/docs/qa/scenarios/LP-terminal-outcome-notification.md
@@ -6,18 +6,19 @@ persona: Lea
 journey: J-recover-loop-node-failure
 expected: Exactly the declared effect for the committed done, no-op, blocked, failed, exhausted, stalled, or canceled outcome is delivered once, and its result is observable without firing another lifecycle hook.
 entry_points: web /loops/:name/editor; web /loop-runs/:id; `compozy loop status --run-id <run-id> -o json`; HTTP/UDS Loop events; SSE
-qa_status: untested
+qa_status: pass
 bug_ids: compozy/compozy#403
-fix_status: pending
-retest_status:
-fix_commits:
-evidence:
-last_report:
+fix_status: fixed
+retest_status: pass
+fix_commits: b3c0087f
+evidence: docs/qa/evidence/2026-08-14-loop-effects-combined/success-reload.png; docs/qa/evidence/2026-08-14-loop-effects-combined/denied-reload.png
+last_report: docs/qa/reports/2026-08-14-loop-effect-tool-policy.md
 overlaps:
 ---
 
-QA for compozy/compozy#403 remains pending. Capture isolated structured and visual evidence before
-changing the scenario status. Prior terminal outcome evidence is available in
-`docs/qa/reports/2026-08-03-loop-node-lifecycle.md`.
+Fresh isolated QA confirmed the permitted and foreign-workspace-denied terminal-effect paths
+through CLI, runtime, API/SSE, and Web before and after reload. The visual read path used the
+separately stacked Web presentation fix; the daemon policy verdict belongs to compozy/compozy#403.
+Prior terminal outcome evidence is available in `docs/qa/reports/2026-08-03-loop-node-lifecycle.md`.
 
 acceptance-walk: Seed separate runs that commit done, no-op, blocked, failed, exhausted, stalled, and canceled, with distinct terminal effects. For the done run, declare a permitted read-only native tool effect that explicitly targets the run workspace. Confirm each run delivers only its committed terminal effect once; the done result is `outcome: ok` with no authored/public `loop-effect` agent; a foreign-workspace target is denied; and refreshed Web, structured CLI, and HTTP event reads expose the same delivery result without recursive lifecycle effects.

--- a/docs/superpowers/plans/2026-08-14-loop-effect-daemon-policy.md
+++ b/docs/superpowers/plans/2026-08-14-loop-effect-daemon-policy.md
@@ -105,16 +105,17 @@ mise exec -- go test -race ./internal/daemon -count=1
    - no `agent not available` or session-ID authorization error occurs;
    - a foreign-workspace target remains denied;
    - no public `loop-effect` agent appears.
-4. Update the existing LP scenario/report with structured CLI/HTTP/UDS evidence and complete mandatory teardown with `"clean": true`.
-5. Run scoped format, lint, convention, and diff checks. Run `deslop`, review the complete diff, and resolve every real finding.
-6. After all writes are complete, run exactly once:
+4. Walk the same completed run in the Web UI and capture visual evidence that its terminal outcome and successful effect result agree with the structured CLI/HTTP/UDS reads.
+5. Update the existing LP scenario/report with visual and structured evidence, then complete mandatory teardown with `"clean": true`.
+6. Run scoped format, lint, convention, and diff checks. Run `deslop`, review the complete diff, and resolve every real finding.
+7. After all writes are complete, run exactly once:
 
 ```bash
 mise exec -- make gate-full
 make gate-status
 ```
 
-7. Create conventional local commits, rebase on the latest `upstream/main` if it advanced, push the feature branch, and open a PR titled:
+8. Create conventional local commits, rebase on the latest `upstream/main` if it advanced, push the feature branch, and open a PR titled:
 
 ```text
 fix: authorize daemon-owned loop tool effects

--- a/docs/superpowers/plans/2026-08-14-loop-effect-daemon-policy.md
+++ b/docs/superpowers/plans/2026-08-14-loop-effect-daemon-policy.md
@@ -1,0 +1,123 @@
+# Loop Effect Daemon Policy Implementation Plan
+
+> For agentic workers: execute this plan with test-first changes, canonical suites, independent review, and evidence-backed verification.
+
+**Goal:** Deliver permitted Loop terminal tool effects under a daemon-owned, same-workspace scope without resolving the synthetic `loop-effect` audit label as an authored agent.
+
+**Architecture:** Preserve the trusted actor kind through native tool policy resolution, bypass only authored-agent policy for daemon actors, and teach the native workspace binder to authorize daemon scopes against their exact workspace identity. Keep the registry, tool policy evaluator, workspace policy, and relay delivery path otherwise unchanged.
+
+**Tech stack:** Go 1.26, Compozy daemon native tool registry, Loop effect outbox/relay, `workspaceaccess` policy, canonical Go unit/integration suites, Mage/Make verification.
+
+**Design:** `docs/superpowers/specs/2026-08-14-loop-effect-daemon-policy-design.md`
+
+**Issue:** [#403](https://github.com/compozy/compozy/issues/403)
+
+## Global constraints
+
+- Follow repository error wrapping, naming, and test conventions.
+- Extend existing canonical suites; do not add a duplicate standalone suite.
+- Preserve the synthetic `loop-effect` label for attribution, but never materialize it as a public agent.
+- Preserve global/workspace policy, source trust, permission ceilings, approval behavior, correlation IDs, and cross-workspace denial.
+- Do not change public ToolIDs, schemas, descriptors, config, extension formats, or generated contracts.
+- Record RED evidence before modifying production code.
+- Run `make gate-full` exactly once, only after all implementation and QA writes are complete.
+
+## Task 1: Prove both authorization barriers
+
+**Files:**
+
+- Modify: `internal/daemon/native_tools_test.go`
+- Modify: `internal/daemon/loop_effect_relay_test.go`
+
+**Invariant:** A trusted daemon-owned tool call uses workspace policy without an authored agent or caller session, and cannot escape its recorded workspace.
+
+**Owning layer:** daemon service integration.
+
+**Existing suites:** `TestDaemonNativeRuntimePolicyResolver`, `TestDaemonNativeTools`, and `TestLoopEffectRelayShouldDrainCommittedEntriesInIsolation`.
+
+1. Add a policy resolver case with `ActorKind: daemon`, a workspace ID, and `AgentName: loop-effect`. Assert that the resolver does not call the authored agent resolver and still returns the configured workspace/global policy.
+2. Add the negative companion: the same unknown name in a non-daemon agent/session scope must retain `workspace.ErrAgentNotAvailable`.
+3. Extend the native workspace input binding subtest with a daemon same-workspace call that succeeds without a session.
+4. Add negative companions for daemon foreign-workspace and missing-workspace scopes.
+5. Add a relay integration case that uses a real native runtime registry, real policy resolver, and real workspace input binder to deliver `compozy__session_prompt` to a target session in the same workspace. Assert one prompt, one successful acknowledgement, the daemon actor kind, and stable delivery correlation.
+6. Run the focused suite and capture the exact pre-fix failures:
+
+```bash
+mise exec -- go test ./internal/daemon -run 'Test(DaemonNativeRuntimePolicyResolver|DaemonNativeTools|LoopEffectRelay)' -count=1
+```
+
+Expected: the new cases fail with the authored-agent lookup and session-ID workspace authorization errors.
+
+## Task 2: Implement the actor-aware root fix
+
+**Files:**
+
+- Modify: `internal/daemon/tool_policy_resolver.go`
+- Modify: `internal/daemon/native_workspace_input_authorizer.go`
+- Test: `internal/daemon/native_tools_test.go`
+- Test: `internal/daemon/loop_effect_relay_test.go`
+
+1. Preserve trimmed `ActorKind` in `normalizeToolPolicyScope`.
+2. Skip authored-agent policy resolution only when `ActorKind` is `workspaceaccess.ActorDaemon`; continue applying every other policy input.
+3. In `nativeWorkspaceAccessActor`, construct an `ActorDaemon` reference from a daemon scope with a non-empty workspace ID before the session path.
+4. Reject daemon scopes with no workspace ID. Do not synthesize a session or add an approval escape hatch.
+5. Run the focused tests until green:
+
+```bash
+mise exec -- go test ./internal/daemon -run 'Test(DaemonNativeRuntimePolicyResolver|DaemonNativeTools|LoopEffectRelay)' -count=1
+mise exec -- go test -race ./internal/daemon -run 'Test(DaemonNativeRuntimePolicyResolver|DaemonNativeTools|LoopEffectRelay)' -count=1
+```
+
+## Task 3: Prove real Loop delivery and update QA ownership
+
+**Files:**
+
+- Modify: `internal/daemon/loop_node_lifecycle_e2e_integration_test.go`
+- Modify: `docs/qa/scenarios/LP-terminal-outcome-notification.md`
+
+**Invariant:** A terminal outcome committed by a real Loop run executes its declared permitted native tool effect and records the successful effect result once.
+
+**Owning layer:** existing daemon Loop integration and LP QA scenario.
+
+1. Extend the existing lifecycle E2E suite with a minimal terminal tool effect through real daemon wiring. Use a read-only native tool and assert the durable effect result/outbox state rather than a fake return.
+2. Add a negative assertion that no authored/public `loop-effect` agent is required or exposed.
+3. Update `LP-terminal-outcome-notification` with issue #403, fix status, and the intended evidence path. Do not create a new scenario.
+4. Run the focused integration case:
+
+```bash
+mise exec -- go test -tags=integration ./internal/daemon -run 'TestLoopNodeLifecycle' -count=1 -v
+```
+
+5. Run daemon convention checks and the complete race suite:
+
+```bash
+mise exec -- go test -race ./internal/daemon -count=1
+```
+
+## Task 4: Build, isolated QA, and ship
+
+1. Run `make build` and record version, commit, and checksum.
+2. Create a fresh isolated lab with `eng-qa-bootstrap`; use isolated HOME, HTTP port, and UDS.
+3. Reproduce the generic Loop from issue #403 with a terminal native tool effect. Confirm:
+   - the run reaches its terminal state;
+   - the effect outbox result is successful;
+   - the target native effect occurs exactly once in the observed delivery;
+   - no `agent not available` or session-ID authorization error occurs;
+   - a foreign-workspace target remains denied;
+   - no public `loop-effect` agent appears.
+4. Update the existing LP scenario/report with structured CLI/HTTP/UDS evidence and complete mandatory teardown with `"clean": true`.
+5. Run scoped format, lint, convention, and diff checks. Run `deslop`, review the complete diff, and resolve every real finding.
+6. After all writes are complete, run exactly once:
+
+```bash
+mise exec -- make gate-full
+make gate-status
+```
+
+7. Create conventional local commits, rebase on the latest `upstream/main` if it advanced, push the feature branch, and open a PR titled:
+
+```text
+fix: authorize daemon-owned loop tool effects
+```
+
+The PR must use the repository template, include `Fixes #403`, list exact verification evidence, include the Compozy Impact Audit, and disclose AI assistance plus independent verification.

--- a/docs/superpowers/specs/2026-08-14-loop-effect-daemon-policy-design.md
+++ b/docs/superpowers/specs/2026-08-14-loop-effect-daemon-policy-design.md
@@ -1,0 +1,79 @@
+# Daemon-Owned Loop Effect Policy Design
+
+## Status
+
+Approved for implementation on 2026-08-14. Tracks [#403](https://github.com/compozy/compozy/issues/403).
+
+## Problem
+
+Loop terminal tool effects are committed to the outbox correctly, but the daemon cannot deliver native tools that require workspace authorization. On Compozy `v0.3.0-beta.16` (`c38ba0fac69aa657140fc578067d2c538b18ec10`), two independent terminal deliveries failed with:
+
+```text
+effect_tool_failed: daemon: resolve agent tool policy "loop-effect": agent not available in workspace: loop-effect
+```
+
+The relay labels its tool scope with `AgentName: "loop-effect"` and `ActorKind: "daemon"`. Policy normalization currently drops `ActorKind`, so the policy resolver mistakes the audit label for an authored agent and queries the workspace agent catalog. No such public agent should exist.
+
+Fixing only that lookup is incomplete. Native tools with a `workspace` input also require a session for every non-operator scope. A daemon-owned outbox delivery deliberately has no caller session, so it would next fail with `native workspace access requires a session id`.
+
+## Invariants
+
+- `loop-effect` remains an attribution label; it does not become an authored, bundled, or public agent.
+- A trusted daemon actor never acquires an authored agent's tool policy from its audit label.
+- Global and workspace tool enablement, source trust, permission ceilings, and approval requirements remain enforced.
+- A daemon-owned effect may target only the workspace recorded on its durable outbox entry.
+- Cross-workspace native tool input remains denied for daemon actors.
+- Unknown agents in agent-session scopes continue to fail closed.
+- Tool IDs, schemas, descriptors, configuration, extension formats, and public catalog entries do not change.
+
+## Design
+
+### Preserve actor identity during policy resolution
+
+`normalizeToolPolicyScope` preserves `ActorKind`. The native policy resolver applies authored-agent policy only when a non-empty agent name belongs to a non-daemon actor. A daemon actor still receives the global and resolved workspace policy inputs, bundled/development extension trust, and the normal approval availability setting.
+
+This is actor-based rather than a special case for the string `loop-effect`. Public operator and hosted-MCP scopes cannot supply `ActorKind`; those scopes are constructed and bound server-side, so the daemon distinction remains a trusted internal classification.
+
+### Authorize daemon-owned workspace inputs
+
+The native workspace input binder recognizes a daemon scope only when it carries a non-empty trusted workspace ID. It constructs a `workspaceaccess.ActorRef` with `Kind: ActorDaemon`, the exact workspace ID, and the audit label.
+
+The existing authorization path then supplies the fence:
+
+- same workspace: accepted by exact workspace identity;
+- different workspace: evaluated by `workspaceaccess.DefaultPolicy`, which denies daemon actors;
+- missing workspace identity: rejected before tool execution.
+
+No synthetic session is created, and no approval prompt can broaden daemon authority.
+
+## Rejected alternatives
+
+- **Register `loop-effect` as a builtin agent.** This would reserve a public authoring name, pollute the catalog, and invent provider/prompt semantics for an internal delivery worker.
+- **Remove `AgentName` from the relay.** This avoids the first failure but loses useful tool-call attribution and still leaves the workspace-input session barrier.
+- **Add a public actor-ID surface.** A separate actor identity may be a useful future model, but it is a much larger cross-surface change than this behavioral repair requires.
+
+## Test strategy
+
+The regression belongs in existing canonical suites:
+
+1. `native_tools_test.go` proves a daemon scope with a synthetic label inherits workspace policy without resolving an authored agent; the same label in an agent-session scope still fails.
+2. The native workspace binding suite proves daemon same-workspace access without a session, denial for a foreign workspace, and denial when daemon workspace identity is absent.
+3. `loop_effect_relay_test.go` crosses the real runtime registry, policy resolver, and workspace binder while delivering a native tool effect. Existing fake-tool relay tests continue to own delivery isolation, approval, retry, and acknowledgement behavior.
+4. The existing Loop integration suite proves a committed terminal tool effect is delivered through real daemon wiring.
+
+Tests must fail for the beta.16 behavior before production changes are applied.
+
+## Documentation and QA impact
+
+- **Native tools:** policy interpretation changes only for trusted daemon-owned calls. No ToolID, schema, descriptor, or MCP/HTTP/UDS shape changes.
+- **Extensibility and hooks:** any installed Loop may declare a permitted terminal tool effect; extension formats and hook contracts are unchanged.
+- **Workspace isolation:** the existing same-workspace fence is made usable for daemon effects, while foreign workspace access remains denied.
+- **Official skill and site:** current Loop documentation already promises daemon-delivered, at-least-once terminal effects. This restores that contract rather than adding a new one, so no public prose change is required.
+- **QA:** update the existing `LP-terminal-outcome-notification` scenario and attach real evidence there; do not create a duplicate scenario.
+
+## Out of scope
+
+- Interactive approvals for background effects.
+- A new public actor identity API.
+- Changes to effect retry or at-least-once delivery semantics.
+- A public `loop-effect` agent definition.

--- a/internal/daemon/loop_effect_relay_test.go
+++ b/internal/daemon/loop_effect_relay_test.go
@@ -9,8 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/compozy/compozy/internal/api/testutil"
+	compozyconfig "github.com/compozy/compozy/internal/config"
 	looppkg "github.com/compozy/compozy/internal/loop"
 	loopdsl "github.com/compozy/compozy/internal/loop/dsl"
+	"github.com/compozy/compozy/internal/session"
+	"github.com/compozy/compozy/internal/store"
 	toolspkg "github.com/compozy/compozy/internal/tools"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 	"github.com/compozy/compozy/internal/workspaceaccess"
@@ -51,6 +55,108 @@ func TestLoopEffectRelayShouldDrainCommittedEntriesInIsolation(t *testing.T) {
 		calls[0].scope.WorkspaceID != "ws-effect" || calls[0].scope.AgentName != loopEffectActorName ||
 		calls[0].scope.ActorKind != string(workspaceaccess.ActorDaemon) {
 		t.Fatalf("tool calls = %#v, want daemon:loop-effect workspace correlation", calls)
+	}
+}
+
+func TestLoopEffectRelayShouldDeliverNativePromptThroughDaemonWorkspaceScope(t *testing.T) {
+	t.Parallel()
+
+	entry := loopEffectEntryForTest(
+		"native-session-prompt",
+		0,
+		`{"kind":"tool","tool":"compozy__session_prompt","with":{"workspace":"ws-effect","session_id":"sess-target","message":"Continue the verified flow.","message_id":"msg-effect","idempotency_key":"idem-effect"}}`,
+	)
+	effectStore := newLoopEffectStoreFake(entry)
+	var (
+		promptCalls int
+		promptID    string
+		promptOpts  session.SendPromptOpts
+	)
+	sessions := testutil.StubSessionManager{
+		StatusFn: func(ctx context.Context, id string) (*session.Info, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			if id != "sess-target" {
+				return nil, session.ErrSessionNotFound
+			}
+			return &session.Info{
+				ID:          "sess-target",
+				AgentName:   "worker",
+				WorkspaceID: "ws-effect",
+				State:       session.StateActive,
+			}, nil
+		},
+		SendPromptFn: func(
+			ctx context.Context,
+			id string,
+			opts session.SendPromptOpts,
+		) (session.SendPromptResult, error) {
+			if err := ctx.Err(); err != nil {
+				return session.SendPromptResult{}, err
+			}
+			promptCalls++
+			promptID = id
+			promptOpts = opts
+			return session.SendPromptResult{
+				Status:    "accepted",
+				Delivery:  store.SessionInputDeliveryDirect,
+				NewTurnID: "turn-effect",
+			}, nil
+		},
+	}
+	cfg := testConfig(t, testHomePaths(t))
+	cfg.Permissions.Mode = compozyconfig.PermissionModeApproveAll
+	agents := &nativeToolPolicyAgentResolverStub{
+		agent: compozyconfig.AgentDef{Name: "authored-agent", Provider: "opencode", Prompt: "Work."},
+	}
+	policyResolver, err := newNativeToolPolicyResolver(nativeToolPolicyResolverDeps{
+		Config:            &cfg,
+		Sessions:          sessions,
+		AgentResolver:     agents,
+		ApprovalAvailable: true,
+	})
+	if err != nil {
+		t.Fatalf("newNativeToolPolicyResolver() error = %v", err)
+	}
+	registry := newDaemonNativeRegistryWithPolicyResolverAndWorkspaceAccess(
+		t,
+		&daemonNativeToolsDeps{
+			Sessions:   sessions,
+			Workspaces: nativeNetworkTestWorkspaceService(t),
+		},
+		policyResolver,
+		nil,
+	)
+	tools := &loopEffectRegistryRecorder{registry: registry}
+	relay := &loopEffectRelay{store: effectStore, tools: tools}
+
+	report, err := relay.DrainPendingLoopEffects(t.Context(), looppkg.EffectDrainPage{})
+	if err != nil {
+		t.Fatalf("DrainPendingLoopEffects() error = %v", err)
+	}
+	acks := effectStore.acknowledgements()
+	if report.Read != 1 || report.Delivered != 1 || report.Failed != 0 ||
+		len(acks) != 1 || acks[0].Outcome != looppkg.EffectResultOK {
+		t.Fatalf("drain report/acknowledgements = %#v/%#v, want one successful delivery", report, acks)
+	}
+	if promptCalls != 1 || promptID != "sess-target" || promptOpts.Message != "Continue the verified flow." {
+		t.Fatalf(
+			"prompt calls/id/options = %d/%q/%#v, want one prompt to sess-target",
+			promptCalls,
+			promptID,
+			promptOpts,
+		)
+	}
+	calls := tools.callsSnapshot()
+	if len(calls) != 1 || calls[0].scope.ActorKind != string(workspaceaccess.ActorDaemon) ||
+		calls[0].scope.WorkspaceID != "ws-effect" ||
+		calls[0].request.ActorKind != string(workspaceaccess.ActorDaemon) ||
+		calls[0].request.CorrelationID != entry.DeliveryID {
+		t.Fatalf("native registry calls = %#v, want daemon actor and stable delivery correlation", calls)
+	}
+	if len(agents.calls) != 0 {
+		t.Fatalf("ResolveAgent calls = %#v, want no authored-agent lookup for daemon effect", agents.calls)
 	}
 }
 
@@ -354,6 +460,37 @@ func (s *loopEffectStoreFake) acknowledgements() []looppkg.EffectAcknowledgement
 type loopEffectToolCall struct {
 	scope   toolspkg.Scope
 	request toolspkg.CallRequest
+}
+
+type loopEffectRegistryRecorder struct {
+	mu       sync.Mutex
+	registry *toolspkg.RuntimeRegistry
+	calls    []loopEffectToolCall
+}
+
+func (r *loopEffectRegistryRecorder) Get(
+	ctx context.Context,
+	scope toolspkg.Scope,
+	id toolspkg.ToolID,
+) (toolspkg.ToolView, error) {
+	return r.registry.Get(ctx, scope, id)
+}
+
+func (r *loopEffectRegistryRecorder) Call(
+	ctx context.Context,
+	scope toolspkg.Scope,
+	req toolspkg.CallRequest,
+) (toolspkg.ToolResult, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, loopEffectToolCall{scope: scope, request: req})
+	r.mu.Unlock()
+	return r.registry.Call(ctx, scope, req)
+}
+
+func (r *loopEffectRegistryRecorder) callsSnapshot() []loopEffectToolCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]loopEffectToolCall(nil), r.calls...)
 }
 
 type loopEffectToolsFake struct {

--- a/internal/daemon/loop_node_lifecycle_e2e_integration_test.go
+++ b/internal/daemon/loop_node_lifecycle_e2e_integration_test.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -19,12 +20,13 @@ import (
 )
 
 const (
-	lifecycleRetryLoopName      = "node-lifecycle-retry"
-	lifecycleRouteLoopName      = "node-lifecycle-route"
-	lifecycleEscalationLoopName = "node-lifecycle-escalation"
+	lifecycleRetryLoopName        = "node-lifecycle-retry"
+	lifecycleRouteLoopName        = "node-lifecycle-route"
+	lifecycleEscalationLoopName   = "node-lifecycle-escalation"
+	lifecycleTerminalToolLoopName = "node-lifecycle-terminal-tool"
 )
 
-func TestDaemonE2ELoopNodeLifecycleShouldRetryRouteAndEscalate(t *testing.T) {
+func TestDaemonE2ELoopNodeLifecycleShouldRetryRouteEscalateAndDeliverEffects(t *testing.T) {
 	acpmock.RequireDriver(t)
 	workspaceRoot := t.TempDir()
 	seedLoopNodeLifecycleDefinitions(t, workspaceRoot)
@@ -39,7 +41,12 @@ func TestDaemonE2ELoopNodeLifecycleShouldRetryRouteAndEscalate(t *testing.T) {
 		StartTimeout: 30 * time.Second,
 	})
 
-	for _, name := range []string{lifecycleRetryLoopName, lifecycleRouteLoopName, lifecycleEscalationLoopName} {
+	for _, name := range []string{
+		lifecycleRetryLoopName,
+		lifecycleRouteLoopName,
+		lifecycleEscalationLoopName,
+		lifecycleTerminalToolLoopName,
+	} {
 		waitForLoopCatalogEntry(t, t.Context(), harness, name)
 	}
 
@@ -137,15 +144,52 @@ func TestDaemonE2ELoopNodeLifecycleShouldRetryRouteAndEscalate(t *testing.T) {
 			"escalation generation 2", "semantic escalation", `"disposition":"escalated"`,
 		})
 	})
+
+	t.Run("Should deliver a daemon-owned terminal tool effect without a public agent", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(t.Context(), 45*time.Second)
+		defer cancel()
+		run := runLoopViaHTTP(t, ctx, harness, lifecycleTerminalToolLoopName)
+		waitForLoopRunStatus(t, ctx, harness, run.ID, compozycontract.LoopRunStatusDone)
+
+		events := readLoopRunSSEUntil(
+			t,
+			ctx,
+			harness,
+			loopRunEventsPath(harness.WorkspaceID, run.ID, 0),
+			func(events []loopRunSSEEvent) bool {
+				_, found := lifecycleEffectResultForTrigger(t, events, "on_done")
+				return found
+			},
+		)
+		result, found := lifecycleEffectResultForTrigger(t, events, "on_done")
+		if !found {
+			t.Fatalf("events = %#v, want a durable on_done effect result", events)
+		}
+		if result.Outcome != "ok" || result.DeliveryID == "" || result.Code != "" || result.Cause != "" {
+			t.Fatalf("on_done effect result = %#v, want a successful native delivery", result)
+		}
+
+		var agents compozycontract.AgentsResponse
+		agentsPath := "/api/agents?workspace=" + url.QueryEscape(harness.WorkspaceRoot)
+		if err := harness.HTTPJSON(ctx, http.MethodGet, agentsPath, nil, &agents); err != nil {
+			t.Fatalf("list authored agents after terminal effect error = %v", err)
+		}
+		for _, agent := range agents.Agents {
+			if agent.Name == loopEffectActorName {
+				t.Fatalf("authored agent catalog exposed daemon audit label %q: %#v", loopEffectActorName, agent)
+			}
+		}
+	})
 }
 
 func seedLoopNodeLifecycleDefinitions(t testing.TB, workspaceRoot string) {
 	t.Helper()
 	root := filepath.Join(workspaceRoot, compozyconfig.DirName, compozyconfig.LoopsDirName)
 	for name, source := range map[string]string{
-		lifecycleRetryLoopName:      lifecycleRetryLoopYAML(),
-		lifecycleRouteLoopName:      lifecycleRouteLoopYAML(),
-		lifecycleEscalationLoopName: lifecycleEscalationLoopYAML(),
+		lifecycleRetryLoopName:        lifecycleRetryLoopYAML(),
+		lifecycleRouteLoopName:        lifecycleRouteLoopYAML(),
+		lifecycleEscalationLoopName:   lifecycleEscalationLoopYAML(),
+		lifecycleTerminalToolLoopName: lifecycleTerminalToolLoopYAML(),
 	} {
 		if _, _, err := looppkg.WriteDefinition(root, []byte(source), looppkg.WriteDefinitionOptions{
 			Source: looppkg.SourceWorkspace,
@@ -153,6 +197,36 @@ func seedLoopNodeLifecycleDefinitions(t testing.TB, workspaceRoot string) {
 			t.Fatalf("WriteDefinition(%s) error = %v", name, err)
 		}
 	}
+}
+
+func lifecycleTerminalToolLoopYAML() string {
+	return `apiVersion: compozy.loop/v1
+kind: Loop
+meta: { name: node-lifecycle-terminal-tool, description: "E2E terminal tool effect probe." }
+concurrency: allow
+contract:
+  goal: "Read the current workspace after deterministic work completes."
+  definition_of_done: "The transform succeeds and its terminal native tool effect is delivered."
+  stop_when: "nodes.prepare.status == 'succeeded'"
+  verification: []
+  terminal_states: [done, failed, blocked, exhausted, stalled]
+  iteration_cap: 1
+  no_progress: { window: 2, hash_fields: ["nodes.prepare.output"] }
+  budget: { tokens: 0, wall_clock_sec: 0, on_exceeded: halt }
+  on_done:
+    - tool: compozy__workspace_info
+      with:
+        workspace: "{{ .effect.identity.workspace_id }}"
+graph:
+  nodes:
+    - id: prepare
+      class: action
+      kind: transform
+      params:
+        map: { status: { value: ready } }
+  edges: []
+start: [{ kind: http }, { kind: uds }]
+`
 }
 
 func lifecycleRetryLoopYAML() string {
@@ -276,6 +350,35 @@ func assertLifecycleEffectEventContains(
 		}
 	}
 	t.Fatalf("events = %#v, want %s payload containing %v", events, kind, fragments)
+}
+
+type lifecycleEffectResult struct {
+	DeliveryID string `json:"delivery_id"`
+	Trigger    string `json:"trigger"`
+	Outcome    string `json:"outcome"`
+	Code       string `json:"code"`
+	Cause      string `json:"cause"`
+}
+
+func lifecycleEffectResultForTrigger(
+	t testing.TB,
+	events []loopRunSSEEvent,
+	trigger string,
+) (lifecycleEffectResult, bool) {
+	t.Helper()
+	for _, event := range events {
+		if event.Kind != compozycontract.LoopRunEventEffectResults {
+			continue
+		}
+		var result lifecycleEffectResult
+		if err := json.Unmarshal(event.Payload, &result); err != nil {
+			t.Fatalf("decode effect_results payload %s error = %v", event.Payload, err)
+		}
+		if result.Trigger == trigger {
+			return result, true
+		}
+	}
+	return lifecycleEffectResult{}, false
 }
 
 func lifecycleEscalationLoopYAML() string {

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -1760,6 +1760,70 @@ func TestDaemonNativeTools(t *testing.T) {
 		if !errors.Is(err, policyErr) {
 			t.Fatalf("AuthorizeCallInput(policy failure) error = %v, want preserved policy error", err)
 		}
+
+		daemonScope := toolspkg.Scope{
+			WorkspaceID: "ws-1",
+			AgentName:   loopEffectActorName,
+			ActorKind:   string(workspaceaccess.ActorDaemon),
+		}
+		daemonPolicy := &recordingNativeWorkspaceAccessPolicy{}
+		daemonBinder := newNativeWorkspaceInputBinder(
+			nativeNetworkTestWorkspaceService(t),
+			nil,
+			daemonPolicy,
+			nil,
+		)
+		daemonSameWorkspaceCall := toolspkg.CallRequest{
+			ToolID: descriptor.ID,
+			Input:  json.RawMessage(`{"workspace":"ws-1"}`),
+		}
+		if err := daemonBinder.AuthorizeCallInput(
+			t.Context(),
+			daemonScope,
+			descriptor,
+			daemonSameWorkspaceCall,
+		); err != nil {
+			t.Fatalf("AuthorizeCallInput(daemon same workspace) error = %v", err)
+		}
+		if daemonPolicy.calls != 0 {
+			t.Fatalf("daemon same-workspace policy calls = %d, want zero", daemonPolicy.calls)
+		}
+
+		daemonForeignWorkspaceCall := toolspkg.CallRequest{
+			ToolID: descriptor.ID,
+			Input:  json.RawMessage(`{"workspace":"ws-2"}`),
+		}
+		err = daemonBinder.AuthorizeCallInput(
+			t.Context(),
+			daemonScope,
+			descriptor,
+			daemonForeignWorkspaceCall,
+		)
+		requireToolReason(t, err, toolspkg.ErrToolDenied, toolspkg.ReasonWorkspaceAccessDenied)
+		if daemonPolicy.calls != 1 ||
+			daemonPolicy.last.Actor.Kind != workspaceaccess.ActorDaemon ||
+			daemonPolicy.last.Actor.WorkspaceID != "ws-1" ||
+			daemonPolicy.last.TargetWorkspaceID != "ws-2" {
+			t.Fatalf(
+				"daemon foreign-workspace policy calls/request = %d/%#v, want daemon ws-1 to ws-2",
+				daemonPolicy.calls,
+				daemonPolicy.last,
+			)
+		}
+
+		err = daemonBinder.AuthorizeCallInput(
+			t.Context(),
+			toolspkg.Scope{
+				AgentName: loopEffectActorName,
+				ActorKind: string(workspaceaccess.ActorDaemon),
+			},
+			descriptor,
+			daemonSameWorkspaceCall,
+		)
+		requireToolReason(t, err, toolspkg.ErrToolDenied, toolspkg.ReasonWorkspaceAccessDenied)
+		if !strings.Contains(err.Error(), "daemon scope has no workspace id") {
+			t.Fatalf("AuthorizeCallInput(daemon missing workspace) error = %v, want missing workspace identity", err)
+		}
 	})
 
 	t.Run("Should reject foreign workspace inputs for scoped session and skill native tools", func(t *testing.T) {
@@ -9326,6 +9390,88 @@ func TestDaemonNativeRuntimePolicyResolver(t *testing.T) {
 		requireToolReason(t, err, toolspkg.ErrToolDenied, toolspkg.ReasonSessionDenied)
 	})
 
+	t.Run("Should resolve daemon policy without treating its audit label as an authored agent", func(t *testing.T) {
+		t.Parallel()
+
+		globalConfig := testConfig(t, testHomePaths(t))
+		globalConfig.Permissions.Mode = compozyconfig.PermissionModeDenyAll
+		workspaceConfig := globalConfig
+		workspaceConfig.Permissions.Mode = compozyconfig.PermissionModeApproveAll
+		workspaceConfig.Tools.Policy.ExternalDefault = compozyconfig.ToolsExternalDefaultAsk
+		workspaces := apitest.StubWorkspaceService{ResolveFn: func(
+			ctx context.Context,
+			ref string,
+		) (workspacepkg.ResolvedWorkspace, error) {
+			if err := ctx.Err(); err != nil {
+				return workspacepkg.ResolvedWorkspace{}, err
+			}
+			if ref != "ws-effect" {
+				return workspacepkg.ResolvedWorkspace{}, workspacepkg.ErrWorkspaceNotFound
+			}
+			return workspacepkg.ResolvedWorkspace{
+				Workspace:   workspacepkg.Workspace{ID: "ws-effect", RootDir: t.TempDir()},
+				WorkspaceID: "ws-effect",
+				Config:      workspaceConfig,
+			}, nil
+		}}
+		agents := &nativeToolPolicyAgentResolverStub{
+			agent: compozyconfig.AgentDef{Name: "authored-agent", Provider: "opencode", Prompt: "Work."},
+		}
+		resolver, err := newNativeToolPolicyResolver(nativeToolPolicyResolverDeps{
+			Config:            &globalConfig,
+			WorkspaceResolver: workspaces,
+			AgentResolver:     agents,
+			ApprovalAvailable: true,
+		})
+		if err != nil {
+			t.Fatalf("newNativeToolPolicyResolver() error = %v", err)
+		}
+
+		inputs, err := resolver.Resolve(t.Context(), toolspkg.Scope{
+			WorkspaceID: "ws-effect",
+			AgentName:   loopEffectActorName,
+			ActorKind:   string(workspaceaccess.ActorDaemon),
+		})
+		if err != nil {
+			t.Fatalf("Resolve(daemon policy) error = %v", err)
+		}
+		if inputs.SystemPermissionMode != toolspkg.PermissionModeApproveAll ||
+			inputs.ExternalDefault != toolspkg.ExternalDefaultAsk ||
+			!inputs.ApprovalAvailable {
+			t.Fatalf("Resolve(daemon policy) inputs = %#v, want workspace policy and approvals", inputs)
+		}
+		if len(agents.calls) != 0 {
+			t.Fatalf("ResolveAgent calls = %#v, want no authored-agent lookup for daemon audit label", agents.calls)
+		}
+	})
+
+	t.Run("Should reject an unknown audit label for non-daemon callers", func(t *testing.T) {
+		t.Parallel()
+
+		cfg := testConfig(t, testHomePaths(t))
+		agents := &nativeToolPolicyAgentResolverStub{
+			agent: compozyconfig.AgentDef{Name: "authored-agent", Provider: "opencode", Prompt: "Work."},
+		}
+		resolver, err := newNativeToolPolicyResolver(nativeToolPolicyResolverDeps{
+			Config:        &cfg,
+			AgentResolver: agents,
+		})
+		if err != nil {
+			t.Fatalf("newNativeToolPolicyResolver() error = %v", err)
+		}
+
+		_, err = resolver.Resolve(t.Context(), toolspkg.Scope{
+			AgentName: loopEffectActorName,
+			ActorKind: string(workspaceaccess.ActorAgentSession),
+		})
+		if !errors.Is(err, workspacepkg.ErrAgentNotAvailable) {
+			t.Fatalf("Resolve(non-daemon unknown agent) error = %v, want ErrAgentNotAvailable", err)
+		}
+		if !slices.Equal(agents.calls, []string{loopEffectActorName}) {
+			t.Fatalf("ResolveAgent calls = %#v, want one lookup for non-daemon caller", agents.calls)
+		}
+	})
+
 	t.Run("Should trust only development extensions linked to the registered runtime workspace", func(t *testing.T) {
 		t.Parallel()
 
@@ -10065,12 +10211,14 @@ func (s *nativeToolPolicySessionStub) Status(context.Context, string) (*session.
 type nativeToolPolicyAgentResolverStub struct {
 	agent compozyconfig.AgentDef
 	err   error
+	calls []string
 }
 
 func (r *nativeToolPolicyAgentResolverStub) ResolveAgent(
 	name string,
 	_ *workspacepkg.ResolvedWorkspace,
 ) (compozyconfig.AgentDef, error) {
+	r.calls = append(r.calls, name)
 	if r.err != nil {
 		return compozyconfig.AgentDef{}, r.err
 	}

--- a/internal/daemon/native_workspace_input_authorizer.go
+++ b/internal/daemon/native_workspace_input_authorizer.go
@@ -111,6 +111,19 @@ func (b *nativeWorkspaceInputBinder) nativeWorkspaceAccessActor(
 	ctx context.Context,
 	scope toolspkg.Scope,
 ) (workspaceaccess.ActorRef, error) {
+	if workspaceaccess.ActorKind(strings.TrimSpace(scope.ActorKind)) == workspaceaccess.ActorDaemon {
+		workspaceID := strings.TrimSpace(scope.WorkspaceID)
+		if workspaceID == "" {
+			return workspaceaccess.ActorRef{}, errors.New(
+				"daemon: native workspace access daemon scope has no workspace id",
+			)
+		}
+		return workspaceaccess.ActorRef{
+			Kind:        workspaceaccess.ActorDaemon,
+			WorkspaceID: workspaceID,
+			AgentName:   strings.TrimSpace(scope.AgentName),
+		}, nil
+	}
 	sessionID := strings.TrimSpace(scope.SessionID)
 	if sessionID == "" {
 		return workspaceaccess.ActorRef{}, errors.New("daemon: native workspace access requires a session id")

--- a/internal/daemon/tool_policy_resolver.go
+++ b/internal/daemon/tool_policy_resolver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/compozy/compozy/internal/store"
 	toolspkg "github.com/compozy/compozy/internal/tools"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
+	"github.com/compozy/compozy/internal/workspaceaccess"
 )
 
 type nativeToolPolicyResolverDeps struct {
@@ -102,7 +103,8 @@ func (r *nativeToolPolicyResolver) Resolve(ctx context.Context, scope toolspkg.S
 	if err := applySessionToolPolicy(&inputs, info); err != nil {
 		return toolspkg.PolicyInputs{}, err
 	}
-	if resolvedScope.AgentName != "" {
+	if resolvedScope.AgentName != "" &&
+		workspaceaccess.ActorKind(resolvedScope.ActorKind) != workspaceaccess.ActorDaemon {
 		if err := r.applyAgentToolPolicy(&inputs, resolvedScope.AgentName, resolvedWorkspace, cfg); err != nil {
 			if inputs.Session.Enforced && errors.Is(err, workspacepkg.ErrAgentNotAvailable) {
 				return inputs, nil
@@ -320,6 +322,7 @@ func normalizeToolPolicyScope(scope toolspkg.Scope) toolspkg.Scope {
 		WorkspaceID: strings.TrimSpace(scope.WorkspaceID),
 		SessionID:   strings.TrimSpace(scope.SessionID),
 		AgentName:   strings.TrimSpace(scope.AgentName),
+		ActorKind:   strings.TrimSpace(scope.ActorKind),
 		Operator:    scope.Operator,
 	}
 }


### PR DESCRIPTION
## What & why

Fixes #403.

Loop terminal tool effects run under a daemon-owned scope, but the native policy path treated the synthetic `loop-effect` audit label as an authored workspace agent. The lookup failed before the declared tool could run.

This change preserves the trusted daemon actor kind through policy resolution, keeps the synthetic label for attribution, and skips authored-agent policy only for daemon-owned calls. Native workspace inputs can now bind a daemon effect to its exact workspace without inventing a session; the existing workspace policy still denies foreign targets. `loop-effect` remains absent from the public agent catalog.

Release note:

- Authorize daemon-owned Loop terminal tool effects without requiring a synthetic workspace agent.

## How you verified it

- `mise exec -- go test -race ./internal/daemon -run 'Test(DaemonNativeRuntimePolicyResolver|DaemonNativeTools|LoopEffectRelay)' -count=1`
- `mise exec -- go test -tags=integration ./internal/daemon -run 'TestDaemonE2ELoopNodeLifecycleShouldRetryRouteEscalateAndDeliverEffects' -count=1 -v`
- `mise exec -- make fmt-check source-size`
- `mise exec -- make gate-full`

The regression coverage exercises the real native registry, confirms that daemon scopes do not resolve the synthetic label as an authored agent, keeps non-daemon unknown agents fail-closed, permits same-workspace binding, and denies foreign-workspace binding.

Fresh isolated QA also exercised the fix together with the Web visibility follow-up from #405: a permitted terminal effect recorded `outcome: ok`, a foreign-workspace effect recorded `tool_denied`, both survived API/SSE replay and Web reload, and the public agent catalog did not expose `loop-effect`. The isolated lab teardown completed with no surviving processes.

Co-authored with Codex. I independently reviewed the diff and reran the focused, integration, race, and repository gates.

## Impact

- **CLI / HTTP / UDS / config / schemas:** unchanged.
- **Web:** unchanged by this PR.
- **Daemon policy:** daemon-owned native calls retain their server-assigned actor kind and exact workspace. They still inherit global/workspace tool policy, source availability, permission ceilings, approval constraints, and cross-workspace denial.
- **Agent policy:** authored agent/session scopes are unchanged; an unknown non-daemon agent still fails closed.
- **Extensions/catalog:** no format change and no synthetic public agent.
- **Docs:** the existing Loop documentation already describes durable daemon-delivered terminal effects; the QA scenario and implementation design are updated here. No site contract change is required.

---

- [x] `make gate` passes locally (`make gate-full` before review on larger changes)
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon workspace authorization for native tools.
  * Ensured daemon-owned actions use the correct workspace policy without requiring an authored agent.
  * Added validation for missing workspace identity and rejection of unauthorized cross-workspace access.
  * Improved reliability of terminal-tool lifecycle handling and durable effect delivery.

* **Tests**
  * Added coverage for session prompts, authorization scenarios, policy resolution, acknowledgements, and effect-result delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->