### PR TITLE
test: preserve loop claim tokens in daemon fixtures

### DIFF
--- a/internal/daemon/task_run_fixture_integration_test.go
+++ b/internal/daemon/task_run_fixture_integration_test.go
@@ -64,6 +64,7 @@ func seedDaemonTaskRunLifecycle(t *testing.T, store taskpkg.Store, target taskpk
 	if fixtureSessionID == "" {
 		fixtureSessionID = "daemon-fixture-" + target.ID
 	}
+	var claimToken string
 	if target.LoopRunID != "" {
 		claimedBy := actor.Actor
 		if target.ClaimedBy != nil {
@@ -83,6 +84,7 @@ func seedDaemonTaskRunLifecycle(t *testing.T, store taskpkg.Store, target taskpk
 					Now:              timeline.claimedAt,
 				})
 				current = claim.Run
+				claimToken = claim.ClaimToken
 				return claimErr
 			},
 		)
@@ -133,6 +135,7 @@ func seedDaemonTaskRunLifecycle(t *testing.T, store taskpkg.Store, target taskpk
 	}
 	running, err := manager.StartRun(ctx, current.ID, taskpkg.StartRun{
 		IdempotencyKey: "daemon-fixture-start:" + current.ID,
+		ClaimToken:     claimToken,
 	}, actor)
 	if err != nil {
 		t.Fatalf("StartRun(%q) error = %v", target.ID, err)


### PR DESCRIPTION
## What & why

Fixes #417.

The shared daemon integration fixture now retains the exact claim token returned for a Loop-bound task run and supplies it when starting that run. This restores the canonical Goal integration suite without weakening production claim-token validation or exposing the raw token.

Implemented with Codex and reviewed locally by Claude Fable. The resulting diff and verification evidence were independently checked before publication.

## How you verified it

- Confirmed the base branch RED: five `TestLoopGoalManagedRuntimeIntegration` cases failed with `task: invalid claim token`.
- Confirmed the fixed suite GREEN: all eight Goal managed-runtime integration cases pass.
- Passed the three neighboring daemon E2Es for ACP crash escalation, automation task delegation, and zero-network local execution.
- Passed the Compozy test-convention checker and the focused integration suite under `-race`.
- Passed scoped Go lint with zero issues.
- Passed `make gate-full`: 22,534 tests, 3 expected skips, zero failures; build and package boundaries passed. The command used a process-local `tag.gpgSign=false` override because the operator's global Git configuration signs tags used by release fixtures.
- Claude Fable verdict: `APPROVED`, with no blocking findings.

## Impact

Test infrastructure only. No CLI command, HTTP/UDS route, `config.toml` key, native tool, extension/hook surface, workspace data path, Web surface, public documentation, or official Compozy skill changes.

---

- [x] `make gate` passes locally (`make gate-full` before review on larger changes)
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of loop-run lifecycle transitions by preserving the lease claim token during fixture-based runs.
  * Direct daemon runs continue to operate without a claim token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->