### PR TITLE
fix: retain terminal loop effect results in web

### DIFF
--- a/docs/superpowers/plans/2026-08-14-loop-terminal-effect-stream.md
+++ b/docs/superpowers/plans/2026-08-14-loop-terminal-effect-stream.md
@@ -1,0 +1,289 @@
+# Terminal Loop Effect Stream Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver terminal `effect_results` frames to the mounted Loop run page after a terminal
+`status_changed` frame, including during retained replay.
+
+**Architecture:** Keep the existing Loop SSE subscription page-owned instead of treating terminal
+run status as an end-of-stream marker. The React effect cleanup remains the sole source-closing
+owner; all parsing, named-event routing, invalidation, stale-subscription fencing, and native
+`EventSource` reconnect behavior remain unchanged.
+
+**Tech Stack:** React 19, TypeScript, native `EventSource`, TanStack Query, XState Store, Vitest,
+Testing Library, Turborepo, Playwright.
+
+## Global Constraints
+
+- Fix [compozy/compozy#405](https://github.com/compozy/compozy/issues/405) independently from
+  daemon authorization issue #403.
+- Do not add timers, grace periods, effect counters, Loop-definition inspection, or a new SSE
+  completion event.
+- Do not change API, SSE payload, ToolID, configuration, or extension schemas.
+- Preserve the workspace/run identity fence and stale-subscription rejection.
+- Run frontend validation through Turborepo from the repository root.
+- Follow strict RED/GREEN: the regression must fail for the confirmed terminal-close cause before
+  production code changes.
+- Persistent artifacts, source, tests, commits, issues, and PR text are English.
+- Run isolated combined visual QA with the #403 daemon fix before opening either PR.
+
+---
+
+### Task 1: Preserve post-terminal event delivery
+
+**Files:**
+
+- Modify: `web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx`
+- Modify: `web/src/systems/loops/hooks/use-loop-stream.ts`
+
+**Interfaces:**
+
+- Consumes: `LoopStreamEventSource`, `LoopRunEventFrame`, `LoopStreamSubscription`, and the
+  existing `attachLoopStreamSource` cleanup contract.
+- Produces: `useLoopStream(workspaceId, runId, options)` with page-owned source lifetime and no
+  public type changes.
+
+- [ ] **Step 1: Make the fake source honor closure**
+
+  Change `FakeLoopStreamEventSource.close` to set a private `closed` flag and make
+  `emitMessage`, `emitNamed`, and `emitError` ignore frames after closure. Keep `close` as a Vitest
+  spy so cleanup cardinality remains observable.
+
+  ```ts
+  private closed = false;
+  public close = vi.fn(() => {
+    this.closed = true;
+  });
+  ```
+
+- [ ] **Step 2: Write the failing regression**
+
+  Replace `Should deliver a terminal status frame before closing its replay source` with
+  `Should keep the source open for effect results after terminal status until cleanup`.
+  Emit these hand-authored frames in order:
+
+  ```ts
+  const terminal = buildFrame({
+    id: "loopevt_terminal",
+    seq: 42,
+    kind: "status_changed",
+    payload: { status: "done" },
+  });
+  const effectResult = buildFrame({
+    id: "loopevt_effect",
+    seq: 43,
+    kind: "effect_results",
+    payload: {
+      delivery_id: "delivery_1",
+      trigger: "on_done",
+      outcome: "ok",
+      code: "",
+      cause: "",
+    },
+  });
+  ```
+
+  Assert `onEvent` receives `[terminal, effectResult]` in that order, the source has not closed
+  before unmount, and unmount closes it exactly once. Expand the local event-kind fixture to the
+  complete current generated vocabulary so its existing “every enumerated kind” assertion includes
+  `effect_results` and does not retain the stale twelve-kind claim.
+
+- [ ] **Step 3: Run the focused test and verify RED**
+
+  Run from the repository root:
+
+  ```bash
+  bunx turbo run test --filter=./web -- src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx
+  ```
+
+  Expected: FAIL because the current terminal branch closes the fake source after the first frame,
+  so `effectResult` is not delivered and closure occurs before unmount.
+
+- [ ] **Step 4: Implement the minimal root fix**
+
+  In `use-loop-stream.ts`, remove the terminal-status close branch, delete the now-unused
+  `isTerminalLoopStatus` import, and delete `isTerminalStatusFrame`. Update the hook docstring to
+  state that source ownership lasts until the React effect cleanup. Do not change event parsing,
+  invalidation, lifecycle-store opening, error handling, or detach behavior.
+
+- [ ] **Step 5: Run the focused test and verify GREEN**
+
+  ```bash
+  bunx turbo run test --filter=./web -- src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx
+  ```
+
+  Expected: PASS with the terminal and effect-result frames delivered in order and the source
+  closed only by unmount.
+
+- [ ] **Step 6: Run focused formatting, type, and lint validation**
+
+  ```bash
+  make bun-lint
+  bunx turbo run typecheck --filter=./web
+  git diff --check
+  ```
+
+  Expected: all commands exit 0 with no warnings.
+
+- [ ] **Step 7: Commit the implementation batch**
+
+  ```bash
+  git add web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx \
+    web/src/systems/loops/hooks/use-loop-stream.ts
+  git commit -m "fix: keep loop streams open for terminal effects"
+  ```
+
+---
+
+### Task 2: Verify the Web branch broadly
+
+**Files:**
+
+- Verify only; no source files should change.
+
+**Interfaces:**
+
+- Consumes: the complete Web workspace test, typecheck, lint, and production build graphs.
+- Produces: fresh branch-level evidence that the transport lifecycle change does not regress other
+  Web systems.
+
+- [ ] **Step 1: Run required frontend gates**
+
+  ```bash
+  make bun-lint
+  make bun-typecheck
+  make bun-test
+  make web-build
+  ```
+
+  Expected: every command exits 0; lint reports zero warnings.
+
+- [ ] **Step 2: Run the canonical Web E2E lane**
+
+  Retry the repository-pinned browser installation once if the earlier CDN timeout is no longer
+  present, then run:
+
+  ```bash
+  cd web && bun run test:e2e:install
+  cd ..
+  COMPOZY_TEST_DAEMON_BIN="$PWD/bin/compozy" make test-e2e-web
+  ```
+
+  Expected: the browser installation and E2E lane exit 0. If the CDN remains unavailable, record
+  the exact external failure and use `/usr/local/bin/chromium` only for the manual isolated QA;
+  do not claim the canonical E2E lane passed.
+
+---
+
+### Task 3: Verify both independent fixes in one isolated visual walk
+
+**Files:**
+
+- Verify in a temporary integration worktree; do not commit its merge result.
+- Evidence: fresh `eng-qa-bootstrap` lab under `~/dev/qa-labs/`.
+
+**Interfaces:**
+
+- Consumes: committed heads of `fix/loop-effect-tool-policy` (#403) and
+  `fix/loop-terminal-effect-stream` (#405).
+- Produces: structured and visual proof that daemon delivery and Web presentation work together
+  without coupling the two PRs.
+
+- [ ] **Step 1: Create a temporary combined worktree**
+
+  After both feature branches are clean and committed, create a disposable integration branch from
+  the #403 head and merge the #405 head without pushing it:
+
+  ```bash
+  git worktree add /home/franciscpd/Projects/_worktrees/loop-effects-integration \
+    -b test/loop-effects-integration fix/loop-effect-tool-policy
+  git -C /home/franciscpd/Projects/_worktrees/loop-effects-integration \
+    merge --no-edit fix/loop-terminal-effect-stream
+  ```
+
+- [ ] **Step 2: Build the combined binary and Web bundle**
+
+  ```bash
+  mise exec -- make build
+  make web-build
+  ```
+
+  Record the version, full commit identities, binary SHA-256, and size.
+
+- [ ] **Step 3: Bootstrap a fresh isolated QA lab**
+
+  Use `eng-qa-bootstrap` with the combined binary, distinct HOME, port, UDS, and Web proxy target.
+  Register every daemon, Vite, browser, and helper PID in the lab before proceeding.
+
+- [ ] **Step 4: Prove structured success and denial**
+
+  Publish a generic transform-only Loop with a same-workspace `on_done` tool effect. Confirm the
+  retained event stream contains terminal `status_changed` followed by successful
+  `effect_results`. Run a second fixture targeting another workspace and confirm its terminal effect
+  is retained with `outcome=failed` and `code=tool_denied`. Confirm `loop-effect` is absent from the
+  public agent catalog.
+
+- [ ] **Step 5: Prove visual delivery live and after reload**
+
+  Open the successful run in the isolated Web app with the exact workspace selected. Confirm the
+  timeline shows the successful terminal effect after the run reaches `Done`. Reload the page and
+  confirm the retained effect row remains. Open the denied run and confirm the failed terminal
+  effect is visible with its denial outcome. Capture screenshots and browser-console/network
+  evidence.
+
+- [ ] **Step 6: Audit and tear down**
+
+  Run the strict QA audit, then execute the exact bootstrap teardown. Require `clean: true`,
+  `survivors: []`, and no listeners on the lab HTTP/Vite ports. Remove the temporary integration
+  worktree only after evidence paths are recorded.
+
+---
+
+### Task 4: Finalize and ship the two focused PRs
+
+**Files:**
+
+- Review each branch against `upstream/main` independently.
+- Update PR bodies only; do not combine implementation commits.
+
+**Interfaces:**
+
+- Consumes: clean #403 and #405 feature branches plus successful combined QA evidence.
+- Produces: two independently reviewable PRs, each linked to its own issue.
+
+- [ ] **Step 1: Apply deslop and review each independent diff**
+
+  Check for unnecessary comments, duplicated lifecycle logic, weak casts, test-only production
+  helpers, unrelated docs, and accidental generated changes. Ensure the Web branch changes only its
+  design/plan and the canonical hook/test files.
+
+- [ ] **Step 2: Run the final full gate exactly once per frozen branch**
+
+  ```bash
+  mise exec -- make gate-full
+  make gate-status
+  ```
+
+  Run these commands in each feature worktree only after all writes for that branch are complete.
+  Require a current full-pass fingerprint before creating its PR.
+
+- [ ] **Step 3: Push and open the daemon PR**
+
+  Push `fix/loop-effect-tool-policy` to the fork and open a PR to `compozy/compozy:main` titled
+  `fix: authorize daemon-owned loop tool effects`. Use the repository PR template, include
+  `Fixes #403`, the structured and combined visual QA evidence, and an explicit impact audit.
+
+- [ ] **Step 4: Push and open the Web PR**
+
+  Push `fix/loop-terminal-effect-stream` to the fork and open a PR to `compozy/compozy:main` titled
+  `fix: retain terminal loop effect stream events`. Use the repository PR template, include
+  `Fixes #405`, the RED/GREEN evidence, screenshot evidence, browser cleanup proof, and an explicit
+  statement that API/SSE payload schemas and daemon behavior are unchanged.
+
+- [ ] **Step 5: Inspect initial CI and review comments**
+
+  Confirm both PRs target `main`, linked issues resolve correctly, required checks start, and no
+  generated or unrelated files appear in either diff. Report all actionable review feedback before
+  applying changes.

--- a/docs/superpowers/plans/2026-08-14-loop-terminal-effect-stream.md
+++ b/docs/superpowers/plans/2026-08-14-loop-terminal-effect-stream.md
@@ -29,6 +29,21 @@ Testing Library, Turborepo, Playwright.
 - Persistent artifacts, source, tests, commits, issues, and PR text are English.
 - Run isolated combined visual QA with the #403 daemon fix before opening either PR.
 
+## Compozy Impact Audit
+
+- **Native tools:** No impact. The change does not alter `compozy__*` IDs, toolsets, descriptors,
+  input/output schemas, risk metadata, capability gates, or CLI/API fallbacks; it only changes how
+  the Web consumer owns an existing Loop SSE subscription.
+- **Extensibility and hooks:** No impact. Loop effect execution, `effect_results` production,
+  extension tools, hook dispatch, skills/capabilities, registries, bridge SDKs, MCP sidecars, and
+  config lifecycle are unchanged. The Web already understands the existing event kind and payload.
+- **Workspace data isolation:** No impact. The existing workspace-scoped stream URL, query keys,
+  `workspace_id`/`loop_run_id` frame checks, active-subscription identity fence, and sequence
+  deduplication remain unchanged. The regression suite must keep covering replacement and stale
+  subscription rejection.
+- **Official Compozy skill:** No impact. The bundled skill already documents the long-lived Loop
+  event stream and `effect_results`; no public tool, CLI, hook, extension, or Loop semantic changes.
+
 ---
 
 ### Task 1: Preserve post-terminal event delivery
@@ -168,8 +183,7 @@ Testing Library, Turborepo, Playwright.
   present, then run:
 
   ```bash
-  cd web && bun run test:e2e:install
-  cd ..
+  bash scripts/worktree.sh bootstrap --e2e --skip-install
   COMPOZY_TEST_DAEMON_BIN="$PWD/bin/compozy" make test-e2e-web
   ```
 
@@ -219,7 +233,13 @@ Testing Library, Turborepo, Playwright.
   Use `eng-qa-bootstrap` with the combined binary, distinct HOME, port, UDS, and Web proxy target.
   Register every daemon, Vite, browser, and helper PID in the lab before proceeding.
 
-- [ ] **Step 4: Prove structured success and denial**
+- [ ] **Step 4: Flag the affected QA tracker scenario**
+
+  Reset `docs/qa/scenarios/LP-terminal-outcome-notification.md` to `qa_status: untested` and append
+  a dated impact note before the acceptance walk. This is a changed user-visible Web behavior, not
+  a pure refactor. Preserve the scenario's full seven-outcome acceptance contract.
+
+- [ ] **Step 5: Prove structured success and denial**
 
   Publish a generic transform-only Loop with a same-workspace `on_done` tool effect. Confirm the
   retained event stream contains terminal `status_changed` followed by successful
@@ -227,7 +247,7 @@ Testing Library, Turborepo, Playwright.
   is retained with `outcome=failed` and `code=tool_denied`. Confirm `loop-effect` is absent from the
   public agent catalog.
 
-- [ ] **Step 5: Prove visual delivery live and after reload**
+- [ ] **Step 6: Prove visual delivery live and after reload**
 
   Open the successful run in the isolated Web app with the exact workspace selected. Confirm the
   timeline shows the successful terminal effect after the run reaches `Done`. Reload the page and
@@ -235,11 +255,15 @@ Testing Library, Turborepo, Playwright.
   effect is visible with its denial outcome. Capture screenshots and browser-console/network
   evidence.
 
-- [ ] **Step 6: Audit and tear down**
+- [ ] **Step 7: Record the tracker verdict, audit, and tear down**
 
-  Run the strict QA audit, then execute the exact bootstrap teardown. Require `clean: true`,
-  `survivors: []`, and no listeners on the lab HTTP/Vite ports. Remove the temporary integration
-  worktree only after evidence paths are recorded.
+  Update `LP-terminal-outcome-notification` with the structured reads, screenshots, console/network
+  evidence, and teardown reference. Mark it `pass` only if the complete acceptance walk passes; if
+  the public fixture still cannot seed all seven terminal outcomes, restore `blocked-verify` and
+  record that exact remaining blocker rather than broadening the focused QA claim. Run the strict QA
+  audit, then execute the exact bootstrap teardown. Require `clean: true`, `survivors: []`, and no
+  listeners on the lab HTTP/Vite ports. Remove the temporary integration worktree only after
+  evidence paths are recorded.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-14-loop-terminal-effect-stream.md
+++ b/docs/superpowers/plans/2026-08-14-loop-terminal-effect-stream.md
@@ -37,6 +37,7 @@ Testing Library, Turborepo, Playwright.
 
 - Modify: `web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx`
 - Modify: `web/src/systems/loops/hooks/use-loop-stream.ts`
+- Modify: `web/src/systems/os/apps/loops/use-loop-run-page.ts`
 
 **Interfaces:**
 
@@ -86,9 +87,8 @@ Testing Library, Turborepo, Playwright.
   ```
 
   Assert `onEvent` receives `[terminal, effectResult]` in that order, the source has not closed
-  before unmount, and unmount closes it exactly once. Expand the local event-kind fixture to the
-  complete current generated vocabulary so its existing “every enumerated kind” assertion includes
-  `effect_results` and does not retain the stale twelve-kind claim.
+  before unmount, and unmount closes it exactly once. Keep the existing event-kind fixture unchanged;
+  the regression directly exercises the separately retained `effect_results` listener.
 
 - [ ] **Step 3: Run the focused test and verify RED**
 
@@ -106,7 +106,8 @@ Testing Library, Turborepo, Playwright.
   In `use-loop-stream.ts`, remove the terminal-status close branch, delete the now-unused
   `isTerminalLoopStatus` import, and delete `isTerminalStatusFrame`. Update the hook docstring to
   state that source ownership lasts until the React effect cleanup. Do not change event parsing,
-  invalidation, lifecycle-store opening, error handling, or detach behavior.
+  invalidation, lifecycle-store opening, error handling, or detach behavior. Update the stale
+  `use-loop-run-page.ts` comment that says the hook closes on the replayed terminal frame.
 
 - [ ] **Step 5: Run the focused test and verify GREEN**
 
@@ -131,7 +132,8 @@ Testing Library, Turborepo, Playwright.
 
   ```bash
   git add web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx \
-    web/src/systems/loops/hooks/use-loop-stream.ts
+    web/src/systems/loops/hooks/use-loop-stream.ts \
+    web/src/systems/os/apps/loops/use-loop-run-page.ts
   git commit -m "fix: keep loop streams open for terminal effects"
   ```
 

--- a/docs/superpowers/specs/2026-08-14-loop-terminal-effect-stream-design.md
+++ b/docs/superpowers/specs/2026-08-14-loop-terminal-effect-stream-design.md
@@ -107,6 +107,21 @@ The test must fail against the current implementation because the terminal frame
 source contract before the later frame is accepted. Existing tests continue owning named-event
 registration, stale-source rejection, error forwarding, invalidation, and cleanup variants.
 
+## Compozy Impact Audit
+
+- **Native tools:** No impact. The fix changes no `compozy__*` ID, toolset, descriptor, schema
+  digest, risk flag, availability diagnostic, capability gate, or CLI/API fallback.
+- **Extensibility and hooks:** No impact. Extension tools, Loop effect delivery, hook dispatch,
+  skills/capabilities, resources, registries, bridge SDKs, MCP sidecars, and config lifecycle keep
+  their existing contracts. The Web continues consuming the existing `effect_results` event.
+- **Workspace data isolation:** No impact. The stream remains scoped by its workspace/run URL and
+  query key, and every frame must still match the active subscription's `workspace_id` and
+  `loop_run_id`. Subscription replacement, sequence fencing, and stale-frame rejection are
+  unchanged and remain covered by the canonical hook suite.
+- **Official Compozy skill:** No impact. The bundled skill already lists `effect_results` in the
+  Loop event vocabulary and describes the server stream as resumable; no documented tool, CLI,
+  hook, extension, or Loop behavior changes.
+
 ## QA
 
 After automated Web tests, typecheck, lint, build, and repository gates pass, isolated QA will use

--- a/docs/superpowers/specs/2026-08-14-loop-terminal-effect-stream-design.md
+++ b/docs/superpowers/specs/2026-08-14-loop-terminal-effect-stream-design.md
@@ -1,0 +1,123 @@
+# Terminal Loop Effect Stream Lifecycle Design
+
+**Issue:** [compozy/compozy#405](https://github.com/compozy/compozy/issues/405)
+
+## Goal
+
+Keep the Loop run event subscription alive for the mounted run-details page so terminal
+`effect_results` frames are delivered after the run's terminal `status_changed` frame. Preserve
+the existing workspace/run identity fence, replay cursor, named-event routing, stale-subscription
+protection, error forwarding, query invalidation, and cleanup behavior.
+
+## Confirmed Reproduction
+
+On 2026-08-14, an isolated Compozy `v0.3.0-beta.16` workspace ran a minimal Loop with an
+`on_done` tool effect. The retained API event stream contained this ordered sequence:
+
+```text
+status_changed(status=done)
+effect_results(trigger=on_done, outcome=ok)
+```
+
+The Web run page rendered the terminal run state but omitted the effect result, including after a
+reload. The server continued serving the retained `effect_results` frame when queried after the
+terminal sequence.
+
+## Root Cause
+
+`useLoopStream` delivers a terminal `status_changed` frame and immediately closes its
+`EventSource`. Terminal effects run asynchronously after terminal state is committed, so their
+durable `effect_results` frames can be appended after that status frame. During replay, the client
+closes at the same terminal frame and never reaches the later retained event.
+
+The server stream is not terminal-status bounded. It keeps polling until the request context is
+cancelled. The Loop event reducer and run-story projection already retain and render
+`effect_results`; the frame is lost before either consumer sees it.
+
+## Design
+
+### Subscription ownership
+
+The mounted run page owns the Loop event subscription. A terminal run status does not close the
+source because it is not an end-of-stream marker. The existing effect cleanup remains the single
+owner of listener removal, lifecycle-store closure, and `EventSource.close()`.
+
+The subscription continues to close when any existing ownership boundary changes:
+
+- the hook unmounts;
+- the workspace or run identity changes;
+- the replay cursor changes;
+- the stream is disabled; or
+- the injected source factory changes.
+
+The active-subscription identity check continues rejecting frames from replaced subscriptions.
+
+### Event delivery
+
+Named and unnamed frames keep their current parsing path. Every valid frame is delivered to the
+latest `onEvent` Effect Event. Lifecycle frames retain their current query invalidation behavior.
+A terminal `status_changed` frame and any following `effect_results` frame therefore reach the
+consumer in producer order.
+
+No timer, grace period, expected-effect counter, or Loop-definition inspection is introduced.
+Those approaches would either race slow effect delivery or couple the transport hook to effect
+execution semantics.
+
+### Errors and reconnects
+
+The native `EventSource` remains responsible for reconnect behavior. Connection errors continue
+through `onError`; the hook does not close the source in response. Parse failures remain isolated
+from consumer failures.
+
+## Alternatives Considered
+
+### Keep the subscription open until its owner releases it — selected
+
+This matches the server's long-lived SSE contract and uses the existing React effect cleanup. It
+is the smallest root-cause fix and does not require a public protocol change.
+
+### Add a server end-of-stream marker
+
+An explicit marker after all terminal effects could allow eager client closure, but it would add a
+new cross-surface protocol and must account for retries and at-least-once effect delivery. That is
+unnecessary for restoring the current UI behavior.
+
+### Close after counting declared terminal effects
+
+The client could inspect the Loop definition and wait for a matching count. This duplicates daemon
+semantics, mishandles retries or unavailable definitions, and makes a transport hook dependent on
+domain execution policy. It is rejected.
+
+### Close after a grace period
+
+A delay only narrows the race and cannot prove that all effects arrived. It is rejected as a timing
+workaround.
+
+## Tests
+
+The canonical hook suite will replace the terminal-close expectation with a regression that:
+
+1. emits a terminal `status_changed` frame;
+2. emits a later `effect_results` frame on the same source;
+3. verifies both frames reach `onEvent` in order;
+4. verifies the source remains open before unmount; and
+5. verifies unmount performs the existing cleanup and closes the source once.
+
+The test must fail against the current implementation because the terminal frame closes the fake
+source contract before the later frame is accepted. Existing tests continue owning named-event
+registration, stale-source rejection, error forwarding, invalidation, and cleanup variants.
+
+## QA
+
+After automated Web tests, typecheck, lint, build, and repository gates pass, isolated QA will use
+the daemon authorization fix from issue #403 together with this Web branch. A generic Loop with a
+successful terminal tool effect must show the terminal `effect_results` row in run details, both
+live and after reload. A failed cross-workspace terminal effect must also remain visible with its
+denial outcome. The QA environment must be torn down with `clean: true` and no survivors.
+
+## Non-goals
+
+- Changing Loop effect authorization or delivery semantics.
+- Adding or renaming API, SSE, configuration, ToolID, or extension contracts.
+- Materializing `loop-effect` as an authored or public agent.
+- Changing the visual design of the Loop timeline.

--- a/web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx
+++ b/web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx
@@ -24,7 +24,10 @@ const LOOP_EVENT_KINDS = [
 ] as const;
 
 class FakeLoopStreamEventSource {
-  public close = vi.fn();
+  private closed = false;
+  public close = vi.fn(() => {
+    this.closed = true;
+  });
   public onmessage: ((event: MessageEvent) => void) | null = null;
   public onerror: ((event: Event) => void) | null = null;
   public readonly addEventListener = vi.fn(this.recordAddListener.bind(this));
@@ -50,7 +53,7 @@ class FakeLoopStreamEventSource {
   }
 
   emitMessage(data: unknown) {
-    if (!this.onmessage) {
+    if (this.closed || !this.onmessage) {
       return;
     }
     this.onmessage(
@@ -61,6 +64,9 @@ class FakeLoopStreamEventSource {
   }
 
   emitNamed(type: string, data: unknown) {
+    if (this.closed) {
+      return;
+    }
     const current = this.listeners.get(type) ?? [];
     if (current.length === 0) {
       return;
@@ -78,7 +84,7 @@ class FakeLoopStreamEventSource {
   }
 
   emitError(event?: Event) {
-    if (!this.onerror) {
+    if (this.closed || !this.onerror) {
       return;
     }
     this.onerror(event ?? new Event("error"));
@@ -290,13 +296,13 @@ describe("useLoopStream", () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["loops", "runs", "ws_1"] });
   });
 
-  it("Should deliver a terminal status frame before closing its replay source", async () => {
+  it("Should keep the source open for effect results after terminal status until cleanup", async () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const eventSource = new FakeLoopStreamEventSource();
     const factory = vi.fn(() => eventSource);
     const onEvent = vi.fn();
 
-    renderHook(
+    const { unmount } = renderHook(
       () =>
         useLoopStream("ws_1", "looprun_1", {
           eventSourceFactory: factory,
@@ -306,19 +312,33 @@ describe("useLoopStream", () => {
     );
 
     const terminal = buildFrame({
+      id: "loopevt_terminal",
+      seq: 42,
       kind: "status_changed",
-      payload: { status: "failed", failure: { kind: "coordinator_failure" } },
+      payload: { status: "done" },
+    });
+    const effectResult = buildFrame({
+      id: "loopevt_effect",
+      seq: 43,
+      kind: "effect_results",
+      payload: {
+        delivery_id: "delivery_1",
+        trigger: "on_done",
+        outcome: "ok",
+        code: "",
+        cause: "",
+      },
     });
     act(() => {
       eventSource.emitNamed("status_changed", terminal);
+      eventSource.emitNamed("effect_results", effectResult);
     });
 
-    await waitFor(() =>
-      expect(onEvent).toHaveBeenCalledWith(
-        terminal,
-        expect.objectContaining({ runId: "looprun_1", workspaceId: "ws_1" })
-      )
-    );
+    await waitFor(() => expect(onEvent).toHaveBeenCalledTimes(2));
+    expect(onEvent.mock.calls.map(([frame]) => frame)).toEqual([terminal, effectResult]);
+    expect(eventSource.close).not.toHaveBeenCalled();
+
+    unmount();
     expect(eventSource.close).toHaveBeenCalledTimes(1);
   });
 

--- a/web/src/systems/loops/hooks/use-loop-stream.ts
+++ b/web/src/systems/loops/hooks/use-loop-stream.ts
@@ -6,7 +6,6 @@ import { LOOP_RUN_EVENT_KINDS, LOOP_RUN_LIFECYCLE_EVENT_KINDS } from "@/generate
 import { createStreamEventSource } from "@/lib/ticketed-event-source";
 
 import { buildLoopStreamUrl } from "../adapters/loops-api";
-import { isTerminalLoopStatus } from "../lib/loop-formatters";
 import { loopsKeys } from "../lib/query-keys";
 import type { LoopRunEventFrame, LoopRunEventKind } from "../types";
 import {
@@ -52,14 +51,6 @@ const LOOP_LIFECYCLE_EVENT_KINDS = new Set<LoopRunEventKind>(
 
 function isLifecycleKind(kind: string): boolean {
   return LOOP_LIFECYCLE_EVENT_KINDS.has(kind as LoopRunEventKind);
-}
-
-function isTerminalStatusFrame(kind: string, frame: LoopRunEventFrame): boolean {
-  if (kind !== "status_changed" || typeof frame.payload !== "object" || frame.payload === null) {
-    return false;
-  }
-  const status = (frame.payload as Record<string, unknown>).status;
-  return typeof status === "string" && isTerminalLoopStatus(status);
 }
 
 function defaultEventSourceFactory(url: string): LoopStreamEventSource {
@@ -111,7 +102,8 @@ function invalidateLoopRunQueries(
  * are display-only, applied via `onEvent`, never invalidating). `onEvent`/`onError`
  * are stabilized through Effect Events so an inline callback never tears down
  * and reopens the EventSource; only the workspace, run, resume seed, or factory
- * identity reopen the stream.
+ * identity reopen the stream. The mounted hook owns the source until cleanup;
+ * terminal effects can append frames after the run status becomes terminal.
  */
 export function useLoopStream(
   workspaceId: string,
@@ -192,10 +184,6 @@ export function useLoopStream(
         );
       }
       notifyEvent(payload, subscription);
-      if (isTerminalStatusFrame(kind, payload)) {
-        lifecycleStore.trigger.subscriptionClosed({ subscription });
-        source.close();
-      }
     };
 
     const handleError = (event: Event) => {

--- a/web/src/systems/os/apps/loops/use-loop-run-page.ts
+++ b/web/src/systems/os/apps/loops/use-loop-run-page.ts
@@ -62,8 +62,8 @@ export function useLoopRunPage(
   const definition = executedDefinition ?? loopQuery.data?.definition;
 
   const isLive = runQuery.isSuccess && !isTerminalLoopStatus(run?.status);
-  // Terminal runs replay their retained status event once so generation-zero
-  // failures remain visible after navigation or reload; the hook closes on it.
+  // Terminal runs keep replaying through their post-status effect results so
+  // generation-zero failures and terminal reactions survive navigation or reload.
   useLoopStream(workspaceId, runId, {
     enabled: runQuery.isSuccess && liveDataEnabled,
     onEvent: (frame, subscription) =>


### PR DESCRIPTION
## What & why

Fixes #405.

Terminal Loop effects are appended after the terminal run state commits. The Web hook closed its `EventSource` as soon as it received `status_changed(done)`, so a later retained or live `effect_results` frame never reached the run timeline. Reloading repeated the same race.

This change makes the mounted run-detail hook own the source through post-terminal frames. Successful and denied effect results now reach the existing reducer in order, while replacement, window deactivation, navigation, and unmount keep the normal cleanup path.

Release note:

- Keep terminal Loop effect results visible in run details after completion and reload.

## How you verified it

- `mise exec -- bunx turbo run test --filter=compozy-web -- --run src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx`
- `mise exec -- make bun-lint bun-typecheck web-build`
- `mise exec -- make fmt-check source-size`
- `mise exec -- make gate-full`

The hook regression test sends terminal `status_changed` followed by `effect_results`, verifies both frames arrive in order, and verifies cleanup closes the source. Existing stale-subscription and replacement coverage remains green.

Fresh isolated visual QA exercised successful and denied terminal effects with the daemon fix from #403. Both results appeared in the timeline live and after a full reload, with no mounted-page console error; the isolated lab teardown completed with no surviving processes.

Co-authored with Codex. I independently reviewed the diff and reran the focused frontend, build, and repository gates.

## Impact

- **Web:** Loop run details retain the stream after terminal status so asynchronous terminal effect results remain observable.
- **CLI / HTTP / UDS / config / schemas:** unchanged.
- **Daemon and extensions:** unchanged by this PR.
- **Docs:** no public behavior or configuration surface changes; the implementation design documents the stream lifecycle.

### Stream lifetime tradeoff

This fixes the event-ordering race by keeping the mounted run-detail subscription alive after terminal status. A visible terminal run page therefore retains one idle SSE connection until normal subscription cleanup. The OS live-data fence limits ownership to a visible document and a window on the active desktop that is not minimized and is active in its stack; deactivation, replacement, navigation, or unmount closes the source.

Closing on `status_changed` is incorrect because effects are asynchronous. Closing on the first `effect_results` is also incorrect because a terminal hook may declare multiple effects. A deterministic earlier close would require a new daemon event meaning “all terminal effects are settled.” That protocol change is intentionally out of scope so the maintainer can decide whether its additional server/API complexity is warranted.

---

- [x] `make gate` passes locally (`make gate-full` before review on larger changes)
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal run streams now continue delivering follow-up effect results after terminal status is received.
  * Preserved generation-zero failures and terminal reactions when navigating away and returning or reloading.
  * Prevented closed streams from delivering additional messages or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->