### PR TITLE
fix: bound desktop runtime health checks

### DIFF
--- a/desktop/src-tauri/src/runtime/probe.rs
+++ b/desktop/src-tauri/src/runtime/probe.rs
@@ -14,7 +14,7 @@ use super::PROCESS_START_TOLERANCE_SECONDS;
 use super::discovery::DaemonRecord;
 
 pub const MAX_KNOWN_STATUS_SCHEMA: &str = "2026-07-16";
-pub const MINIMUM_RUNTIME: &str = ">=0.3.0-beta.8";
+pub const MINIMUM_RUNTIME: &str = ">=0.3.0-beta.18";
 const MAX_IDENTITY_BODY_BYTES: usize = 8 * 1024;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
@@ -427,8 +427,8 @@ mod tests {
     fn should_apply_minimum_version_and_date_schema_handshake() {
         let minimum = VersionReq::parse(MINIMUM_RUNTIME).expect("requirement parses");
         let cases = [
-            ("0.3.0-beta.8", MAX_KNOWN_STATUS_SCHEMA, "compatible"),
-            ("0.3.0-beta.7", MAX_KNOWN_STATUS_SCHEMA, "older"),
+            ("0.3.0-beta.18", MAX_KNOWN_STATUS_SCHEMA, "compatible"),
+            ("0.3.0-beta.17", MAX_KNOWN_STATUS_SCHEMA, "older"),
             ("0.3.0", "2099-01-01", "newer"),
         ];
         for (version, schema, expected) in cases {

--- a/desktop/src-tauri/src/runtime/probe.rs
+++ b/desktop/src-tauri/src/runtime/probe.rs
@@ -15,7 +15,7 @@ use super::discovery::DaemonRecord;
 
 pub const MAX_KNOWN_STATUS_SCHEMA: &str = "2026-07-16";
 pub const MINIMUM_RUNTIME: &str = ">=0.3.0-beta.8";
-const MAX_STATUS_BODY_BYTES: usize = 64 * 1024;
+const MAX_IDENTITY_BODY_BYTES: usize = 8 * 1024;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct StatusPayload {
@@ -98,25 +98,25 @@ impl StatusTransport for HttpStatusTransport {
         let Some(client) = &self.client else {
             return TransportResult::Unreachable;
         };
-        let Ok(url) = origin.join("/api/status") else {
+        let Ok(url) = origin.join("/api/status/identity") else {
             return TransportResult::Unreachable;
         };
         match client.get(url).timeout(deadline).send() {
             Ok(response) if response.status().is_success() => {
                 let mut bytes = Vec::new();
-                let mut limited = response.take((MAX_STATUS_BODY_BYTES + 1) as u64);
+                let mut limited = response.take((MAX_IDENTITY_BODY_BYTES + 1) as u64);
                 match limited.read_to_end(&mut bytes) {
-                    Ok(_) if bytes.len() <= MAX_STATUS_BODY_BYTES => TransportResult::Ok(bytes),
+                    Ok(_) if bytes.len() <= MAX_IDENTITY_BODY_BYTES => TransportResult::Ok(bytes),
                     Ok(_) => TransportResult::HttpFailure,
                     Err(error) => {
-                        crate::logging::error(format!("read runtime status: {error}"));
+                        crate::logging::error(format!("read runtime identity: {error}"));
                         TransportResult::Unreachable
                     }
                 }
             }
             Ok(_) => TransportResult::HttpFailure,
             Err(error) => {
-                crate::logging::error(format!("request runtime status: {error}"));
+                crate::logging::error(format!("request runtime identity: {error}"));
                 TransportResult::Unreachable
             }
         }
@@ -236,6 +236,8 @@ fn schema_date(value: &str) -> Option<NaiveDate> {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+    use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
 
     use super::*;
@@ -392,6 +394,33 @@ mod tests {
         let probe = BoundProbe::new(DeadlineTransport(Arc::clone(&observed)), deadline);
         assert_eq!(probe.probe(&fixture_record(), None), Identity::Unreachable);
         assert_eq!(*observed.lock().expect("deadline lock"), Some(deadline));
+    }
+
+    #[test]
+    fn should_request_the_bounded_runtime_identity_surface() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("test listener binds");
+        let address = listener.local_addr().expect("test listener has an address");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("identity request connects");
+            let mut request = [0_u8; 1024];
+            let length = stream.read(&mut request).expect("identity request reads");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}")
+                .expect("identity response writes");
+            String::from_utf8(request[..length].to_vec()).expect("identity request is UTF-8")
+        });
+
+        let origin = Url::parse(&format!("http://{address}")).expect("test origin parses");
+        let transport = HttpStatusTransport::default();
+        assert!(matches!(
+            transport.get_status(&origin, Duration::from_secs(1)),
+            TransportResult::Ok(body) if body == b"{}"
+        ));
+        let request = server.join().expect("identity server joins");
+        assert!(
+            request.starts_with("GET /api/status/identity HTTP/1.1\r\n"),
+            "request line = {request:?}"
+        );
     }
 
     #[test]

--- a/docs/qa/charters/CH-bounded-runtime-identity.md
+++ b/docs/qa/charters/CH-bounded-runtime-identity.md
@@ -1,0 +1,27 @@
+# CH-bounded-runtime-identity: Keep daemon liveness bounded under status load
+
+```yaml
+charter:
+  id: CH-bounded-runtime-identity
+  mission: "As Ada, repeatedly bind to one live daemon through HTTP and UDS while full status is read in parallel, proving liveness stays bounded and the diagnostic snapshot stays truthful."
+  mode: charter-with-tour
+  persona:
+    name: Ada
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-operate-daemon-schema
+  scenarios: [RT-bounded-runtime-identity, RT-001]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Read `/api/status/identity` repeatedly over HTTP and UDS; confirm every response names the same process, listener, home, build, and schema."
+      - "Read `/api/status` before, during, and after the identity burst; confirm its complete sections remain available and unchanged in shape."
+      - "Compare response sizes and elapsed time, then request an unknown identity subpath and confirm a 404 without affecting later reads."
+      - "Capture the Rust transport regression and Go route tests alongside the live public-surface evidence."
+    must_avoid:
+      - "Do not use the identity response as a replacement for status or doctor diagnostics."
+```
+
+<!-- The charter is durable and immutable: re-run it in later cycles; each run's debrief goes in that run's report (Session Debriefs), never here. -->

--- a/docs/qa/journeys/J-operate-daemon-schema.md
+++ b/docs/qa/journeys/J-operate-daemon-schema.md
@@ -26,7 +26,7 @@ flowchart TD
     FRESH --> BOOT
     BACKUP --> FRESH
     BOOT --> DOMAINS[Read workspace and memory catalogs through public CLI surfaces]
-    DOMAINS --> STATUS[Inspect GET /api/status over HTTP and UDS]
+    DOMAINS --> STATUS[Inspect full status and bounded identity over HTTP and UDS]
     STATUS --> CLI[Inspect compozy status -o json]
     CLI --> AUDIT[Run gateway audit over CLI, HTTP, UDS, and the native tool]
     AUDIT --> MATCH{schema and gateway observations match?}
@@ -47,6 +47,8 @@ journey:
     - url: "CLI: compozy daemon start --foreground"
       origin: direct
     - url: "HTTP/UDS: GET /api/status"
+      origin: direct
+    - url: "HTTP/UDS: GET /api/status/identity"
       origin: direct
     - url: "CLI: compozy status -o json"
       origin: direct
@@ -72,8 +74,8 @@ journey:
       verb: "Exercise global and memory read paths after migration and restart"
       expected_observable: "Workspace and memory catalog reads succeed while the two version streams remain independently visible."
     - step: 5
-      verb: "Compare schema status over HTTP, UDS, and CLI JSON"
-      expected_observable: "All surfaces return the same ordered global and memory entries with version, applied count, and schema digest."
+      verb: "Compare full status and bounded runtime identity over HTTP, UDS, and CLI JSON"
+      expected_observable: "Full status keeps the same ordered global and memory entries; repeated identity reads return only the process and listener identity on both transports."
     - step: 6
       verb: "Run the gateway self-audit through each structured surface"
       expected_observable: "Every surface returns the same stable, severity-ranked findings or an explicit no-findings result without changing gateway state or exposing credentials."
@@ -90,7 +92,7 @@ journey:
     - at_step: 1
       how: "The database was written by a newer post-squash binary and the matching binary is unavailable."
       resume: "Leave the home unchanged and resume only with a compatible newer binary or a separately selected fresh COMPOZY_HOME."
-  crosses: [daemon-boot, session-readers, ledger-materialization, SQLite, Goose, HTTP, UDS, CLI]
+  crosses: [daemon-boot, desktop-liveness, session-readers, ledger-materialization, SQLite, Goose, HTTP, UDS, CLI]
 ```
 
 Taxonomy note: this journey covers the functional happy path, global and per-session legacy/ahead/corruption error and

--- a/docs/qa/reports/2026-08-16-issue-413-bounded-liveness.md
+++ b/docs/qa/reports/2026-08-16-issue-413-bounded-liveness.md
@@ -1,0 +1,72 @@
+# QA Run Report — 2026-08-16 — issue-413-bounded-liveness
+
+- **Scope:** Issue #413 bounded Desktop liveness endpoint and full-status canary
+- **Cadence tier:** targeted
+- **Build:** 17f70f99 + working tree · **Environment:** isolated bootstrap lab, HTTP and UDS
+- **Started:** 2026-08-16T02:55:54-03:00 · **Finished:** 2026-08-16T03:04:27-03:00 · **Status:** passed
+- **Behavioral verdict:** PASS
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | Power User | desktop / wifi-fast / en-US | CH-bounded-runtime-identity |
+
+## Flows in Scope
+
+- `J-operate-daemon-schema` — start and inspect the daemon through structured surfaces (`../journeys/J-operate-daemon-schema.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-bounded-runtime-identity | J-operate-daemon-schema / RT-bounded-runtime-identity | Ada | Feature Tour | Pass | | |
+| 2 | CH-bounded-runtime-identity | J-operate-daemon-schema / RT-001 | Ada | Feature Tour | Pass | | |
+
+## Session Debriefs
+
+### CH-bounded-runtime-identity — Ada
+
+- Entered through the documented HTTP endpoint, then independently repeated the read over UDS and the CLI.
+- 500 HTTP and 500 UDS identity reads all returned status 200 and the same 214-byte process identity. Worst observed times were 2.783 ms over HTTP and 0.844 ms over UDS.
+- Ten complete status snapshots remained readable during the identity burst. The worst observed status time was 11.313 ms, and every snapshot retained the running daemon PID plus the ordered global and memory schema streams.
+- HTTP, UDS, and CLI complete-status reads agreed on PID 76366, listener port 53846, and both schema streams.
+- An unknown identity subpath returned the router's standard 404; the next documented identity read returned the unchanged payload in 0.598 ms.
+- Automated evidence passed for the Go session/observer/API suites under the race detector and for the Rust probe's actual TCP request line.
+- Goal reached: yes. True end state: confirmed. Scenarios settled: `RT-bounded-runtime-identity=pass`, `RT-001=pass`.
+
+Evidence root: `/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/`.
+Teardown evidence: `/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/teardown.json` (`clean: true`, no survivors).
+
+## What Was Fixed
+
+The Desktop health probe now reads a bounded runtime identity instead of the complete status aggregate. Internal memory, title, and dreaming sessions no longer wake the public session catalog, and the built-in dreaming curator resolves through effective workspace configuration.
+
+## Paper Cuts
+
+- Dull: an unknown API subpath returns the router's existing plain-text 404 rather than a structured error. Recovery is immediate and this issue does not change the router-wide error contract.
+
+## Runtime Errors Observed
+
+None.
+
+## Human Verifications Needed
+
+None. The native WebView was not launched in this targeted structured-surface run; its request path is covered by the Rust TCP transport regression.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The bounded payload stayed 85 times smaller than the complete fresh-daemon snapshot in this run (214 bytes versus roughly 18.3 KB).
+- Moving liveness off the diagnostic aggregate preserves full status for operators while preventing the Desktop's two-second monitor from paying for session and subsystem aggregation.
+- Production-parity qualification: the run used the source-built dirty binary in a fresh isolated home, not a packaged macOS application; provider and browser surfaces were intentionally outside this read-only journey.
+
+## Final Status
+
+- **Exit gate (full automated suite):** pending final `make gate-full`; the immutable run log will be written to `/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/final-make-verify.log` after this report is finalized.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 journeys walked; 2/2 scenarios passed
+- **Verdict:** ready for the final full automated gate.

--- a/docs/qa/scenarios/RT-001.md
+++ b/docs/qa/scenarios/RT-001.md
@@ -11,8 +11,8 @@ bug_ids: BUG-0003
 fix_status: fixed
 retest_status: pass
 fix_commits: 8eeb8a38
-evidence: /Users/pedronauck/dev/qa-labs/compozy-store-redesign-20260712-144704-069939-lab/qa-artifacts/qa/evidence/fresh-status-cli.json;/Users/pedronauck/dev/qa-labs/compozy-store-redesign-20260712-144704-069939-lab/qa-artifacts/qa/evidence/fresh-status-http.json;/Users/pedronauck/dev/qa-labs/compozy-store-redesign-20260712-144704-069939-lab/qa-artifacts/qa/evidence/fresh-status-uds.json; /Users/pedronauck/dev/qa-labs/compozy-northstar-pay-20260729-021949-664736-lab/qa-artifacts/qa/evidence/001-runtime-readiness
-last_report: docs/qa/reports/2026-07-28-untested-full.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-store-redesign-20260712-144704-069939-lab/qa-artifacts/qa/evidence/fresh-status-cli.json;/Users/pedronauck/dev/qa-labs/compozy-store-redesign-20260712-144704-069939-lab/qa-artifacts/qa/evidence/fresh-status-http.json;/Users/pedronauck/dev/qa-labs/compozy-store-redesign-20260712-144704-069939-lab/qa-artifacts/qa/evidence/fresh-status-uds.json; /Users/pedronauck/dev/qa-labs/compozy-northstar-pay-20260729-021949-664736-lab/qa-artifacts/qa/evidence/001-runtime-readiness;/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/status-http.json;/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/status-uds.json;/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/status-cli.json
+last_report: docs/qa/reports/2026-08-16-issue-413-bounded-liveness.md
 overlaps: RT-inspect-schema-streams;RT-001
 ---
 
@@ -37,5 +37,8 @@ reports availability plus disabled/ready/active participation truth and removes 
 port, and ordered global/memory schema-stream entries over CLI, HTTP, and UDS. Network reported
 enabled/ready, the complete status envelope remained usable, and credential output exposed slot
 names and remediation only, never secret values.
+
+Issue #413 replay 2026-08-16: the isolated daemon kept the complete status envelope and ordered
+global/memory schema streams available over HTTP, UDS, and CLI during 1,000 bounded identity reads.
 
 src: docs/qa/_seeds/feature-stories/01_analysis_runtime-sessions.md

--- a/docs/qa/scenarios/RT-bounded-runtime-identity.md
+++ b/docs/qa/scenarios/RT-bounded-runtime-identity.md
@@ -1,0 +1,21 @@
+---
+id: RT-bounded-runtime-identity
+area: RT
+title: Keep desktop liveness independent from full status
+persona: Ada
+journey: J-operate-daemon-schema
+expected: Repeated HTTP and UDS `GET /api/status/identity` reads return only the schema and daemon identity without delaying or changing the complete `GET /api/status` snapshot.
+entry_points: GET /api/status/identity over HTTP; GET /api/status/identity over UDS; GET /api/status
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/identity-http.json;/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/identity-uds.json;/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/identity-http-burst.tsv;/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/identity-uds-burst.tsv;/Users/pedronauck/dev/qa-labs/compozy-issue-413-bounded-liveness-20260816-055839-132323-lab/qa-artifacts/qa/logs/desktop-probe-regression.log
+last_report: docs/qa/reports/2026-08-16-issue-413-bounded-liveness.md
+overlaps: RT-001
+---
+
+Issue #413 impact flag: the native desktop shell now binds and monitors the daemon through the bounded identity surface instead of polling the complete runtime status aggregate.
+
+Taxonomy: the journey covers the repeated-read happy path, HTTP/UDS consistency, malformed route handling, and the adjacent complete-status canary. Rendered UI, locale, and mobile dimensions are not applicable to this structured liveness contract.

--- a/internal/api/contract/runtime_identity.go
+++ b/internal/api/contract/runtime_identity.go
@@ -1,0 +1,19 @@
+package contract
+
+import "time"
+
+// RuntimeIdentityPayload is the bounded daemon identity used by local liveness clients.
+type RuntimeIdentityPayload struct {
+	SchemaVersion string                `json:"schema_version"`
+	Daemon        DaemonIdentityPayload `json:"daemon"`
+}
+
+// DaemonIdentityPayload identifies one concrete daemon process and listener.
+type DaemonIdentityPayload struct {
+	PID         int       `json:"pid"`
+	StartedAt   time.Time `json:"started_at"`
+	HTTPHost    string    `json:"http_host"`
+	HTTPPort    int       `json:"http_port"`
+	UserHomeDir string    `json:"user_home_dir"`
+	Version     string    `json:"version"`
+}

--- a/internal/api/core/runtime_identity.go
+++ b/internal/api/core/runtime_identity.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/compozy/compozy/internal/api/contract"
+	"github.com/compozy/compozy/internal/version"
+	"github.com/gin-gonic/gin"
+)
+
+// GetRuntimeIdentity returns the bounded daemon identity shared by HTTP and UDS.
+func (h *BaseHandlers) GetRuntimeIdentity(c *gin.Context) {
+	httpPort := h.HTTPPortValue()
+	if httpPort <= 0 {
+		httpPort = h.Config.HTTP.Port
+	}
+	c.JSON(http.StatusOK, contract.RuntimeIdentityPayload{
+		SchemaVersion: contract.StatusSchemaVersion,
+		Daemon: contract.DaemonIdentityPayload{
+			PID:         h.PID(),
+			StartedAt:   h.StartedAt,
+			HTTPHost:    strings.TrimSpace(h.Config.HTTP.Host),
+			HTTPPort:    httpPort,
+			UserHomeDir: h.daemonUserHomeDir(),
+			Version:     strings.TrimSpace(version.Current().Version),
+		},
+	})
+}

--- a/internal/api/httpapi/handlers_test.go
+++ b/internal/api/httpapi/handlers_test.go
@@ -2017,50 +2017,55 @@ func TestDaemonStatusHandlerReturnsUserHomeDir(t *testing.T) {
 }
 
 func TestRuntimeIdentityHandlerStaysIndependentFromRuntimeAggregation(t *testing.T) {
-	t.Parallel()
+	t.Run("Should return identity without runtime aggregation", func(t *testing.T) {
+		t.Parallel()
 
-	var sessionCalls atomic.Int32
-	var observerCalls atomic.Int32
-	homePaths := newTestHomePaths(t)
-	manager := stubSessionManager{
-		ListAllFn: func(context.Context) ([]*session.Info, error) {
-			sessionCalls.Add(1)
-			return nil, errors.New("session aggregation must not run")
-		},
-	}
-	observer := stubObserver{
-		HealthFn: func(context.Context) (observe.Health, error) {
-			observerCalls.Add(1)
-			return observe.Health{}, errors.New("observer aggregation must not run")
-		},
-	}
-	engine := newTestRouter(t, newTestHandlers(t, manager, observer, homePaths))
+		var sessionCalls atomic.Int32
+		var observerCalls atomic.Int32
+		homePaths := newTestHomePaths(t)
+		manager := stubSessionManager{
+			ListAllFn: func(context.Context) ([]*session.Info, error) {
+				sessionCalls.Add(1)
+				return nil, errors.New("session aggregation must not run")
+			},
+		}
+		observer := stubObserver{
+			HealthFn: func(context.Context) (observe.Health, error) {
+				observerCalls.Add(1)
+				return observe.Health{}, errors.New("observer aggregation must not run")
+			},
+		}
+		engine := newTestRouter(t, newTestHandlers(t, manager, observer, homePaths))
 
-	recorder := performRequest(t, engine, http.MethodGet, "/api/status/identity", nil)
-	if recorder.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
-	}
-	if sessionCalls.Load() != 0 || observerCalls.Load() != 0 {
-		t.Fatalf(
-			"identity aggregation calls = sessions:%d observer:%d, want zero",
-			sessionCalls.Load(),
-			observerCalls.Load(),
-		)
-	}
+		recorder := performRequest(t, engine, http.MethodGet, "/api/status/identity", nil)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+		}
+		if sessionCalls.Load() != 0 || observerCalls.Load() != 0 {
+			t.Fatalf(
+				"identity aggregation calls = sessions:%d observer:%d, want zero",
+				sessionCalls.Load(),
+				observerCalls.Load(),
+			)
+		}
 
-	var response map[string]json.RawMessage
-	decodeJSONResponse(t, recorder, &response)
-	if len(response) != 2 || response["schema_version"] == nil || response["daemon"] == nil {
-		t.Fatalf("identity response keys = %v, want schema_version and daemon only", slices.Sorted(maps.Keys(response)))
-	}
-	var daemon contract.DaemonIdentityPayload
-	if err := json.Unmarshal(response["daemon"], &daemon); err != nil {
-		t.Fatalf("json.Unmarshal(daemon identity) error = %v", err)
-	}
-	if daemon.PID <= 0 || daemon.StartedAt.IsZero() || daemon.HTTPHost != "127.0.0.1" ||
-		daemon.HTTPPort != 2123 || daemon.UserHomeDir == "" || daemon.Version == "" {
-		t.Fatalf("daemon identity = %#v, want complete bounded runtime identity", daemon)
-	}
+		var response map[string]json.RawMessage
+		decodeJSONResponse(t, recorder, &response)
+		if len(response) != 2 || response["schema_version"] == nil || response["daemon"] == nil {
+			t.Fatalf(
+				"identity response keys = %v, want schema_version and daemon only",
+				slices.Sorted(maps.Keys(response)),
+			)
+		}
+		var daemon contract.DaemonIdentityPayload
+		if err := json.Unmarshal(response["daemon"], &daemon); err != nil {
+			t.Fatalf("json.Unmarshal(daemon identity) error = %v", err)
+		}
+		if daemon.PID <= 0 || daemon.StartedAt.IsZero() || daemon.HTTPHost != "127.0.0.1" ||
+			daemon.HTTPPort != 2123 || daemon.UserHomeDir == "" || daemon.Version == "" {
+			t.Fatalf("daemon identity = %#v, want complete bounded runtime identity", daemon)
+		}
+	})
 }
 
 func TestGetWorkspaceHandlerReturnsDetail(t *testing.T) {

--- a/internal/api/httpapi/handlers_test.go
+++ b/internal/api/httpapi/handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -187,6 +188,7 @@ func assertRegisteredRouteContract(t *testing.T) {
 		"GET /api/network/status",
 		"GET /api/workspaces/:workspace_id/network/work/:work_id",
 		"GET /api/status",
+		"GET /api/status/identity",
 		"POST /api/undrain",
 		"GET /api/onboarding",
 		"POST /api/onboarding/complete",
@@ -2012,6 +2014,53 @@ func TestDaemonStatusHandlerReturnsUserHomeDir(t *testing.T) {
 			)
 		}
 	})
+}
+
+func TestRuntimeIdentityHandlerStaysIndependentFromRuntimeAggregation(t *testing.T) {
+	t.Parallel()
+
+	var sessionCalls atomic.Int32
+	var observerCalls atomic.Int32
+	homePaths := newTestHomePaths(t)
+	manager := stubSessionManager{
+		ListAllFn: func(context.Context) ([]*session.Info, error) {
+			sessionCalls.Add(1)
+			return nil, errors.New("session aggregation must not run")
+		},
+	}
+	observer := stubObserver{
+		HealthFn: func(context.Context) (observe.Health, error) {
+			observerCalls.Add(1)
+			return observe.Health{}, errors.New("observer aggregation must not run")
+		},
+	}
+	engine := newTestRouter(t, newTestHandlers(t, manager, observer, homePaths))
+
+	recorder := performRequest(t, engine, http.MethodGet, "/api/status/identity", nil)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if sessionCalls.Load() != 0 || observerCalls.Load() != 0 {
+		t.Fatalf(
+			"identity aggregation calls = sessions:%d observer:%d, want zero",
+			sessionCalls.Load(),
+			observerCalls.Load(),
+		)
+	}
+
+	var response map[string]json.RawMessage
+	decodeJSONResponse(t, recorder, &response)
+	if len(response) != 2 || response["schema_version"] == nil || response["daemon"] == nil {
+		t.Fatalf("identity response keys = %v, want schema_version and daemon only", slices.Sorted(maps.Keys(response)))
+	}
+	var daemon contract.DaemonIdentityPayload
+	if err := json.Unmarshal(response["daemon"], &daemon); err != nil {
+		t.Fatalf("json.Unmarshal(daemon identity) error = %v", err)
+	}
+	if daemon.PID <= 0 || daemon.StartedAt.IsZero() || daemon.HTTPHost != "127.0.0.1" ||
+		daemon.HTTPPort != 2123 || daemon.UserHomeDir == "" || daemon.Version == "" {
+		t.Fatalf("daemon identity = %#v, want complete bounded runtime identity", daemon)
+	}
 }
 
 func TestGetWorkspaceHandlerReturnsDetail(t *testing.T) {

--- a/internal/api/httpapi/routes.go
+++ b/internal/api/httpapi/routes.go
@@ -35,6 +35,7 @@ func registerLocalRoutes(router gin.IRouter, handlers *Handlers) {
 
 func registerStatusRoutes(api gin.IRouter, handlers *Handlers) {
 	api.GET("/status", handlers.GetStatus)
+	api.GET("/status/identity", handlers.GetRuntimeIdentity)
 	api.GET("/doctor", handlers.GetDoctor)
 	privileged := handlers.privilegedMutationGuard()
 	api.POST("/drain", privileged, handlers.DrainDaemon)

--- a/internal/api/spec/runtime_status.go
+++ b/internal/api/spec/runtime_status.go
@@ -33,6 +33,17 @@ func runtimeStatusOperations() []OperationSpec {
 				{Status: 500, Description: specInternalServerErrorDescription, Body: contract.ErrorPayload{}},
 			},
 		},
+		{
+			Method:      httpMethodGet,
+			Path:        "/api/status/identity",
+			OperationID: "getRuntimeIdentity",
+			Summary:     "Get the bounded runtime identity",
+			Tags:        []string{specDiagnosticsKey},
+			Transports:  []Transport{TransportHTTP, TransportUDS},
+			Responses: []ResponseSpec{
+				{Status: 200, Description: "OK", Body: contract.RuntimeIdentityPayload{}},
+			},
+		},
 		drainStateOperation(httpMethodPost, "/api/drain", "drainDaemon", "Stop admitting new work"),
 		drainStateOperation(httpMethodPost, "/api/undrain", "undrainDaemon", "Resume admission of new work"),
 	}

--- a/internal/api/udsapi/handlers_test.go
+++ b/internal/api/udsapi/handlers_test.go
@@ -181,6 +181,7 @@ func TestRegisterRoutesCoversTechSpecEndpoints(t *testing.T) {
 			"GET /api/network/status",
 			"GET /api/workspaces/:workspace_id/network/work/:work_id",
 			"GET /api/status",
+			"GET /api/status/identity",
 			"POST /api/undrain",
 			"GET /api/onboarding",
 			"POST /api/onboarding/complete",

--- a/internal/api/udsapi/routes.go
+++ b/internal/api/udsapi/routes.go
@@ -43,6 +43,7 @@ func RegisterRoutes(router gin.IRouter, handlers *Handlers) {
 
 func registerStatusRoutes(api gin.IRouter, handlers *Handlers) {
 	api.GET("/status", handlers.GetStatus)
+	api.GET("/status/identity", handlers.GetRuntimeIdentity)
 	api.GET("/doctor", handlers.GetDoctor)
 	api.POST("/drain", handlers.DrainDaemon)
 	api.POST("/undrain", handlers.UndrainDaemon)

--- a/internal/observe/agent_resolution.go
+++ b/internal/observe/agent_resolution.go
@@ -111,6 +111,9 @@ func loadObservedAgent(
 	if err != nil {
 		return compozyconfig.Config{}, compozyconfig.AgentDef{}, fmt.Errorf("load config: %w", err)
 	}
+	if agentDef, ok := compozyconfig.BuiltinAgentDef(agentName); ok {
+		return cfg, agentDef, nil
+	}
 	agentDef, err := agentDefByName(resolvedWorkspace.Agents, agentName)
 	if err != nil {
 		return compozyconfig.Config{}, compozyconfig.AgentDef{}, fmt.Errorf("load agent %q: %w", agentName, err)

--- a/internal/observe/helpers_test.go
+++ b/internal/observe/helpers_test.go
@@ -216,6 +216,60 @@ command = "codex"
 	}
 }
 
+func TestDefaultPermissionModeResolverUsesBuiltinAgentInWorkspace(t *testing.T) {
+	t.Parallel()
+
+	home, err := compozyconfig.ResolveHomePathsFrom(filepath.Join(t.TempDir(), "home"))
+	if err != nil {
+		t.Fatalf("ResolveHomePathsFrom() error = %v", err)
+	}
+	if err := compozyconfig.EnsureHomeLayout(home); err != nil {
+		t.Fatalf("EnsureHomeLayout() error = %v", err)
+	}
+	if err := os.WriteFile(home.ConfigFile, []byte(`
+[defaults]
+provider = "codex"
+
+[providers.codex]
+command = "codex"
+
+[permissions]
+mode = "deny-all"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(global config) error = %v", err)
+	}
+
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	workspaceConfigDir := filepath.Join(workspace, compozyconfig.DirName)
+	if err := os.MkdirAll(workspaceConfigDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace config) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workspaceConfigDir, compozyconfig.ConfigName), []byte(`
+[permissions]
+mode = "approve-all"
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile(workspace config) error = %v", err)
+	}
+
+	resolver := defaultPermissionModeResolver(home, &fakeObserveWorkspaceResolver{
+		expectedRef: "ws-observe",
+		resolved: workspacepkg.ResolvedWorkspace{
+			Workspace: workspacepkg.Workspace{ID: "ws-observe", RootDir: workspace},
+		},
+	})
+	got, err := resolver(
+		testutil.Context(t),
+		compozyconfig.BuiltinDreamingCuratorAgentName,
+		"ws-observe",
+	)
+	if err != nil {
+		t.Fatalf("resolver(builtin workspace agent) error = %v", err)
+	}
+	if got != "approve-all" {
+		t.Fatalf("resolver(builtin workspace agent) = %q, want approve-all", got)
+	}
+}
+
 func TestDefaultPermissionModeResolverUsesWorkspaceResolvedAgentDef(t *testing.T) {
 	t.Parallel()
 

--- a/internal/observe/helpers_test.go
+++ b/internal/observe/helpers_test.go
@@ -217,16 +217,17 @@ command = "codex"
 }
 
 func TestDefaultPermissionModeResolverUsesBuiltinAgentInWorkspace(t *testing.T) {
-	t.Parallel()
+	t.Run("Should resolve built-in agent with workspace permissions", func(t *testing.T) {
+		t.Parallel()
 
-	home, err := compozyconfig.ResolveHomePathsFrom(filepath.Join(t.TempDir(), "home"))
-	if err != nil {
-		t.Fatalf("ResolveHomePathsFrom() error = %v", err)
-	}
-	if err := compozyconfig.EnsureHomeLayout(home); err != nil {
-		t.Fatalf("EnsureHomeLayout() error = %v", err)
-	}
-	if err := os.WriteFile(home.ConfigFile, []byte(`
+		home, err := compozyconfig.ResolveHomePathsFrom(filepath.Join(t.TempDir(), "home"))
+		if err != nil {
+			t.Fatalf("ResolveHomePathsFrom() error = %v", err)
+		}
+		if err := compozyconfig.EnsureHomeLayout(home); err != nil {
+			t.Fatalf("EnsureHomeLayout() error = %v", err)
+		}
+		if err := os.WriteFile(home.ConfigFile, []byte(`
 [defaults]
 provider = "codex"
 
@@ -236,38 +237,39 @@ command = "codex"
 [permissions]
 mode = "deny-all"
 `), 0o644); err != nil {
-		t.Fatalf("WriteFile(global config) error = %v", err)
-	}
+			t.Fatalf("WriteFile(global config) error = %v", err)
+		}
 
-	workspace := filepath.Join(t.TempDir(), "workspace")
-	workspaceConfigDir := filepath.Join(workspace, compozyconfig.DirName)
-	if err := os.MkdirAll(workspaceConfigDir, 0o755); err != nil {
-		t.Fatalf("MkdirAll(workspace config) error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workspaceConfigDir, compozyconfig.ConfigName), []byte(`
+		workspace := filepath.Join(t.TempDir(), "workspace")
+		workspaceConfigDir := filepath.Join(workspace, compozyconfig.DirName)
+		if err := os.MkdirAll(workspaceConfigDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(workspace config) error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(workspaceConfigDir, compozyconfig.ConfigName), []byte(`
 [permissions]
 mode = "approve-all"
 `), 0o644); err != nil {
-		t.Fatalf("WriteFile(workspace config) error = %v", err)
-	}
+			t.Fatalf("WriteFile(workspace config) error = %v", err)
+		}
 
-	resolver := defaultPermissionModeResolver(home, &fakeObserveWorkspaceResolver{
-		expectedRef: "ws-observe",
-		resolved: workspacepkg.ResolvedWorkspace{
-			Workspace: workspacepkg.Workspace{ID: "ws-observe", RootDir: workspace},
-		},
+		resolver := defaultPermissionModeResolver(home, &fakeObserveWorkspaceResolver{
+			expectedRef: "ws-observe",
+			resolved: workspacepkg.ResolvedWorkspace{
+				Workspace: workspacepkg.Workspace{ID: "ws-observe", RootDir: workspace},
+			},
+		})
+		got, err := resolver(
+			testutil.Context(t),
+			compozyconfig.BuiltinDreamingCuratorAgentName,
+			"ws-observe",
+		)
+		if err != nil {
+			t.Fatalf("resolver(builtin workspace agent) error = %v", err)
+		}
+		if got != "approve-all" {
+			t.Fatalf("resolver(builtin workspace agent) = %q, want approve-all", got)
+		}
 	})
-	got, err := resolver(
-		testutil.Context(t),
-		compozyconfig.BuiltinDreamingCuratorAgentName,
-		"ws-observe",
-	)
-	if err != nil {
-		t.Fatalf("resolver(builtin workspace agent) error = %v", err)
-	}
-	if got != "approve-all" {
-		t.Fatalf("resolver(builtin workspace agent) = %q, want approve-all", got)
-	}
 }
 
 func TestDefaultPermissionModeResolverUsesWorkspaceResolvedAgentDef(t *testing.T) {

--- a/internal/session/catalog_page.go
+++ b/internal/session/catalog_page.go
@@ -250,10 +250,7 @@ func sessionMatchesListQuery(info *Info, query ListQuery, now time.Time) bool {
 }
 
 func sessionMatchesIdentityFilters(info *Info, query ListQuery) bool {
-	if info == nil || info.Type == SessionTypeDream {
-		return false
-	}
-	if lineage := info.Lineage; lineage != nil && IsInternalSpawnRole(lineage.SpawnRole) {
+	if !isPublicSessionCatalogInfo(info) {
 		return false
 	}
 	return (query.WorkspaceID == "" || strings.TrimSpace(info.WorkspaceID) == query.WorkspaceID) &&
@@ -261,6 +258,14 @@ func sessionMatchesIdentityFilters(info *Info, query ListQuery) bool {
 		(query.State == "" || strings.TrimSpace(string(info.State)) == query.State) &&
 		(query.SessionType == "" || normalizeSessionType(info.Type) == query.SessionType) &&
 		(query.AgentName == "" || strings.TrimSpace(info.AgentName) == query.AgentName)
+}
+
+func isPublicSessionCatalogInfo(info *Info) bool {
+	if info == nil || info.Type == SessionTypeDream {
+		return false
+	}
+	lineage := info.Lineage
+	return lineage == nil || !IsInternalSpawnRole(lineage.SpawnRole)
 }
 
 func sessionMatchesLineageFilters(info *Info, query ListQuery) bool {

--- a/internal/session/session_catalog_stream.go
+++ b/internal/session/session_catalog_stream.go
@@ -124,7 +124,7 @@ func (m *Manager) publishSessionCatalogWakeForEvent(session *Session, event acp.
 }
 
 func sessionCatalogEventFromInfo(kind CatalogEventKind, info *Info) CatalogEvent {
-	if info == nil {
+	if !isPublicSessionCatalogInfo(info) {
 		return CatalogEvent{}
 	}
 	return CatalogEvent{

--- a/internal/session/session_stream_broadcast_test.go
+++ b/internal/session/session_stream_broadcast_test.go
@@ -170,6 +170,42 @@ func (n *streamIdentityNotifier) OnAgentEventForSession(_ context.Context, sess 
 func TestSessionCatalogBroadcaster(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should keep daemon-owned sessions out of the public catalog stream", func(t *testing.T) {
+		t.Parallel()
+
+		manager, err := NewManager(WithHomePaths(testHomePaths(t)))
+		if err != nil {
+			t.Fatalf("NewManager() error = %v", err)
+		}
+		cleanupTestManager(t, manager)
+		events, cancel, err := manager.SubscribeSessionCatalogEvents(testutil.Context(t))
+		if err != nil {
+			t.Fatalf("SubscribeSessionCatalogEvents() error = %v", err)
+		}
+		defer cancel()
+
+		internalSessions := []*Session{
+			{
+				ID: "sess-memory-extractor", WorkspaceID: "ws-internal",
+				Lineage: &store.SessionLineage{SpawnRole: SpawnRoleMemoryExtractor},
+			},
+			{
+				ID: "sess-auto-title", WorkspaceID: "ws-internal",
+				Lineage: &store.SessionLineage{SpawnRole: SpawnRoleAutoTitle},
+			},
+			{ID: "sess-dream", WorkspaceID: "ws-internal", Type: SessionTypeDream},
+		}
+		for _, sess := range internalSessions {
+			manager.publishSessionCatalogWakeForEvent(sess, acp.AgentEvent{Type: acp.EventTypePermission})
+		}
+
+		select {
+		case event := <-events:
+			t.Fatalf("daemon-owned session woke the public catalog: %#v", event)
+		default:
+		}
+	})
+
 	t.Run("Should wake the owning workspace catalog for permission state changes", func(t *testing.T) {
 		t.Parallel()
 

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -154324,6 +154324,72 @@
         ]
       }
     },
+    "/api/status/identity": {
+      "get": {
+        "operationId": "getRuntimeIdentity",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "daemon": {
+                      "properties": {
+                        "http_host": {
+                          "type": "string"
+                        },
+                        "http_port": {
+                          "type": "integer"
+                        },
+                        "pid": {
+                          "type": "integer"
+                        },
+                        "started_at": {
+                          "format": "date-time",
+                          "type": "string"
+                        },
+                        "user_home_dir": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "http_host",
+                        "http_port",
+                        "pid",
+                        "started_at",
+                        "user_home_dir",
+                        "version"
+                      ],
+                      "type": "object"
+                    },
+                    "schema_version": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "daemon",
+                    "schema_version"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Get the bounded runtime identity",
+        "tags": [
+          "diagnostics"
+        ],
+        "x-compozy-transports": [
+          "http",
+          "uds"
+        ]
+      }
+    },
     "/api/support/bundles": {
       "post": {
         "operationId": "createSupportBundle",

--- a/packages/site/content/docs/operations/daemon.mdx
+++ b/packages/site/content/docs/operations/daemon.mdx
@@ -60,6 +60,7 @@ If HTTP is enabled on the default host and port, the same data is available over
 
 ```bash
 curl -s http://localhost:2123/api/status | jq '.daemon'
+curl -s http://localhost:2123/api/status/identity | jq '.daemon'
 curl -s 'http://localhost:2123/api/status?workspace_id=<workspace-id>' | jq '.skills'
 curl -s http://localhost:2123/api/doctor | jq '.items'
 ```
@@ -67,6 +68,10 @@ curl -s http://localhost:2123/api/doctor | jq '.items'
 `GET /api/status` accepts either `workspace_id=<id>` or `workspace=<id|name|path>` when the caller
 needs skill diagnostics resolved for one workspace. Bare `compozy status` remains the daemon-wide
 process view and does not infer a workspace.
+
+The native desktop shell uses `GET /api/status/identity` for its frequent liveness checks. This
+bounded response contains only the schema version and the daemon process, listener, home, and build
+identity. Use `GET /api/status` or `compozy status` when you need the complete runtime snapshot.
 
 <Mermaid
   chart={`flowchart LR

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -552,6 +552,10 @@ Do not treat stale UI state, chat messages, or memory notes as runtime authority
 
 `compozy status -o json` is the consolidated daemon-wide status surface for daemon health, providers, MCP servers, config apply status, schema migration streams, and log tail summary. To resolve skill diagnostics for one workspace, call `GET /api/status?workspace_id=<id>` or `GET /api/status?workspace=<id|name|path>`; bare `compozy status` does not select a workspace. Inspect `schema_streams` after startup to confirm that the global and memory streams report their expected version, applied migration count, and digest. An incompatible daemon-global `compozy.db` is refused during boot, before readiness. By contrast, an incompatible per-session `events.db` can be discovered after the daemon is ready when a reader such as `compozy session history <id> -o json` or `GET /api/workspaces/{workspace_id}/sessions/{session_id}/history` opens that session; that operation fails without making the healthy daemon-global store unavailable.
 
+`GET /api/status/identity` is the bounded HTTP/UDS process and listener identity used by the native
+desktop shell for frequent liveness checks. It intentionally omits runtime diagnostics; use
+`compozy status -o json`, `GET /api/status`, or `compozy doctor -o json` for inspection.
+
 Inspect `.subprocess_health` in `compozy status -o json` and run
 `compozy doctor --only runtime.subprocess_health -o json` for active ACP subprocess verdicts. With the
 default `daemon.subprocess_health_escalation_threshold = 3`, three consecutive failed checks—or an

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -3537,6 +3537,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/status/identity": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the bounded runtime identity */
+    get: operations["getRuntimeIdentity"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/support/bundles": {
     parameters: {
       query?: never;
@@ -63035,6 +63052,37 @@ export interface operations {
               title: string;
             } | null;
             error: string;
+          };
+        };
+      };
+    };
+  };
+  getRuntimeIdentity: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            daemon: {
+              http_host: string;
+              http_port: number;
+              pid: number;
+              /** Format: date-time */
+              started_at: string;
+              user_home_dir: string;
+              version: string;
+            };
+            schema_version: string;
           };
         };
       };


### PR DESCRIPTION
Fixes #413.

## Summary

This removes the request/reload feedback loop that made the macOS Desktop unusable during long-running sessions with a large internal session catalog.

- moves the Desktop's two-second liveness probe from the full `/api/status` aggregate to a new bounded `GET /api/status/identity` surface over HTTP and UDS
- stops memory-extractor, auto-title, and dream sessions from publishing wake events to the public session catalog
- resolves built-in background agents, including `dreaming-curator`, through effective workspace configuration instead of treating them as missing workspace-authored agents
- publishes the identity contract through OpenAPI, generated TypeScript types, daemon operations docs, and the official Compozy skill

## Root cause

The incident combined three amplifiers:

1. The native health monitor fetched the complete runtime snapshot every two seconds. That snapshot aggregates sessions, observer health, logs, providers, memory, tasks, skills, automation, network, and configuration. When it crossed the Desktop's two-second deadline, health failures caused the shell to replace the main WebView; the replacement immediately started another request burst.
2. Daemon-owned background sessions were excluded from public session lists but still emitted public catalog wake events. Every internal memory/title/dream lifecycle could therefore invalidate and refetch the visible catalog even though the result could not contain that session.
3. Observer resolution loaded built-in `dreaming-curator` as though it had to exist in the workspace agent catalog. Session events repeatedly paid for the failed lookup and emitted thousands of warnings.

The one extractor JSON decode failure in the incident did not form a retry loop, so this change does not add speculative retry behavior.

## Implementation

`GET /api/status/identity` returns only the status schema version and the daemon process/listener identity needed for Desktop attachment: PID, start time, HTTP host/port, operator home, and version. The handler does not call the observer or session manager. The Desktop also caps this response at 8 KiB.

The complete `/api/status` contract remains unchanged for operators, the Web UI, CLI diagnostics, and support tooling. Public catalog visibility now has one canonical predicate used by both list filtering and event publication. Built-in agent lookup happens after effective workspace configuration is loaded, so workspace permission overlays still apply.

## Regression coverage

- real TCP Rust test asserts the Desktop sends `GET /api/status/identity HTTP/1.1`
- HTTP handler test asserts the identity response has only `schema_version` and `daemon` and makes zero observer/session aggregation calls
- HTTP and UDS route-contract tests cover the new public surface
- session catalog broadcaster test proves memory-extractor, auto-title, and dream sessions cannot wake the public catalog
- observer resolver test proves `dreaming-curator` resolves with the workspace's effective permission mode while missing custom agents remain errors

## QA

An isolated targeted lab used its own `COMPOZY_HOME`, HTTP port, and UDS socket.

- 500 HTTP and 500 UDS identity reads: 1,000/1,000 status 200, identical 214-byte payloads
- worst identity latency: 2.783 ms HTTP, 0.844 ms UDS
- 10 complete status reads during the identity burst: 10/10 status 200, worst 11.313 ms
- full HTTP, UDS, and CLI status remained consistent on daemon PID, listener, and ordered global/memory schema streams
- teardown: `clean: true`, zero surviving processes
- QA audit: PASS, zero blockers and zero warnings

The targeted run used the source-built Desktop probe and daemon rather than a packaged macOS WebView soak. It proves the bounded public transport and no-reload trigger path; it does not claim a new 90-minute WebContent heap measurement.

## Verification

- `make desktop-lint`
- `make desktop-test` — 145 library tests plus Desktop integration suites passed
- `make gate-full` — PASS, fingerprint `bda8e2fe9d6c583f979570a74ac0daab417319f2`
  - Bun lint/typecheck/test and Web build passed
  - Go lint reported 0 issues
  - 22,539 Go tests passed; 1 helper-process test intentionally skipped
  - Go build and package-boundary checks passed

## Compozy Impact Audit

- **Native tools:** no `compozy__*` IDs, descriptors, schemas, digests, risk flags, or capability gates changed; the existing status and doctor tools keep the full diagnostic contract.
- **Extensibility and hooks:** no extension, hook, MCP resource, registry, bridge SDK, or configuration key changed. The new read-only HTTP/UDS identity surface is documented; no `config.toml` or settings lifecycle change is required.
- **Workspace data isolation:** runtime identity is daemon-global and carries no workspace/session/agent data. Public catalog events retain their existing `workspace_id` for visible sessions; daemon-owned sessions now publish no public wake event, so no cross-workspace path was added.
- **Official Compozy skill:** `skills/compozy/references/runtime-operations.md` now distinguishes bounded liveness identity from complete status/doctor diagnostics.
- **Web/Docs:** generated OpenAPI TypeScript declarations and daemon operations docs are updated. Web status polling remains on the complete shared status query; no Web route or component behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime identity diagnostics endpoint, available over HTTP and local socket connections.
  * Reports daemon version, process details, start time, listener information, and home directory.
  * Updated runtime compatibility requirements to the latest minimum version.

* **Bug Fixes**
  * Improved built-in agent resolution so workspace permissions are applied correctly.
  * Prevented internal, dream, and automatically generated sessions from appearing in public session catalogs.
  * Limited identity responses to 8 KiB for safer status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->