### PR TITLE
Pin Go 1.26.6 in mise.toml

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,3 +5,4 @@
 [tools]
 golangci-lint = "2.12.2"
 gotestsum = "1.13.0"
+go = "1.26.6"


### PR DESCRIPTION
# Pin Go version in mise.toml

## What & why

Pins Go `1.26.6` in the repository's `mise.toml`.

Without a repository-local Go version, running Go commands through Mise could fail with:

```text
mise ERROR No version is set for shim: go
Set a global default version with one of the following:
mise use -g go@1.26.5
mise use -g go@1.26.6
```

This was encountered when running:

```sh
go build -o ./bin/compozy .
```

Adding Go to `[tools]` ensures contributors using Mise get the expected Go version from the repository configuration instead of requiring a global Mise configuration.

## How you verified it

Re-ran:

```sh
go build -o ./bin/compozy .
```

after adding:

```toml
go = "1.26.6"
```

to `mise.toml`.

Mise now resolves the repository-local Go version instead of failing with `No version is set for shim: go`, allowing the build to proceed.

No tests were added because this change only fixes the development toolchain configuration and does not introduce or modify application behavior.

## Impact

No runtime, CLI interface, HTTP/UDS route, `config.toml`, or web surface impact.

This only affects local development environments using Mise by ensuring the Go toolchain is configured by the repository.

No documentation update is required.

---

* [ ] `make gate` passes locally (`make gate-full` before review on larger changes)
* [x] New or changed behavior is covered by tests, or I explained above why not
* [ ] If an agent wrote or co-wrote this, I named it above and verified the result myself
