### PR TITLE
fix: support resource-only extension development

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ compozy extension dev hello
 compozy tool invoke ext__hello__search --workspace . --input '{"query":"compozy"}'
 ```
 
-Authoring is code-first: you declare the tool once in code and `compozy extension build` generates
-the manifest. Walkthrough:
+Executable extensions are code-first: declare the tool once in code and `compozy extension build`
+generates the manifest. Resource-only extensions can instead hand-write `extension.toml` and use the
+same build, dev, reload, and watch loop without running extension code. Walkthrough:
 [Build your first extension](https://compozy.com/docs/guides/build-your-first-extension).
 
 ### SDK support

--- a/docs/qa/charters/CH-resource-only-extension-dev.md
+++ b/docs/qa/charters/CH-resource-only-extension-dev.md
@@ -1,0 +1,27 @@
+# CH-resource-only-extension-dev: Iterate on a passive extension kit and preserve last-good resources
+
+```yaml
+charter:
+  id: CH-resource-only-extension-dev
+  mission: "As Bruno, build and dev-link a passive extension kit with no language project, then edit, reload, recover from an invalid resource, and confirm its declarations stay isolated to the selected workspace."
+  mode: scenario-based
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-extension-dev-lifecycle
+  scenarios: [ET-resource-only-extension-dev, ET-extension-dev-reload-loop]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Build the real Batuta source twice and compare generation hashes before validating the copied agent, loop, and skill resources."
+      - "Dev-link a minimal passive agent kit, read the agent through the workspace API, edit and reload it, then independently read the changed prompt."
+      - "Break the agent definition, confirm reload fails and the prior generation remains readable, then remove the dev link and verify the workspace resource disappears."
+      - "Run the existing code-backed authoring lifecycle as an adjacent compatibility canary."
+    must_avoid:
+      - "Adding package.json or go.mod, installing the extension globally, reading the registry database, or using an internal-only API as proof."
+```
+
+<!-- The charter is durable and immutable: re-run it in later cycles; each run's debrief goes in the dated report (Session Debriefs), never here. -->

--- a/docs/qa/charters/CH-resource-only-extension-watch.md
+++ b/docs/qa/charters/CH-resource-only-extension-watch.md
@@ -1,0 +1,27 @@
+# CH-resource-only-extension-watch: Rebuild a passive extension from a live source edit
+
+```yaml
+charter:
+  id: CH-resource-only-extension-watch
+  mission: "As Bruno, build a passive extension with an agent, a skill, and a Network requirement, keep dev watch running while editing the skill, and confirm the new generation and workspace resources through public surfaces."
+  mode: scenario-based
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-extension-dev-lifecycle
+  scenarios: [ET-resource-only-extension-dev, ET-extension-dev-reload-loop]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Build without package.json or go.mod, then read the generated manifest and confirm its Network requirement matches the source."
+      - "Start extension dev with --watch, edit SKILL.md while the process remains active, and capture the reload output with a different generation hash."
+      - "Read both the agent and skill from the selected workspace and confirm neither appears in the global catalogs."
+      - "Run the existing code-backed authoring lifecycle as the adjacent compatibility canary."
+    must_avoid:
+      - "Adding a language toolchain, polling internal storage, or treating the generated file alone as proof that the daemon reloaded it."
+```
+
+<!-- The charter is durable and immutable: re-run it in later cycles; each run's debrief goes in the dated report. -->

--- a/docs/qa/journeys/J-extension-dev-lifecycle.md
+++ b/docs/qa/journeys/J-extension-dev-lifecycle.md
@@ -1,6 +1,6 @@
 # J-extension-dev-lifecycle: Operate a workspace-scoped extension generation safely
 
-An extension author moves from code-first build through dev, reload, watch, logs, and failure
+An extension author moves from a code-backed or passive resource-only build through dev, reload, watch, logs, and failure
 recovery. The journey concentrates the workspace isolation, immutable-generation, last-good, and
 redaction invariants shared by CLI, HTTP, UDS, native tools, and the Web logs panel.
 
@@ -40,7 +40,7 @@ journey:
       origin: in-app-nav
   actions:
     - step: 1
-      verb: Build and validate the code-first project
+      verb: Build and validate the code-backed project or passive resource kit
       expected_observable: Identical source yields a byte-identical manifest and immutable generation handle
     - step: 2
       verb: Link the generation to the current workspace

--- a/docs/qa/reports/2026-08-17-pr-423-resource-only-watch.md
+++ b/docs/qa/reports/2026-08-17-pr-423-resource-only-watch.md
@@ -1,0 +1,81 @@
+# QA Run Report — 2026-08-17 — PR 423 resource-only watch
+
+- **Scope:** PR #423 resource-only extension generation fidelity, live watch reload, workspace projection, and code-backed compatibility canary
+- **Cadence tier:** targeted
+- **Build:** base `2b7c07d4b725ee0b0b95a6824e230279d37feee1`; frozen product diff SHA-256 `31dc432f9e63e260c7ce2a32d2c5fda3fcbfe4af1a892fb0671096cbffd09e63`
+- **Environment:** isolated CLI/API/runtime lab `compozy-pr-423-resource-only-watch-20260817-185100-670194-lab`; real built binary and daemon on isolated port 61408; provider and browser intentionally outside the targeted contract
+- **Started:** 2026-08-17T15:50:21-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-resource-only-extension-watch |
+
+## Flows in Scope
+
+- `J-extension-dev-lifecycle` — operate immutable workspace-scoped extension generations safely (`../journeys/J-extension-dev-lifecycle.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-resource-only-extension-watch | J-extension-dev-lifecycle / ET-resource-only-extension-dev | Bruno | Feature Tour | Pass | | |
+| 2 | CH-resource-only-extension-watch | J-extension-dev-lifecycle / ET-extension-dev-reload-loop | Bruno | Feature Tour | Pass | adjacent code-backed canary only; broad scenario keeps prior verdict | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-resource-only-extension-watch — Bruno
+
+- **Ran:** 2026-08-17T15:53:38-03:00 → 2026-08-17T15:59:02-03:00 (box respected: yes)
+- **Findings:**
+  - A passive agent-and-skill source with no language project built as generation `898e6f20…`; both JSON output and the generated manifest retained the required Live Network block and `builders` scope.
+  - The first dev attempt refused before linking and returned digest `24e0db59…`; retrying with that exact digest linked the same generation without an install trust prompt.
+  - `extension dev --watch` stayed active through a `SKILL.md` edit and emitted generation `8df8e674…`. A fresh workspace skill read returned the changed description; workspace agent read succeeded; both global catalogs excluded the extension resources.
+  - An invalid YAML edit stopped the watcher with a specific staged `SKILL.md` diagnostic. A fresh extension list still reported active generation `8df8e674…` with `activation_failed`, and the skill catalog retained the prior valid description.
+  - The adjacent Go scaffold built, dev-linked, and returned `No results for alpha` through `ext__code_canary__search`.
+- **Bugs filed/updated:** none
+- **Scenarios settled:** ET-resource-only-extension-dev → pass; ET-extension-dev-reload-loop retained its prior pass and served only as an adjacent code-backed canary
+- **Paper cuts:** none
+- **Surprises:** the initial Network refusal and invalid-watch failure both preserved state and returned actionable structured diagnostics.
+- **Suggested next charter:** concurrent watch processes in two workspaces if workspace reload coordination changes again.
+
+## What Was Fixed
+
+No QA-session fixes.
+
+## Paper Cuts
+
+None.
+
+## Runtime Errors Observed
+
+- Expected negative probe: missing Network confirmation returned `extension_network_confirmation_required` with the exact current digest and no dev link.
+- Expected negative probe: malformed skill YAML ended the watcher while the daemon retained the last-good generation.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The CLI watch process itself is the strongest proof for watch behavior; manually calling reload does not cover the polling boundary.
+- The generated manifest and a fresh workspace catalog are complementary read paths: one proves package fidelity, the other proves daemon activation and scope.
+- Taxonomy sweep: happy path, Network refusal, invalid-edit recovery, workspace/global isolation, deterministic structured output, and the code-backed regression canary were covered. Browser, mobile, locale, and provider dimensions were deliberately skipped because this charter is CLI/API/runtime-only.
+- Experiential lenses: usability, perceived performance, error recovery, and production parity passed for the targeted CLI flow; accessibility and browser compatibility were not applicable to the declared surfaces.
+
+## Final Status
+
+- **Automated QA precondition:** `make gate` passed lint and all affected Go packages with `-race`; evidence: `/Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/verify-affected.log`.
+- **Strict evidence audit:** `/Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/qa-audit-report.json`.
+- **Teardown evidence:** `/Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/teardown.json`.
+- **Repository close gate:** `make gate-full` runs once after QA teardown and the final repository mutation; its tree-fingerprint record, not this behavior report, owns merge readiness.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1 changed journey walked by Bruno; code-backed lane exercised as the adjacent canary; browser/provider dimensions intentionally excluded by the targeted contract.
+- **Verdict:** **PASS** — the targeted CLI/API/runtime behavior is ready; repository merge readiness remains owned by the separate workstream-close gate.

--- a/docs/qa/reports/2026-08-17-resource-only-extension-dev.md
+++ b/docs/qa/reports/2026-08-17-resource-only-extension-dev.md
@@ -1,0 +1,82 @@
+# QA Run Report — 2026-08-17 — resource-only-extension-dev
+
+- **Scope:** Issue #421 resource-only extension build, dev, reload, watch-compatible generations, workspace resource projection, last-good recovery, and code-backed compatibility canary
+- **Cadence tier:** targeted
+- **Build:** 5c5789e3 + local `fix/resource-only-extension-dev` diff · **Environment:** isolated CLI/API/runtime lab `compozy-resource-only-extension-dev-20260817-020712-286410-lab`; browser unavailable and outside this CLI/API charter
+- **Started:** 2026-08-17T02:07:12-03:00 · **Status:** pass
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-resource-only-extension-dev |
+
+## Flows in Scope
+
+- `J-extension-dev-lifecycle` — iterate on immutable workspace-scoped extension generations and preserve last-good behavior (`../journeys/J-extension-dev-lifecycle.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-resource-only-extension-dev | J-extension-dev-lifecycle / ET-resource-only-extension-dev | Bruno | Feature Tour | Pass | | |
+| 2 | CH-resource-only-extension-dev | J-extension-dev-lifecycle / ET-extension-dev-reload-loop | Bruno | Feature Tour | Pass | adjacent code-backed canary | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-resource-only-extension-dev — Bruno
+
+- **Ran:** 2026-08-17T02:09:11Z → 2026-08-17T02:14:00Z (box respected: yes)
+- **Findings:**
+  - No functional divergence. A native manifest plus static agent built without a language project, linked without install trust, and appeared as a workspace-owned agent through the public HTTP catalog.
+  - Repeating the build preserved generation `562afc3a…`; changing the prompt produced `cd0ca6ff…`; malformed YAML failed before activation and the API still returned generation two from `cd0ca6ff…`.
+  - The global agent catalog never exposed the workspace agent, and removing the dev link removed it from a fresh workspace catalog read.
+  - The code-backed Go scaffold remained active and `ext__code_canary__search` returned `No results for alpha` through the public invoke API.
+  - After source freeze, the lab was reused from 2026-08-17T02:51:21Z to 02:54:32Z. The current binary reproduced deterministic build `aa93e277…`, workspace-only API and native-tool projection, valid reload `6542fc8f…`, last-good retention after malformed YAML, and clean removal.
+- **Bugs filed/updated:** none
+- **Scenarios settled:** ET-resource-only-extension-dev → pass; ET-extension-dev-reload-loop → pass
+- **Paper cuts:** none
+- **Surprises:** the malformed agent diagnostic correctly named both the staged resource and YAML parser location while leaving the prior generation healthy.
+- **Suggested next charter:** add a watch-process interruption charter if watch debounce behavior changes independently of the shared reload path.
+
+## What Was Fixed
+
+- Workspace development resources are now collected alongside enabled global extensions and retain their workspace ownership through agents, skills, Loops, automation, and layouts.
+- Automation jobs and triggers bind their domain scope and workspace ID before validation; layout record and spec IDs remain identical.
+- Staged or inactive development links no longer project a global fallback or abort unrelated resource synchronization.
+- `compozy__workspace_describe` now consumes the workspace-aware agent catalog, matching the HTTP workspace surfaces.
+- Sources with neither a supported toolchain nor a native manifest now receive an actionable authoring diagnostic.
+
+## Paper Cuts
+
+None.
+
+## Runtime Errors Observed
+
+- Expected negative probe: malformed `AGENT.md` returned a staged static-resource validation error; the active extension and workspace agent remained healthy.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The public workspace agent catalog is a useful independent read path for passive extension generations; global catalog absence simultaneously proves the isolation boundary.
+- A code-backed extension can share the same isolated daemon as the passive kit and gives a cheap compatibility canary for the pre-existing toolchain lane.
+
+## Final Status
+
+**PASS** — issue #421 is ready for owner review. No PR, push, or commit was created.
+
+- Canonical E2E: `CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts$' -count=1` — pass.
+- Final `make verify` evidence: `GOTOOLCHAIN=go1.26.4 GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=tag.gpgSign GIT_CONFIG_VALUE_0=false make gate` escalated to the full verifier and passed.
+- Closing gate: the same environment with `make gate-full` reported current passing evidence; `make gate-status` recorded fingerprint `fb9e5e013540a5cc8a7d9478fae3b07a5aa8d078` as `pass CURRENT` at 2026-08-17T03:33:57Z.
+- QA evidence: `qa-artifacts/qa/journey-log.jsonl` and `qa-artifacts/qa/qa-audit-report.json` in the isolated lab.
+- Teardown: `qa-artifacts/qa/teardown.json` records `clean: true` and no surviving processes.
+- Findings: 0 open bugs, 0 paper cuts, 0 human verifications, 0 human decisions.

--- a/docs/qa/scenarios/ET-resource-only-extension-dev.md
+++ b/docs/qa/scenarios/ET-resource-only-extension-dev.md
@@ -4,15 +4,15 @@ area: ET
 title: Iterate on a resource-only extension without a build toolchain
 persona: Bruno
 journey: J-extension-dev-lifecycle
-expected: A native extension that declares only static agents, skills, loops, automation, or layouts builds without package.json or go.mod and without running build or describe commands; dev and reload publish its resources only to the selected workspace, identical input keeps the same generation, changed valid input creates a new generation, and an invalid edit leaves the last-good generation active.
+expected: A native extension that declares only static agents, skills, loops, automation, or layouts builds without package.json or go.mod and without running build or describe commands; network participation remains in the generated manifest and contributes to its generation hash; dev, reload, and watch publish changed resources only to the selected workspace; and an invalid edit leaves the last-good generation active.
 entry_points: `compozy extension build <dir>`; `compozy extension dev <dir> --workspace <ref>`; `compozy extension reload <name> <dir> --workspace <ref>`; `compozy extension dev <dir> --watch`; `GET /api/agents?workspace=<ref>`
 qa_status: pass
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/qa-artifacts/qa/journey-log.jsonl; /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/qa-artifacts/qa/qa-audit-report.json; /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/qa-artifacts/qa/teardown.json; /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/project/resource-only-kit/dist/gen-6542fc8f1f0d926e9c2eff47fe0e6f4040f96a0f38b44499bad1c1cc681c3eb5
-last_report: docs/qa/reports/2026-08-17-resource-only-extension-dev.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/generated-manifest.toml; /Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/watch-reload.jsonl; /Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/workspace-skills.json; /Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/extensions-after-invalid.json; /Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/qa-audit-report.json; /Users/pedronauck/dev/qa-labs/compozy-pr-423-resource-only-watch-20260817-185100-670194-lab/qa-artifacts/qa/teardown.json
+last_report: docs/qa/reports/2026-08-17-pr-423-resource-only-watch.md
 overlaps: ET-extension-dev-reload-loop; ET-agent-plugin-dev-reload
 ---
 
@@ -32,3 +32,13 @@ and confirmed malformed YAML left the new last-good generation active. Removal c
 agent, and a code-backed scaffold remained callable as the adjacent compatibility canary. The
 source-freeze retest also confirmed the workspace agent through `compozy__workspace_describe` before
 strict evidence audit and clean teardown.
+
+QA impact 2026-08-17 (PR #423 review): reset after the resource-only watch path, generated Network
+requirement fidelity, and cross-workspace consumer synchronization were strengthened. The new targeted
+walk must exercise an actual long-running `--watch` process and a fresh public read after the edit.
+
+QA 2026-08-17 (PR #423 review): Bruno observed the Network consent refusal, retried with the exact
+digest, kept `extension dev --watch` active, changed only `SKILL.md`, and received generation
+`8df8e674…` after `898e6f20…`. Workspace API reads returned the changed skill and agent while global
+reads returned neither. A malformed skill then failed with a positioned YAML error while the daemon
+kept `8df8e674…` and its prior skill active. A code-backed tool-provider remained callable.

--- a/docs/qa/scenarios/ET-resource-only-extension-dev.md
+++ b/docs/qa/scenarios/ET-resource-only-extension-dev.md
@@ -1,0 +1,34 @@
+---
+id: ET-resource-only-extension-dev
+area: ET
+title: Iterate on a resource-only extension without a build toolchain
+persona: Bruno
+journey: J-extension-dev-lifecycle
+expected: A native extension that declares only static agents, skills, loops, automation, or layouts builds without package.json or go.mod and without running build or describe commands; dev and reload publish its resources only to the selected workspace, identical input keeps the same generation, changed valid input creates a new generation, and an invalid edit leaves the last-good generation active.
+entry_points: `compozy extension build <dir>`; `compozy extension dev <dir> --workspace <ref>`; `compozy extension reload <name> <dir> --workspace <ref>`; `compozy extension dev <dir> --watch`; `GET /api/agents?workspace=<ref>`
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/qa-artifacts/qa/journey-log.jsonl; /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/qa-artifacts/qa/qa-audit-report.json; /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/qa-artifacts/qa/teardown.json; /home/franciscpd/dev/qa-labs/compozy-resource-only-extension-dev-20260817-020712-286410-lab/project/resource-only-kit/dist/gen-6542fc8f1f0d926e9c2eff47fe0e6f4040f96a0f38b44499bad1c1cc681c3eb5
+last_report: docs/qa/reports/2026-08-17-resource-only-extension-dev.md
+overlaps: ET-extension-dev-reload-loop; ET-agent-plugin-dev-reload
+---
+
+Issue #421 adds the passive resource-kit lane to the existing immutable generation and workspace
+overlay lifecycle. This scenario owns absence of a language toolchain and absence of extension
+build/describe subprocesses; the generic dev scenario remains canonical for logs, executable tool
+invocation, and published-instance restoration.
+
+The failure probes are part of the user promise: an authored subprocess, capability, permission,
+dynamic publication family, or explicit build command must fail with a toolchain diagnostic instead
+of being silently treated as a passive kit. Invalid static resource edits must fail before the daemon
+replaces the workspace's active generation.
+
+QA 2026-08-17: Bruno built a passive agent kit twice to the same generation, linked it to one
+workspace, observed it only through that workspace's public agent catalog, reloaded a changed prompt,
+and confirmed malformed YAML left the new last-good generation active. Removal cleared the projected
+agent, and a code-backed scaffold remained callable as the adjacent compatibility canary. The
+source-freeze retest also confirmed the workspace agent through `compozy__workspace_describe` before
+strict evidence audit and clean teardown.

--- a/docs/superpowers/plans/2026-08-16-resource-only-extension-dev.md
+++ b/docs/superpowers/plans/2026-08-16-resource-only-extension-dev.md
@@ -19,7 +19,7 @@
 
 ## Compozy Impact Audit
 
-- Native tools: `compozy__extensions_build`, `_dev`, and `_reload` gain resource-only source support through their existing `BuildBundle` dependency; tool IDs, descriptors, schemas, risk flags, and capability gates do not change.
+- Native tools: `compozy__extensions_build` gains resource-only source support through `BuildBundle`; `_dev` and `_reload` remain hash-based consumers of a completed build. Tool IDs, descriptors, schemas, risk flags, and capability gates do not change.
 - Extensibility and hooks: native resource-only manifests can enter the existing generation/dev-overlay lifecycle; code-backed extension, hook, MCP sidecar, and dynamic `resources.publish` contracts remain unchanged and executable extension contracts still require a toolchain.
 - Workspace data isolation: no stored shape or scope changes; existing dev links remain keyed by daemon-resolved `workspace_id`, and the QA scenario must prove the overlay is visible only in its workspace.
 - Official Compozy skill: update `skills/compozy/references/extensions.md` and `skills/compozy/references/extension-authoring.md` so agents select the resource-only authoring path correctly.
@@ -169,4 +169,3 @@ make gate-status
 ```
 
 Expected: the scoped gate and exactly one fresh full gate pass with zero warnings and errors.
-

--- a/docs/superpowers/plans/2026-08-16-resource-only-extension-dev.md
+++ b/docs/superpowers/plans/2026-08-16-resource-only-extension-dev.md
@@ -1,0 +1,172 @@
+# Resource-Only Extension Development Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let native resource-only extensions use `extension build`, `dev`, `reload`, and `dev --watch` without running build or describe subprocesses.
+
+**Architecture:** Classify a source with no Go or TypeScript toolchain by loading its native manifest. A valid manifest with at least one static resource tree and no executable extension contract follows a dedicated path that validates and publishes the manifest plus declared resources into the existing immutable-generation pipeline. Code-backed sources keep the current build and describe path unchanged.
+
+**Tech Stack:** Go 1.26, Cobra CLI, TOML extension manifests, existing extension generation and runtime integration tests, Fumadocs MDX.
+
+## Global Constraints
+
+- Confirmed reproduction on 2026-08-16: `go run . extension validate /home/franciscpd/Projects/batuta-compozy -o json` returns `status: valid`; `go run . extension build /home/franciscpd/Projects/batuta-compozy -o json` fails with `extension: unsupported source; expected package.json or go.mod`.
+- A resource-only build must execute neither the build command nor `__describe`.
+- A source with executable extension behavior but no supported toolchain must fail closed.
+- Go and TypeScript authoring behavior must not change.
+- Artifacts and documentation are written in English; conversation remains Brazilian Portuguese.
+- The final gate is one fresh `make gate-full` after source freeze.
+
+## Compozy Impact Audit
+
+- Native tools: `compozy__extensions_build`, `_dev`, and `_reload` gain resource-only source support through their existing `BuildBundle` dependency; tool IDs, descriptors, schemas, risk flags, and capability gates do not change.
+- Extensibility and hooks: native resource-only manifests can enter the existing generation/dev-overlay lifecycle; code-backed extension, hook, MCP sidecar, and dynamic `resources.publish` contracts remain unchanged and executable extension contracts still require a toolchain.
+- Workspace data isolation: no stored shape or scope changes; existing dev links remain keyed by daemon-resolved `workspace_id`, and the QA scenario must prove the overlay is visible only in its workspace.
+- Official Compozy skill: update `skills/compozy/references/extensions.md` and `skills/compozy/references/extension-authoring.md` so agents select the resource-only authoring path correctly.
+- Web/Docs Impact: no `web/` code impact because the change is source packaging before the existing daemon API; update the extension development and manifest documentation under `packages/site`.
+- Config lifecycle: no config key, default, validation, or settings surface changes; `extensions.dev.watch_interval` retains its current meaning.
+
+---
+
+### Task 1: Resource-only build classification and publication
+
+**Files:**
+- Create: `internal/extension/build_resource_only.go`
+- Modify: `internal/extension/build.go`
+- Modify: `internal/extension/build_toolchain.go`
+- Test: `internal/extension/build_test.go`
+
+**Interfaces:**
+- Consumes: `LoadManifest`, `requiresSubprocess`, `staticResourcePathGroups`, `prepareBuildOutput`, and `publishBuildGeneration`.
+- Produces: `buildResourceOnlyBundle(ctx context.Context, req BuildRequest) (*BuildResult, error)` and a matchable internal no-toolchain condition from `detectBuildToolchain`.
+
+- [ ] **Step 1: Add the failing build regression cases**
+
+Add cases to `TestBuildBundle` that create a native `extension.toml` with `skills = ["skills"]`, call `buildBundle` with `newBuildTestRunner`, and assert a generation contains the manifest and skill while `runner.Commands()` is empty. Rebuild after changing `SKILL.md` and assert the generation hash changes. Add negative companions for an empty resource manifest and a manifest with `[subprocess] command`, asserting no generation is published.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -race ./internal/extension -run 'TestBuildBundle/Should (publish a resource-only generation without commands|reject resource-only sources that require executable behavior)' -count=1
+```
+
+Expected: the positive case fails with `unsupported source; expected package.json or go.mod`.
+
+- [ ] **Step 3: Add a typed no-toolchain branch**
+
+Change the no-`package.json`/no-`go.mod` result in `detectBuildToolchain` to a package-private sentinel and branch on it with `errors.Is` in `buildBundle`. All other toolchain errors continue to return unchanged.
+
+- [ ] **Step 4: Implement the dedicated resource-only build**
+
+Implement the focused helper with this order:
+
+```go
+manifest, err := LoadManifest(req.SourceDir)
+if err != nil {
+    return nil, fmt.Errorf("extension: load resource-only manifest: %w", err)
+}
+if err := validateResourceOnlyBuildRequest(req, manifest); err != nil {
+    return nil, err
+}
+if err := os.MkdirAll(req.OutputDir, 0o755); err != nil {
+    return nil, fmt.Errorf("extension: create build output %q: %w", req.OutputDir, err)
+}
+if err := prepareBuildOutput(req.OutputDir); err != nil {
+    return nil, err
+}
+return publishBuildGeneration(ctx, req.OutputDir, req.SourceDir, manifest)
+```
+
+The validator accepts only native Compozy manifests with at least one skill, Loop, agent, automation, or layout path; it rejects `BuildCmd`, `requiresSubprocess(manifest)`, and portable Agent Plugin synthesis with actionable errors.
+
+- [ ] **Step 5: Run focused and package tests GREEN**
+
+Run:
+
+```bash
+python3 .agents/skills/eng/eng-test-conventions/scripts/check-test-conventions.py internal/extension/build_test.go
+CGO_ENABLED=1 go test -race ./internal/extension -run '^TestBuildBundle$' -count=1
+CGO_ENABLED=1 go test -race ./internal/extension -count=1
+```
+
+Expected: all new cases pass; record any unrelated pre-existing timeout separately without weakening assertions.
+
+### Task 2: Public documentation and official skill
+
+**Files:**
+- Modify: `packages/site/content/docs/extensions/develop.mdx`
+- Modify: `packages/site/content/docs/extensions/manifest.mdx`
+- Modify: `skills/compozy/references/extensions.md`
+- Modify: `skills/compozy/references/extension-authoring.md`
+
+**Interfaces:**
+- Consumes: the Task 1 source-classification contract.
+- Produces: one public development workflow and matching agent guidance.
+
+- [ ] **Step 1: Document source classification**
+
+State that code-backed sources compile and run describe mode, while native resource-only sources validate and publish the handwritten manifest plus declared resource trees without executing extension code.
+
+- [ ] **Step 2: Document the resource-only loop**
+
+Add a minimal `extension.toml` + `agents/hello/AGENT.md` example and the commands:
+
+```bash
+compozy extension build .
+compozy extension dev .
+compozy extension reload hello .
+compozy extension dev . --watch
+```
+
+Document that executable contracts (`subprocess`, capabilities, permissions, or dynamic publication) still need `package.json` or `go.mod`.
+
+- [ ] **Step 3: Align the official Compozy skill**
+
+Update both extension references with the same branch selection and failure boundary; keep them concise and avoid duplicating the site guide.
+
+- [ ] **Step 4: Verify docs and skill links**
+
+Run the site/docs lane selected by `make gate` after the Go diff is complete; do not add prose-string tests.
+
+### Task 3: Real authoring lifecycle and QA evidence
+
+**Files:**
+- Modify: `internal/daemon/daemon_extension_authoring_e2e_integration_test.go`
+- Create or reset: one content-addressed scenario under `docs/qa/scenarios/`
+
+**Interfaces:**
+- Consumes: the real CLI, daemon, immutable generation, workspace dev-link, resource registry, reload, and last-good behavior.
+- Produces: behavior evidence for build, dev, resource exposure, changed generation, invalid-edit retention, and watch-compatible rebuilds.
+
+- [ ] **Step 1: Extend the canonical authoring E2E suite**
+
+Add a resource-only subtest that writes a native manifest plus an agent/skill in the harness workspace, runs real `extension build` and `extension dev`, verifies the workspace overlay and resources, edits a resource and reloads to a new hash, then makes an invalid edit and verifies the previous generation remains active.
+
+- [ ] **Step 2: Run the focused integration test**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts$/Should_complete_the_resource-only_development_loop$' -count=1
+```
+
+Expected: PASS with no orphan daemon or extension process.
+
+- [ ] **Step 3: Flag and execute the user-visible QA scenario**
+
+Create or reset the content-addressed extension-authoring scenario, bootstrap a fresh isolated QA lab, run the build/dev/reload/watch workflow with a native resource-only fixture, record evidence, and always execute the manifest teardown command. The final evidence must include `teardown.json` with `"clean": true`.
+
+- [ ] **Step 4: Run scoped and final gates**
+
+Run:
+
+```bash
+make gate
+make gate-full
+make gate-status
+```
+
+Expected: the scoped gate and exactly one fresh full gate pass with zero warnings and errors.
+

--- a/internal/api/core/authored_context_test.go
+++ b/internal/api/core/authored_context_test.go
@@ -120,6 +120,13 @@ func (c packageOwnedAgentCatalog) ListAgents(context.Context) ([]core.AgentCatal
 	}}, nil
 }
 
+func (c packageOwnedAgentCatalog) ListAgentsForWorkspace(
+	ctx context.Context,
+	_ *workspacepkg.ResolvedWorkspace,
+) ([]core.AgentCatalogEntry, error) {
+	return c.ListAgents(ctx)
+}
+
 func (c packageOwnedAgentCatalog) GetAgent(context.Context, string) (core.AgentCatalogEntry, error) {
 	return core.AgentCatalogEntry{
 		Def:    compozyconfig.CloneAgentDef(c.artifacts.Agent),

--- a/internal/api/core/handlers_test.go
+++ b/internal/api/core/handlers_test.go
@@ -4118,6 +4118,13 @@ func (s stubAgentCatalog) ListAgents(context.Context) ([]core.AgentCatalogEntry,
 	return entries, nil
 }
 
+func (s stubAgentCatalog) ListAgentsForWorkspace(
+	ctx context.Context,
+	_ *workspacepkg.ResolvedWorkspace,
+) ([]core.AgentCatalogEntry, error) {
+	return s.ListAgents(ctx)
+}
+
 func (s stubAgentCatalog) GetAgent(_ context.Context, name string) (core.AgentCatalogEntry, error) {
 	if s.getErr != nil {
 		return core.AgentCatalogEntry{}, s.getErr

--- a/internal/api/core/interfaces.go
+++ b/internal/api/core/interfaces.go
@@ -34,6 +34,7 @@ type AgentLoader func(name string, homePaths compozyconfig.HomePaths) (compozyco
 // AgentCatalog exposes projected resource-backed agent definitions.
 type AgentCatalog interface {
 	ListAgents(ctx context.Context) ([]AgentCatalogEntry, error)
+	ListAgentsForWorkspace(context.Context, *workspacepkg.ResolvedWorkspace) ([]AgentCatalogEntry, error)
 	GetAgent(ctx context.Context, name string) (AgentCatalogEntry, error)
 }
 

--- a/internal/api/core/workspaces.go
+++ b/internal/api/core/workspaces.go
@@ -119,7 +119,7 @@ func (h *BaseHandlers) workspaceDetailAgentEntries(
 	}
 
 	if h.AgentCatalog != nil {
-		catalogAgents, err := h.AgentCatalog.ListAgents(ctx)
+		catalogAgents, err := h.AgentCatalog.ListAgentsForWorkspace(ctx, resolved)
 		if err != nil {
 			if !errors.Is(err, os.ErrNotExist) {
 				return nil, err

--- a/internal/api/httpapi/transport_parity_integration_test.go
+++ b/internal/api/httpapi/transport_parity_integration_test.go
@@ -399,6 +399,10 @@ func transportHarnessSessionPath(
 }
 
 func TestHTTPTransportExtensionParityMatchesUDS(t *testing.T) {
+	t.Run("Should preserve extension behavior across HTTP, UDS, and CLI", testHTTPTransportExtensionParityMatchesUDS)
+}
+
+func testHTTPTransportExtensionParityMatchesUDS(t *testing.T) {
 	acpmock.RequireDriver(t)
 	t.Parallel()
 
@@ -614,6 +618,14 @@ func TestHTTPTransportExtensionParityMatchesUDS(t *testing.T) {
 	}
 	if !extensionSemanticallyEqual(httpEnable.Extension, cliEnable.Extension) {
 		t.Fatalf("HTTP enabled extension = %#v, want CLI parity %#v", httpEnable.Extension, cliEnable.Extension)
+	}
+	if !httpEnable.Extension.Enabled || !udsEnable.Extension.Enabled || !cliEnable.Extension.Enabled {
+		t.Fatalf(
+			"enabled states = HTTP:%t UDS:%t CLI:%t, want all true",
+			httpEnable.Extension.Enabled,
+			udsEnable.Extension.Enabled,
+			cliEnable.Extension.Enabled,
+		)
 	}
 
 	logsPath := "/api/extensions/" + url.PathEscape(extensionName) + "/logs"

--- a/internal/api/httpapi/transport_parity_integration_test.go
+++ b/internal/api/httpapi/transport_parity_integration_test.go
@@ -556,6 +556,9 @@ func TestHTTPTransportExtensionParityMatchesUDS(t *testing.T) {
 		)
 		httpBody := readAndCloseHTTPBody(t, httpResponse)
 		udsBody := readAndCloseHTTPBody(t, udsResponse)
+		if httpResponse.StatusCode < http.StatusBadRequest {
+			t.Fatalf("HTTP %s %s status = %d, want error; body=%s", method, path, httpResponse.StatusCode, httpBody)
+		}
 		if httpResponse.StatusCode != udsResponse.StatusCode || !reflect.DeepEqual(httpBody, udsBody) {
 			t.Fatalf(
 				"HTTP error = status %d body %s, want UDS parity status %d body %s",
@@ -588,11 +591,30 @@ func TestHTTPTransportExtensionParityMatchesUDS(t *testing.T) {
 		missingBody,
 		"extension", "status", "missing-portable-package", "-o", "json",
 	)
-	consentBody := assertTransportErrorParity(
-		http.MethodPost,
-		"/api/extensions/"+url.PathEscape(extensionName)+"/enable",
-	)
-	assertCLIErrorParity(consentBody, "extension", "enable", extensionName, "-o", "json")
+	enablePath := "/api/extensions/" + url.PathEscape(extensionName) + "/enable"
+	var httpEnable compozycontract.ExtensionResponse
+	if err := runtimeHarness.HTTPJSON(ctx, http.MethodPost, enablePath, nil, &httpEnable); err != nil {
+		t.Fatalf("HTTP enable extension error = %v", err)
+	}
+	var udsEnable compozycontract.ExtensionResponse
+	if err := runtimeHarness.UDSJSON(ctx, http.MethodPost, enablePath, nil, &udsEnable); err != nil {
+		t.Fatalf("UDS enable extension error = %v", err)
+	}
+	if !extensionSemanticallyEqual(httpEnable.Extension, udsEnable.Extension) {
+		t.Fatalf("HTTP enabled extension = %#v, want UDS parity %#v", httpEnable.Extension, udsEnable.Extension)
+	}
+	var cliEnable compozycontract.ExtensionEnableResult
+	if err := clients.CLI.RunJSONInDir(
+		ctx,
+		runtimeHarness.WorkspaceRoot,
+		&cliEnable,
+		"extension", "enable", extensionName, "-o", "json",
+	); err != nil {
+		t.Fatalf("CLI enable extension error = %v", err)
+	}
+	if !extensionSemanticallyEqual(httpEnable.Extension, cliEnable.Extension) {
+		t.Fatalf("HTTP enabled extension = %#v, want CLI parity %#v", httpEnable.Extension, cliEnable.Extension)
+	}
 
 	logsPath := "/api/extensions/" + url.PathEscape(extensionName) + "/logs"
 	httpLogsResp := mustHTTPRequest(

--- a/internal/api/udsapi/udsapi_integration_test.go
+++ b/internal/api/udsapi/udsapi_integration_test.go
@@ -3277,7 +3277,8 @@ func newIntegrationRuntime(t *testing.T) integrationRuntime {
 		if resourceDriver == nil {
 			return nil
 		}
-		return resourceDriver.Trigger(ctx, kind, reason)
+		_, err := resourceDriver.Trigger(ctx, kind, reason)
+		return err
 	}
 
 	fanout := &integrationNotifierFanout{}

--- a/internal/cli/extension_test.go
+++ b/internal/cli/extension_test.go
@@ -12,6 +12,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/compozy/compozy/internal/api/contract"
 	compozyconfig "github.com/compozy/compozy/internal/config"
@@ -1012,6 +1014,127 @@ func main() {
 	if output.WorkspaceID != "workspace-stable" || !output.Dev {
 		t.Fatalf("extension dev output = %#v", output)
 	}
+}
+
+func TestExtensionDevWatchReloadsResourceOnlyChanges(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should rebuild and reload a changed resource-only source", func(t *testing.T) {
+		t.Parallel()
+
+		synctest.Test(t, func(t *testing.T) {
+			sourceDir := filepath.Join(t.TempDir(), "resource-watch")
+			skillDir := filepath.Join(sourceDir, "skills", "writer")
+			if err := os.MkdirAll(skillDir, 0o755); err != nil {
+				t.Fatalf("os.MkdirAll(skillDir) error = %v", err)
+			}
+			writeExtensionManifest(t, filepath.Join(sourceDir, "extension.toml"), `[extension]
+name = "resource-watch"
+version = "0.1.0"
+description = "Resource-only watch fixture"
+min_compozy_version = "0.5.0"
+
+[resources]
+skills = ["skills"]
+`)
+			skillPath := filepath.Join(skillDir, "SKILL.md")
+			writeExtensionManifest(t, skillPath, `---
+name: writer
+description: Write clear release notes.
+---
+
+# Writer
+`)
+
+			initialHash := make(chan string, 1)
+			reloadHash := make(chan string, 1)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			client := &stubClient{
+				getWorkspaceFn: func(_ context.Context, ref string) (WorkspaceDetailRecord, error) {
+					if ref != "workspace-alias" {
+						return WorkspaceDetailRecord{}, fmt.Errorf(
+							"GetWorkspace() ref = %q, want workspace-alias",
+							ref,
+						)
+					}
+					return WorkspaceDetailRecord{Workspace: WorkspaceRecord{
+						ID: "workspace-stable", Name: ref, RootDir: filepath.Dir(sourceDir),
+					}}, nil
+				},
+				devExtensionFn: func(
+					_ context.Context,
+					workspaceRef string,
+					request DevLinkExtensionRequest,
+				) (ExtensionRecord, error) {
+					initialHash <- request.GenerationHash
+					return ExtensionRecord{
+						Name: "resource-watch", WorkspaceID: workspaceRef, Dev: true, DaemonRunning: true,
+					}, nil
+				},
+				reloadDevExtensionFn: func(
+					_ context.Context,
+					workspaceRef string,
+					name string,
+					request ReloadExtensionRequest,
+				) (ExtensionRecord, error) {
+					if workspaceRef != "workspace-stable" || name != "resource-watch" {
+						return ExtensionRecord{}, fmt.Errorf(
+							"ReloadDevExtension() target = %q/%q, want workspace-stable/resource-watch",
+							workspaceRef,
+							name,
+						)
+					}
+					reloadHash <- request.GenerationHash
+					cancel()
+					return ExtensionRecord{
+						Name: name, WorkspaceID: workspaceRef, Dev: true, DaemonRunning: true,
+					}, nil
+				},
+			}
+			deps, homePaths := newExtensionLocalDeps(t, client)
+			deps.readDaemonInfo = func(string) (compozydaemon.Info, error) {
+				return compozydaemon.Info{PID: 101, StartedAt: fixedTestNow}, nil
+			}
+			deps.processAlive = func(int) bool { return true }
+			deps.loadConfig = func() (compozyconfig.Config, error) {
+				cfg := compozyconfig.DefaultWithHome(homePaths)
+				cfg.Extensions.Dev.WatchInterval = time.Second
+				return cfg, nil
+			}
+
+			result := make(chan error, 1)
+			go func() {
+				command := newRootCommand(deps)
+				command.SetOut(io.Discard)
+				command.SetErr(io.Discard)
+				command.SetArgs([]string{
+					"extension", "dev", sourceDir, "--watch", "--workspace", "workspace-alias", "-o", "json",
+				})
+				result <- command.ExecuteContext(ctx)
+			}()
+
+			firstGeneration := <-initialHash
+			synctest.Wait()
+			writeExtensionManifest(t, skillPath, `---
+name: writer
+description: Write concise release notes.
+---
+
+# Writer
+`)
+			time.Sleep(time.Second)
+			synctest.Wait()
+
+			secondGeneration := <-reloadHash
+			if secondGeneration == firstGeneration {
+				t.Fatalf("reload generation = %q, want a new hash after the skill changed", secondGeneration)
+			}
+			if err := <-result; !errors.Is(err, context.Canceled) {
+				t.Fatalf("extension dev --watch error = %v, want context cancellation", err)
+			}
+		})
+	})
 }
 
 func TestExtensionBundleAndHelpers(t *testing.T) {

--- a/internal/daemon/agent_resource_catalog.go
+++ b/internal/daemon/agent_resource_catalog.go
@@ -30,6 +30,25 @@ func (c *resourceAgentCatalog) ListAgents(ctx context.Context) ([]core.AgentCata
 	return c.agentEntriesForWorkspace(nil), nil
 }
 
+func (c *resourceAgentCatalog) ListAgentsForWorkspace(
+	ctx context.Context,
+	resolved *workspacepkg.ResolvedWorkspace,
+) ([]core.AgentCatalogEntry, error) {
+	if ctx == nil {
+		return nil, errors.New("daemon: list workspace agent catalog context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if resolved == nil {
+		return nil, errors.New("daemon: resolved workspace is required to list agent catalog")
+	}
+	if c == nil || c.catalog == nil {
+		return nil, nil
+	}
+	return c.agentEntriesForWorkspace(resolved), nil
+}
+
 func (c *resourceAgentCatalog) GetAgent(ctx context.Context, name string) (core.AgentCatalogEntry, error) {
 	if ctx == nil {
 		return core.AgentCatalogEntry{}, errors.New("daemon: get agent catalog context is required")

--- a/internal/daemon/agent_sidecar_resources.go
+++ b/internal/daemon/agent_sidecar_resources.go
@@ -25,7 +25,7 @@ func (s *agentSkillSourceSyncer) appendDesiredSidecars(
 		return errors.New("daemon: desired agent resources are required")
 	}
 	for _, item := range items.souls {
-		agentID, ok := agentIDsBySourceKey[item.agentSourceKey]
+		agentID, ok := agentIDsBySourceKey[scopedAgentSourceKey(item.scope, item.agentSourceKey)]
 		if !ok {
 			return fmt.Errorf("daemon: soul %q has no desired agent", item.sourceKey)
 		}
@@ -45,7 +45,7 @@ func (s *agentSkillSourceSyncer) appendDesiredSidecars(
 		}
 	}
 	for _, item := range items.heartbeats {
-		agentID, ok := agentIDsBySourceKey[item.agentSourceKey]
+		agentID, ok := agentIDsBySourceKey[scopedAgentSourceKey(item.scope, item.agentSourceKey)]
 		if !ok {
 			return fmt.Errorf("daemon: heartbeat %q has no desired agent", item.sourceKey)
 		}

--- a/internal/daemon/agent_skill_desired_resources.go
+++ b/internal/daemon/agent_skill_desired_resources.go
@@ -102,9 +102,14 @@ func (s *agentSkillSourceSyncer) appendDesiredAgents(
 		desired.agents[id] = desiredAgentResource{
 			id: id, scope: item.scope.Normalize(), owner: item.owner, spec: spec, encoded: encoded,
 		}
-		agentIDsBySourceKey[item.sourceKey] = id
+		agentIDsBySourceKey[scopedAgentSourceKey(item.scope, item.sourceKey)] = id
 	}
 	return nil
+}
+
+func scopedAgentSourceKey(scope resources.ResourceScope, sourceKey string) string {
+	normalized := scope.Normalize()
+	return string(normalized.Kind) + "\x00" + normalized.ID + "\x00" + strings.TrimSpace(sourceKey)
 }
 
 func (s *agentSkillSourceSyncer) appendDesiredSkills(

--- a/internal/daemon/agent_skill_publisher.go
+++ b/internal/daemon/agent_skill_publisher.go
@@ -6,7 +6,6 @@ import (
 
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 
 	compozyconfig "github.com/compozy/compozy/internal/config"
@@ -211,28 +210,13 @@ func extensionAgentSkillDeclarationProvider(
 			return agentSkillDeclarations{}, nil
 		}
 
-		infos, err := registry.List()
-		if err != nil {
-			return agentSkillDeclarations{}, fmt.Errorf("daemon: list extensions for agent/skill sync: %w", err)
-		}
-		slices.SortFunc(infos, func(left, right extensionpkg.ExtensionInfo) int {
-			return strings.Compare(left.Name, right.Name)
-		})
-
 		desired := agentSkillDeclarations{}
-		globalScope := resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal}
-		for _, info := range infos {
-			if !info.Enabled {
-				continue
-			}
-			ext, err := loadExtensionSnapshot(registry, manager, logger, info.Name)
-			if err != nil {
-				return agentSkillDeclarations{}, fmt.Errorf(
-					"daemon: load extension %q for agent/skill sync: %w",
-					info.Name,
-					err,
-				)
-			}
+		snapshots, err := extensionResourceSnapshots(registry, manager, logger)
+		if err != nil {
+			return agentSkillDeclarations{}, err
+		}
+		for _, snapshot := range snapshots {
+			ext := snapshot.extension
 			if ext == nil || ext.Manifest == nil || !ext.Status.Registered {
 				continue
 			}
@@ -244,8 +228,8 @@ func extensionAgentSkillDeclarationProvider(
 					err,
 				)
 			}
-			appendExtensionAgentResources(&desired, globalScope, ext.Info.Name, agents)
-			appendSkillResources(&desired, globalScope, skillPublicationSource{
+			appendExtensionAgentResources(&desired, snapshot.scope, ext.Info.Name, agents)
+			appendSkillResources(&desired, snapshot.scope, skillPublicationSource{
 				prefix: "extension/" + strings.TrimSpace(ext.Info.Name) + "/skills",
 				owner:  extensionOwner(ext.Info.Name),
 			}, ext.Skills)

--- a/internal/daemon/agent_skill_resources_test.go
+++ b/internal/daemon/agent_skill_resources_test.go
@@ -20,89 +20,94 @@ import (
 
 func TestResourceAgentCatalogListsGetsAndResolvesByScope(t *testing.T) {
 	t.Parallel()
+	t.Run("Should list, get, and resolve agents by scope", func(t *testing.T) {
+		t.Parallel()
 
-	catalog := newResourceCatalog(cloneAgentDef)
-	catalog.Replace(5, []resources.Record[compozyconfig.AgentDef]{
-		{
-			ID:    "global:alpha",
-			Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal},
-			Spec:  compozyconfig.AgentDef{Name: "alpha", Prompt: "global alpha"},
-		},
-		{
-			ID:    "global:onboarding",
-			Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal},
-			Spec:  compozyconfig.AgentDef{Name: "onboarding", Prompt: "global onboarding"},
-		},
-		{
-			ID:    "global:coder",
-			Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal},
-			Spec:  compozyconfig.AgentDef{Name: "coder", Prompt: "global coder"},
-		},
-		{
-			ID:    "workspace:coder",
-			Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindWorkspace, ID: "ws-1"},
-			Spec:  compozyconfig.AgentDef{Name: "coder", Prompt: "workspace coder", Tools: []string{"compozy__lookup"}},
-		},
-		{
-			ID:    "workspace:onboarding",
-			Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindWorkspace, ID: "ws-1"},
-			Spec:  compozyconfig.AgentDef{Name: "onboarding", Prompt: "workspace onboarding"},
-		},
+		catalog := newResourceCatalog(cloneAgentDef)
+		catalog.Replace(5, []resources.Record[compozyconfig.AgentDef]{
+			{
+				ID:    "global:alpha",
+				Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal},
+				Spec:  compozyconfig.AgentDef{Name: "alpha", Prompt: "global alpha"},
+			},
+			{
+				ID:    "global:onboarding",
+				Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal},
+				Spec:  compozyconfig.AgentDef{Name: "onboarding", Prompt: "global onboarding"},
+			},
+			{
+				ID:    "global:coder",
+				Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal},
+				Spec:  compozyconfig.AgentDef{Name: "coder", Prompt: "global coder"},
+			},
+			{
+				ID:    "workspace:coder",
+				Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindWorkspace, ID: "ws-1"},
+				Spec: compozyconfig.AgentDef{
+					Name: "coder", Prompt: "workspace coder", Tools: []string{"compozy__lookup"},
+				},
+			},
+			{
+				ID:    "workspace:onboarding",
+				Scope: resources.ResourceScope{Kind: resources.ResourceScopeKindWorkspace, ID: "ws-1"},
+				Spec:  compozyconfig.AgentDef{Name: "onboarding", Prompt: "workspace onboarding"},
+			},
+		})
+
+		dependency := agentCatalogDependency(catalog)
+		listed, err := dependency.ListAgents(context.Background())
+		if err != nil {
+			t.Fatalf("ListAgents() error = %v", err)
+		}
+		if got, want := len(listed), 3; got != want {
+			t.Fatalf("len(ListAgents()) = %d, want %d", got, want)
+		}
+		if listed[0].Def.Name != "alpha" || listed[1].Def.Name != "coder" || listed[2].Def.Name != "onboarding" {
+			t.Fatalf("ListAgents() = %#v, want global agents sorted by name", listed)
+		}
+		if listed[0].Origin != contract.AgentOriginGlobal || listed[0].WorkspaceID != "" {
+			t.Fatalf("ListAgents()[0] origin = %#v", listed[0])
+		}
+
+		got, err := dependency.GetAgent(context.Background(), "alpha")
+		if err != nil {
+			t.Fatalf("GetAgent(alpha) error = %v", err)
+		}
+		if got.Def.Prompt != "global alpha" {
+			t.Fatalf("GetAgent(alpha).Def.Prompt = %q, want global alpha", got.Def.Prompt)
+		}
+		if _, err := dependency.GetAgent(context.Background(), "missing"); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("GetAgent(missing) error = %v, want os.ErrNotExist", err)
+		}
+		onboardingEntry, err := dependency.GetAgent(context.Background(), "onboarding")
+		if err != nil || onboardingEntry.Def.Prompt != "global onboarding" {
+			t.Fatalf("GetAgent(onboarding) = %#v, %v", onboardingEntry, err)
+		}
+
+		resolved := &workspacepkg.ResolvedWorkspace{Workspace: workspacepkg.Workspace{ID: "ws-1"}}
+		workspaceEntries, err := dependency.ListAgentsForWorkspace(context.Background(), resolved)
+		if err != nil {
+			t.Fatalf("ListAgentsForWorkspace() error = %v", err)
+		}
+		if len(workspaceEntries) != 3 || workspaceEntries[1].Origin != contract.AgentOriginWorkspace ||
+			workspaceEntries[1].WorkspaceID != "ws-1" {
+			t.Fatalf("workspace entries = %#v", workspaceEntries)
+		}
+		coder, err := dependency.ResolveAgent("coder", resolved)
+		if err != nil {
+			t.Fatalf("ResolveAgent(coder) error = %v", err)
+		}
+		if coder.Prompt != "workspace coder" || len(coder.Tools) != 1 || coder.Tools[0] != "compozy__lookup" {
+			t.Fatalf("ResolveAgent(coder) = %#v, want workspace override", coder)
+		}
+		onboarding, err := dependency.ResolveAgent("onboarding", resolved)
+		if err != nil {
+			t.Fatalf("ResolveAgent(onboarding) error = %v", err)
+		}
+		if onboarding.Prompt != "workspace onboarding" {
+			t.Fatalf("ResolveAgent(onboarding).Prompt = %q, want workspace onboarding", onboarding.Prompt)
+		}
 	})
-
-	dependency := agentCatalogDependency(catalog)
-	listed, err := dependency.ListAgents(context.Background())
-	if err != nil {
-		t.Fatalf("ListAgents() error = %v", err)
-	}
-	if got, want := len(listed), 3; got != want {
-		t.Fatalf("len(ListAgents()) = %d, want %d", got, want)
-	}
-	if listed[0].Def.Name != "alpha" || listed[1].Def.Name != "coder" || listed[2].Def.Name != "onboarding" {
-		t.Fatalf("ListAgents() = %#v, want global agents sorted by name", listed)
-	}
-	if listed[0].Origin != contract.AgentOriginGlobal || listed[0].WorkspaceID != "" {
-		t.Fatalf("ListAgents()[0] origin = %#v", listed[0])
-	}
-
-	got, err := dependency.GetAgent(context.Background(), "alpha")
-	if err != nil {
-		t.Fatalf("GetAgent(alpha) error = %v", err)
-	}
-	if got.Def.Prompt != "global alpha" {
-		t.Fatalf("GetAgent(alpha).Def.Prompt = %q, want global alpha", got.Def.Prompt)
-	}
-	if _, err := dependency.GetAgent(context.Background(), "missing"); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("GetAgent(missing) error = %v, want os.ErrNotExist", err)
-	}
-	onboardingEntry, err := dependency.GetAgent(context.Background(), "onboarding")
-	if err != nil || onboardingEntry.Def.Prompt != "global onboarding" {
-		t.Fatalf("GetAgent(onboarding) = %#v, %v", onboardingEntry, err)
-	}
-
-	resolved := &workspacepkg.ResolvedWorkspace{Workspace: workspacepkg.Workspace{ID: "ws-1"}}
-	workspaceEntries, err := dependency.ListAgentsForWorkspace(context.Background(), resolved)
-	if err != nil {
-		t.Fatalf("ListAgentsForWorkspace() error = %v", err)
-	}
-	if len(workspaceEntries) != 3 || workspaceEntries[1].Origin != contract.AgentOriginWorkspace ||
-		workspaceEntries[1].WorkspaceID != "ws-1" {
-		t.Fatalf("workspace entries = %#v", workspaceEntries)
-	}
-	coder, err := dependency.ResolveAgent("coder", resolved)
-	if err != nil {
-		t.Fatalf("ResolveAgent(coder) error = %v", err)
-	}
-	if coder.Prompt != "workspace coder" || len(coder.Tools) != 1 || coder.Tools[0] != "compozy__lookup" {
-		t.Fatalf("ResolveAgent(coder) = %#v, want workspace override", coder)
-	}
-	onboarding, err := dependency.ResolveAgent("onboarding", resolved)
-	if err != nil {
-		t.Fatalf("ResolveAgent(onboarding) error = %v", err)
-	}
-	if onboarding.Prompt != "workspace onboarding" {
-		t.Fatalf("ResolveAgent(onboarding).Prompt = %q, want workspace onboarding", onboarding.Prompt)
-	}
 }
 
 func TestAgentSkillSourceSyncerSerializesConvergence(t *testing.T) {

--- a/internal/daemon/agent_skill_resources_test.go
+++ b/internal/daemon/agent_skill_resources_test.go
@@ -81,7 +81,10 @@ func TestResourceAgentCatalogListsGetsAndResolvesByScope(t *testing.T) {
 	}
 
 	resolved := &workspacepkg.ResolvedWorkspace{Workspace: workspacepkg.Workspace{ID: "ws-1"}}
-	workspaceEntries := dependency.agentEntriesForWorkspace(resolved)
+	workspaceEntries, err := dependency.ListAgentsForWorkspace(context.Background(), resolved)
+	if err != nil {
+		t.Fatalf("ListAgentsForWorkspace() error = %v", err)
+	}
 	if len(workspaceEntries) != 3 || workspaceEntries[1].Origin != contract.AgentOriginWorkspace ||
 		workspaceEntries[1].WorkspaceID != "ws-1" {
 		t.Fatalf("workspace entries = %#v", workspaceEntries)

--- a/internal/daemon/boot_components.go
+++ b/internal/daemon/boot_components.go
@@ -26,6 +26,7 @@ func (d *Daemon) bootComponents(ctx context.Context, state *bootState, cleanup *
 		func() error { return d.bootAutomation(ctx, state, cleanup) },
 		func() error { return d.bootResourceReconcile(ctx, state, cleanup) },
 		func() error { return d.bootExtensions(ctx, state, cleanup) },
+		func() error { return d.bootResourceWatchers(ctx, state, cleanup) },
 		func() error { return d.bootBridgeDeliveryReconcile(ctx, state) },
 		func() error { return d.bootSettings(ctx, state) },
 		func() error { return d.bootSupportBundles(state, cleanup) },

--- a/internal/daemon/boot_hooks.go
+++ b/internal/daemon/boot_hooks.go
@@ -41,39 +41,6 @@ func (d *Daemon) bootHooks(ctx context.Context, state *bootState, cleanup *bootC
 		return nil
 	})
 
-	if state.skillsRegistry != nil {
-		state.skillsCancel, state.skillsDone = startSkillsWatcher(
-			ctx,
-			state.skillsRegistry,
-			state.cfg.Skills.PollInterval,
-			workspaceSkillWatcherRoots(d.homePaths, state.registry),
-			func(refreshCtx context.Context) error {
-				if state.agentSkillResources != nil {
-					if err := state.agentSkillResources.Sync(refreshCtx); err != nil {
-						return err
-					}
-				}
-				return hookBindings.Sync(refreshCtx)
-			},
-		)
-		cleanup.add(func(cleanupCtx context.Context) error {
-			return stopSkillsWatcher(cleanupCtx, state.skillsCancel, state.skillsDone)
-		})
-	}
-	if state.loopResources != nil {
-		state.loopsCancel, state.loopsDone = startLoopWatcher(
-			ctx,
-			state.cfg.Skills.PollInterval,
-			[]string{d.homePaths.LoopsDir},
-			workspaceLoopWatcherRoots(d.homePaths, state.registry),
-			state.loopResources,
-			state.logger,
-		)
-		cleanup.add(func(cleanupCtx context.Context) error {
-			return stopLoopWatcher(cleanupCtx, state.loopsCancel, state.loopsDone)
-		})
-	}
-
 	state.hooks = hooks
 	state.hookDispatcher = hooks
 	state.hookBindings = hookBindings

--- a/internal/daemon/boot_resource_watchers.go
+++ b/internal/daemon/boot_resource_watchers.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+)
+
+func (d *Daemon) bootResourceWatchers(ctx context.Context, state *bootState, cleanup *bootCleanup) error {
+	agentSkillResources := state.agentSkillResources
+	hookBindings := state.hookBindings
+	if state.skillsRegistry != nil {
+		if hookBindings == nil {
+			return errors.New("daemon: hook bindings are required before starting the skills watcher")
+		}
+		state.skillsCancel, state.skillsDone = startSkillsWatcher(
+			ctx,
+			state.skillsRegistry,
+			state.cfg.Skills.PollInterval,
+			workspaceSkillWatcherRoots(d.homePaths, state.registry),
+			func(refreshCtx context.Context) error {
+				if agentSkillResources != nil {
+					if err := agentSkillResources.Sync(refreshCtx); err != nil {
+						return err
+					}
+				}
+				return hookBindings.Sync(refreshCtx)
+			},
+		)
+		cleanup.add(func(cleanupCtx context.Context) error {
+			return stopSkillsWatcher(cleanupCtx, state.skillsCancel, state.skillsDone)
+		})
+	}
+
+	loopResources := state.loopResources
+	if loopResources != nil {
+		state.loopsCancel, state.loopsDone = startLoopWatcher(
+			ctx,
+			state.cfg.Skills.PollInterval,
+			[]string{d.homePaths.LoopsDir},
+			workspaceLoopWatcherRoots(d.homePaths, state.registry),
+			loopResources,
+			state.logger,
+		)
+		cleanup.add(func(cleanupCtx context.Context) error {
+			return stopLoopWatcher(cleanupCtx, state.loopsCancel, state.loopsDone)
+		})
+	}
+	return nil
+}

--- a/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
@@ -215,6 +215,10 @@ func testDaemonE2EResourceOnlyExtensionAuthoring(t *testing.T) {
 	if err == nil {
 		t.Fatalf("invalid resource-only reload error = nil; stdout=%s stderr=%s", stdout, stderr)
 	}
+	if strings.TrimSpace(stdout) != "" || !strings.Contains(stderr, "AGENT.md") ||
+		!strings.Contains(stderr, "decode agent frontmatter") {
+		t.Fatalf("invalid resource-only reload stdout=%q stderr=%q, want invalid AGENT.md diagnostic", stdout, stderr)
+	}
 	active := findWorkspaceExtension(t, ctx, harness, resourceOnlyExtensionAuthoringE2EName)
 	if active.GenerationHash != reloaded.GenerationHash || !active.Dev {
 		t.Fatalf("active extension after invalid edit = %#v, want generation %q", active, reloaded.GenerationHash)

--- a/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
@@ -31,6 +31,7 @@ const (
 	extensionAuthoringE2EName             = "authoring-dev-e2e"
 	resourceOnlyExtensionAuthoringE2EName = "resource-only-authoring-e2e"
 	resourceOnlyAuthoringAgentName        = "resource-only-agent"
+	resourceOnlyAuthoringSkillName        = "resource-only-skill"
 )
 
 func TestDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts(t *testing.T) {
@@ -171,6 +172,14 @@ func testDaemonE2EResourceOnlyExtensionAuthoring(t *testing.T) {
 	)); err != nil {
 		t.Fatalf("os.Stat(generated agent) error = %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(
+		firstBuild.GenerationDir,
+		"skills",
+		resourceOnlyAuthoringSkillName,
+		"SKILL.md",
+	)); err != nil {
+		t.Fatalf("os.Stat(generated skill) error = %v", err)
+	}
 
 	var linked compozycontract.ExtensionPayload
 	runExtensionAuthoringCLI(
@@ -186,7 +195,9 @@ func testDaemonE2EResourceOnlyExtensionAuthoring(t *testing.T) {
 		t.Fatalf("resource-only extension dev result = %#v, want generation %q", linked, firstBuild.GenerationHash)
 	}
 	assertResourceOnlyAuthoringAgent(t, ctx, harness, "generation one")
+	assertResourceOnlyAuthoringSkill(t, ctx, harness)
 	assertResourceOnlyAuthoringAgentIsWorkspaceScoped(t, ctx, harness)
+	assertResourceOnlyAuthoringSkillIsWorkspaceScoped(t, ctx, harness)
 
 	writeResourceOnlyAuthoringAgent(t, sourceDir, "generation two")
 	var reloaded compozycontract.ExtensionPayload
@@ -252,11 +263,13 @@ min_compozy_version = "0.3.0-beta.1"
 
 [resources]
 agents = ["agents"]
+skills = ["skills"]
 `, resourceOnlyExtensionAuthoringE2EName)
 	if err := os.WriteFile(filepath.Join(sourceDir, "extension.toml"), []byte(manifest), 0o600); err != nil {
 		t.Fatalf("os.WriteFile(resource-only manifest) error = %v", err)
 	}
 	writeResourceOnlyAuthoringAgent(t, sourceDir, prompt)
+	writeResourceOnlyAuthoringSkill(t, sourceDir)
 }
 
 func writeResourceOnlyAuthoringAgent(t *testing.T, sourceDir, prompt string) {
@@ -276,6 +289,24 @@ func writeInvalidResourceOnlyAuthoringAgent(t *testing.T, sourceDir string) {
 	agentPath := filepath.Join(sourceDir, "agents", resourceOnlyAuthoringAgentName, "AGENT.md")
 	if err := os.WriteFile(agentPath, []byte("---\nname: [\n---\ninvalid\n"), 0o600); err != nil {
 		t.Fatalf("os.WriteFile(invalid resource-only agent) error = %v", err)
+	}
+}
+
+func writeResourceOnlyAuthoringSkill(t *testing.T, sourceDir string) {
+	t.Helper()
+	skillDir := filepath.Join(sourceDir, "skills", resourceOnlyAuthoringSkillName)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(resource-only skill) error = %v", err)
+	}
+	content := fmt.Sprintf(`---
+name: %s
+description: Exercise resource-only extension authoring.
+---
+
+# Resource-only authoring
+`, resourceOnlyAuthoringSkillName)
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(resource-only skill) error = %v", err)
 	}
 }
 
@@ -313,6 +344,35 @@ func assertResourceOnlyAuthoringAgentIsWorkspaceScoped(
 	}
 }
 
+func assertResourceOnlyAuthoringSkill(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+) {
+	t.Helper()
+	response := listAuthoringSkills(t, ctx, harness, harness.WorkspaceRoot)
+	for _, skill := range response.Skills {
+		if skill.Name == resourceOnlyAuthoringSkillName {
+			return
+		}
+	}
+	t.Fatalf("workspace skills = %#v, want %q", response.Skills, resourceOnlyAuthoringSkillName)
+}
+
+func assertResourceOnlyAuthoringSkillIsWorkspaceScoped(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+) {
+	t.Helper()
+	response := listAuthoringSkills(t, ctx, harness, "")
+	for _, skill := range response.Skills {
+		if skill.Name == resourceOnlyAuthoringSkillName {
+			t.Fatalf("global skills contain workspace resource-only skill: %#v", skill)
+		}
+	}
+}
+
 func listAuthoringAgents(
 	t *testing.T,
 	ctx context.Context,
@@ -327,6 +387,24 @@ func listAuthoringAgents(
 	var response compozycontract.AgentsResponse
 	if err := harness.HTTPJSON(ctx, http.MethodGet, path, nil, &response); err != nil {
 		t.Fatalf("list agents for workspace %q error = %v", workspace, err)
+	}
+	return response
+}
+
+func listAuthoringSkills(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	workspace string,
+) compozycontract.SkillsResponse {
+	t.Helper()
+	path := "/api/skills"
+	if workspace != "" {
+		path += "?workspace=" + url.QueryEscape(workspace)
+	}
+	var response compozycontract.SkillsResponse
+	if err := harness.HTTPJSON(ctx, http.MethodGet, path, nil, &response); err != nil {
+		t.Fatalf("list skills for workspace %q error = %v", workspace, err)
 	}
 	return response
 }

--- a/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_authoring_e2e_integration_test.go
@@ -2,6 +2,11 @@
 
 package daemon
 
+// Suite: Extension authoring lifecycle E2E
+// Invariant: Code-backed and passive resource-only sources complete the workspace development loop without install trust.
+// Boundary IN: CLI build/dev/reload, immutable generations, daemon dev links, and workspace resource projection.
+// Boundary OUT: Distribution, marketplace installation, and client-side watch polling.
+
 import (
 	"context"
 	"encoding/json"
@@ -22,12 +27,20 @@ import (
 	"golang.org/x/sys/execabs"
 )
 
-const extensionAuthoringE2EName = "authoring-dev-e2e"
+const (
+	extensionAuthoringE2EName             = "authoring-dev-e2e"
+	resourceOnlyExtensionAuthoringE2EName = "resource-only-authoring-e2e"
+	resourceOnlyAuthoringAgentName        = "resource-only-agent"
+)
 
 func TestDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts(t *testing.T) {
 	t.Run(
 		"Should complete the development loop without trust prompts",
 		testDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrustPrompts,
+	)
+	t.Run(
+		"Should complete the resource-only development loop",
+		testDaemonE2EResourceOnlyExtensionAuthoring,
 	)
 }
 
@@ -124,6 +137,215 @@ func testDaemonE2EExtensionAuthoringShouldCompleteTheDevelopmentLoopWithoutTrust
 	if removed.Name != extensionAuthoringE2EName || removed.Status != "removed" || removed.Path != sourceDir {
 		t.Fatalf("extension remove result = %#v, want removed dev link", removed)
 	}
+}
+
+func testDaemonE2EResourceOnlyExtensionAuthoring(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
+	defer cancel()
+
+	repoRoot := extensionAuthoringE2ERepoRoot(t)
+	binaryPath := buildStampedExtensionAuthoringBinary(t, ctx, repoRoot)
+	harness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+		BinaryPath:   binaryPath,
+		StartTimeout: 30 * time.Second,
+	})
+	sourceDir := filepath.Join(harness.WorkspaceRoot, resourceOnlyExtensionAuthoringE2EName)
+	writeResourceOnlyAuthoringFixture(t, sourceDir, "generation one")
+
+	var firstBuild extensionpkg.BuildResult
+	runExtensionAuthoringCLI(
+		t,
+		ctx,
+		harness,
+		&firstBuild,
+		"extension", "build", sourceDir, "-o", "json",
+	)
+	assertExtensionAuthoringValidation(t, ctx, harness, firstBuild.GenerationDir)
+	if _, err := os.Stat(filepath.Join(
+		firstBuild.GenerationDir,
+		"agents",
+		resourceOnlyAuthoringAgentName,
+		"AGENT.md",
+	)); err != nil {
+		t.Fatalf("os.Stat(generated agent) error = %v", err)
+	}
+
+	var linked compozycontract.ExtensionPayload
+	runExtensionAuthoringCLI(
+		t,
+		ctx,
+		harness,
+		&linked,
+		"extension", "dev", sourceDir,
+		"--workspace", harness.WorkspaceRoot,
+		"-o", "json",
+	)
+	if !linked.Dev || linked.WorkspaceID != harness.WorkspaceID || linked.GenerationHash != firstBuild.GenerationHash {
+		t.Fatalf("resource-only extension dev result = %#v, want generation %q", linked, firstBuild.GenerationHash)
+	}
+	assertResourceOnlyAuthoringAgent(t, ctx, harness, "generation one")
+	assertResourceOnlyAuthoringAgentIsWorkspaceScoped(t, ctx, harness)
+
+	writeResourceOnlyAuthoringAgent(t, sourceDir, "generation two")
+	var reloaded compozycontract.ExtensionPayload
+	runExtensionAuthoringCLI(
+		t,
+		ctx,
+		harness,
+		&reloaded,
+		"extension", "reload", resourceOnlyExtensionAuthoringE2EName, sourceDir,
+		"--workspace", harness.WorkspaceRoot,
+		"-o", "json",
+	)
+	if !reloaded.Dev || reloaded.GenerationHash == firstBuild.GenerationHash {
+		t.Fatalf("resource-only extension reload result = %#v, want a new dev generation", reloaded)
+	}
+	assertResourceOnlyAuthoringAgent(t, ctx, harness, "generation two")
+
+	writeInvalidResourceOnlyAuthoringAgent(t, sourceDir)
+	stdout, stderr, err := harness.CLI.RunInDir(
+		ctx,
+		harness.WorkspaceRoot,
+		"extension", "reload", resourceOnlyExtensionAuthoringE2EName, sourceDir,
+		"--workspace", harness.WorkspaceRoot,
+		"-o", "json",
+	)
+	if err == nil {
+		t.Fatalf("invalid resource-only reload error = nil; stdout=%s stderr=%s", stdout, stderr)
+	}
+	active := findWorkspaceExtension(t, ctx, harness, resourceOnlyExtensionAuthoringE2EName)
+	if active.GenerationHash != reloaded.GenerationHash || !active.Dev {
+		t.Fatalf("active extension after invalid edit = %#v, want generation %q", active, reloaded.GenerationHash)
+	}
+	assertResourceOnlyAuthoringAgent(t, ctx, harness, "generation two")
+
+	var removed compozycontract.ManagedExtensionRemovePayload
+	runExtensionAuthoringCLI(
+		t,
+		ctx,
+		harness,
+		&removed,
+		"extension", "remove", resourceOnlyExtensionAuthoringE2EName,
+		"--workspace", harness.WorkspaceRoot,
+		"-o", "json",
+	)
+	if removed.Status != "removed" || removed.Path != sourceDir {
+		t.Fatalf("resource-only extension remove result = %#v, want removed source %q", removed, sourceDir)
+	}
+}
+
+func writeResourceOnlyAuthoringFixture(t *testing.T, sourceDir, prompt string) {
+	t.Helper()
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(resource-only source) error = %v", err)
+	}
+	manifest := fmt.Sprintf(`[extension]
+name = %q
+version = "0.1.0"
+min_compozy_version = "0.3.0-beta.1"
+
+[resources]
+agents = ["agents"]
+`, resourceOnlyExtensionAuthoringE2EName)
+	if err := os.WriteFile(filepath.Join(sourceDir, "extension.toml"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(resource-only manifest) error = %v", err)
+	}
+	writeResourceOnlyAuthoringAgent(t, sourceDir, prompt)
+}
+
+func writeResourceOnlyAuthoringAgent(t *testing.T, sourceDir, prompt string) {
+	t.Helper()
+	agentDir := filepath.Join(sourceDir, "agents", resourceOnlyAuthoringAgentName)
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatalf("os.MkdirAll(resource-only agent) error = %v", err)
+	}
+	content := fmt.Sprintf("---\nname: %s\n---\n%s\n", resourceOnlyAuthoringAgentName, prompt)
+	if err := os.WriteFile(filepath.Join(agentDir, "AGENT.md"), []byte(content), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(resource-only agent) error = %v", err)
+	}
+}
+
+func writeInvalidResourceOnlyAuthoringAgent(t *testing.T, sourceDir string) {
+	t.Helper()
+	agentPath := filepath.Join(sourceDir, "agents", resourceOnlyAuthoringAgentName, "AGENT.md")
+	if err := os.WriteFile(agentPath, []byte("---\nname: [\n---\ninvalid\n"), 0o600); err != nil {
+		t.Fatalf("os.WriteFile(invalid resource-only agent) error = %v", err)
+	}
+}
+
+func assertResourceOnlyAuthoringAgent(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	wantPrompt string,
+) {
+	t.Helper()
+	response := listAuthoringAgents(t, ctx, harness, harness.WorkspaceRoot)
+	for _, agent := range response.Agents {
+		if agent.Name != resourceOnlyAuthoringAgentName {
+			continue
+		}
+		if strings.TrimSpace(agent.Prompt) != wantPrompt || agent.WorkspaceID != harness.WorkspaceID {
+			t.Fatalf("resource-only agent = %#v, want prompt %q in workspace %q", agent, wantPrompt, harness.WorkspaceID)
+		}
+		return
+	}
+	t.Fatalf("workspace agents = %#v, want %q", response.Agents, resourceOnlyAuthoringAgentName)
+}
+
+func assertResourceOnlyAuthoringAgentIsWorkspaceScoped(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+) {
+	t.Helper()
+	response := listAuthoringAgents(t, ctx, harness, "")
+	for _, agent := range response.Agents {
+		if agent.Name == resourceOnlyAuthoringAgentName {
+			t.Fatalf("global agents contain workspace resource-only agent: %#v", agent)
+		}
+	}
+}
+
+func listAuthoringAgents(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	workspace string,
+) compozycontract.AgentsResponse {
+	t.Helper()
+	path := "/api/agents"
+	if workspace != "" {
+		path += "?workspace=" + url.QueryEscape(workspace)
+	}
+	var response compozycontract.AgentsResponse
+	if err := harness.HTTPJSON(ctx, http.MethodGet, path, nil, &response); err != nil {
+		t.Fatalf("list agents for workspace %q error = %v", workspace, err)
+	}
+	return response
+}
+
+func findWorkspaceExtension(
+	t *testing.T,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	name string,
+) compozycontract.ExtensionPayload {
+	t.Helper()
+	var response compozycontract.ExtensionsResponse
+	path := "/api/extensions?workspace=" + url.QueryEscape(harness.WorkspaceID)
+	if err := harness.HTTPJSON(ctx, http.MethodGet, path, nil, &response); err != nil {
+		t.Fatalf("list workspace extensions error = %v", err)
+	}
+	for _, extension := range response.Extensions {
+		if extension.Name == name {
+			return extension
+		}
+	}
+	t.Fatalf("workspace extensions = %#v, want %q", response.Extensions, name)
+	return compozycontract.ExtensionPayload{}
 }
 
 // quickstartGuidePath is the published page that owns the replayed command list. The fenced block

--- a/internal/daemon/daemon_extension_distribution_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_distribution_e2e_integration_test.go
@@ -44,6 +44,7 @@ func testDaemonE2EExtensionDistributionAcrossIsolatedHomes(t *testing.T) {
 	repoRoot := extensionAuthoringE2ERepoRoot(t)
 	binaryPath := buildStampedExtensionAuthoringBinary(t, ctx, repoRoot)
 	configSeed := e2etest.ConfigSeedOptions{Mutate: func(cfg *compozyconfig.Config) {
+		cfg.Marketplace.Catalog.BaseURL = githubServer.URL
 		cfg.Extensions.Trust.AllowUnverified = true
 		cfg.Extensions.Sources.GitHub.Enabled = true
 		cfg.Extensions.Sources.GitHub.BaseURL = githubServer.URL
@@ -534,6 +535,13 @@ func (s *distributionGitHubServer) handle(t *testing.T, writer http.ResponseWrit
 	}
 	path := request.URL.Path
 	switch {
+	case request.Method == http.MethodGet &&
+		(path == "/mcp.json" || path == "/extensions.json" || path == "/skills.json"):
+		writeDistributionGitHubJSON(t, writer, map[string]any{
+			"manifest_version": 2,
+			"generated_at":     "2026-08-17T00:00:00Z",
+			"entries":          []any{},
+		}, http.StatusOK)
 	case request.Method == http.MethodGet && path == "/repos/acme/hello/releases/latest":
 		s.writeLatest(t, writer)
 	case request.Method == http.MethodGet && strings.HasPrefix(path, "/repos/acme/hello/releases/tags/"):

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2275,6 +2275,9 @@ func TestBootHooksBuildsResourceBackedRuntimeAndAttachesObserver(t *testing.T) {
 	if err := d.bootHooks(testutil.Context(t), state, cleanup); err != nil {
 		t.Fatalf("bootHooks() error = %v", err)
 	}
+	if err := d.bootResourceWatchers(testutil.Context(t), state, cleanup); err != nil {
+		t.Fatalf("bootResourceWatchers() error = %v", err)
+	}
 	t.Cleanup(func() {
 		for i, v := range slices.Backward(cleanup.fns) {
 			if err := v(testutil.Context(t)); err != nil {
@@ -2310,6 +2313,19 @@ func TestBootHooksBuildsResourceBackedRuntimeAndAttachesObserver(t *testing.T) {
 	}
 	if len(records) == 0 {
 		t.Fatal("store.List() count = 0, want native hook bindings")
+	}
+}
+
+func TestBootResourceWatchersRequiresHookBindingsForSkillsWatcher(t *testing.T) {
+	t.Parallel()
+
+	state := &bootState{skillsRegistry: skills.NewRegistry(skills.RegistryConfig{})}
+	err := (&Daemon{}).bootResourceWatchers(testutil.Context(t), state, &bootCleanup{})
+	if err == nil {
+		t.Fatal("bootResourceWatchers() error = nil, want missing hook bindings error")
+	}
+	if got, want := err.Error(), "daemon: hook bindings are required before starting the skills watcher"; got != want {
+		t.Fatalf("bootResourceWatchers() error = %q, want %q", got, want)
 	}
 }
 
@@ -5208,7 +5224,7 @@ args = ["-c", "printf '{}'"]
 	})
 }
 
-func TestBootSkillsWatcherRefreshesOnGlobalChangesAndStopsOnShutdown(t *testing.T) {
+func TestBootResourceWatchersStartAndSkillsWatcherRefreshes(t *testing.T) {
 	t.Parallel()
 
 	homePaths := testHomePaths(t)
@@ -5243,6 +5259,10 @@ func TestBootSkillsWatcherRefreshesOnGlobalChangesAndStopsOnShutdown(t *testing.
 	if skillsDone == nil {
 		t.Fatal("boot() did not start the skills watcher")
 	}
+	loopsDone := d.loopsDone
+	if loopsDone == nil {
+		t.Fatal("boot() did not start the loops watcher after configuring extension publishers")
+	}
 
 	writeDaemonSkill(t, homePaths.SkillsDir, "watched-skill", "Global watched skill")
 	waitForCondition(t, "watcher refresh after boot", func() bool {
@@ -5257,6 +5277,11 @@ func TestBootSkillsWatcherRefreshesOnGlobalChangesAndStopsOnShutdown(t *testing.
 	case <-skillsDone:
 	default:
 		t.Fatal("skills watcher was still running after shutdown")
+	}
+	select {
+	case <-loopsDone:
+	default:
+		t.Fatal("loops watcher was still running after shutdown")
 	}
 	versionAfterShutdown := registry.GlobalVersion()
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2319,14 +2319,18 @@ func TestBootHooksBuildsResourceBackedRuntimeAndAttachesObserver(t *testing.T) {
 func TestBootResourceWatchersRequiresHookBindingsForSkillsWatcher(t *testing.T) {
 	t.Parallel()
 
-	state := &bootState{skillsRegistry: skills.NewRegistry(skills.RegistryConfig{})}
-	err := (&Daemon{}).bootResourceWatchers(testutil.Context(t), state, &bootCleanup{})
-	if err == nil {
-		t.Fatal("bootResourceWatchers() error = nil, want missing hook bindings error")
-	}
-	if got, want := err.Error(), "daemon: hook bindings are required before starting the skills watcher"; got != want {
-		t.Fatalf("bootResourceWatchers() error = %q, want %q", got, want)
-	}
+	t.Run("Should reject skills watcher startup without hook bindings", func(t *testing.T) {
+		t.Parallel()
+
+		state := &bootState{skillsRegistry: skills.NewRegistry(skills.RegistryConfig{})}
+		err := (&Daemon{}).bootResourceWatchers(testutil.Context(t), state, &bootCleanup{})
+		if err == nil {
+			t.Fatal("bootResourceWatchers() error = nil, want missing hook bindings error")
+		}
+		if got, want := err.Error(), "daemon: hook bindings are required before starting the skills watcher"; got != want {
+			t.Fatalf("bootResourceWatchers() error = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestAttachExtensionRuntimeUsesHookBindingSyncBeforeRebuild(t *testing.T) {

--- a/internal/daemon/extension_kit_resources.go
+++ b/internal/daemon/extension_kit_resources.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 
 	automationpkg "github.com/compozy/compozy/internal/automation"
@@ -156,29 +155,19 @@ func (s *extensionKitSourceSyncer) desired(
 	if manager == nil {
 		return jobs, triggers, layouts, nil
 	}
-	infos, err := s.registry.List()
+	snapshots, err := extensionResourceSnapshots(s.registry, manager, s.logger)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("daemon: list extensions for kit sync: %w", err)
+		return nil, nil, nil, err
 	}
-	slices.SortFunc(infos, func(left, right extensionpkg.ExtensionInfo) int {
-		return strings.Compare(left.Name, right.Name)
-	})
-	globalScope := resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal}
-	for _, info := range infos {
-		if !info.Enabled {
-			continue
-		}
-		ext, err := loadExtensionSnapshot(s.registry, manager, s.logger, info.Name)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("daemon: load extension %q for kit sync: %w", info.Name, err)
-		}
+	for _, snapshot := range snapshots {
+		ext := snapshot.extension
 		if ext == nil || ext.Manifest == nil || !ext.Status.Registered {
 			continue
 		}
 		if err := s.collectDesiredExtensionKitResources(
 			ctx,
 			ext,
-			globalScope,
+			snapshot.scope,
 			jobs,
 			triggers,
 			layouts,
@@ -199,6 +188,7 @@ func (s *extensionKitSourceSyncer) collectDesiredExtensionKitResources(
 ) error {
 	owner := extensionOwner(ext.Info.Name)
 	for _, job := range ext.AutomationJobs {
+		job = bindExtensionJobScope(job, scope)
 		value, encoded, err := validateAndEncodeResource(ctx, s.jobCodec, scope, job)
 		if err != nil {
 			return fmt.Errorf(
@@ -208,19 +198,21 @@ func (s *extensionKitSourceSyncer) collectDesiredExtensionKitResources(
 				err,
 			)
 		}
-		id := value.ID
-		if strings.TrimSpace(id) == "" {
+		resourceID := value.ID
+		if strings.TrimSpace(resourceID) == "" {
 			return fmt.Errorf(
 				"daemon: extension %q job %q has an empty resource ID",
 				ext.Info.Name,
 				job.Name,
 			)
 		}
+		id := managedPublicationID("", scope, resourceID, encoded, owner)
 		jobs[id] = managedResourceValue[automationpkg.Job]{
 			id: id, scope: scope, owner: owner, spec: value, encoded: encoded,
 		}
 	}
 	for _, trigger := range ext.AutomationTriggers {
+		trigger = bindExtensionTriggerScope(trigger, scope)
 		value, encoded, err := validateAndEncodeResource(ctx, s.triggerCodec, scope, trigger)
 		if err != nil {
 			return fmt.Errorf(
@@ -230,22 +222,24 @@ func (s *extensionKitSourceSyncer) collectDesiredExtensionKitResources(
 				err,
 			)
 		}
-		id := value.ID
-		if strings.TrimSpace(id) == "" {
+		resourceID := value.ID
+		if strings.TrimSpace(resourceID) == "" {
 			return fmt.Errorf(
 				"daemon: extension %q trigger %q has an empty resource ID",
 				ext.Info.Name,
 				trigger.Name,
 			)
 		}
+		id := managedPublicationID("", scope, resourceID, encoded, owner)
 		triggers[id] = managedResourceValue[automationpkg.Trigger]{
 			id: id, scope: scope, owner: owner, spec: value, encoded: encoded,
 		}
 	}
 	for _, layout := range ext.Layouts {
 		id := "extension/" + ext.Info.Name + "/window_layout/" + strings.TrimSpace(layout.ID)
+		publicationID := managedPublicationID("", scope, id, nil, owner)
 		materialized := windowmanager.CloneLayoutResource(layout)
-		materialized.ID = id
+		materialized.ID = publicationID
 		value, encoded, err := validateAndEncodeResource(ctx, s.layoutCodec, scope, materialized)
 		if err != nil {
 			return fmt.Errorf(
@@ -255,9 +249,25 @@ func (s *extensionKitSourceSyncer) collectDesiredExtensionKitResources(
 				err,
 			)
 		}
-		layouts[id] = managedResourceValue[windowmanager.LayoutResource]{
-			id: id, scope: scope, owner: owner, spec: value, encoded: encoded,
+		layouts[publicationID] = managedResourceValue[windowmanager.LayoutResource]{
+			id: publicationID, scope: scope, owner: owner, spec: value, encoded: encoded,
 		}
 	}
 	return nil
+}
+
+func bindExtensionJobScope(job automationpkg.Job, scope resources.ResourceScope) automationpkg.Job {
+	if normalized := scope.Normalize(); normalized.Kind == resources.ResourceScopeKindWorkspace {
+		job.Scope = automationpkg.AutomationScopeWorkspace
+		job.WorkspaceID = normalized.ID
+	}
+	return job
+}
+
+func bindExtensionTriggerScope(trigger automationpkg.Trigger, scope resources.ResourceScope) automationpkg.Trigger {
+	if normalized := scope.Normalize(); normalized.Kind == resources.ResourceScopeKindWorkspace {
+		trigger.Scope = automationpkg.AutomationScopeWorkspace
+		trigger.WorkspaceID = normalized.ID
+	}
+	return trigger
 }

--- a/internal/daemon/extension_resource_snapshots.go
+++ b/internal/daemon/extension_resource_snapshots.go
@@ -58,10 +58,11 @@ func extensionResourceSnapshots(
 	}
 	scopedRuntime, ok := runtime.(scopedExtensionRuntime)
 	if !ok {
-		return nil, fmt.Errorf("daemon: extension runtime does not support workspace development resources")
+		logUnsupportedDevelopmentLinks(logger, len(links))
+		return snapshots, nil
 	}
 	for _, link := range links {
-		key := extensionpkg.InstanceKey{Name: link.ExtensionName, WorkspaceID: link.WorkspaceID}
+		key := (extensionpkg.InstanceKey{Name: link.ExtensionName, WorkspaceID: link.WorkspaceID}).Normalize()
 		ext, loadErr := scopedRuntime.GetForInstance(key)
 		if loadErr != nil {
 			if errors.Is(loadErr, extensionpkg.ErrExtensionNotFound) {
@@ -95,9 +96,15 @@ func extensionResourceSnapshots(
 			extension: ext,
 			scope: resources.ResourceScope{
 				Kind: resources.ResourceScopeKindWorkspace,
-				ID:   strings.TrimSpace(link.WorkspaceID),
+				ID:   key.WorkspaceID,
 			},
 		})
 	}
 	return snapshots, nil
+}
+
+func logUnsupportedDevelopmentLinks(logger *slog.Logger, count int) {
+	if logger != nil {
+		logger.Warn("extension.resource_sync.dev_links_unsupported", "dev_link_count", count)
+	}
 }

--- a/internal/daemon/extension_resource_snapshots.go
+++ b/internal/daemon/extension_resource_snapshots.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+
+	extensionpkg "github.com/compozy/compozy/internal/extension"
+	"github.com/compozy/compozy/internal/resources"
+)
+
+type scopedExtensionResourceSnapshot struct {
+	extension *extensionpkg.Extension
+	scope     resources.ResourceScope
+}
+
+type scopedExtensionRuntime interface {
+	GetForInstance(extensionpkg.InstanceKey) (*extensionpkg.Extension, error)
+}
+
+func extensionResourceSnapshots(
+	registry *extensionpkg.Registry,
+	runtime extensionRuntime,
+	logger *slog.Logger,
+) ([]scopedExtensionResourceSnapshot, error) {
+	infos, err := registry.List()
+	if err != nil {
+		return nil, fmt.Errorf("daemon: list installed extensions for resource sync: %w", err)
+	}
+	slices.SortFunc(infos, func(left, right extensionpkg.ExtensionInfo) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+
+	snapshots := make([]scopedExtensionResourceSnapshot, 0, len(infos))
+	globalScope := resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal}
+	for _, info := range infos {
+		if !info.Enabled {
+			continue
+		}
+		ext, loadErr := loadExtensionSnapshot(registry, runtime, logger, info.Name)
+		if loadErr != nil {
+			return nil, fmt.Errorf("daemon: load installed extension %q for resource sync: %w", info.Name, loadErr)
+		}
+		snapshots = append(snapshots, scopedExtensionResourceSnapshot{extension: ext, scope: globalScope})
+	}
+
+	links, err := registry.ListDevLinks()
+	if err != nil {
+		return nil, fmt.Errorf("daemon: list development extensions for resource sync: %w", err)
+	}
+	if len(links) == 0 {
+		return snapshots, nil
+	}
+	if runtime == nil {
+		return snapshots, nil
+	}
+	scopedRuntime, ok := runtime.(scopedExtensionRuntime)
+	if !ok {
+		return nil, fmt.Errorf("daemon: extension runtime does not support workspace development resources")
+	}
+	for _, link := range links {
+		key := extensionpkg.InstanceKey{Name: link.ExtensionName, WorkspaceID: link.WorkspaceID}
+		ext, loadErr := scopedRuntime.GetForInstance(key)
+		if loadErr != nil {
+			if errors.Is(loadErr, extensionpkg.ErrExtensionNotFound) {
+				if logger != nil {
+					logger.Debug(
+						"extension.resource_sync.dev_link_inactive",
+						"extension", key.Name,
+						"workspace_id", key.WorkspaceID,
+					)
+				}
+				continue
+			}
+			return nil, fmt.Errorf(
+				"daemon: load development extension %q for workspace %q resource sync: %w",
+				key.Name,
+				key.WorkspaceID,
+				loadErr,
+			)
+		}
+		if ext == nil || strings.TrimSpace(ext.Status.WorkspaceID) != key.WorkspaceID {
+			if logger != nil {
+				logger.Debug(
+					"extension.resource_sync.dev_link_not_activated",
+					"extension", key.Name,
+					"workspace_id", key.WorkspaceID,
+				)
+			}
+			continue
+		}
+		snapshots = append(snapshots, scopedExtensionResourceSnapshot{
+			extension: ext,
+			scope: resources.ResourceScope{
+				Kind: resources.ResourceScopeKindWorkspace,
+				ID:   strings.TrimSpace(link.WorkspaceID),
+			},
+		})
+	}
+	return snapshots, nil
+}

--- a/internal/daemon/extension_resource_snapshots_test.go
+++ b/internal/daemon/extension_resource_snapshots_test.go
@@ -1,0 +1,349 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	automationpkg "github.com/compozy/compozy/internal/automation"
+	compozyconfig "github.com/compozy/compozy/internal/config"
+	extensionpkg "github.com/compozy/compozy/internal/extension"
+	"github.com/compozy/compozy/internal/resources"
+	"github.com/compozy/compozy/internal/soul"
+	"github.com/compozy/compozy/internal/windowmanager"
+)
+
+const resourceSnapshotGeneration = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+type resourceSnapshotRuntime struct {
+	*fakeExtensionRuntime
+	instances map[extensionpkg.InstanceKey]*extensionpkg.Extension
+	fallback  *extensionpkg.Extension
+}
+
+func (r *resourceSnapshotRuntime) GetForInstance(key extensionpkg.InstanceKey) (*extensionpkg.Extension, error) {
+	if ext := r.instances[key.Normalize()]; ext != nil {
+		return ext, nil
+	}
+	if r.fallback != nil {
+		return r.fallback, nil
+	}
+	return nil, extensionpkg.ErrExtensionNotFound
+}
+
+func TestExtensionResourceSnapshotsIncludesWorkspaceDevelopmentLinks(t *testing.T) {
+	t.Parallel()
+	t.Run("Should include development resources only in their workspace scope", testExtensionResourceSnapshots)
+}
+
+func testExtensionResourceSnapshots(t *testing.T) {
+	t.Parallel()
+
+	db := openDaemonTestGlobalDB(t)
+	registry := extensionpkg.NewRegistry(db.DB())
+	const (
+		extensionName = "resource-only-kit"
+		workspaceID   = "workspace-resource-only"
+	)
+	if _, err := registry.LinkDev(extensionpkg.DevLinkRequest{
+		Name:           extensionName,
+		WorkspaceID:    workspaceID,
+		OriginPath:     t.TempDir(),
+		GenerationHash: resourceSnapshotGeneration,
+		Format:         extensionpkg.FormatCompozy,
+	}); err != nil {
+		t.Fatalf("registry.LinkDev() error = %v", err)
+	}
+
+	key := extensionpkg.InstanceKey{Name: extensionName, WorkspaceID: workspaceID}
+	ext := &extensionpkg.Extension{
+		Info: extensionpkg.ExtensionInfo{Name: extensionName, Enabled: true},
+		Status: extensionpkg.ExtensionStatus{
+			Name: extensionName, Enabled: true, Registered: true, WorkspaceID: workspaceID,
+		},
+		Manifest: &extensionpkg.Manifest{Name: extensionName, Format: extensionpkg.FormatCompozy},
+	}
+	runtime := &resourceSnapshotRuntime{
+		fakeExtensionRuntime: &fakeExtensionRuntime{},
+		instances:            map[extensionpkg.InstanceKey]*extensionpkg.Extension{key: ext},
+	}
+
+	snapshots, err := extensionResourceSnapshots(registry, runtime, discardLogger())
+	if err != nil {
+		t.Fatalf("extensionResourceSnapshots() error = %v", err)
+	}
+	if len(snapshots) != 1 {
+		t.Fatalf("len(extensionResourceSnapshots()) = %d, want 1", len(snapshots))
+	}
+	if snapshots[0].extension != ext || snapshots[0].scope != (resources.ResourceScope{
+		Kind: resources.ResourceScopeKindWorkspace,
+		ID:   workspaceID,
+	}) {
+		t.Fatalf("extensionResourceSnapshots()[0] = %#v, want workspace development snapshot", snapshots[0])
+	}
+}
+
+func TestExtensionResourceSnapshotsIgnoreInactiveDevelopmentLinks(t *testing.T) {
+	t.Parallel()
+	t.Run("Should skip staged links that have no matching workspace runtime", func(t *testing.T) {
+		t.Parallel()
+
+		db := openDaemonTestGlobalDB(t)
+		registry := extensionpkg.NewRegistry(db.DB())
+		const (
+			extensionName = "staged-kit"
+			workspaceID   = "workspace-staged"
+		)
+		if _, err := registry.LinkDev(extensionpkg.DevLinkRequest{
+			Name: extensionName, WorkspaceID: workspaceID, OriginPath: t.TempDir(),
+			GenerationHash: resourceSnapshotGeneration, Format: extensionpkg.FormatCompozy,
+		}); err != nil {
+			t.Fatalf("registry.LinkDev() error = %v", err)
+		}
+		global := &extensionpkg.Extension{
+			Info: extensionpkg.ExtensionInfo{Name: extensionName, Enabled: true},
+			Status: extensionpkg.ExtensionStatus{
+				Name: extensionName, Enabled: true, Registered: true,
+			},
+			Manifest: &extensionpkg.Manifest{Name: extensionName, Format: extensionpkg.FormatCompozy},
+		}
+
+		testCases := []struct {
+			name    string
+			runtime extensionRuntime
+		}{
+			{
+				name:    "runtime unavailable",
+				runtime: nil,
+			},
+			{
+				name: "missing workspace instance",
+				runtime: &resourceSnapshotRuntime{
+					fakeExtensionRuntime: &fakeExtensionRuntime{},
+					instances:            map[extensionpkg.InstanceKey]*extensionpkg.Extension{},
+				},
+			},
+			{
+				name: "global runtime fallback",
+				runtime: &resourceSnapshotRuntime{
+					fakeExtensionRuntime: &fakeExtensionRuntime{},
+					instances:            map[extensionpkg.InstanceKey]*extensionpkg.Extension{},
+					fallback:             global,
+				},
+			},
+		}
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				snapshots, err := extensionResourceSnapshots(registry, testCase.runtime, discardLogger())
+				if err != nil {
+					t.Fatalf("extensionResourceSnapshots() error = %v", err)
+				}
+				if len(snapshots) != 0 {
+					t.Fatalf("extensionResourceSnapshots() = %#v, want no inactive development snapshots", snapshots)
+				}
+			})
+		}
+	})
+}
+
+func TestExtensionKitResourcesBindWorkspaceScope(t *testing.T) {
+	t.Parallel()
+	t.Run("Should bind automation and layout identities to the development workspace", func(t *testing.T) {
+		t.Parallel()
+
+		jobCodec, err := automationpkg.NewJobResourceCodec()
+		if err != nil {
+			t.Fatalf("automation.NewJobResourceCodec() error = %v", err)
+		}
+		triggerCodec, err := automationpkg.NewTriggerResourceCodec()
+		if err != nil {
+			t.Fatalf("automation.NewTriggerResourceCodec() error = %v", err)
+		}
+		layoutCodec, err := windowmanager.NewLayoutResourceCodec()
+		if err != nil {
+			t.Fatalf("windowmanager.NewLayoutResourceCodec() error = %v", err)
+		}
+		syncer := &extensionKitSourceSyncer{
+			jobCodec: jobCodec, triggerCodec: triggerCodec, layoutCodec: layoutCodec,
+		}
+		const (
+			extensionName = "workspace-kit"
+			workspaceID   = "workspace-kit-test"
+		)
+		ext := &extensionpkg.Extension{
+			Info: extensionpkg.ExtensionInfo{Name: extensionName},
+			AutomationJobs: []automationpkg.Job{{
+				ID: "extension/workspace-kit/automation.job/daily", Scope: automationpkg.AutomationScopeGlobal,
+				Name: "workspace-kit/daily", AgentName: "writer", Prompt: "Review repository",
+				Schedule: &automationpkg.ScheduleSpec{
+					Mode: automationpkg.ScheduleModeAt,
+					Time: time.Date(2030, 1, 1, 12, 0, 0, 0, time.UTC).Format(time.RFC3339),
+				},
+				Enabled: true, Retry: automationpkg.DefaultRetryConfig(),
+				FireLimit: automationpkg.DefaultFireLimitConfig(), Source: automationpkg.JobSourcePackage,
+			}},
+			AutomationTriggers: []automationpkg.Trigger{{
+				ID:    "extension/workspace-kit/automation.trigger/stopped",
+				Scope: automationpkg.AutomationScopeGlobal, Name: "workspace-kit/stopped",
+				AgentName: "writer", Prompt: "Review stopped session", Event: "session.stopped", Enabled: true,
+				Retry: automationpkg.DefaultRetryConfig(), FireLimit: automationpkg.DefaultFireLimitConfig(),
+				Source: automationpkg.JobSourcePackage,
+			}},
+			Layouts: []windowmanager.LayoutResource{{
+				Version: windowmanager.LayoutResourceVersion, ID: "focus", DisplayName: "Focus",
+				AspectVariant: windowmanager.LayoutAspectAny, OverflowPolicy: windowmanager.LayoutOverflowStack,
+				Document: windowmanager.LayoutDocument{
+					Version: windowmanager.SnapshotVersion,
+					Desktops: []windowmanager.Desktop{{
+						ID: "desktop-main", Name: "Main", Purpose: windowmanager.DesktopPurposeStandard,
+						Groups: []windowmanager.LayoutGroup{}, Floating: []windowmanager.WindowID{},
+					}},
+					Windows: map[windowmanager.WindowID]windowmanager.Window{},
+				},
+			}},
+		}
+		scope := resources.ResourceScope{Kind: resources.ResourceScopeKindWorkspace, ID: workspaceID}
+		jobs := make(map[string]managedResourceValue[automationpkg.Job])
+		triggers := make(map[string]managedResourceValue[automationpkg.Trigger])
+		layouts := make(map[string]managedResourceValue[windowmanager.LayoutResource])
+
+		if err := syncer.collectDesiredExtensionKitResources(
+			context.Background(), ext, scope, jobs, triggers, layouts,
+		); err != nil {
+			t.Fatalf("collectDesiredExtensionKitResources() error = %v", err)
+		}
+		for _, job := range jobs {
+			if job.spec.Scope != automationpkg.AutomationScopeWorkspace || job.spec.WorkspaceID != workspaceID {
+				t.Fatalf(
+					"workspace job scope = %q/%q, want workspace/%q",
+					job.spec.Scope,
+					job.spec.WorkspaceID,
+					workspaceID,
+				)
+			}
+		}
+		for _, trigger := range triggers {
+			if trigger.spec.Scope != automationpkg.AutomationScopeWorkspace || trigger.spec.WorkspaceID != workspaceID {
+				t.Fatalf(
+					"workspace trigger scope = %q/%q, want workspace/%q",
+					trigger.spec.Scope,
+					trigger.spec.WorkspaceID,
+					workspaceID,
+				)
+			}
+		}
+		for id, layout := range layouts {
+			if layout.spec.ID != id {
+				t.Fatalf("workspace layout spec ID = %q, want record ID %q", layout.spec.ID, id)
+			}
+		}
+		if len(jobs) != 1 || len(triggers) != 1 || len(layouts) != 1 {
+			t.Fatalf("workspace kit counts = %d/%d/%d, want 1/1/1", len(jobs), len(triggers), len(layouts))
+		}
+	})
+}
+
+func TestManagedPublicationIDSeparatesExtensionWorkspaceScopes(t *testing.T) {
+	t.Parallel()
+	t.Run("Should preserve global IDs and separate workspace publications", testManagedPublicationIDScopes)
+}
+
+func testManagedPublicationIDScopes(t *testing.T) {
+	t.Parallel()
+
+	owner := extensionOwner("resource-only-kit")
+	global := managedPublicationID(
+		"daemon.sync.test.",
+		resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal},
+		"extension/resource-only-kit/agent/writer",
+		nil,
+		owner,
+	)
+	workspace := managedPublicationID(
+		"daemon.sync.test.",
+		resources.ResourceScope{Kind: resources.ResourceScopeKindWorkspace, ID: "workspace-a"},
+		"extension/resource-only-kit/agent/writer",
+		nil,
+		owner,
+	)
+	if global != "extension/resource-only-kit/agent/writer" {
+		t.Fatalf("global publication ID = %q, want stable source key", global)
+	}
+	if workspace == global {
+		t.Fatalf("workspace publication ID = global publication ID %q", global)
+	}
+}
+
+func TestAgentSidecarsResolveAgentsWithinTheSameResourceScope(t *testing.T) {
+	t.Parallel()
+	t.Run("Should keep global and workspace sidecars attached to their matching agents", func(t *testing.T) {
+		t.Parallel()
+
+		agentCodec, err := compozyconfig.NewAgentResourceCodec()
+		if err != nil {
+			t.Fatalf("compozyconfig.NewAgentResourceCodec() error = %v", err)
+		}
+		soulCodec, err := soul.NewResourceCodec()
+		if err != nil {
+			t.Fatalf("soul.NewResourceCodec() error = %v", err)
+		}
+		globalScope := resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal}
+		workspaceScope := resources.ResourceScope{Kind: resources.ResourceScopeKindWorkspace, ID: "workspace-a"}
+		const sourceKey = "extension/resource-only-kit/agent/writer"
+		declarations := agentSkillDeclarations{
+			agents: []agentPublicationInput{
+				{
+					sourceKey: sourceKey, scope: globalScope,
+					spec: compozyconfig.AgentDef{Name: "writer", Prompt: "global agent"},
+				},
+				{
+					sourceKey: sourceKey, scope: workspaceScope,
+					spec: compozyconfig.AgentDef{Name: "writer", Prompt: "workspace agent"},
+				},
+			},
+			souls: []soulPublicationInput{
+				{
+					sourceKey: sourceKey + "/soul", agentSourceKey: sourceKey,
+					scope: globalScope, agentName: "writer", sourcePath: "/global/SOUL.md", body: "global soul",
+				},
+				{
+					sourceKey: sourceKey + "/soul", agentSourceKey: sourceKey,
+					scope: workspaceScope, agentName: "writer",
+					sourcePath: "/workspace/SOUL.md", body: "workspace soul",
+				},
+			},
+		}
+		syncer := &agentSkillSourceSyncer{
+			agentCodec: agentCodec,
+			soulCodec:  soulCodec,
+			providers: []agentSkillDeclarationProvider{func(context.Context) (agentSkillDeclarations, error) {
+				return declarations, nil
+			}},
+		}
+
+		desired, err := syncer.desiredResources(context.Background())
+		if err != nil {
+			t.Fatalf("desiredResources() error = %v", err)
+		}
+		if len(desired.agents) != 2 || len(desired.souls) != 2 {
+			t.Fatalf("desired resources = agents:%d souls:%d, want 2/2", len(desired.agents), len(desired.souls))
+		}
+		agentIDs := make(map[resources.ResourceScope]string, len(desired.agents))
+		for id, agent := range desired.agents {
+			agentIDs[agent.scope] = id
+		}
+		for _, sidecar := range desired.souls {
+			if sidecar.spec.AgentResourceID != agentIDs[sidecar.scope] {
+				t.Fatalf(
+					"soul in scope %#v references agent %q, want %q",
+					sidecar.scope,
+					sidecar.spec.AgentResourceID,
+					agentIDs[sidecar.scope],
+				)
+			}
+		}
+	})
+}
+
+var _ extensionRuntime = (*resourceSnapshotRuntime)(nil)
+var _ scopedExtensionRuntime = (*resourceSnapshotRuntime)(nil)

--- a/internal/daemon/extension_resource_snapshots_test.go
+++ b/internal/daemon/extension_resource_snapshots_test.go
@@ -34,6 +34,51 @@ func (r *resourceSnapshotRuntime) GetForInstance(key extensionpkg.InstanceKey) (
 func TestExtensionResourceSnapshotsIncludesWorkspaceDevelopmentLinks(t *testing.T) {
 	t.Parallel()
 	t.Run("Should include development resources only in their workspace scope", testExtensionResourceSnapshots)
+	t.Run("Should normalize workspace IDs before resolving development resources", func(t *testing.T) {
+		t.Parallel()
+
+		db := openDaemonTestGlobalDB(t)
+		registry := extensionpkg.NewRegistry(db.DB())
+		const (
+			extensionName = "normalized-resource-kit"
+			workspaceID   = "workspace-normalized"
+		)
+		if _, err := registry.LinkDev(extensionpkg.DevLinkRequest{
+			Name: extensionName, WorkspaceID: workspaceID, OriginPath: t.TempDir(),
+			GenerationHash: resourceSnapshotGeneration, Format: extensionpkg.FormatCompozy,
+		}); err != nil {
+			t.Fatalf("registry.LinkDev() error = %v", err)
+		}
+		if _, err := db.DB().ExecContext(
+			t.Context(),
+			`UPDATE extension_dev_links SET workspace_id = ? WHERE extension_name = ?`,
+			"  "+workspaceID+"  ",
+			extensionName,
+		); err != nil {
+			t.Fatalf("pad persisted workspace ID: %v", err)
+		}
+
+		key := extensionpkg.InstanceKey{Name: extensionName, WorkspaceID: workspaceID}
+		ext := &extensionpkg.Extension{
+			Info: extensionpkg.ExtensionInfo{Name: extensionName, Enabled: true},
+			Status: extensionpkg.ExtensionStatus{
+				Name: extensionName, Enabled: true, Registered: true, WorkspaceID: workspaceID,
+			},
+			Manifest: &extensionpkg.Manifest{Name: extensionName, Format: extensionpkg.FormatCompozy},
+		}
+		runtime := &resourceSnapshotRuntime{
+			fakeExtensionRuntime: &fakeExtensionRuntime{},
+			instances:            map[extensionpkg.InstanceKey]*extensionpkg.Extension{key: ext},
+		}
+
+		snapshots, err := extensionResourceSnapshots(registry, runtime, discardLogger())
+		if err != nil {
+			t.Fatalf("extensionResourceSnapshots() error = %v", err)
+		}
+		if len(snapshots) != 1 || snapshots[0].scope.ID != workspaceID {
+			t.Fatalf("extensionResourceSnapshots() = %#v, want normalized workspace snapshot", snapshots)
+		}
+	})
 }
 
 func testExtensionResourceSnapshots(t *testing.T) {
@@ -142,6 +187,47 @@ func TestExtensionResourceSnapshotsIgnoreInactiveDevelopmentLinks(t *testing.T) 
 					t.Fatalf("extensionResourceSnapshots() = %#v, want no inactive development snapshots", snapshots)
 				}
 			})
+		}
+	})
+}
+
+func TestExtensionResourceSnapshotsPreserveGlobalResourcesWithoutScopedRuntime(t *testing.T) {
+	t.Parallel()
+	t.Run("Should keep global snapshots when development lookup is unsupported", func(t *testing.T) {
+		t.Parallel()
+
+		db := openDaemonTestGlobalDB(t)
+		const (
+			extensionName = "global-resource-kit"
+			workspaceID   = "workspace-global-fallback"
+		)
+		installDaemonTestExtension(t, db, extensionName, daemonTestExtensionOptions{}, true)
+		registry := extensionpkg.NewRegistry(db.DB())
+		if _, err := registry.LinkDev(extensionpkg.DevLinkRequest{
+			Name: extensionName, WorkspaceID: workspaceID, OriginPath: t.TempDir(),
+			GenerationHash: resourceSnapshotGeneration, Format: extensionpkg.FormatCompozy,
+		}); err != nil {
+			t.Fatalf("registry.LinkDev() error = %v", err)
+		}
+		global := &extensionpkg.Extension{
+			Info: extensionpkg.ExtensionInfo{Name: extensionName, Enabled: true},
+			Status: extensionpkg.ExtensionStatus{
+				Name: extensionName, Enabled: true, Registered: true,
+			},
+			Manifest: &extensionpkg.Manifest{Name: extensionName, Format: extensionpkg.FormatCompozy},
+		}
+
+		snapshots, err := extensionResourceSnapshots(
+			registry,
+			&fakeExtensionRuntime{getExt: global},
+			discardLogger(),
+		)
+		if err != nil {
+			t.Fatalf("extensionResourceSnapshots() error = %v", err)
+		}
+		if len(snapshots) != 1 || snapshots[0].extension != global ||
+			snapshots[0].scope.Kind != resources.ResourceScopeKindGlobal {
+			t.Fatalf("extensionResourceSnapshots() = %#v, want preserved global snapshot", snapshots)
 		}
 	})
 }

--- a/internal/daemon/extensions.go
+++ b/internal/daemon/extensions.go
@@ -83,15 +83,23 @@ func (s *daemonExtensionService) reload(ctx context.Context) error {
 }
 
 func (s *daemonExtensionService) syncExtensionConsumers(ctx context.Context) error {
+	const waitError = "daemon: wait for extension consumer sync: %w"
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf(waitError, err)
+	}
+
 	gate := s.extensionConsumerSyncGate()
 	select {
 	case <-ctx.Done():
-		return fmt.Errorf("daemon: wait for extension consumer sync: %w", ctx.Err())
+		return fmt.Errorf(waitError, ctx.Err())
 	case <-gate:
 	}
 	defer func() {
 		gate <- struct{}{}
 	}()
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf(waitError, err)
+	}
 
 	var syncErr error
 	if s.agentSkill != nil {

--- a/internal/daemon/extensions.go
+++ b/internal/daemon/extensions.go
@@ -83,6 +83,16 @@ func (s *daemonExtensionService) reload(ctx context.Context) error {
 }
 
 func (s *daemonExtensionService) syncExtensionConsumers(ctx context.Context) error {
+	gate := s.extensionConsumerSyncGate()
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("daemon: wait for extension consumer sync: %w", ctx.Err())
+	case <-gate:
+	}
+	defer func() {
+		gate <- struct{}{}
+	}()
+
 	var syncErr error
 	if s.agentSkill != nil {
 		syncErr = errors.Join(syncErr, s.agentSkill.Sync(ctx))

--- a/internal/daemon/extensions_service.go
+++ b/internal/daemon/extensions_service.go
@@ -18,6 +18,8 @@ import (
 type daemonExtensionService struct {
 	marketplaceMu      sync.RWMutex
 	searchMu           sync.Mutex
+	consumerSyncOnce   sync.Once
+	consumerSyncGate   chan struct{}
 	searchCache        map[string]extensionSearchSnapshot
 	registry           *extensionpkg.Registry
 	runtime            extensionRuntime
@@ -169,6 +171,14 @@ func newDaemonExtensionService(
 		}
 	}
 	return service
+}
+
+func (s *daemonExtensionService) extensionConsumerSyncGate() chan struct{} {
+	s.consumerSyncOnce.Do(func() {
+		s.consumerSyncGate = make(chan struct{}, 1)
+		s.consumerSyncGate <- struct{}{}
+	})
+	return s.consumerSyncGate
 }
 
 func (s *daemonExtensionService) marketplaceConfig() compozyconfig.ExtensionsConfig {

--- a/internal/daemon/extensions_test.go
+++ b/internal/daemon/extensions_test.go
@@ -21,6 +21,85 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
+func TestDaemonExtensionServiceConsumerSync(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should cancel a queued sync without entering resource consumers", func(t *testing.T) {
+		t.Parallel()
+
+		firstEntered := make(chan struct{})
+		firstRelease := make(chan struct{})
+		secondEntered := make(chan struct{})
+		publisher := &blockingExtensionConsumerPublisher{
+			firstEntered:  firstEntered,
+			firstRelease:  firstRelease,
+			secondEntered: secondEntered,
+		}
+		registry := extensionpkg.NewRegistry(openDaemonTestGlobalDB(t).DB())
+		service := newDaemonExtensionService(daemonExtensionServiceDeps{
+			Registry: registry,
+			Loops:    publisher,
+		}).(*daemonExtensionService)
+
+		firstResult := make(chan error, 1)
+		go func() {
+			firstResult <- service.syncExtensionConsumers(t.Context())
+		}()
+		requireLifecycleSignal(t, firstEntered, "first resource consumer sync")
+
+		secondCtx, cancelSecond := context.WithCancel(t.Context())
+		secondStarted := make(chan struct{})
+		secondResult := make(chan error, 1)
+		go func() {
+			close(secondStarted)
+			secondResult <- service.syncExtensionConsumers(secondCtx)
+		}()
+		requireLifecycleSignal(t, secondStarted, "queued resource consumer sync")
+		cancelSecond()
+
+		queuedErr := requireLifecycleResult(t, secondResult, "queued resource consumer sync")
+		if !errors.Is(queuedErr, context.Canceled) {
+			t.Fatalf("queued sync error = %v, want context cancellation", queuedErr)
+		}
+		select {
+		case <-secondEntered:
+			t.Fatal("queued sync entered the resource consumer while another sync was active")
+		default:
+		}
+
+		close(firstRelease)
+		if err := requireLifecycleResult(t, firstResult, "first resource consumer sync"); err != nil {
+			t.Fatalf("first sync error = %v", err)
+		}
+	})
+}
+
+type blockingExtensionConsumerPublisher struct {
+	mu            sync.Mutex
+	calls         int
+	firstEntered  chan<- struct{}
+	firstRelease  <-chan struct{}
+	secondEntered chan<- struct{}
+}
+
+func (p *blockingExtensionConsumerPublisher) Sync(ctx context.Context) error {
+	p.mu.Lock()
+	p.calls++
+	call := p.calls
+	p.mu.Unlock()
+	if call == 1 {
+		close(p.firstEntered)
+		select {
+		case <-p.firstRelease:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	close(p.secondEntered)
+	return ctx.Err()
+}
+
 func TestExtensionLifecycleCoordinator(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/extensions_test.go
+++ b/internal/daemon/extensions_test.go
@@ -24,6 +24,29 @@ import (
 func TestDaemonExtensionServiceConsumerSync(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should reject a canceled sync before entering resource consumers", func(t *testing.T) {
+		t.Parallel()
+
+		entered := make(chan struct{})
+		publisher := agentSkillPublisherFunc(func(context.Context) error {
+			close(entered)
+			return nil
+		})
+		service := &daemonExtensionService{agentSkill: publisher}
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err := service.syncExtensionConsumers(ctx)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("sync error = %v, want context cancellation", err)
+		}
+		select {
+		case <-entered:
+			t.Fatal("canceled sync entered a resource consumer")
+		default:
+		}
+	})
+
 	t.Run("Should cancel a queued sync without entering resource consumers", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/loop_resources.go
+++ b/internal/daemon/loop_resources.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 
 	compozyconfig "github.com/compozy/compozy/internal/config"
@@ -329,31 +328,20 @@ func extensionLoopDeclarationProvider(
 		if manager == nil {
 			return nil, nil
 		}
-		infos, err := registry.List()
-		if err != nil {
-			return nil, fmt.Errorf("daemon: list extensions for loop sync: %w", err)
-		}
-		slices.SortFunc(infos, func(left, right extensionpkg.ExtensionInfo) int {
-			return strings.Compare(left.Name, right.Name)
-		})
-
-		globalScope := resources.ResourceScope{Kind: resources.ResourceScopeKindGlobal}
 		var desired []loopPublicationInput
-		for _, info := range infos {
-			if !info.Enabled {
-				continue
-			}
-			ext, err := loadExtensionSnapshot(registry, manager, logger, info.Name)
-			if err != nil {
-				return nil, fmt.Errorf("daemon: load extension %q for loop sync: %w", info.Name, err)
-			}
+		snapshots, err := extensionResourceSnapshots(registry, manager, logger)
+		if err != nil {
+			return nil, err
+		}
+		for _, snapshot := range snapshots {
+			ext := snapshot.extension
 			if ext == nil || ext.Manifest == nil || !ext.Status.Registered {
 				continue
 			}
 			for _, spec := range ext.Loops {
 				desired = append(desired, loopPublicationInput{
 					sourceKey: "extension/" + ext.Info.Name + "/loops/" + strings.TrimSpace(spec.Name),
-					scope:     globalScope,
+					scope:     snapshot.scope,
 					owner:     extensionOwner(ext.Info.Name),
 					spec:      looppkg.CloneResourceSpec(spec),
 				})

--- a/internal/daemon/native_agent_catalog.go
+++ b/internal/daemon/native_agent_catalog.go
@@ -26,7 +26,7 @@ func (n *daemonNativeTools) workspaceAgents(
 		}
 	}
 	if n.deps.AgentCatalog != nil {
-		catalogAgents, err := n.deps.AgentCatalog.ListAgents(ctx)
+		catalogAgents, err := n.deps.AgentCatalog.ListAgentsForWorkspace(ctx, resolved)
 		if err != nil {
 			return nil, fmt.Errorf("daemon: list agent catalog entries: %w", err)
 		}

--- a/internal/daemon/native_create_tools_test.go
+++ b/internal/daemon/native_create_tools_test.go
@@ -584,6 +584,8 @@ func TestNativeWorkspaceDescribeIncludesOrdinaryOnboardingAgent(t *testing.T) {
 			AgentCatalog: nativeAgentCatalogStub{agents: []compozyconfig.AgentDef{
 				{Name: "catalog-visible", Provider: "codex", Prompt: "Catalog visible."},
 				{Name: "onboarding", Provider: "codex", Prompt: "Catalog onboarding."},
+			}, workspaceAgents: []compozyconfig.AgentDef{
+				{Name: "dev-linked", Provider: "codex", Prompt: "Workspace extension agent."},
 			}},
 		}, nativeApproveAllPolicyInputs())
 
@@ -596,12 +598,14 @@ func TestNativeWorkspaceDescribeIncludesOrdinaryOnboardingAgent(t *testing.T) {
 		}
 		requireNativeStructuredContains(t, result, []byte("\"general\""))
 		requireNativeStructuredContains(t, result, []byte("\"catalog-visible\""))
+		requireNativeStructuredContains(t, result, []byte("\"dev-linked\""))
 		requireNativeStructuredContains(t, result, []byte("\"onboarding\""))
 	})
 }
 
 type nativeAgentCatalogStub struct {
-	agents []compozyconfig.AgentDef
+	agents          []compozyconfig.AgentDef
+	workspaceAgents []compozyconfig.AgentDef
 }
 
 func (s nativeAgentCatalogStub) ListAgents(context.Context) ([]core.AgentCatalogEntry, error) {
@@ -610,6 +614,24 @@ func (s nativeAgentCatalogStub) ListAgents(context.Context) ([]core.AgentCatalog
 		entries = append(entries, core.AgentCatalogEntry{
 			Def:    compozyconfig.CloneAgentDef(agent),
 			Origin: contract.AgentOriginGlobal,
+		})
+	}
+	return entries, nil
+}
+
+func (s nativeAgentCatalogStub) ListAgentsForWorkspace(
+	ctx context.Context,
+	workspace *workspacepkg.ResolvedWorkspace,
+) ([]core.AgentCatalogEntry, error) {
+	entries, err := s.ListAgents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, agent := range s.workspaceAgents {
+		entries = append(entries, core.AgentCatalogEntry{
+			Def:         compozyconfig.CloneAgentDef(agent),
+			Origin:      contract.AgentOriginWorkspace,
+			WorkspaceID: workspace.ID,
 		})
 	}
 	return entries, nil

--- a/internal/daemon/tool_mcp_resources_encoding.go
+++ b/internal/daemon/tool_mcp_resources_encoding.go
@@ -82,7 +82,12 @@ func managedPublicationID(
 	if owner == nil || owner.Kind.Normalize() != extensionResourceOwnerKind {
 		return contentAddressedManagedPublicationID(prefix, scope, sourceKey, encoded)
 	}
-	return extensionSourceKeyPublicationID(sourceKey)
+	id := extensionSourceKeyPublicationID(sourceKey)
+	normalizedScope := scope.Normalize()
+	if normalizedScope.Kind == resources.ResourceScopeKindWorkspace {
+		return id + "/workspace/" + normalizedScope.ID
+	}
+	return id
 }
 
 func cloneResourceRecords[T any](records []resources.Record[T], cloneSpec func(T) T) []resources.Record[T] {

--- a/internal/extension/build.go
+++ b/internal/extension/build.go
@@ -48,6 +48,9 @@ func buildBundle(ctx context.Context, req BuildRequest, runner buildCommandRunne
 	}
 	toolchain, err := detectBuildToolchain(normalized, runner)
 	if err != nil {
+		if errors.Is(err, errBuildToolchainNotFound) {
+			return buildResourceOnlyBundle(ctx, normalized)
+		}
 		return nil, err
 	}
 	if err := os.MkdirAll(normalized.OutputDir, 0o755); err != nil {

--- a/internal/extension/build_resource_only.go
+++ b/internal/extension/build_resource_only.go
@@ -1,0 +1,80 @@
+package extensionpkg
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+func buildResourceOnlyBundle(ctx context.Context, req BuildRequest) (*BuildResult, error) {
+	manifest, err := LoadManifest(req.SourceDir)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"extension: unsupported source; expected package.json or go.mod, or a native extension.toml "+
+				"with static resources: %w",
+			err,
+		)
+	}
+	if err := validateResourceOnlyBuildRequest(req, manifest); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(req.OutputDir, 0o755); err != nil {
+		return nil, fmt.Errorf("extension: create build output %q: %w", req.OutputDir, err)
+	}
+	if err := prepareBuildOutput(req.OutputDir); err != nil {
+		return nil, err
+	}
+	return publishBuildGeneration(ctx, req.OutputDir, req.SourceDir, manifest)
+}
+
+func validateResourceOnlyBuildRequest(req BuildRequest, manifest *Manifest) error {
+	if manifest == nil {
+		return &ManifestValidationError{Field: manifestResourcesKey, Message: "manifest is required"}
+	}
+	if manifest.Format != FormatCompozy {
+		return &ManifestValidationError{
+			Field:   "format",
+			Message: "resource-only authoring requires a native Compozy manifest",
+		}
+	}
+	if len(req.BuildCmd) > 0 {
+		return &ManifestValidationError{
+			Field:   "build_command",
+			Message: "a build command requires package.json or go.mod",
+		}
+	}
+	if resourceOnlyManifestRequiresToolchain(manifest) {
+		return &ManifestValidationError{
+			Field:   manifestSubprocessKey,
+			Message: "executable extension behavior requires package.json or go.mod",
+		}
+	}
+	if !hasStaticResourcePaths(manifest.Resources) {
+		return &ManifestValidationError{
+			Field: manifestResourcesKey,
+			Message: "resource-only extensions must declare at least one skill, loop, agent, " +
+				"automation, or layout path",
+		}
+	}
+	return nil
+}
+
+func resourceOnlyManifestRequiresToolchain(manifest *Manifest) bool {
+	if requiresSubprocess(manifest) {
+		return true
+	}
+	resources := manifest.Resources
+	return len(resources.Hooks) > 0 || len(resources.Tools) > 0 ||
+		len(resources.CommandGroups) > 0 || len(resources.MCPServers) > 0 ||
+		manifest.Bridge.Platform != "" || manifest.Bridge.DisplayName != "" ||
+		len(manifest.Bridge.SecretSlots) > 0 || manifest.Bridge.ConfigSchema != nil
+}
+
+func hasStaticResourcePaths(resources ResourcesConfig) bool {
+	for _, group := range staticResourcePathGroups(resources) {
+		if len(group.paths) > 0 {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extension/build_test.go
+++ b/internal/extension/build_test.go
@@ -146,6 +146,7 @@ skills = ["skills"]
 			buildCmd  []string
 			resources bool
 			wantError string
+			wantField string
 		}{
 			{
 				name:      "Should explain how to author a source without a manifest or toolchain",
@@ -159,6 +160,7 @@ version = "0.1.0"
 min_compozy_version = "0.0.0"
 `,
 				wantError: "must declare at least one skill",
+				wantField: manifestResourcesKey,
 			},
 			{
 				name: "Should reject an authored subprocess",
@@ -175,6 +177,7 @@ command = "./bin/extension"
 `,
 				resources: true,
 				wantError: "requires package.json or go.mod",
+				wantField: manifestSubprocessKey,
 			},
 			{
 				name: "Should reject runtime capabilities",
@@ -191,6 +194,7 @@ provides = ["tool.provider"]
 `,
 				resources: true,
 				wantError: "requires package.json or go.mod",
+				wantField: manifestSubprocessKey,
 			},
 			{
 				name: "Should reject executable hooks",
@@ -211,6 +215,7 @@ executor.args = ["hook.js"]
 `,
 				resources: true,
 				wantError: "requires package.json or go.mod",
+				wantField: manifestSubprocessKey,
 			},
 			{
 				name: "Should reject static tool backends",
@@ -232,6 +237,7 @@ handler = "lookup"
 `,
 				resources: true,
 				wantError: "requires package.json or go.mod",
+				wantField: manifestSubprocessKey,
 			},
 			{
 				name: "Should reject MCP server declarations",
@@ -249,6 +255,7 @@ transport = "stdio"
 `,
 				resources: true,
 				wantError: "requires package.json or go.mod",
+				wantField: manifestSubprocessKey,
 			},
 			{
 				name: "Should reject a build command override",
@@ -263,6 +270,7 @@ skills = ["skills"]
 				buildCmd:  []string{"make", "extension"},
 				resources: true,
 				wantError: "requires package.json or go.mod",
+				wantField: "build_command",
 			},
 		}
 
@@ -291,6 +299,12 @@ skills = ["skills"]
 				}
 				if !strings.Contains(err.Error(), testCase.wantError) {
 					t.Fatalf("buildBundle() error = %v, want %q", err, testCase.wantError)
+				}
+				if testCase.wantField != "" {
+					var validationErr *ManifestValidationError
+					if !errors.As(err, &validationErr) || validationErr.Field != testCase.wantField {
+						t.Fatalf("buildBundle() error = %#v, want validation field %q", err, testCase.wantField)
+					}
 				}
 				generations, globErr := filepath.Glob(filepath.Join(dir, "dist", "gen-*"))
 				if globErr != nil {

--- a/internal/extension/build_test.go
+++ b/internal/extension/build_test.go
@@ -80,6 +80,229 @@ func TestBuildBundle(t *testing.T) {
 		}
 	})
 
+	t.Run("Should publish a resource-only generation without running commands", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		skillDir := filepath.Join(dir, "skills", "writer")
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			t.Fatalf("os.MkdirAll(skillDir) error = %v", err)
+		}
+		writeFile(t, filepath.Join(skillDir, "SKILL.md"), "# Writer\n")
+		writeFile(t, filepath.Join(dir, manifestTOMLFileName), `[extension]
+name = "resource-only"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[resources]
+skills = ["skills"]
+`)
+		runner := newBuildTestRunner(validDescribePayload())
+
+		result, err := buildBundle(testutil.Context(t), BuildRequest{SourceDir: dir}, runner)
+		if err != nil {
+			t.Fatalf("buildBundle() error = %v", err)
+		}
+		copied, err := os.ReadFile(filepath.Join(result.GenerationDir, "skills", "writer", "SKILL.md"))
+		if err != nil {
+			t.Fatalf("os.ReadFile(copied skill) error = %v", err)
+		}
+		if string(copied) != "# Writer\n" {
+			t.Fatalf("copied skill = %q, want %q", copied, "# Writer\n")
+		}
+		if len(runner.Commands()) != 0 {
+			t.Fatalf("commands = %#v, want none", runner.Commands())
+		}
+		unchanged, err := buildBundle(testutil.Context(t), BuildRequest{SourceDir: dir}, runner)
+		if err != nil {
+			t.Fatalf("buildBundle(unchanged) error = %v", err)
+		}
+		if unchanged.GenerationHash != result.GenerationHash {
+			t.Fatalf(
+				"unchanged generation hash = %q, want %q",
+				unchanged.GenerationHash,
+				result.GenerationHash,
+			)
+		}
+		writeFile(t, filepath.Join(skillDir, "SKILL.md"), "# Editor\n")
+		changed, err := buildBundle(testutil.Context(t), BuildRequest{SourceDir: dir}, runner)
+		if err != nil {
+			t.Fatalf("buildBundle(changed) error = %v", err)
+		}
+		if changed.GenerationHash == result.GenerationHash {
+			t.Fatalf("changed generation hash = %q, want a new hash", changed.GenerationHash)
+		}
+		if len(runner.Commands()) != 0 {
+			t.Fatalf("commands after rebuild = %#v, want none", runner.Commands())
+		}
+	})
+
+	t.Run("Should reject resource-only sources that are not passive static kits", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name      string
+			manifest  string
+			buildCmd  []string
+			resources bool
+			wantError string
+		}{
+			{
+				name:      "Should explain how to author a source without a manifest or toolchain",
+				wantError: "expected package.json or go.mod, or a native extension.toml",
+			},
+			{
+				name: "Should reject a manifest without static resources",
+				manifest: `[extension]
+name = "empty"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+`,
+				wantError: "must declare at least one skill",
+			},
+			{
+				name: "Should reject an authored subprocess",
+				manifest: `[extension]
+name = "executable"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[resources]
+skills = ["skills"]
+
+[subprocess]
+command = "./bin/extension"
+`,
+				resources: true,
+				wantError: "requires package.json or go.mod",
+			},
+			{
+				name: "Should reject runtime capabilities",
+				manifest: `[extension]
+name = "capability"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[resources]
+skills = ["skills"]
+
+[capabilities]
+provides = ["tool.provider"]
+`,
+				resources: true,
+				wantError: "requires package.json or go.mod",
+			},
+			{
+				name: "Should reject executable hooks",
+				manifest: `[extension]
+name = "hook"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[resources]
+skills = ["skills"]
+
+[[resources.hooks]]
+name = "observe"
+event = "prompt.post_assemble"
+executor.kind = "subprocess"
+executor.command = "node"
+executor.args = ["hook.js"]
+`,
+				resources: true,
+				wantError: "requires package.json or go.mod",
+			},
+			{
+				name: "Should reject static tool backends",
+				manifest: `[extension]
+name = "tool"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[resources]
+skills = ["skills"]
+
+[resources.tools.lookup]
+description = "Look up content"
+read_only = true
+
+[resources.tools.lookup.backend]
+kind = "extension_host"
+handler = "lookup"
+`,
+				resources: true,
+				wantError: "requires package.json or go.mod",
+			},
+			{
+				name: "Should reject MCP server declarations",
+				manifest: `[extension]
+name = "mcp"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[resources]
+skills = ["skills"]
+
+[resources.mcp_servers.local]
+command = "mcp-server"
+transport = "stdio"
+`,
+				resources: true,
+				wantError: "requires package.json or go.mod",
+			},
+			{
+				name: "Should reject a build command override",
+				manifest: `[extension]
+name = "custom-build"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[resources]
+skills = ["skills"]
+`,
+				buildCmd:  []string{"make", "extension"},
+				resources: true,
+				wantError: "requires package.json or go.mod",
+			},
+		}
+
+		for _, testCase := range testCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				t.Parallel()
+
+				dir := t.TempDir()
+				if testCase.resources {
+					skillDir := filepath.Join(dir, "skills", "writer")
+					if err := os.MkdirAll(skillDir, 0o755); err != nil {
+						t.Fatalf("os.MkdirAll(skillDir) error = %v", err)
+					}
+					writeFile(t, filepath.Join(skillDir, "SKILL.md"), "# Writer\n")
+				}
+				if testCase.manifest != "" {
+					writeFile(t, filepath.Join(dir, manifestTOMLFileName), testCase.manifest)
+				}
+
+				result, err := buildBundle(testutil.Context(t), BuildRequest{
+					SourceDir: dir,
+					BuildCmd:  testCase.buildCmd,
+				}, newBuildTestRunner(validDescribePayload()))
+				if err == nil || result != nil {
+					t.Fatalf("buildBundle() = %#v, %v; want rejection", result, err)
+				}
+				if !strings.Contains(err.Error(), testCase.wantError) {
+					t.Fatalf("buildBundle() error = %v, want %q", err, testCase.wantError)
+				}
+				generations, globErr := filepath.Glob(filepath.Join(dir, "dist", "gen-*"))
+				if globErr != nil {
+					t.Fatalf("filepath.Glob(generations) error = %v", globErr)
+				}
+				if len(generations) != 0 {
+					t.Fatalf("published generations = %#v, want none", generations)
+				}
+			})
+		}
+	})
+
 	t.Run("Should Produce Byte Identical Immutable Generations", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/extension/build_test.go
+++ b/internal/extension/build_test.go
@@ -88,11 +88,22 @@ func TestBuildBundle(t *testing.T) {
 		if err := os.MkdirAll(skillDir, 0o755); err != nil {
 			t.Fatalf("os.MkdirAll(skillDir) error = %v", err)
 		}
-		writeFile(t, filepath.Join(skillDir, "SKILL.md"), "# Writer\n")
+		writeFile(t, filepath.Join(skillDir, "SKILL.md"), `---
+name: writer
+description: Write clear release notes.
+---
+
+# Writer
+`)
 		writeFile(t, filepath.Join(dir, manifestTOMLFileName), `[extension]
 name = "resource-only"
 version = "0.1.0"
 min_compozy_version = "0.0.0"
+
+[network_participation]
+required = true
+mode = "live"
+channel_scopes = ["builders"]
 
 [resources]
 skills = ["skills"]
@@ -107,8 +118,17 @@ skills = ["skills"]
 		if err != nil {
 			t.Fatalf("os.ReadFile(copied skill) error = %v", err)
 		}
-		if string(copied) != "# Writer\n" {
-			t.Fatalf("copied skill = %q, want %q", copied, "# Writer\n")
+		if !strings.Contains(string(copied), "# Writer") {
+			t.Fatalf("copied skill = %q, want Writer content", copied)
+		}
+		if result.Manifest.NetworkParticipation == nil ||
+			!result.Manifest.NetworkParticipation.Required ||
+			result.Manifest.NetworkParticipation.Mode != "live" ||
+			!reflect.DeepEqual(result.Manifest.NetworkParticipation.ChannelScopes, []string{"builders"}) {
+			t.Fatalf(
+				"generated NetworkParticipation = %#v, want required live builders scope",
+				result.Manifest.NetworkParticipation,
+			)
 		}
 		if len(runner.Commands()) != 0 {
 			t.Fatalf("commands = %#v, want none", runner.Commands())
@@ -124,7 +144,13 @@ skills = ["skills"]
 				result.GenerationHash,
 			)
 		}
-		writeFile(t, filepath.Join(skillDir, "SKILL.md"), "# Editor\n")
+		writeFile(t, filepath.Join(skillDir, "SKILL.md"), `---
+name: writer
+description: Edit clear release notes.
+---
+
+# Editor
+`)
 		changed, err := buildBundle(testutil.Context(t), BuildRequest{SourceDir: dir}, runner)
 		if err != nil {
 			t.Fatalf("buildBundle(changed) error = %v", err)
@@ -134,6 +160,33 @@ skills = ["skills"]
 		}
 		if len(runner.Commands()) != 0 {
 			t.Fatalf("commands after rebuild = %#v, want none", runner.Commands())
+		}
+		writeFile(t, filepath.Join(dir, manifestTOMLFileName), `[extension]
+name = "resource-only"
+version = "0.1.0"
+min_compozy_version = "0.0.0"
+
+[network_participation]
+required = true
+mode = "live"
+channel_scopes = ["release"]
+
+[resources]
+skills = ["skills"]
+`)
+		networkChanged, err := buildBundle(testutil.Context(t), BuildRequest{SourceDir: dir}, runner)
+		if err != nil {
+			t.Fatalf("buildBundle(network changed) error = %v", err)
+		}
+		if networkChanged.GenerationHash == changed.GenerationHash {
+			t.Fatalf("network-changed generation hash = %q, want a new hash", networkChanged.GenerationHash)
+		}
+		if networkChanged.Manifest.NetworkParticipation == nil ||
+			!reflect.DeepEqual(networkChanged.Manifest.NetworkParticipation.ChannelScopes, []string{"release"}) {
+			t.Fatalf(
+				"network-changed participation = %#v, want release scope",
+				networkChanged.Manifest.NetworkParticipation,
+			)
 		}
 	})
 

--- a/internal/extension/build_toolchain.go
+++ b/internal/extension/build_toolchain.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 )
 
+var errBuildToolchainNotFound = errors.New("extension: build toolchain not found")
+
 type buildToolchain struct {
 	BuildArgv    []string
 	DescribeArgv []string
@@ -46,7 +48,7 @@ func detectBuildToolchain(req BuildRequest, runner buildCommandRunner) (buildToo
 	case goModExists:
 		detected, err = detectGoToolchain(req)
 	default:
-		err = errors.New("extension: unsupported source; expected package.json or go.mod")
+		err = errBuildToolchainNotFound
 	}
 	if err != nil {
 		return buildToolchain{}, err

--- a/internal/extension/host_api_errors.go
+++ b/internal/extension/host_api_errors.go
@@ -81,7 +81,7 @@ func rpcCapabilityDenied(err error) error {
 		return hostAPIStatusRPCError(403, "Forbidden", map[string]any{
 			extensionStateError: denied.Error(),
 			hostAPIMethodKey:    strings.TrimSpace(denied.Data.Method),
-			"required":          append([]string(nil), denied.Data.Required...),
+			manifestRequiredKey: append([]string(nil), denied.Data.Required...),
 			"granted":           append([]string(nil), denied.Data.Granted...),
 		})
 	}

--- a/internal/extension/manifest.go
+++ b/internal/extension/manifest.go
@@ -42,6 +42,7 @@ const (
 	manifestPermissionsKey              = "permissions"
 	manifestPublishKey                  = "publish"
 	manifestReadOnlyKey                 = "read_only"
+	manifestRequiredKey                 = "required"
 	manifestResourcesKey                = "resources"
 	manifestResourcesPublishPath        = "resources.publish"
 	manifestRiskKey                     = "risk"

--- a/internal/extension/manifest_encode.go
+++ b/internal/extension/manifest_encode.go
@@ -43,6 +43,12 @@ func manifestTOMLDocument(manifest *Manifest) (map[string]any, error) {
 		},
 		manifestSubprocessKey: subprocessTOMLTable(manifest.Subprocess),
 	}
+	if requirement := manifest.NetworkParticipation.Normalize(); requirement != nil {
+		networkParticipation := map[string]any{manifestRequiredKey: requirement.Required}
+		putNonEmpty(networkParticipation, "mode", requirement.Mode)
+		putNonEmptyStrings(networkParticipation, "channel_scopes", requirement.ChannelScopes)
+		document[manifestFieldNetworkParticipation] = networkParticipation
+	}
 
 	resources, err := resourcesTOMLTable(manifest.Resources)
 	if err != nil {

--- a/packages/site/content/docs/agents/definitions.mdx
+++ b/packages/site/content/docs/agents/definitions.mdx
@@ -67,7 +67,8 @@ Discovery order is first-wins:
 If two definitions use the same `name`, CompozyOS keeps the first one it found. It does not merge or
 inherit from the lower-precedence definition.
 
-Extensions can also provide global agent candidates. Those agents keep their extension-local
+Enabled published extensions can also provide global agent candidates, while active development
+links provide candidates only in their linked workspace. Those agents keep their extension-local
 `AGENT.md` as the effective authored definition, so definition updates reconcile the extension file
 into the same catalog used by agent reads.
 

--- a/packages/site/content/docs/extensions/develop.mdx
+++ b/packages/site/content/docs/extensions/develop.mdx
@@ -1,9 +1,10 @@
 ---
 title: Develop Extensions
-description: The code-first authoring loop for CompozyOS extensions — init, build, validate, dev, reload, logs, publish — plus provide surfaces, Host API access, and resources.
+description: The authoring loop for code-backed and resource-only CompozyOS extensions — build, validate, dev, reload, logs, and publish.
 ---
 
-You write code. CompozyOS generates the manifest.
+Code-backed extensions declare behavior through an SDK. Resource-only extensions declare static kit
+resources in `extension.toml`. Both become immutable generations that use the same development loop.
 
 An extension is one installable unit of runtime behavior. A **subprocess extension** runs your code
 over JSON-RPC and can call the daemon through the Host API. A **resource-only extension** ships files
@@ -31,7 +32,7 @@ invoke --> publish["extension publish"]`}
 | Verb                         | Daemon required | What it does                                                          |
 | ---------------------------- | --------------- | --------------------------------------------------------------------- |
 | `compozy extension init`     | no              | Writes a project from an embedded template.                           |
-| `compozy extension build`    | no              | Compiles, runs describe mode, emits an immutable generation.          |
+| `compozy extension build`    | no              | Builds code or validates static resources, then emits a generation.   |
 | `compozy extension validate` | no              | Reads a bundle and reports issues plus derived consent. Runs no code. |
 | `compozy extension dev`      | yes             | Builds and links your source to the current workspace.                |
 | `compozy extension reload`   | yes             | Builds and atomically swaps the running generation.                   |
@@ -91,6 +92,43 @@ that a hand-written manifest allowed cannot occur.
 
 Registering a tool adds `tool.provider` to `capabilities.provides` automatically.
 
+## Start from a resource-only manifest
+
+A resource-only source has no `package.json` or `go.mod`. Write `extension.toml` and declare at least
+one skill, agent, Loop, automation, or layout path:
+
+```toml title="extension.toml"
+[extension]
+name = "hello-resources"
+version = "0.1.0"
+min_compozy_version = "0.3.0-beta.13"
+
+[resources]
+agents = ["agents"]
+```
+
+```md title="agents/hello/AGENT.md"
+---
+name: hello
+---
+
+You are hello.
+```
+
+Use the same loop as a code-backed extension:
+
+```bash
+compozy extension build .
+compozy extension dev .
+compozy extension reload hello-resources .
+compozy extension dev . --watch
+```
+
+This build reads and validates the manifest, copies the declared resource trees, and publishes the
+generation. It runs no build or describe command. A manifest that declares a subprocess, runtime
+capabilities, Host API permissions, hooks, tools, MCP servers, bridge metadata, command groups, or
+dynamic resource publication still needs `package.json` or `go.mod` and an SDK declaration.
+
 ## Build and validate
 
 ```bash
@@ -111,10 +149,11 @@ and is the only generation identity any surface accepts — no path, symlink, or
 substitutes for it. Builds never mutate a prior generation, and identical source produces a
 byte-identical manifest.
 
-Build detects the toolchain: a `package.json` `build` script runs through Bun or npm, a `go.mod` runs
-`go build`. Override with `--build-command`, raise the describe timeout with `--timeout`, and move the
-generation root with `--output-dir` (a custom output root is for standalone packaging — only
-`<source>/dist` can back a dev link).
+For code-backed sources, build detects the toolchain: a `package.json` `build` script runs through Bun
+or npm, and a `go.mod` runs `go build`. Override with `--build-command`, raise the describe timeout
+with `--timeout`, and move the generation root with `--output-dir` (a custom output root is for
+standalone packaging — only `<source>/dist` can back a dev link). Resource-only sources do not accept
+`--build-command` because their build never executes code.
 
 ```bash
 compozy extension validate ./dist/gen-cc1358…
@@ -130,7 +169,7 @@ compozy extension dev .
 ```
 
 `dev` builds, then links the generation to the current workspace. There is no trust prompt, no
-`allow_unverified` policy, and no marketplace vocabulary anywhere in the flow: it is your code, in
+`allow_unverified` policy, and no marketplace vocabulary anywhere in the flow: it is your source, in
 your workspace.
 
 A dev link is an **overlay**, not an install. It lives in its own side table and never displaces a
@@ -145,7 +184,8 @@ compozy extension logs my-ext --follow
 
 - `reload` builds a new generation and swaps atomically. If the new generation fails to activate, the
   **last-good** generation keeps serving and status reports `activation_failed` with the running
-  generation in `last_error`. A broken edit never takes the extension down.
+  generation in `last_error`. If local build or resource validation fails, reload is never sent and
+  the current generation stays active. A broken edit never takes the extension down.
 - `--watch` polls the source tree every `extensions.dev.watch_interval` (default `2s`), skipping
   `.git`, `dist`, and `node_modules`. The watcher is client-side; the daemon never watches author
   directories.
@@ -162,6 +202,11 @@ Every runtime surface is keyed by **instance** — extension name plus workspace
 installation is the global instance (empty workspace); each dev link is a workspace instance.
 Subprocess, coordinator, last-good generation, log ring, status, and events are per instance, so two
 workspaces linking the same extension share nothing.
+
+Declared agents, skills, Loops, automations, and layouts follow the same boundary. Resources from an
+enabled published installation enter the global catalogs; resources from an active dev link enter
+only the linked workspace's catalogs and workspace detail. Reload replaces that workspace snapshot
+atomically, and unlinking removes it without changing the published installation.
 
 The workspace is bound server-side from the operator's resolved workspace or an agent session's
 trusted scope — never from a request body or tool input. Global-instance logs are operator-transport

--- a/packages/site/content/docs/extensions/index.mdx
+++ b/packages/site/content/docs/extensions/index.mdx
@@ -13,14 +13,16 @@ provide surfaces, or a daemon-facing Host API service, an extension gives that p
 manifest, trust tier, enablement state, and operational lifecycle.
 
 <OperatorNote>
-  Resource-only extensions ship files CompozyOS already loads (skills, agents, hooks, MCP servers).
-  Subprocess extensions also run code over JSON-RPC and call the daemon through the Host API after
-  permission checks. The trust tier of the source determines which extensions are even eligible.
+  Resource-only extensions ship files CompozyOS already loads (skills, agents, Loops, automations,
+  and layouts) without executing extension code. Code-backed extensions can also provide hooks, MCP
+  servers, tools, and subprocess behavior over JSON-RPC after permission checks. The trust tier of
+  the source determines which extensions are even eligible.
 </OperatorNote>
 
-Authors start at [Build your first extension](/docs/guides/build-your-first-extension): three
-commands from an empty directory to a tool you can invoke. Authoring is code-first — you write code
-and `compozy extension build` generates the manifest.
+Authors of executable extensions start at
+[Build your first extension](/docs/guides/build-your-first-extension): three commands from an empty
+directory to a tool you can invoke. Executable authoring is code-first, while resource-only authors
+can hand-write `extension.toml` and use the same build and workspace development lifecycle.
 
 Operators start at the install page for adding, enabling, disabling, inspecting, updating, or
 removing an extension.

--- a/packages/site/content/docs/extensions/manifest.mdx
+++ b/packages/site/content/docs/extensions/manifest.mdx
@@ -11,7 +11,14 @@ describe mode and generates the manifest into an immutable generation directory.
 manifest by hand means editing a file the next build overwrites — change the code instead.
 
 You write `extension.toml` by hand only for **resource-only** extensions: packages that ship skills,
-agents, automation, layouts, hooks, or MCP servers and run no code of their own.
+agents, Loops, automation, or layouts and run no code of their own.
+
+A native resource-only source can use `extension build`, `dev`, `reload`, and `dev --watch` when it
+declares at least one skill, agent, Loop, automation, or layout path. Build validates the handwritten
+manifest and copies those resource trees without running a build or describe command. Top-level
+subprocess behavior, runtime capabilities, Host API permissions, hooks, tools, MCP servers, bridge
+metadata, command groups, and dynamic resource publication remain code-backed contracts and require
+`package.json` or `go.mod`.
 
 CompozyOS reads `extension.toml` first and `extension.json` second. Both formats carry the same schema.
 

--- a/packages/site/content/docs/extensions/manifest.mdx
+++ b/packages/site/content/docs/extensions/manifest.mdx
@@ -222,7 +222,8 @@ a hand-maintained manifest allowed cannot occur.
 ### `[[resources.hooks]]`
 
 Hooks declared through the SDK's supported hook events are generated with a subprocess executor
-pointed at the same binary. A resource-only extension writes them by hand:
+pointed at the same binary. Hooks require a supported code toolchain; resource-only sources cannot
+declare executable hooks:
 
 ```toml
 [[resources.hooks]]
@@ -291,7 +292,7 @@ No code, no subprocess, no permissions:
 [extension]
 name = "review-pack"
 version = "0.1.0"
-description = "Review skills, hooks, and MCP helpers"
+description = "Review skills, agents, automation, and layouts"
 min_compozy_version = "0.3.0-beta.1"
 
 [resources]
@@ -299,11 +300,6 @@ skills = ["skills"]
 agents = ["agents"]
 automation = ["automation"]
 layouts = ["layouts"]
-
-[resources.mcp_servers.git]
-command = "uvx"
-args = ["mcp-server-git"]
-env = { REPO_ROOT = "{{env:REPO_ROOT}}" }
 ```
 
 Installation is inert. These resources become live only after the extension is enabled, and disable

--- a/packages/site/content/docs/skills/bundled.mdx
+++ b/packages/site/content/docs/skills/bundled.mdx
@@ -37,7 +37,7 @@ reference files:
 | `references/loops.md`                   | Loop and Goal authoring/operation, `/goal` commands, run states, approvals, and watch behavior.                 |
 | `references/window-management.md`       | Desktops, windows, tab stacks, layouts, revisions, clients, and recovery.                                       |
 | `references/extensions.md`              | Extension kits, install trust, the authoring and dev loop, instance scoping, and hook management.               |
-| `references/extension-authoring.md`     | Code-first extension authoring: SDK declaration, permissions, provide surfaces, and contributed commands.       |
+| `references/extension-authoring.md`     | Code-backed and resource-only authoring: SDK declarations, static manifests, permissions, and provide surfaces. |
 | `references/configuration.md`           | `config.toml` desired state, the settings apply lifecycle, and the settings key reference.                      |
 
 ## How bundled loading works

--- a/packages/site/content/docs/skills/index.mdx
+++ b/packages/site/content/docs/skills/index.mdx
@@ -132,9 +132,10 @@ Their `activation.active` field is `false`, and `activation.reasons` reports the
 `metadata.compozy.when` gates. The CLI and Skills UI present this runtime activation state separately
 from the administrative enabled switch.
 
-Enabled extensions can also register runtime-owned skills into the live registry. Those overlays
-are not filesystem-backed, so they are documented as runtime registry behavior rather than as one
-more scan root.
+Enabled published extensions can register global runtime-owned skills into the live registry, and
+active development links can register them only for the linked workspace. Those overlays are not
+filesystem-backed, so they are documented as runtime registry behavior rather than as one more scan
+root.
 
 ## Provenance And Shadow Audit
 

--- a/skills/compozy/SKILL.md
+++ b/skills/compozy/SKILL.md
@@ -53,7 +53,7 @@ Match the task to the row. Read the listed files in full before producing output
 - references/tasks-and-orchestration.md - coordinator, worker, and reviewer loops, task authority boundaries, typed blocks and the unblock-loop breaker, wake-creator, completion claims, review verdict rules, and sensitive-data limits.
 - references/loops.md - Loop and Goal authoring/operation, `/goal` commands, native tools, terminal and context states, approval/recovery semantics, reference grammar, hooks, and watch behavior.
 - references/extensions.md - extension kits, install trust, the authoring and dev loop, instance scoping, dev overlays, logs, and hook management.
-- references/extension-authoring.md - code-first extension authoring: templates, SDK declaration shape, closed permissions and derived consent, provide surfaces, contributed commands, generated manifest, and structured workflows.
+- references/extension-authoring.md - code-backed and resource-only extension authoring: templates, SDK declarations, static manifests, permissions, provide surfaces, contributed commands, and structured workflows.
 - references/configuration.md - config.toml desired state, the settings apply lifecycle, and the key reference for gateway, scheduler, Loop, Goal, automation, compaction, role, and window-manager settings.
 - references/worktrees.md - workspace worktree lifecycle, session binding, exit plans and actions, forge integration, cleanup evidence, and public management surfaces.
 

--- a/skills/compozy/references/agent-definitions.md
+++ b/skills/compozy/references/agent-definitions.md
@@ -14,7 +14,7 @@
 
 ## Files And Precedence
 
-CompozyOS agent definitions live in AGENT.md files with YAML frontmatter and a Markdown prompt body. User-authored global agents live under $COMPOZY_HOME/agents/<name>/AGENT.md; workspace agents live under <workspace>/.compozy/agents/<name>/AGENT.md. Extension-provided agents participate as global candidates while keeping their extension-local AGENT.md as the effective authored definition.
+CompozyOS agent definitions live in AGENT.md files with YAML frontmatter and a Markdown prompt body. User-authored global agents live under $COMPOZY_HOME/agents/<name>/AGENT.md; workspace agents live under <workspace>/.compozy/agents/<name>/AGENT.md. Agents from enabled published extensions participate as global candidates; agents from active development links participate only in the linked workspace. Both keep their extension-local AGENT.md as the effective authored definition.
 
 Runtime configuration starts from $COMPOZY_HOME/config.toml, then workspace configuration can overlay it with <workspace>/.compozy/config.toml. Agent-local skills and MCP sidecars are resolved after the effective agent definition is chosen.
 

--- a/skills/compozy/references/extension-authoring.md
+++ b/skills/compozy/references/extension-authoring.md
@@ -23,7 +23,10 @@ The SDK declaration is the single source of truth. `compozy extension build` sta
 with the `__describe` argument, reads the contract it prints, and generates
 `dist/gen-<hash>/extension.toml`. Never hand-write or hand-edit a manifest for a subprocess
 extension: the next build overwrites it. Hand-written manifests are for resource-only extensions,
-which run no code.
+which run no extension process. When a native resource-only manifest declares at least one skill,
+agent, Loop, automation, or layout path, `build` validates and copies those resources without running
+build or describe commands. Executable extension contracts — including hooks, tools, MCP servers,
+bridge metadata, and command groups — still require `package.json` or `go.mod`.
 
 There is no second place to declare identity, schemas, permissions, tools, hooks, or commands, so
 schema-digest drift cannot occur. Manifest generation is deterministic; identical source produces a
@@ -223,9 +226,11 @@ What `build` writes, for reading rather than editing: `[extension]` (`name`, `ve
 kind `extension_host`, canonical `input_schema`/`output_schema`, risk metadata, optional `command`),
 `[[resources.hooks]]`, and `[[resources.command_groups]]`.
 
-Resource-only extensions additionally hand-write `resources.skills|agents|loops|automation|layouts|mcp_servers`
-and `[resources.publish]` (families plus `max_scope`). Resource paths resolve inside the extension
-root; `{{config_dir}}` is that root and `{{env:NAME}}` reads the daemon process environment.
+Resource-only extensions additionally hand-write `resources.skills|agents|loops|automation|layouts`
+and may declare `[resources.publish]` (families plus `max_scope`). Resource paths resolve inside the
+extension root; `{{config_dir}}` is that root and `{{env:NAME}}` reads the daemon process environment.
+Hooks, tools, command groups, MCP servers, bridge metadata, and subprocess behavior require a supported
+code toolchain.
 
 Static kit resources stay inert after install. Enable publishes the instance-owned resources; disable
 removes them. Use extension inventory to compare shipped and live resources, and preview to inspect
@@ -257,6 +262,10 @@ Pre-install review:
 compozy extension build <dir> -o json      -> generation_hash, generation_dir, manifest_path
 compozy extension validate <gen-dir> -o json -> issues[] (path/line/column/field/severity), consent_areas[]
 ```
+
+Resource-only development uses the same commands. Start from a handwritten native manifest with at
+least one `resources.skills|agents|loops|automation|layouts` path; `build`, `dev`, `reload`, and
+`dev --watch` publish changes without executing extension code.
 
 Iterate:
 

--- a/skills/compozy/references/extension-authoring.md
+++ b/skills/compozy/references/extension-authoring.md
@@ -224,13 +224,12 @@ What `build` writes, for reading rather than editing: `[extension]` (`name`, `ve
 `[permissions] requires`, `[subprocess]` (`command`, `args`, `env`, `secret_env`,
 `health_check_interval`, `shutdown_timeout`), `[resources.tools.<handler>]` (id, handler, backend
 kind `extension_host`, canonical `input_schema`/`output_schema`, risk metadata, optional `command`),
-`[[resources.hooks]]`, and `[[resources.command_groups]]`.
+`[[resources.hooks]]`, `[[resources.command_groups]]`, and `[network_participation]`.
 
-Resource-only extensions additionally hand-write `resources.skills|agents|loops|automation|layouts`
-and may declare `[resources.publish]` (families plus `max_scope`). Resource paths resolve inside the
-extension root; `{{config_dir}}` is that root and `{{env:NAME}}` reads the daemon process environment.
-Hooks, tools, command groups, MCP servers, bridge metadata, and subprocess behavior require a supported
-code toolchain.
+Resource-only extensions hand-write only `resources.skills|agents|loops|automation|layouts`.
+Resource paths resolve inside the extension root; `{{config_dir}}` is that root and
+`{{env:NAME}}` reads the daemon process environment. Hooks, tools, command groups, MCP servers,
+dynamic resource publication, bridge metadata, and subprocess behavior require a supported code toolchain.
 
 Static kit resources stay inert after install. Enable publishes the instance-owned resources; disable
 removes them. Use extension inventory to compare shipped and live resources, and preview to inspect

--- a/skills/compozy/references/extensions.md
+++ b/skills/compozy/references/extensions.md
@@ -121,8 +121,14 @@ and risk flags live in `references/native-tools.md`; what goes in the code lives
 `POST /api/extensions/dev`, `POST /api/extensions/{name}/reload`, and
 `GET /api/extensions/{name}/logs`. Publish has no HTTP/UDS route.
 
-`build` compiles source, runs SDK describe mode, and publishes one immutable generation at
-`<origin>/dist/gen-<hash>`, where `generation_hash` is the 64-lowercase-hex checksum of that tree.
+`build` publishes one immutable generation at `<origin>/dist/gen-<hash>`, where `generation_hash` is
+the 64-lowercase-hex checksum of that tree. For a code-backed source it compiles and runs SDK describe
+mode. For a native resource-only source with at least one declared skill, agent, Loop, automation, or
+layout path, it validates the handwritten manifest and copies those trees without running a build or
+describe command. A resource-only source cannot use a build-command override or declare a top-level
+subprocess, runtime capabilities, Host API permissions, hooks, tools, MCP servers, bridge metadata,
+command groups, or dynamic resource publication; those contracts require `package.json` or `go.mod`.
+
 That hash is the only generation identity any surface accepts: `dev` takes
 `{origin_path, generation_hash}`, `reload` takes `{generation_hash}`, and the daemon reconstructs the
 directory, re-verifies the tree digest and manifest, and matches the manifest name before activation.
@@ -147,6 +153,11 @@ Every runtime extension surface is keyed by instance — extension name plus wor
 installation is the global instance (empty workspace); a dev link is a workspace instance. Subprocess,
 operation coordinator, last-good generation, log ring, status, and events are per instance, so two
 workspaces linking the same extension share no process, logs, or failure state.
+
+Declared agents, skills, Loops, automations, and layouts use the same scope. Enabled published
+instances populate global resource catalogs; active dev instances populate only the linked
+workspace's catalogs and workspace detail. Reload swaps that workspace snapshot atomically, and
+unlinking removes it without mutating the published installation.
 
 The workspace is bound server-side — from the operator's resolved workspace or the agent session's
 trusted scope — never from a request body or tool input. An agent caller that names a different


### PR DESCRIPTION
## What & why

Fixes #421.

- Resource-only extension authors can now use `build`, `dev`, `reload`, and `dev --watch` without adding a Go or TypeScript toolchain.
- The passive build path validates and publishes declared agents, skills, Loops, automations, and layouts without running build or describe subprocesses.
- Active development links project those resources only into the linked workspace, preserving deterministic generations, atomic reload, and last-good fallback.

## Changes

- **Build lifecycle**: add a fail-closed resource-only path while retaining the existing Go and TypeScript paths unchanged.
- **Workspace resources**: reconcile dev-linked agents, skills, Loops, automations, and layouts through workspace-scoped snapshots and expose workspace agents through HTTP and native workspace detail.
- **Coverage and guidance**: add unit, integration, E2E, QA, README, docs-site, and bundled-skill coverage for the resource-only authoring lifecycle.

## Release Notes

### 🐛 Bug Fixes

- Resource-only extensions can use the complete development loop without a code toolchain.

## How you verified it

- `GOTOOLCHAIN=go1.26.4 make gate-full` — 22,830 tests passed with 3 platform-specific skips; formatting, lint, typecheck, web build, Go build, and package boundaries passed.
- Applied the complete change over `main + #420`; the affected API, daemon, and extension packages passed 4,603 tests.
- Authored with OpenAI Codex and reviewed by Claude Fable in two rounds; all findings were addressed before publication.

## Impact

- Changes existing extension CLI behavior for resource-only sources; no flags or command syntax changed.
- Existing HTTP and native workspace-detail surfaces now include agents from active workspace development links.
- No new route, `config.toml` key, migration, or web UI surface.
- Extension, agent, and skill documentation now distinguishes global published resources from workspace-scoped development resources.

---

- [x] `make gate` passes locally (`make gate-full` before review on larger changes)
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resource-only extension builds when no toolchain is required.
  * Added workspace-scoped extension resources, agents, skills, automations, layouts, and triggers.
  * Workspace-linked development extensions are now discovered and reloaded within their associated workspace.
  * Added validation for resource-only extension manifests and supported static resources.
  * Added automatic monitoring and refresh for skill and loop resources.

* **Bug Fixes**
  * Prevented resource and agent conflicts across different scopes.
  * Improved workspace-specific agent, sidecar, and resource resolution.
  * Preserved existing resources when extension edits are invalid.
  * Improved synchronization during extension updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->