### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,11 +274,11 @@ Read [AGENTS.md](AGENTS.md) and the surface-specific instructions before editing
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=compozy%2Fcompozy&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#compozy/compozy&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=compozy/compozy&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=compozy/compozy&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=compozy/compozy&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=compozy/compozy&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=compozy/compozy&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=compozy/compozy&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This switches the chart to a working mirror, so the chart renders again and continues to reflect the repository's history. Also updates the wrapping link to the new hash-based URL format.