### PR TITLE
fix: preserve run-agent session lifecycle

### DIFF
--- a/docs/qa/charters/CH-run-agent-session-lifecycle.md
+++ b/docs/qa/charters/CH-run-agent-session-lifecycle.md
@@ -1,0 +1,28 @@
+# CH-run-agent-session-lifecycle: Complete a Loop without leaking worker sessions
+
+```yaml
+charter:
+  id: CH-run-agent-session-lifecycle
+  mission: "As Bruno, start a nested Loop from Batuta, follow one run-agent worker through completion, and trust both its family lineage and terminal session state."
+  mode: strategy-based
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-complete-partial-loop
+  scenarios: [LP-run-agent-session-lifecycle]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Start the Loop from a real Batuta session and capture the child Loop Run plus its bound run-agent session through structured output."
+      - "Compare parent_session_id and root_session_id through CLI and one independent HTTP or UDS read while the worker is active."
+      - "Let the worker return schema-valid output, refresh the Loop and session reads, and confirm the worker is stopped while Batuta remains active."
+      - "Exercise one retry-eligible failure and confirm the same binding stays active until the cell settles terminally."
+    must_avoid:
+      - "Using database reads, unit tests, or source inspection as pass evidence."
+      - "Stopping the worker or Batuta manually before the terminal-state check."
+```
+
+<!-- The charter is durable and immutable: each run's debrief belongs in the dated report. -->

--- a/docs/qa/charters/CH-run-agent-terminal-cleanup.md
+++ b/docs/qa/charters/CH-run-agent-terminal-cleanup.md
@@ -1,0 +1,28 @@
+# CH-run-agent-terminal-cleanup: Settle run-agent sessions on every terminal path
+
+```yaml
+charter:
+  id: CH-run-agent-terminal-cleanup
+  mission: "As Bruno, drive one run-agent cell through retry, final failure, and cancellation, and trust that only reusable work keeps its worker session active."
+  mode: strategy-based
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-complete-partial-loop
+  scenarios: [LP-run-agent-session-lifecycle, LP-run-agent-output-ownership]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Start each Loop through the structured CLI and capture the exact run-agent worker session."
+      - "Allow a retry-eligible failure to advance to its next attempt before checking terminal cleanup."
+      - "Reach one final failure and cancel one live node lane, then confirm each worker is stopped through a fresh CLI read and an independent HTTP read."
+      - "Confirm schema-valid output still settles through the daemon-owned task path."
+    must_avoid:
+      - "Using database reads, unit tests, or source inspection as pass evidence."
+      - "Stopping a worker manually before its terminal-state check."
+```
+
+<!-- The charter is durable and immutable: re-run it in later cycles; each run's debrief goes in that run's report (Session Debriefs), never here. -->

--- a/docs/qa/journeys/J-complete-partial-loop.md
+++ b/docs/qa/journeys/J-complete-partial-loop.md
@@ -7,14 +7,16 @@ flowchart TD
     C -->|lint error| D[Repair the exact field without losing draft state]
     D --> C
     C -->|valid| E[Run a wide fan-out through a bounded active window]
-    E --> F{Settlement strategy}
+    E --> E1[Inspect run-agent child-session lineage]
+    E1 --> F{Settlement strategy}
     F -->|fail_fast| G[Keep completed lanes and cancel unfinished siblings]
     F -->|best_effort threshold met| H[Settle collect partial and continue downstream]
     F -->|wait_all| I[Wait for every materialized lane]
     G --> J[Read route, prune, progress, and lane-control history]
     H --> J
     I --> J
-    J --> K[Fresh CLI, HTTP/UDS, native, SSE, and Web reads agree]
+    J --> J1[Confirm settled run-agent sessions are stopped]
+    J1 --> K[Fresh CLI, HTTP/UDS, native, SSE, and Web reads agree]
     K --> L[True end: terminal status and completion_state tell the same truth]
     B -.->|author closes editor| X1[Abandon: chrome and draft state restore without publishing]
     E -.->|daemon restarts mid-window| X2[Resume: no lane duplicates and active width remains bounded]
@@ -44,7 +46,7 @@ journey:
       expected_observable: "At most the declared width is active, restart does not duplicate a lane, and per-lane controls affect only the addressed item."
     - step: 3
       verb: "Let fail_fast or best_effort settle the collect"
-      expected_observable: "Completed work is preserved, unfinished work is canceled by cause, oversized action results fail without leaking their lease, progress is truthful, and partial coverage remains first-class."
+      expected_observable: "Completed work is preserved, unfinished work is canceled by cause, oversized action results fail without leaking their lease, progress is truthful, run-agent child sessions stop at terminal settlement, and partial coverage remains first-class."
     - step: 4
       verb: "Refresh and compare terminal projections"
       expected_observable: "Run status, completion_state, collect counts, route causes, and bounded history agree across all public surfaces."

--- a/docs/qa/reports/2026-08-20-run-agent-session-lifecycle.md
+++ b/docs/qa/reports/2026-08-20-run-agent-session-lifecycle.md
@@ -1,0 +1,104 @@
+# QA Run Report — 2026-08-20 — run-agent-session-lifecycle
+
+- **Scope:** Run-agent session lineage and terminal cleanup for session-started Loops.
+- **Cadence tier:** feature
+- **Build:** `9eb83ca4` plus the `fix/run-agent-session-lifecycle` working tree · **Environment:** fresh isolated local lab; CLI, HTTP/UDS, runtime, and a live Batuta provider session required
+- **Started:** 2026-08-20T18:50:50-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-run-agent-session-lifecycle |
+
+## Flows in Scope
+
+- `J-complete-partial-loop` — Author and complete a routed partial Loop (`../journeys/J-complete-partial-loop.md`).
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-run-agent-session-lifecycle | J-complete-partial-loop / LP-run-agent-session-lifecycle | Bruno | Feature Tour | Pass | #444, #445 | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-run-agent-session-lifecycle — Bruno
+
+- **Ran:** 2026-08-20T22:11:30Z → 2026-08-20T22:17:23Z (box respected: yes)
+- **Findings:** Batuta started both Loops through the native tool. Active worker reads from CLI and
+  HTTP agreed on the Batuta parent and root IDs. Successful settlement stopped the worker without
+  stopping Batuta. An invalid first result reused the same active worker for recovery and stopped it
+  only after the schema-valid result settled.
+- **Bugs filed/updated:** GitHub #444 and #445.
+- **Scenarios settled:** LP-run-agent-session-lifecycle → pass.
+- **Paper cuts:** The Batuta gate asked for the already stored `false` preference once before its
+  structured reread; the operator answered the normal product question and dispatch continued.
+- **Surprises:** The terminal worker's HTTP projection reports the stop as `user_canceled`, although
+  the daemon initiated cleanup after successful Loop settlement. Session state and attachability are
+  correct; the cause label is outside this fix's scope.
+- **Suggested next charter:** Inspect the terminal stop-reason copy independently from lifecycle
+  ownership.
+
+## What Was Fixed
+
+- Run-agent execution now records the nearest originating session as parent lineage without borrowing
+  it.
+- Successful worker settlement atomically closes its run-owned binding and queues durable cleanup.
+- Retry recovery keeps the exact worker active until the cell reaches terminal settlement.
+
+## Paper Cuts
+
+- Batuta asked for the already stored `false` preference before continuing; dull, because the normal
+  answer recovered immediately.
+
+## Runtime Errors Observed
+
+- No unexpected runtime errors. The deliberately invalid first result was recovered by the same
+  worker session as planned.
+
+## Human Verifications Needed
+
+- None identified.
+
+## Decisions for a Human
+
+- None identified.
+
+## Learnings
+
+- Session lineage must be captured while the worker is active; terminal catalog views may hide stopped
+  system sessions by default.
+- A semantic `session wait --until stopped` provides direct evidence for cleanup without polling the
+  database or internal state.
+
+## Official Skill Audit
+
+Only `skills/compozy/references/loops.md` changed. Every writing-skills checklist item was rechecked:
+
+| Item | Verdict | Item | Verdict |
+|---|---|---|---|
+| A1 Invocation earned | Pass | A1 Leading word front-loaded | Pass |
+| A1 One trigger per branch | Pass | A1 Triggers only | Pass |
+| A2 Content typed | Pass | A2 Completion criteria | Pass |
+| A2 Disclosure by branch | Pass | A2 Pointers worded for when | Pass |
+| A2 Co-location | Pass | A3 Single source of truth | Pass |
+| A3 Relevance | Pass | A3 No-op hunt | Pass |
+| A3 Negation | Pass | A3 Leading words | Pass |
+| B1 Naming | Pass | B1 Description length | Pass |
+| B1 Trigger coverage | Pass | B1 Third-person tone | Pass |
+| B2 Standard folders | Pass | B2 No human docs | Pass |
+| B2 Forward slashes | Pass | B2 Explicit helper paths | Pass |
+| B2 No orphans | Pass | B3 Lean body | Pass |
+| B3 Imperative mood | Pass | B3 Domain-native terms | Pass |
+| B3 CLI design | Pass | B3 Helper roles | Pass |
+| B3 Failure states | Pass |  |  |
+
+## Final Status
+
+- **QA exit gate:** `GOFLAGS=-timeout=40m COMPOZY_GO_TEST_P=1 make gate` passed; the Go test lane completed in 1,801 seconds and recorded `.cache/gate/go-test.json`. The immutable workstream tree proceeds to `make gate-full` after this report is finalized.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 2 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 journeys walked
+- **Verdict:** PASS — ready for the workstream completion gate and pull request.

--- a/docs/qa/reports/2026-08-20-run-agent-terminal-cleanup.md
+++ b/docs/qa/reports/2026-08-20-run-agent-terminal-cleanup.md
@@ -1,0 +1,117 @@
+# QA Run Report — 2026-08-20 — run-agent-terminal-cleanup
+
+- **Scope:** Review remediation for run-agent session cleanup after final failure, node-lane cancellation, and Loop terminalization, with retry reuse as the adjacent canary.
+- **Cadence tier:** targeted
+- **Build:** `8ac88e33` plus the `fix/run-agent-session-lifecycle` working tree · **Environment:** fresh isolated CLI/runtime/provider lab at `/home/francisross/dev/qa-labs/compozy-run-agent-terminal-cleanup-20260821-010622-057996-lab`; browser unavailable and outside this CLI/runtime charter
+- **Started:** 2026-08-20T22:07:24-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-run-agent-terminal-cleanup |
+
+## Flows in Scope
+
+- `J-complete-partial-loop` — Author and complete a routed partial Loop (`../journeys/J-complete-partial-loop.md`).
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-run-agent-terminal-cleanup | J-complete-partial-loop / LP-run-agent-session-lifecycle | Bruno | Feature Tour | Pass | #444, #445 | |
+| 2 | CH-run-agent-terminal-cleanup | J-complete-partial-loop / LP-run-agent-output-ownership | Bruno | Feature Tour | Pass | | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-run-agent-terminal-cleanup — Bruno
+
+- **Ran:** 2026-08-21T01:12:08Z → 2026-08-21T01:16:13Z (box respected: yes)
+- **Findings:** A live Codex worker produced schema-valid output, and the resulting session became
+  stopped after successful settlement. A bounded failure advanced through its configured retry and
+  the final escalated attempt's worker became stopped. Canceling an active node lane changed its
+  output to canceled and stopped the captured worker. Fresh CLI run reads and independent HTTP
+  session reads agreed on each terminal state.
+- **Bugs filed/updated:** GitHub #444 and #445.
+- **Scenarios settled:** LP-run-agent-session-lifecycle → pass;
+  LP-run-agent-output-ownership → pass.
+- **Paper cuts:** The first fixture publish omitted the required start surface and the CLI correctly
+  refused the run until the definition was republished.
+- **Surprises:** Terminal cleanup reports `user_canceled` as its stop reason even after successful or
+  failed settlement. State and attachability are correct; cause labeling remains outside this fix.
+- **Suggested next charter:** Audit terminal stop-reason semantics separately from binding cleanup.
+
+## What Was Fixed
+
+- Final failed coordinator dispositions close only their run-owned worker binding and queue durable
+  stop cleanup.
+- Terminal Loop settlement closes live run-agent bindings left by failure or recovery paths.
+- Exact node-lane cancellation captures and closes the worker binding before clearing task ownership.
+- Retry dispositions remain excluded from terminal cleanup.
+
+## Paper Cuts
+
+- Initial fixture publication omitted a start surface. The public CLI returned
+  `start_kind_not_allowed`; publishing version 2 with CLI, UDS, and HTTP starts resolved it.
+
+## Runtime Errors Observed
+
+- No unexpected daemon error occurred. Deliberate worker timeout and node cancellation produced the
+  expected terminal dispositions.
+
+## Human Verifications Needed
+
+None identified.
+
+## Decisions for a Human
+
+None identified.
+
+## Learnings
+
+- Final failure proof must use the disposition from the exhausted attempt, not the intermediate retry.
+- Node cancellation must capture its task-owned session before clearing the output's `task_run_id`.
+- Independent HTTP reads provide a fresh-state check after structured CLI control operations.
+
+## Evidence
+
+- Success: `qa/logs/success-terminal-session.json` — run
+  `looprun-7435332441516c1f`, session `sess_3c4fa1984696a96f90fc02fa41f6ec47`.
+- Final failure: `qa/logs/failure-terminal-session.json` — run
+  `looprun-3a90358907d0edb2`, session `sess_ecba95fd6a065a0f720d0f3895eb27ec`.
+- Node cancellation: `qa/logs/canceled-terminal-session.json` — run
+  `looprun-b3b122ffd0f31668`, session `sess_b54f0de2b480d51bf6425f01a9ded0e7`.
+- Bootstrap manifest: `qa/bootstrap-manifest.json`.
+- Teardown: `qa/teardown.json` (`clean: true`).
+
+## Official Skill Audit
+
+Only `skills/compozy/references/loops.md` changed. Every writing-skills checklist item was rechecked:
+
+| Item | Verdict | Item | Verdict |
+|---|---|---|---|
+| A1 Invocation earned | Pass | A1 Leading word front-loaded | Pass |
+| A1 One trigger per branch | Pass | A1 Triggers only | Pass |
+| A2 Content typed | Pass | A2 Completion criteria | Pass |
+| A2 Disclosure by branch | Pass | A2 Pointers worded for when | Pass |
+| A2 Co-location | Pass | A3 Single source of truth | Pass |
+| A3 Relevance | Pass | A3 No-op hunt | Pass |
+| A3 Negation | Pass | A3 Leading words | Pass |
+| B1 Naming | Pass | B1 Description length | Pass |
+| B1 Trigger coverage | Pass | B1 Third-person tone | Pass |
+| B2 Standard folders | Pass | B2 No human docs | Pass |
+| B2 Forward slashes | Pass | B2 Explicit helper paths | Pass |
+| B2 No orphans | Pass | B3 Lean body | Pass |
+| B3 Imperative mood | Pass | B3 Domain-native terms | Pass |
+| B3 CLI design | Pass | B3 Helper roles | Pass |
+| B3 Failure states | Pass |  |  |
+
+## Final Status
+
+- **QA exit gate:** Focused public CLI/runtime/provider walk passed. The immutable workstream tree
+  proceeds to `make gate-full`; its current evidence is recorded separately by `make gate-status`.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 2 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 journeys walked
+- **Verdict:** PASS — ready for the workstream completion gate and pull request update.

--- a/docs/qa/scenarios/LP-run-agent-session-lifecycle.md
+++ b/docs/qa/scenarios/LP-run-agent-session-lifecycle.md
@@ -1,24 +1,24 @@
 ---
 id: LP-run-agent-session-lifecycle
 area: LP
-title: Stop completed run-agent child sessions
+title: Stop terminal run-agent child sessions
 persona: Bruno
 journey: J-complete-partial-loop
-expected: A session-started Loop creates each run-agent worker as a run-owned system child of the nearest origin session, stops it after successful terminal settlement, and keeps it active only while a retry can resume the same cell.
+expected: A session-started Loop creates each run-agent worker as a run-owned system child of the nearest origin session, stops it after successful, failed, or canceled terminal settlement, and keeps it active only while a retry can resume the same cell.
 entry_points: compozy__loop_run; compozy loop status; compozy session status; session catalog HTTP/UDS/CLI
 qa_status: pass
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: docs/qa/reports/2026-08-20-run-agent-session-lifecycle.md
-last_report: docs/qa/reports/2026-08-20-run-agent-session-lifecycle.md
+evidence: docs/qa/reports/2026-08-20-run-agent-session-lifecycle.md; docs/qa/reports/2026-08-20-run-agent-terminal-cleanup.md
+last_report: docs/qa/reports/2026-08-20-run-agent-terminal-cleanup.md
 overlaps: LP-run-agent-output-ownership; RT-loop-goal-origin-session-lineage; LP-crash-death-resume
 ---
 
 Added for GitHub issues #444 and #445. The acceptance walk starts a nested Loop from a real
 Batuta session, captures the `run-agent` worker session while it is active, and confirms its
 `parent_session_id` and `root_session_id` point to the nearest originating session without borrowing
-that session. After schema-valid completion, fresh structured reads must show the worker stopped and
-unbound while the Batuta session remains active. A retry probe must keep the exact worker binding
-active until the cell reaches a true terminal boundary.
+that session. After successful, failed, or canceled terminal settlement, fresh structured reads
+must show the worker stopped and unbound while the Batuta session remains active. A retry probe must
+keep the exact worker binding active until the cell reaches a true terminal boundary.

--- a/docs/qa/scenarios/LP-run-agent-session-lifecycle.md
+++ b/docs/qa/scenarios/LP-run-agent-session-lifecycle.md
@@ -1,0 +1,24 @@
+---
+id: LP-run-agent-session-lifecycle
+area: LP
+title: Stop completed run-agent child sessions
+persona: Bruno
+journey: J-complete-partial-loop
+expected: A session-started Loop creates each run-agent worker as a run-owned system child of the nearest origin session, stops it after successful terminal settlement, and keeps it active only while a retry can resume the same cell.
+entry_points: compozy__loop_run; compozy loop status; compozy session status; session catalog HTTP/UDS/CLI
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: docs/qa/reports/2026-08-20-run-agent-session-lifecycle.md
+last_report: docs/qa/reports/2026-08-20-run-agent-session-lifecycle.md
+overlaps: LP-run-agent-output-ownership; RT-loop-goal-origin-session-lineage; LP-crash-death-resume
+---
+
+Added for GitHub issues #444 and #445. The acceptance walk starts a nested Loop from a real
+Batuta session, captures the `run-agent` worker session while it is active, and confirms its
+`parent_session_id` and `root_session_id` point to the nearest originating session without borrowing
+that session. After schema-valid completion, fresh structured reads must show the worker stopped and
+unbound while the Batuta session remains active. A retry probe must keep the exact worker binding
+active until the cell reaches a true terminal boundary.

--- a/internal/config/release_config_test.go
+++ b/internal/config/release_config_test.go
@@ -597,14 +597,12 @@ esac
 			t,
 			repo,
 			"git",
-			"-c",
-			"commit.gpgsign=false",
 			"commit",
 			"-m",
 			"test: seed beta resolver",
 		)
 		for _, tag := range []string{"v0.3.0-beta.13", "v0.3.0-beta.14", "v0.3.0-beta.preview"} {
-			runReleasePreflightFixtureCommand(t, repo, "git", "-c", "tag.gpgsign=false", "tag", tag)
+			runReleasePreflightFixtureCommand(t, repo, "git", "tag", tag)
 		}
 
 		cmd := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "resolve-auto-beta-version.sh"))
@@ -638,8 +636,6 @@ esac
 			t,
 			repo,
 			"git",
-			"-c",
-			"commit.gpgsign=false",
 			"commit",
 			"-m",
 			"test: seed release body",
@@ -648,8 +644,6 @@ esac
 			t,
 			repo,
 			"git",
-			"-c",
-			"tag.gpgsign=false",
 			"tag",
 			"v0.3.0-beta.14",
 		)
@@ -661,8 +655,6 @@ esac
 			t,
 			repo,
 			"git",
-			"-c",
-			"commit.gpgsign=false",
 			"commit",
 			"-m",
 			"fix: validate release body",
@@ -1765,8 +1757,6 @@ func newReleasePreflightFixture(t *testing.T) (string, string) {
 		t,
 		repo,
 		"git",
-		"-c",
-		"commit.gpgsign=false",
 		"commit",
 		"-m",
 		"test: seed release preflight",
@@ -1779,6 +1769,11 @@ func runReleasePreflightFixtureCommand(t *testing.T, dir string, name string, ar
 
 	cmd := exec.CommandContext(t.Context(), name, args...)
 	cmd.Dir = dir
+	cmd.Env = append(
+		os.Environ(),
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_SYSTEM="+os.DevNull,
+	)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("%s %s error = %v, output = %s", name, strings.Join(args, " "), err, output)
 	}

--- a/internal/config/release_config_test.go
+++ b/internal/config/release_config_test.go
@@ -604,7 +604,7 @@ esac
 			"test: seed beta resolver",
 		)
 		for _, tag := range []string{"v0.3.0-beta.13", "v0.3.0-beta.14", "v0.3.0-beta.preview"} {
-			runReleasePreflightFixtureCommand(t, repo, "git", "tag", tag)
+			runReleasePreflightFixtureCommand(t, repo, "git", "-c", "tag.gpgsign=false", "tag", tag)
 		}
 
 		cmd := exec.CommandContext(t.Context(), "bash", filepath.Join(root, "scripts", "resolve-auto-beta-version.sh"))
@@ -644,7 +644,15 @@ esac
 			"-m",
 			"test: seed release body",
 		)
-		runReleasePreflightFixtureCommand(t, repo, "git", "tag", "v0.3.0-beta.14")
+		runReleasePreflightFixtureCommand(
+			t,
+			repo,
+			"git",
+			"-c",
+			"tag.gpgsign=false",
+			"tag",
+			"v0.3.0-beta.14",
+		)
 		if err := os.WriteFile(seed, []byte("beta 15\n"), 0o600); err != nil {
 			t.Fatalf("os.WriteFile(candidate) error = %v", err)
 		}

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -199,7 +199,7 @@ func TestLoopActionSessionBinderShouldApplyPolicyGate(t *testing.T) {
 		}
 	})
 
-	t.Run("Should carry provenance only in run-owned Goal creation options", func(t *testing.T) {
+	t.Run("Should carry provenance in run-owned managed creation options", func(t *testing.T) {
 		t.Parallel()
 
 		resolved := loopActionBinderWorkspace(t, []compozyconfig.AgentDef{{

--- a/internal/loop/action_runagent.go
+++ b/internal/loop/action_runagent.go
@@ -141,6 +141,9 @@ func (e *RunAgentActionExecutor) bindRunAgentSession(
 		SharedKey:          actionSessionSharedKey(in.Generation, in.NodeID, in.ItemIndex, handle),
 		ItemIndex:          in.ItemIndex,
 		TargetBindingEpoch: in.CellEpoch + 1,
+		ProvenanceParentSessionID: strings.TrimSpace(
+			in.ProvenanceParentSessionID,
+		),
 		CellFence: &ActionSessionCellFence{
 			Epoch:     in.CellEpoch,
 			TaskRunID: strings.TrimSpace(in.CorrelationID),

--- a/internal/loop/action_test.go
+++ b/internal/loop/action_test.go
@@ -516,13 +516,15 @@ func TestReservedActionExecutorsShouldRunAgentLoopAndTransform(t *testing.T) {
 			},
 		}
 		raw, err := executor.Execute(ctx, node, loop.ActionExecutionInput{
-			WorkspaceID:   "ws-1",
-			LoopRunID:     "looprun-managed",
-			Generation:    1,
-			NodeID:        "agent",
-			ItemIndex:     2,
-			CellEpoch:     4,
-			CorrelationID: "taskrun-managed-5",
+			WorkspaceID:               "ws-1",
+			LoopRunID:                 "looprun-managed",
+			Generation:                1,
+			NodeID:                    "agent",
+			ItemIndex:                 2,
+			CellEpoch:                 4,
+			CorrelationID:             "taskrun-managed-5",
+			OriginSessionID:           "sess-origin",
+			ProvenanceParentSessionID: "sess-provenance-parent",
 			Namespace: map[string]any{
 				"inputs": map[string]any{"topic": "delivery"},
 			},
@@ -566,6 +568,9 @@ func TestReservedActionExecutorsShouldRunAgentLoopAndTransform(t *testing.T) {
 		if bind.TargetBindingEpoch != 5 || bind.ExpectedControlEpoch != 0 || bind.CellFence == nil ||
 			bind.CellFence.Epoch != 4 || bind.CellFence.TaskRunID != "taskrun-managed-5" {
 			t.Fatalf("managed bind fence = %#v, want binding epoch 5 + exact cell owner", bind)
+		}
+		if bind.OriginSessionID != "" || bind.ProvenanceParentSessionID != "sess-provenance-parent" {
+			t.Fatalf("managed bind provenance = %#v, want a new child of the nearest parent", bind)
 		}
 		if bind.Runtime.Model != "gpt-5.4" || bind.MaxTurns != 3 || len(bind.AllowedTools) != 1 {
 			t.Fatalf("bind overrides = %#v, want model/tool/max_turns", bind)

--- a/internal/loop/coordinator_action.go
+++ b/internal/loop/coordinator_action.go
@@ -61,7 +61,8 @@ func (r *CoordinatorRunner) ExecuteActionRun(
 		return task.RunResult{}, err
 	}
 	provenanceParentSessionID := ""
-	if dsl.ActionKind(actionCtx.node.Kind) == dsl.ActionGoal {
+	actionKind := dsl.ActionKind(actionCtx.node.Kind)
+	if actionKind == dsl.ActionGoal || actionKind == dsl.ActionRunAgent {
 		provenanceParentSessionID, err = r.provenanceParentSessionID(ctx, actionCtx.loopRun)
 		if err != nil {
 			return task.RunResult{}, err

--- a/internal/loop/coordinator_test.go
+++ b/internal/loop/coordinator_test.go
@@ -216,7 +216,7 @@ func TestCoordinatorRunnerShouldResolveFanOutFromWorkspaceDefaults(t *testing.T)
 	})
 }
 
-func TestCoordinatorActionExecutionInputShouldCarryPinnedGoalPolicy(t *testing.T) {
+func TestCoordinatorActionExecutionInputShouldCarryPinnedPolicyAndSessionProvenance(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Should copy the Run context nudge ratio into every Goal action input", func(t *testing.T) {
@@ -323,6 +323,64 @@ func TestCoordinatorActionExecutionInputShouldCarryPinnedGoalPolicy(t *testing.T
 		}
 		if got := capture.input.ProvenanceParentSessionID; got != "session-origin" {
 			t.Fatalf("executed provenance parent = %q, want session-origin", got)
+		}
+	})
+
+	t.Run("Should resolve the nearest session before executing a run-agent action", func(t *testing.T) {
+		t.Parallel()
+
+		node := dsl.Node{ID: "agent", Class: dsl.NodeClassAction, Kind: string(dsl.ActionRunAgent)}
+		origin := Run{
+			ID: "looprun-agent-origin", WorkspaceID: "ws-agent-provenance",
+			StartedBy: task.ActorIdentity{Kind: task.ActorKindAgentSession, Ref: "session-agent-origin"},
+			Origin:    &RunOrigin{Kind: RunOriginCatalog},
+		}
+		loopRun := Run{
+			ID: "looprun-agent-provenance", WorkspaceID: origin.WorkspaceID,
+			ParentLoopRunID: origin.ID, Inputs: map[string]any{},
+			StartedBy: task.ActorIdentity{Kind: task.ActorKindDaemon, Ref: "loop-runner"},
+			Origin:    &RunOrigin{Kind: RunOriginCatalog},
+		}
+		coordinatorRun := controlCoordinatorRun(loopRun, 1)
+		capture := &recordingActionExecutor{}
+		actions, err := NewActionRegistry(
+			&internalActionRegistryFake{},
+			WithActionRunAgentExecutor(capture),
+		)
+		if err != nil {
+			t.Fatalf("NewActionRegistry() error = %v", err)
+		}
+		runner := newCoordinatorRunnerForTestWithDefinition(
+			t,
+			loopRun,
+			coordinatorRun,
+			nil,
+			coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{1: {{
+				Generation: 1, NodeID: string(node.ID), Status: generationOutputRunning, TaskRunID: "run-agent",
+			}}}},
+			dsl.Definition{Graph: dsl.Graph{Nodes: []dsl.Node{node}}},
+			WithCoordinatorActionRegistry(actions),
+		)
+		setCoordinatorRunnerRunsForTest(t, runner, map[RunID]Run{
+			loopRun.ID: loopRun,
+			origin.ID:  origin,
+		})
+		metadata, err := json.Marshal(coordinatorActionRunMetadata{
+			Generation: 1, NodeID: string(node.ID), Attempt: 1,
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal(action metadata) error = %v", err)
+		}
+		workerRun := task.Run{
+			ID: "run-agent", RunKind: task.RunKindWorker, LoopRunID: string(loopRun.ID),
+			Status: task.TaskRunStatusClaimed, Metadata: metadata,
+		}
+
+		if _, err := runner.ExecuteActionRun(t.Context(), workerRun, task.ActorContext{}); err != nil {
+			t.Fatalf("ExecuteActionRun() error = %v", err)
+		}
+		if got := capture.input.ProvenanceParentSessionID; got != "session-agent-origin" {
+			t.Fatalf("executed provenance parent = %q, want session-agent-origin", got)
 		}
 	})
 

--- a/internal/store/globaldb/global_db_goal_binding_integration_test.go
+++ b/internal/store/globaldb/global_db_goal_binding_integration_test.go
@@ -172,7 +172,6 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 		); err != nil {
 			t.Fatalf("insert run-agent generation error = %v", err)
 		}
-
 		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
 		taskRecord.Status = taskpkg.TaskStatusReady
 		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
@@ -249,6 +248,397 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 		if len(cleanups) != 1 || cleanups[0].SessionID != sessionID ||
 			cleanups[0].Cause != goal.SessionCleanupCauseTerminal {
 			t.Fatalf("run-agent cleanups = %#v, want one terminal session cleanup", cleanups)
+		}
+	})
+
+	t.Run("Should keep a retried run-agent binding and close it after final failure", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			workspaceID = "ws-run-agent-failure"
+			loopRunID   = "run-agent-failure"
+			taskID      = "task-run-agent-failure"
+			taskRunID   = "taskrun-run-agent-failure"
+			handle      = "action:run-agent-failure"
+			sessionID   = "session-run-agent-failure"
+		)
+		globalDB := openLoopTestGlobalDB(t, workspaceID)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 8, 20, 20, 35, 0, 0, time.UTC)
+		loopRun := testLoopRun(loopRunID, now, looppkg.StatusRunning)
+		loopRun.WorkspaceID = workspaceID
+		created, err := globalDB.CreateLoopRunForStart(ctx, loopRun, dsl.ConcurrencyAllow)
+		if err != nil {
+			t.Fatalf("CreateLoopRunForStart() error = %v", err)
+		}
+
+		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
+		taskRecord.Status = taskpkg.TaskStatusReady
+		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
+			t.Fatalf("CreateTask() error = %v", err)
+		}
+		metadata, err := json.Marshal(map[string]any{
+			"generation":     1,
+			"node_id":        "execute",
+			"item_index":     0,
+			"attempt":        1,
+			"epoch":          4,
+			"node_kind":      string(dsl.ActionRunAgent),
+			"session_handle": handle,
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
+		}
+		run := taskRunForTest(taskRunID, taskID)
+		run.RunKind = taskpkg.RunKindWorker
+		run.LoopRunID = loopRunID
+		run.Metadata = metadata
+		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
+			t.Fatalf("CreateTaskRun() error = %v", err)
+		}
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`INSERT INTO loop_generation_outputs (
+				loop_run_id, generation, node_id, item_index, status, task_run_id, attempt, epoch
+			 ) VALUES (?, 1, 'execute', 0, 'enqueued', ?, 1, 4)`,
+			loopRunID,
+			taskRunID,
+		); err != nil {
+			t.Fatalf("insert run-agent cell error = %v", err)
+		}
+		bindingKey := goal.BindingKey{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			Handle:      handle,
+		}
+		seedActiveGoalBindingForTest(t, globalDB, loopRunID, workspaceID, handle, 5, sessionID, now)
+
+		leaseOwner := taskpkg.ActorIdentity{Kind: taskpkg.ActorKindDaemon, Ref: "loop-action-runtime"}
+		claim, err := globalDB.ClaimNextRun(ctx, taskpkg.ClaimCriteria{
+			RunID: taskRunID, Scope: taskpkg.ScopeWorkspace, WorkspaceID: workspaceID,
+			RunKind: taskpkg.RunKindWorker, ClaimedBy: &leaseOwner,
+			LeaseDuration: time.Minute, Now: now.Add(time.Second),
+		})
+		if err != nil {
+			t.Fatalf("ClaimNextRun() error = %v", err)
+		}
+		actor := taskpkg.ActorContext{
+			Actor:     leaseOwner,
+			Origin:    taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "daemon.loop-action"},
+			Authority: taskpkg.Authority{Read: true, Write: true},
+		}
+		failedAt := now.Add(2 * time.Second)
+		if _, err := globalDB.FailRunLease(ctx, taskpkg.LeaseFailure{
+			Actor: actor, RunID: claim.Run.ID, ClaimToken: claim.ClaimToken,
+			Failure: taskpkg.RunFailure{Error: "provider transport failed"},
+			Now:     failedAt,
+		}); err != nil {
+			t.Fatalf("FailRunLease() error = %v", err)
+		}
+
+		binding, err := globalDB.GetSessionBindingAttempt(ctx, bindingKey, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt(after failure) error = %v", err)
+		}
+		if binding.State != goal.BindingStateActive {
+			t.Fatalf("binding state after unsettled failure = %q, want %q", binding.State, goal.BindingStateActive)
+		}
+
+		nextAttemptAt := now.Add(time.Minute)
+		expectedEpoch := int64(4)
+		failureClass := looppkg.FailureTransport
+		coordinatorClaim := claimCoordinatorRunForTest(
+			ctx,
+			t,
+			globalDB,
+			created.ID,
+			"run-agent-retry",
+			now.Add(3*time.Second),
+		)
+		if _, err := globalDB.CompleteCoordinatorAndEnqueueNext(
+			ctx,
+			taskpkg.CoordinatorCompletion{
+				RunID: coordinatorClaim.Run.ID, ClaimToken: coordinatorClaim.ClaimToken,
+				Actor: coordinatorActorContextForTest(), Now: now.Add(4 * time.Second),
+				Plan: taskpkg.CoordinatorCompletionPlan{
+					Yield: true,
+					Snapshot: taskpkg.GenerationSnapshot{
+						LoopRunID: loopRunID, Generation: 1,
+						Payload: looppkg.GenerationSnapshotPayload{
+							Outputs: []looppkg.GenerationOutput{{
+								Generation: 1, NodeID: "execute", Status: "retrying", TaskRunID: taskRunID,
+								Attempt: 1, NextAttemptAt: &nextAttemptAt, Epoch: 5, ExpectedEpoch: &expectedEpoch,
+							}},
+							Attempts: []looppkg.NodeAttempt{{
+								LoopRunID: created.ID, Generation: 1, NodeID: "execute", Attempt: 1,
+								FailureClass: &failureClass, FailureCode: "provider_transport",
+								Cause: "provider transport failed", Disposition: looppkg.AttemptRetried,
+								StartedAt: now.Add(time.Second), EndedAt: &failedAt, NextAttemptAt: &nextAttemptAt,
+							}},
+						},
+					},
+				},
+			},
+			looppkg.NewStoreFinalizer(),
+		); err != nil {
+			t.Fatalf("CompleteCoordinatorAndEnqueueNext(retry) error = %v", err)
+		}
+		binding, err = globalDB.GetSessionBindingAttempt(ctx, bindingKey, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt(after retry) error = %v", err)
+		}
+		if binding.State != goal.BindingStateActive {
+			t.Fatalf("binding state after retry = %q, want %q", binding.State, goal.BindingStateActive)
+		}
+		cleanups, err := globalDB.ClaimGoalSessionCleanup(ctx, 10)
+		if err != nil {
+			t.Fatalf("ClaimGoalSessionCleanup(after retry) error = %v", err)
+		}
+		if len(cleanups) != 0 {
+			t.Fatalf("run-agent retry cleanups = %#v, want none", cleanups)
+		}
+
+		finalSnapshot := taskpkg.GenerationSnapshot{
+			LoopRunID:  loopRunID,
+			Generation: 1,
+			Payload: looppkg.GenerationSnapshotPayload{
+				Outputs: []looppkg.GenerationOutput{{
+					Generation: 1, NodeID: "execute", Status: "failed", TaskRunID: taskRunID,
+					Attempt: 1, Epoch: 5,
+				}},
+				Attempts: []looppkg.NodeAttempt{{
+					LoopRunID: created.ID, Generation: 1, NodeID: "execute", Attempt: 1,
+					FailureClass: &failureClass, FailureCode: "provider_transport",
+					Cause: "provider transport failed", Disposition: looppkg.AttemptEscalated,
+					StartedAt: now.Add(time.Second), EndedAt: &failedAt,
+				}},
+			},
+		}
+		if err := globalDB.withTaskImmediateTransaction(ctx, "final run-agent failure", func(exec taskSQLExecutor) error {
+			return applyCoordinatorGenerationSnapshotIntentsWithExecutor(
+				ctx,
+				exec,
+				created,
+				finalSnapshot,
+				now.Add(5*time.Second),
+			)
+		}); err != nil {
+			t.Fatalf("applyCoordinatorGenerationSnapshotIntentsWithExecutor(final failure) error = %v", err)
+		}
+		binding, err = globalDB.GetSessionBindingAttempt(ctx, bindingKey, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt(after final failure) error = %v", err)
+		}
+		if binding.State != goal.BindingStateClosed {
+			t.Fatalf("binding state after final failure = %q, want %q", binding.State, goal.BindingStateClosed)
+		}
+		cleanups, err = globalDB.ClaimGoalSessionCleanup(ctx, 10)
+		if err != nil {
+			t.Fatalf("ClaimGoalSessionCleanup(after final failure) error = %v", err)
+		}
+		if len(cleanups) != 1 || cleanups[0].SessionID != sessionID ||
+			cleanups[0].Cause != goal.SessionCleanupCauseTerminal {
+			t.Fatalf("run-agent final failure cleanups = %#v, want one terminal session cleanup", cleanups)
+		}
+	})
+
+	t.Run("Should close a live run-agent binding when its loop reaches a terminal boundary", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			workspaceID = "ws-run-agent-loop-terminal"
+			loopRunID   = "run-agent-loop-terminal"
+			taskID      = "task-run-agent-loop-terminal"
+			taskRunID   = "taskrun-run-agent-loop-terminal"
+			handle      = "action:run-agent-loop-terminal"
+			sessionID   = "session-run-agent-loop-terminal"
+		)
+		globalDB := openLoopTestGlobalDB(t, workspaceID)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 8, 20, 20, 50, 0, 0, time.UTC)
+		loopRun := testLoopRun(loopRunID, now, looppkg.StatusRunning)
+		loopRun.WorkspaceID = workspaceID
+		created, err := globalDB.CreateLoopRunForStart(ctx, loopRun, dsl.ConcurrencyAllow)
+		if err != nil {
+			t.Fatalf("CreateLoopRunForStart() error = %v", err)
+		}
+
+		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
+		taskRecord.Status = taskpkg.TaskStatusReady
+		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
+			t.Fatalf("CreateTask() error = %v", err)
+		}
+		metadata, err := json.Marshal(map[string]any{
+			"generation":     1,
+			"node_id":        "execute",
+			"item_index":     0,
+			"attempt":        1,
+			"epoch":          4,
+			"node_kind":      string(dsl.ActionRunAgent),
+			"session_handle": handle,
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
+		}
+		run := taskRunForTest(taskRunID, taskID)
+		run.RunKind = taskpkg.RunKindWorker
+		run.LoopRunID = loopRunID
+		run.Metadata = metadata
+		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
+			t.Fatalf("CreateTaskRun() error = %v", err)
+		}
+		seedActiveGoalBindingForTest(t, globalDB, loopRunID, workspaceID, handle, 5, sessionID, now)
+
+		coordinatorClaim := claimCoordinatorRunForTest(
+			ctx,
+			t,
+			globalDB,
+			created.ID,
+			"run-agent-loop-terminal",
+			now.Add(time.Second),
+		)
+		if _, err := globalDB.CompleteCoordinatorAndEnqueueNext(
+			ctx,
+			taskpkg.CoordinatorCompletion{
+				RunID: coordinatorClaim.Run.ID, ClaimToken: coordinatorClaim.ClaimToken,
+				Actor: coordinatorActorContextForTest(), Now: now.Add(2 * time.Second),
+				Plan: taskpkg.CoordinatorCompletionPlan{
+					Snapshot: taskpkg.GenerationSnapshot{LoopRunID: loopRunID, Generation: 1},
+					Terminal: &taskpkg.CoordinatorTerminal{
+						Status: string(looppkg.StatusFailed), Cause: "terminal worker failure",
+					},
+				},
+			},
+			looppkg.NewStoreFinalizer(),
+		); err != nil {
+			t.Fatalf("CompleteCoordinatorAndEnqueueNext(terminal) error = %v", err)
+		}
+
+		binding, err := globalDB.GetSessionBindingAttempt(ctx, goal.BindingKey{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			Handle:      handle,
+		}, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt() error = %v", err)
+		}
+		if binding.State != goal.BindingStateClosed {
+			t.Fatalf("binding state after Loop terminal boundary = %q, want %q", binding.State, goal.BindingStateClosed)
+		}
+		cleanups, err := globalDB.ClaimGoalSessionCleanup(ctx, 10)
+		if err != nil {
+			t.Fatalf("ClaimGoalSessionCleanup() error = %v", err)
+		}
+		if len(cleanups) != 1 || cleanups[0].SessionID != sessionID ||
+			cleanups[0].Cause != goal.SessionCleanupCauseTerminal {
+			t.Fatalf("run-agent Loop terminal cleanups = %#v, want one terminal session cleanup", cleanups)
+		}
+	})
+
+	t.Run("Should close the exact run-agent binding when its node lane is canceled", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			workspaceID = "ws-run-agent-lane-cancel"
+			loopRunID   = "run-agent-lane-cancel"
+			taskID      = "task-run-agent-lane-cancel"
+			taskRunID   = "taskrun-run-agent-lane-cancel"
+			handle      = "action:run-agent-lane-cancel"
+			sessionID   = "session-run-agent-lane-cancel"
+		)
+		globalDB := openLoopTestGlobalDB(t, workspaceID)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 8, 20, 21, 0, 0, 0, time.UTC)
+		insertGoalSchemaLoopRun(t, globalDB, loopRunID, workspaceID, "catalog", nil)
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`INSERT INTO loop_generations (loop_run_id, generation, parent_generation, origin, created_at)
+			 VALUES (?, 1, 0, 'initial', ?)`,
+			loopRunID,
+			store.FormatTimestamp(now),
+		); err != nil {
+			t.Fatalf("insert run-agent generation error = %v", err)
+		}
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`UPDATE loop_runs SET generation = 1 WHERE id = ?`,
+			loopRunID,
+		); err != nil {
+			t.Fatalf("advance run-agent generation error = %v", err)
+		}
+
+		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
+		taskRecord.Status = taskpkg.TaskStatusReady
+		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
+			t.Fatalf("CreateTask() error = %v", err)
+		}
+		metadata, err := json.Marshal(map[string]any{
+			"generation":     1,
+			"node_id":        "execute",
+			"item_index":     0,
+			"attempt":        1,
+			"epoch":          4,
+			"node_kind":      string(dsl.ActionRunAgent),
+			"session_handle": handle,
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
+		}
+		run := taskRunForTest(taskRunID, taskID)
+		run.RunKind = taskpkg.RunKindWorker
+		run.LoopRunID = loopRunID
+		run.Metadata = metadata
+		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
+			t.Fatalf("CreateTaskRun() error = %v", err)
+		}
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`INSERT INTO loop_generation_outputs (
+				loop_run_id, generation, node_id, item_index, status, task_run_id, attempt, epoch
+			 ) VALUES (?, 1, 'execute', 0, 'enqueued', ?, 1, 4)`,
+			loopRunID,
+			taskRunID,
+		); err != nil {
+			t.Fatalf("insert run-agent cell error = %v", err)
+		}
+		seedActiveGoalBindingForTest(t, globalDB, loopRunID, workspaceID, handle, 5, sessionID, now)
+
+		itemIndex := 0
+		result, err := globalDB.RequestNodeCancellation(ctx, looppkg.CancellationMutation{
+			WorkspaceID: workspaceID,
+			RunID:       loopRunID,
+			NodeID:      "execute",
+			ItemIndex:   &itemIndex,
+			Kind:        looppkg.RunCancelCancel,
+			Reason:      "operator canceled lane",
+			Actor:       operatorActorContextForTest("operator:lane-cancel"),
+			RequestedAt: now.Add(time.Second),
+		})
+		if err != nil {
+			t.Fatalf("RequestNodeCancellation() error = %v", err)
+		}
+		if !result.Applied {
+			t.Fatalf("RequestNodeCancellation() = %#v, want applied", result)
+		}
+
+		binding, err := globalDB.GetSessionBindingAttempt(ctx, goal.BindingKey{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			Handle:      handle,
+		}, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt() error = %v", err)
+		}
+		if binding.State != goal.BindingStateClosed {
+			t.Fatalf("binding state after node lane cancellation = %q, want %q", binding.State, goal.BindingStateClosed)
+		}
+		cleanups, err := globalDB.ClaimGoalSessionCleanup(ctx, 10)
+		if err != nil {
+			t.Fatalf("ClaimGoalSessionCleanup() error = %v", err)
+		}
+		if len(cleanups) != 1 || cleanups[0].SessionID != sessionID ||
+			cleanups[0].Cause != goal.SessionCleanupCauseTerminal {
+			t.Fatalf("run-agent lane cancellation cleanups = %#v, want one terminal session cleanup", cleanups)
 		}
 	})
 

--- a/internal/store/globaldb/global_db_goal_binding_integration_test.go
+++ b/internal/store/globaldb/global_db_goal_binding_integration_test.go
@@ -4,6 +4,7 @@ package globaldb
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strconv"
@@ -12,8 +13,10 @@ import (
 	"time"
 
 	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/compozy/compozy/internal/loop/goal"
 	"github.com/compozy/compozy/internal/store"
+	taskpkg "github.com/compozy/compozy/internal/task"
 	"github.com/compozy/compozy/internal/testutil"
 )
 
@@ -144,6 +147,110 @@ func TestGoalSessionCreationIdentityIntegration(t *testing.T) {
 
 func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Should close a completed run-agent binding and publish durable cleanup", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			workspaceID = "ws-run-agent-completion"
+			loopRunID   = "run-agent-completion"
+			taskID      = "task-run-agent-completion"
+			taskRunID   = "taskrun-run-agent-completion"
+			handle      = "action:run-agent-completion"
+			sessionID   = "session-run-agent-completion"
+		)
+		globalDB := openLoopTestGlobalDB(t, workspaceID)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 8, 20, 19, 52, 11, 0, time.UTC)
+		insertGoalSchemaLoopRun(t, globalDB, loopRunID, workspaceID, "catalog", nil)
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`INSERT INTO loop_generations (loop_run_id, generation, parent_generation, origin, created_at)
+			 VALUES (?, 1, 0, 'initial', ?)`,
+			loopRunID,
+			store.FormatTimestamp(now),
+		); err != nil {
+			t.Fatalf("insert run-agent generation error = %v", err)
+		}
+
+		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
+		taskRecord.Status = taskpkg.TaskStatusReady
+		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
+			t.Fatalf("CreateTask() error = %v", err)
+		}
+		metadata, err := json.Marshal(map[string]any{
+			"generation":     1,
+			"node_id":        "execute",
+			"item_index":     0,
+			"attempt":        1,
+			"epoch":          4,
+			"node_kind":      string(dsl.ActionRunAgent),
+			"session_handle": handle,
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
+		}
+		run := taskRunForTest(taskRunID, taskID)
+		run.RunKind = taskpkg.RunKindWorker
+		run.LoopRunID = loopRunID
+		run.Metadata = metadata
+		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
+			t.Fatalf("CreateTaskRun() error = %v", err)
+		}
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`INSERT INTO loop_generation_outputs (
+				loop_run_id, generation, node_id, item_index, status, task_run_id, epoch
+			 ) VALUES (?, 1, 'execute', 0, 'enqueued', ?, 4)`,
+			loopRunID,
+			taskRunID,
+		); err != nil {
+			t.Fatalf("insert run-agent cell error = %v", err)
+		}
+		seedActiveGoalBindingForTest(t, globalDB, loopRunID, workspaceID, handle, 5, sessionID, now)
+
+		leaseOwner := taskpkg.ActorIdentity{Kind: taskpkg.ActorKindDaemon, Ref: "loop-action-runtime"}
+		claim, err := globalDB.ClaimNextRun(ctx, taskpkg.ClaimCriteria{
+			RunID: taskRunID, Scope: taskpkg.ScopeWorkspace, WorkspaceID: workspaceID,
+			RunKind: taskpkg.RunKindWorker, ClaimedBy: &leaseOwner,
+			LeaseDuration: time.Minute, Now: now.Add(time.Second),
+		})
+		if err != nil {
+			t.Fatalf("ClaimNextRun() error = %v", err)
+		}
+		actor := taskpkg.ActorContext{
+			Actor:     leaseOwner,
+			Origin:    taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "daemon.loop-action"},
+			Authority: taskpkg.Authority{Read: true, Write: true},
+		}
+		if _, err := globalDB.CompleteRunLease(ctx, taskpkg.LeaseCompletion{
+			Actor: actor, RunID: claim.Run.ID, ClaimToken: claim.ClaimToken,
+			Result: taskpkg.RunResult{Value: json.RawMessage(`{"summary":"done"}`)},
+			Now:    now.Add(2 * time.Second),
+		}); err != nil {
+			t.Fatalf("CompleteRunLease() error = %v", err)
+		}
+
+		binding, err := globalDB.GetSessionBindingAttempt(ctx, goal.BindingKey{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			Handle:      handle,
+		}, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt() error = %v", err)
+		}
+		if binding.State != goal.BindingStateClosed {
+			t.Fatalf("binding state = %q, want %q", binding.State, goal.BindingStateClosed)
+		}
+		cleanups, err := globalDB.ClaimGoalSessionCleanup(ctx, 10)
+		if err != nil {
+			t.Fatalf("ClaimGoalSessionCleanup() error = %v", err)
+		}
+		if len(cleanups) != 1 || cleanups[0].SessionID != sessionID ||
+			cleanups[0].Cause != goal.SessionCleanupCauseTerminal {
+			t.Fatalf("run-agent cleanups = %#v, want one terminal session cleanup", cleanups)
+		}
+	})
 
 	t.Run(
 		"Should fence ordinary action activation by cell owner and publish cleanup for stale creation",

--- a/internal/store/globaldb/global_db_goal_binding_integration_test.go
+++ b/internal/store/globaldb/global_db_goal_binding_integration_test.go
@@ -172,40 +172,17 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 		); err != nil {
 			t.Fatalf("insert run-agent generation error = %v", err)
 		}
-		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
-		taskRecord.Status = taskpkg.TaskStatusReady
-		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
-			t.Fatalf("CreateTask() error = %v", err)
-		}
-		metadata, err := json.Marshal(map[string]any{
-			"generation":     1,
-			"node_id":        "execute",
-			"item_index":     0,
-			"attempt":        1,
-			"epoch":          4,
-			"node_kind":      string(dsl.ActionRunAgent),
-			"session_handle": handle,
+		seedRunAgentCellForTest(t, globalDB, runAgentCellFixture{
+			WorkspaceID:  workspaceID,
+			LoopRunID:    loopRunID,
+			TaskID:       taskID,
+			TaskRunID:    taskRunID,
+			Handle:       handle,
+			Generation:   1,
+			Attempt:      1,
+			Epoch:        4,
+			InsertOutput: true,
 		})
-		if err != nil {
-			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
-		}
-		run := taskRunForTest(taskRunID, taskID)
-		run.RunKind = taskpkg.RunKindWorker
-		run.LoopRunID = loopRunID
-		run.Metadata = metadata
-		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
-			t.Fatalf("CreateTaskRun() error = %v", err)
-		}
-		if _, err := globalDB.db.ExecContext(
-			ctx,
-			`INSERT INTO loop_generation_outputs (
-				loop_run_id, generation, node_id, item_index, status, task_run_id, epoch
-			 ) VALUES (?, 1, 'execute', 0, 'enqueued', ?, 4)`,
-			loopRunID,
-			taskRunID,
-		); err != nil {
-			t.Fatalf("insert run-agent cell error = %v", err)
-		}
 		seedActiveGoalBindingForTest(t, globalDB, loopRunID, workspaceID, handle, 5, sessionID, now)
 
 		leaseOwner := taskpkg.ActorIdentity{Kind: taskpkg.ActorKindDaemon, Ref: "loop-action-runtime"}
@@ -251,6 +228,102 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 		}
 	})
 
+	t.Run("Should settle a run-agent without closing an origin-borrowed binding", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			workspaceID = "ws-run-agent-borrowed"
+			loopRunID   = "run-agent-borrowed"
+			taskID      = "task-run-agent-borrowed"
+			taskRunID   = "taskrun-run-agent-borrowed"
+			handle      = "action:run-agent-borrowed"
+			sessionID   = "session-run-agent-borrowed"
+		)
+		globalDB := openLoopTestGlobalDB(t, workspaceID)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 8, 21, 0, 15, 0, 0, time.UTC)
+		insertGoalSchemaLoopRun(t, globalDB, loopRunID, workspaceID, "catalog", nil)
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`INSERT INTO loop_generations (loop_run_id, generation, parent_generation, origin, created_at)
+			 VALUES (?, 1, 0, 'initial', ?)`,
+			loopRunID,
+			store.FormatTimestamp(now),
+		); err != nil {
+			t.Fatalf("insert run-agent generation error = %v", err)
+		}
+		seedRunAgentCellForTest(t, globalDB, runAgentCellFixture{
+			WorkspaceID:  workspaceID,
+			LoopRunID:    loopRunID,
+			TaskID:       taskID,
+			TaskRunID:    taskRunID,
+			Handle:       handle,
+			Generation:   1,
+			Attempt:      1,
+			Epoch:        0,
+			InsertOutput: true,
+		})
+		seedActiveGoalBindingWithOwnershipForTest(
+			t,
+			globalDB,
+			loopRunID,
+			workspaceID,
+			handle,
+			1,
+			sessionID,
+			goal.BindingOwnershipOriginBorrowed,
+			now,
+		)
+
+		leaseOwner := taskpkg.ActorIdentity{Kind: taskpkg.ActorKindDaemon, Ref: "loop-action-runtime"}
+		claim, err := globalDB.ClaimNextRun(ctx, taskpkg.ClaimCriteria{
+			RunID: taskRunID, Scope: taskpkg.ScopeWorkspace, WorkspaceID: workspaceID,
+			RunKind: taskpkg.RunKindWorker, ClaimedBy: &leaseOwner,
+			LeaseDuration: time.Minute, Now: now.Add(time.Second),
+		})
+		if err != nil {
+			t.Fatalf("ClaimNextRun() error = %v", err)
+		}
+		actor := taskpkg.ActorContext{
+			Actor:     leaseOwner,
+			Origin:    taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "daemon.loop-action"},
+			Authority: taskpkg.Authority{Read: true, Write: true},
+		}
+		if _, err := globalDB.CompleteRunLease(ctx, taskpkg.LeaseCompletion{
+			Actor: actor, RunID: claim.Run.ID, ClaimToken: claim.ClaimToken,
+			Result: taskpkg.RunResult{Value: json.RawMessage(`{"summary":"done"}`)},
+			Now:    now.Add(2 * time.Second),
+		}); err != nil {
+			t.Fatalf("CompleteRunLease() error = %v", err)
+		}
+
+		settled, err := globalDB.GetTaskRun(ctx, taskRunID)
+		if err != nil {
+			t.Fatalf("GetTaskRun() error = %v", err)
+		}
+		if settled.Status != taskpkg.TaskRunStatusCompleted {
+			t.Fatalf("task run status = %q, want %q", settled.Status, taskpkg.TaskRunStatusCompleted)
+		}
+		binding, err := globalDB.GetSessionBindingAttempt(ctx, goal.BindingKey{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			Handle:      handle,
+		}, 1)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt() error = %v", err)
+		}
+		if binding.State != goal.BindingStateActive {
+			t.Fatalf("borrowed binding state = %q, want %q", binding.State, goal.BindingStateActive)
+		}
+		cleanups, err := globalDB.ClaimGoalSessionCleanup(ctx, 10)
+		if err != nil {
+			t.Fatalf("ClaimGoalSessionCleanup() error = %v", err)
+		}
+		if len(cleanups) != 0 {
+			t.Fatalf("borrowed binding cleanups = %#v, want none", cleanups)
+		}
+	})
+
 	t.Run("Should keep a retried run-agent binding and close it after final failure", func(t *testing.T) {
 		t.Parallel()
 
@@ -272,40 +345,17 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 			t.Fatalf("CreateLoopRunForStart() error = %v", err)
 		}
 
-		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
-		taskRecord.Status = taskpkg.TaskStatusReady
-		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
-			t.Fatalf("CreateTask() error = %v", err)
-		}
-		metadata, err := json.Marshal(map[string]any{
-			"generation":     1,
-			"node_id":        "execute",
-			"item_index":     0,
-			"attempt":        1,
-			"epoch":          4,
-			"node_kind":      string(dsl.ActionRunAgent),
-			"session_handle": handle,
+		seedRunAgentCellForTest(t, globalDB, runAgentCellFixture{
+			WorkspaceID:  workspaceID,
+			LoopRunID:    loopRunID,
+			TaskID:       taskID,
+			TaskRunID:    taskRunID,
+			Handle:       handle,
+			Generation:   1,
+			Attempt:      1,
+			Epoch:        4,
+			InsertOutput: true,
 		})
-		if err != nil {
-			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
-		}
-		run := taskRunForTest(taskRunID, taskID)
-		run.RunKind = taskpkg.RunKindWorker
-		run.LoopRunID = loopRunID
-		run.Metadata = metadata
-		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
-			t.Fatalf("CreateTaskRun() error = %v", err)
-		}
-		if _, err := globalDB.db.ExecContext(
-			ctx,
-			`INSERT INTO loop_generation_outputs (
-				loop_run_id, generation, node_id, item_index, status, task_run_id, attempt, epoch
-			 ) VALUES (?, 1, 'execute', 0, 'enqueued', ?, 1, 4)`,
-			loopRunID,
-			taskRunID,
-		); err != nil {
-			t.Fatalf("insert run-agent cell error = %v", err)
-		}
 		bindingKey := goal.BindingKey{
 			WorkspaceID: workspaceID,
 			LoopRunID:   loopRunID,
@@ -414,16 +464,43 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 				}},
 			},
 		}
-		if err := globalDB.withTaskImmediateTransaction(ctx, "final run-agent failure", func(exec taskSQLExecutor) error {
-			return applyCoordinatorGenerationSnapshotIntentsWithExecutor(
-				ctx,
-				exec,
-				created,
-				finalSnapshot,
-				now.Add(5*time.Second),
-			)
-		}); err != nil {
-			t.Fatalf("applyCoordinatorGenerationSnapshotIntentsWithExecutor(final failure) error = %v", err)
+		wake, added, err := globalDB.EnqueueLoopCoordinatorWake(
+			ctx,
+			string(created.ID),
+			"run-agent-final-failure",
+			taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "loop"},
+			now.Add(5*time.Second),
+		)
+		if err != nil || !added {
+			t.Fatalf("EnqueueLoopCoordinatorWake(final failure) added = %t, error = %v", added, err)
+		}
+		finalCoordinatorClaim := claimExactLoopTaskRunForTest(
+			ctx,
+			t,
+			globalDB,
+			created,
+			wake.ID,
+			taskpkg.RunKindCoordinator,
+			now.Add(5*time.Second),
+		)
+		if _, err := globalDB.CompleteCoordinatorAndEnqueueNext(
+			ctx,
+			taskpkg.CoordinatorCompletion{
+				RunID:      finalCoordinatorClaim.Run.ID,
+				ClaimToken: finalCoordinatorClaim.ClaimToken,
+				Actor:      coordinatorActorContextForTest(),
+				Now:        now.Add(6 * time.Second),
+				Plan: taskpkg.CoordinatorCompletionPlan{
+					Snapshot: finalSnapshot,
+					Terminal: &taskpkg.CoordinatorTerminal{
+						Status: string(looppkg.StatusFailed),
+						Cause:  "provider transport failed",
+					},
+				},
+			},
+			looppkg.NewStoreFinalizer(),
+		); err != nil {
+			t.Fatalf("CompleteCoordinatorAndEnqueueNext(final failure) error = %v", err)
 		}
 		binding, err = globalDB.GetSessionBindingAttempt(ctx, bindingKey, 5)
 		if err != nil {
@@ -439,6 +516,136 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 		if len(cleanups) != 1 || cleanups[0].SessionID != sessionID ||
 			cleanups[0].Cause != goal.SessionCleanupCauseTerminal {
 			t.Fatalf("run-agent final failure cleanups = %#v, want one terminal session cleanup", cleanups)
+		}
+	})
+
+	t.Run("Should match a settled run-agent output by snapshot generation", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			workspaceID      = "ws-run-agent-generation"
+			loopRunID        = "run-agent-generation"
+			staleTaskID      = "task-run-agent-generation-stale"
+			staleTaskRunID   = "taskrun-run-agent-generation-stale"
+			staleHandle      = "action:run-agent-generation-stale"
+			staleSessionID   = "session-run-agent-generation-stale"
+			currentTaskID    = "task-run-agent-generation-current"
+			currentTaskRunID = "taskrun-run-agent-generation-current"
+			currentHandle    = "action:run-agent-generation-current"
+			currentSessionID = "session-run-agent-generation-current"
+		)
+		globalDB := openLoopTestGlobalDB(t, workspaceID)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 8, 21, 0, 30, 0, 0, time.UTC)
+		loopRun := testLoopRun(loopRunID, now, looppkg.StatusRunning)
+		loopRun.WorkspaceID = workspaceID
+		created, err := globalDB.CreateLoopRunForStart(ctx, loopRun, dsl.ConcurrencyAllow)
+		if err != nil {
+			t.Fatalf("CreateLoopRunForStart() error = %v", err)
+		}
+		seedRunAgentCellForTest(t, globalDB, runAgentCellFixture{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			TaskID:      staleTaskID,
+			TaskRunID:   staleTaskRunID,
+			Handle:      staleHandle,
+			Generation:  2,
+			Attempt:     1,
+			Epoch:       4,
+		})
+		seedRunAgentCellForTest(t, globalDB, runAgentCellFixture{
+			WorkspaceID:  workspaceID,
+			LoopRunID:    loopRunID,
+			TaskID:       currentTaskID,
+			TaskRunID:    currentTaskRunID,
+			Handle:       currentHandle,
+			Generation:   1,
+			Attempt:      1,
+			Epoch:        4,
+			InsertOutput: true,
+		})
+		seedActiveGoalBindingForTest(
+			t, globalDB, loopRunID, workspaceID, staleHandle, 5, staleSessionID, now,
+		)
+		seedActiveGoalBindingForTest(
+			t, globalDB, loopRunID, workspaceID, currentHandle, 5, currentSessionID, now,
+		)
+
+		endedAt := now.Add(time.Second)
+		coordinatorClaim := claimCoordinatorRunForTest(
+			ctx,
+			t,
+			globalDB,
+			created.ID,
+			"run-agent-generation",
+			now.Add(2*time.Second),
+		)
+		if _, err := globalDB.CompleteCoordinatorAndEnqueueNext(
+			ctx,
+			taskpkg.CoordinatorCompletion{
+				RunID:      coordinatorClaim.Run.ID,
+				ClaimToken: coordinatorClaim.ClaimToken,
+				Actor:      coordinatorActorContextForTest(),
+				Now:        now.Add(3 * time.Second),
+				Plan: taskpkg.CoordinatorCompletionPlan{
+					Yield: true,
+					Snapshot: taskpkg.GenerationSnapshot{
+						LoopRunID:  loopRunID,
+						Generation: 1,
+						Payload: looppkg.GenerationSnapshotPayload{
+							Outputs: []looppkg.GenerationOutput{
+								{
+									Generation: 2, NodeID: "execute", Status: "failed",
+									TaskRunID: staleTaskRunID, Attempt: 1, Epoch: 4,
+								},
+								{
+									NodeID: "execute", Status: "failed", TaskRunID: currentTaskRunID,
+									Attempt: 1, Epoch: 4,
+								},
+							},
+							Attempts: []looppkg.NodeAttempt{{
+								LoopRunID: created.ID, Generation: 1, NodeID: "execute", Attempt: 1,
+								FailureCode: "provider_failure", Cause: "provider failed",
+								Disposition: looppkg.AttemptEscalated,
+								StartedAt:   now, EndedAt: &endedAt,
+							}},
+						},
+					},
+				},
+			},
+			looppkg.NewStoreFinalizer(),
+		); err != nil {
+			t.Fatalf("CompleteCoordinatorAndEnqueueNext() error = %v", err)
+		}
+
+		staleBinding, err := globalDB.GetSessionBindingAttempt(ctx, goal.BindingKey{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			Handle:      staleHandle,
+		}, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt(stale) error = %v", err)
+		}
+		if staleBinding.State != goal.BindingStateActive {
+			t.Fatalf("stale generation binding state = %q, want %q", staleBinding.State, goal.BindingStateActive)
+		}
+		currentBinding, err := globalDB.GetSessionBindingAttempt(ctx, goal.BindingKey{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			Handle:      currentHandle,
+		}, 5)
+		if err != nil {
+			t.Fatalf("GetSessionBindingAttempt(current) error = %v", err)
+		}
+		if currentBinding.State != goal.BindingStateClosed {
+			t.Fatalf("current generation binding state = %q, want %q", currentBinding.State, goal.BindingStateClosed)
+		}
+		cleanups, err := globalDB.ClaimGoalSessionCleanup(ctx, 10)
+		if err != nil {
+			t.Fatalf("ClaimGoalSessionCleanup() error = %v", err)
+		}
+		if len(cleanups) != 1 || cleanups[0].SessionID != currentSessionID {
+			t.Fatalf("generation cleanups = %#v, want current session only", cleanups)
 		}
 	})
 
@@ -463,30 +670,16 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 			t.Fatalf("CreateLoopRunForStart() error = %v", err)
 		}
 
-		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
-		taskRecord.Status = taskpkg.TaskStatusReady
-		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
-			t.Fatalf("CreateTask() error = %v", err)
-		}
-		metadata, err := json.Marshal(map[string]any{
-			"generation":     1,
-			"node_id":        "execute",
-			"item_index":     0,
-			"attempt":        1,
-			"epoch":          4,
-			"node_kind":      string(dsl.ActionRunAgent),
-			"session_handle": handle,
+		seedRunAgentCellForTest(t, globalDB, runAgentCellFixture{
+			WorkspaceID: workspaceID,
+			LoopRunID:   loopRunID,
+			TaskID:      taskID,
+			TaskRunID:   taskRunID,
+			Handle:      handle,
+			Generation:  1,
+			Attempt:     1,
+			Epoch:       4,
 		})
-		if err != nil {
-			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
-		}
-		run := taskRunForTest(taskRunID, taskID)
-		run.RunKind = taskpkg.RunKindWorker
-		run.LoopRunID = loopRunID
-		run.Metadata = metadata
-		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
-			t.Fatalf("CreateTaskRun() error = %v", err)
-		}
 		seedActiveGoalBindingForTest(t, globalDB, loopRunID, workspaceID, handle, 5, sessionID, now)
 
 		coordinatorClaim := claimCoordinatorRunForTest(
@@ -567,40 +760,17 @@ func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 			t.Fatalf("advance run-agent generation error = %v", err)
 		}
 
-		taskRecord := workspaceTaskRecordForTest(taskID, workspaceID)
-		taskRecord.Status = taskpkg.TaskStatusReady
-		if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
-			t.Fatalf("CreateTask() error = %v", err)
-		}
-		metadata, err := json.Marshal(map[string]any{
-			"generation":     1,
-			"node_id":        "execute",
-			"item_index":     0,
-			"attempt":        1,
-			"epoch":          4,
-			"node_kind":      string(dsl.ActionRunAgent),
-			"session_handle": handle,
+		seedRunAgentCellForTest(t, globalDB, runAgentCellFixture{
+			WorkspaceID:  workspaceID,
+			LoopRunID:    loopRunID,
+			TaskID:       taskID,
+			TaskRunID:    taskRunID,
+			Handle:       handle,
+			Generation:   1,
+			Attempt:      1,
+			Epoch:        4,
+			InsertOutput: true,
 		})
-		if err != nil {
-			t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
-		}
-		run := taskRunForTest(taskRunID, taskID)
-		run.RunKind = taskpkg.RunKindWorker
-		run.LoopRunID = loopRunID
-		run.Metadata = metadata
-		if err := globalDB.CreateTaskRun(ctx, run); err != nil {
-			t.Fatalf("CreateTaskRun() error = %v", err)
-		}
-		if _, err := globalDB.db.ExecContext(
-			ctx,
-			`INSERT INTO loop_generation_outputs (
-				loop_run_id, generation, node_id, item_index, status, task_run_id, attempt, epoch
-			 ) VALUES (?, 1, 'execute', 0, 'enqueued', ?, 1, 4)`,
-			loopRunID,
-			taskRunID,
-		); err != nil {
-			t.Fatalf("insert run-agent cell error = %v", err)
-		}
 		seedActiveGoalBindingForTest(t, globalDB, loopRunID, workspaceID, handle, 5, sessionID, now)
 
 		itemIndex := 0
@@ -1655,6 +1825,69 @@ func goalSessionInfoForTest(id string, workspaceID string, now time.Time) store.
 	}
 }
 
+type runAgentCellFixture struct {
+	WorkspaceID  string
+	LoopRunID    string
+	TaskID       string
+	TaskRunID    string
+	Handle       string
+	Generation   int
+	Attempt      int
+	Epoch        int64
+	InsertOutput bool
+}
+
+func seedRunAgentCellForTest(
+	t *testing.T,
+	globalDB *GlobalDB,
+	fixture runAgentCellFixture,
+) taskpkg.Run {
+	t.Helper()
+
+	ctx := testutil.Context(t)
+	taskRecord := workspaceTaskRecordForTest(fixture.TaskID, fixture.WorkspaceID)
+	taskRecord.Status = taskpkg.TaskStatusReady
+	if err := globalDB.CreateTask(ctx, taskRecord); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	metadata, err := json.Marshal(map[string]any{
+		"generation":     fixture.Generation,
+		"node_id":        "execute",
+		"item_index":     0,
+		"attempt":        fixture.Attempt,
+		"epoch":          fixture.Epoch,
+		"node_kind":      string(dsl.ActionRunAgent),
+		"session_handle": fixture.Handle,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal(run-agent metadata) error = %v", err)
+	}
+	run := taskRunForTest(fixture.TaskRunID, fixture.TaskID)
+	run.RunKind = taskpkg.RunKindWorker
+	run.LoopRunID = fixture.LoopRunID
+	run.Metadata = metadata
+	if err := globalDB.CreateTaskRun(ctx, run); err != nil {
+		t.Fatalf("CreateTaskRun() error = %v", err)
+	}
+	if !fixture.InsertOutput {
+		return run
+	}
+	if _, err := globalDB.db.ExecContext(
+		ctx,
+		`INSERT INTO loop_generation_outputs (
+			loop_run_id, generation, node_id, item_index, status, task_run_id, attempt, epoch
+		 ) VALUES (?, ?, 'execute', 0, 'enqueued', ?, ?, ?)`,
+		fixture.LoopRunID,
+		fixture.Generation,
+		fixture.TaskRunID,
+		fixture.Attempt,
+		fixture.Epoch,
+	); err != nil {
+		t.Fatalf("insert run-agent cell error = %v", err)
+	}
+	return run
+}
+
 func seedActiveGoalBindingForTest(
 	t *testing.T,
 	globalDB *GlobalDB,
@@ -1663,6 +1896,31 @@ func seedActiveGoalBindingForTest(
 	handle string,
 	bindingEpoch int64,
 	sessionID string,
+	now time.Time,
+) {
+	t.Helper()
+	seedActiveGoalBindingWithOwnershipForTest(
+		t,
+		globalDB,
+		runID,
+		workspaceID,
+		handle,
+		bindingEpoch,
+		sessionID,
+		goal.BindingOwnershipRunOwned,
+		now,
+	)
+}
+
+func seedActiveGoalBindingWithOwnershipForTest(
+	t *testing.T,
+	globalDB *GlobalDB,
+	runID string,
+	workspaceID string,
+	handle string,
+	bindingEpoch int64,
+	sessionID string,
+	ownership goal.BindingOwnership,
 	now time.Time,
 ) {
 	t.Helper()
@@ -1686,16 +1944,17 @@ func seedActiveGoalBindingForTest(
 			loop_run_id, handle, binding_epoch, binding_attempt_id, session_id, workspace_id,
 			creation_profile_ref, policy_spec_digest, creation_digest, ownership, state,
 			created_at, activated_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'run-owned', 'active', ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)`,
 		runID,
 		handle,
 		bindingEpoch,
-		"binding-attempt:"+runID,
+		"binding-attempt:"+runID+":"+handle,
 		sessionID,
 		workspaceID,
 		profileRef,
 		policyDigest,
 		creationDigest,
+		ownership,
 		store.FormatTimestamp(now),
 		store.FormatTimestamp(now),
 	); err != nil {

--- a/internal/store/globaldb/global_db_loop_cancel_lane.go
+++ b/internal/store/globaldb/global_db_loop_cancel_lane.go
@@ -27,7 +27,7 @@ func (g *LoopRepo) requestNodeLaneCancellation(
 	if err != nil {
 		return err
 	}
-	if err := prepareNodeLaneCancellation(ctx, exec, mutation, run); err != nil {
+	if err := g.prepareNodeLaneCancellation(ctx, exec, mutation, run); err != nil {
 		return err
 	}
 	failureCode := string(looppkg.TransitionCauseOperatorCancel)
@@ -90,7 +90,7 @@ func (g *LoopRepo) requestNodeLaneCancellation(
 	return nil
 }
 
-func prepareNodeLaneCancellation(
+func (g *LoopRepo) prepareNodeLaneCancellation(
 	ctx context.Context,
 	exec taskSQLExecutor,
 	mutation looppkg.CancellationMutation,
@@ -99,7 +99,7 @@ func prepareNodeLaneCancellation(
 	if err := claimCancellationWaits(ctx, exec, mutation, run); err != nil {
 		return err
 	}
-	return closeCanceledRunAgentLaneBinding(ctx, exec, mutation, run.Generation)
+	return g.tasks.closeCanceledRunAgentLaneBinding(ctx, exec, mutation, run.Generation)
 }
 
 func nodeLaneLive(

--- a/internal/store/globaldb/global_db_loop_cancel_lane.go
+++ b/internal/store/globaldb/global_db_loop_cancel_lane.go
@@ -27,7 +27,7 @@ func (g *LoopRepo) requestNodeLaneCancellation(
 	if err != nil {
 		return err
 	}
-	if err := claimCancellationWaits(ctx, exec, mutation, run); err != nil {
+	if err := prepareNodeLaneCancellation(ctx, exec, mutation, run); err != nil {
 		return err
 	}
 	failureCode := string(looppkg.TransitionCauseOperatorCancel)
@@ -88,6 +88,18 @@ func (g *LoopRepo) requestNodeLaneCancellation(
 	result.Coordinator = coordinator
 	result.Applied = true
 	return nil
+}
+
+func prepareNodeLaneCancellation(
+	ctx context.Context,
+	exec taskSQLExecutor,
+	mutation looppkg.CancellationMutation,
+	run looppkg.Run,
+) error {
+	if err := claimCancellationWaits(ctx, exec, mutation, run); err != nil {
+		return err
+	}
+	return closeCanceledRunAgentLaneBinding(ctx, exec, mutation, run.Generation)
 }
 
 func nodeLaneLive(

--- a/internal/store/globaldb/global_db_task_claim_complete.go
+++ b/internal/store/globaldb/global_db_task_claim_complete.go
@@ -107,7 +107,7 @@ func (g *TaskRunRepo) completeRunLeaseWithExecutor(
 	if err := recordCompletedRunLoopOutput(ctx, exec, current, normalized, outputRef, resultPayload); err != nil {
 		return taskpkg.Run{}, err
 	}
-	if err := closeCompletedRunAgentBinding(ctx, exec, current, normalized.Now); err != nil {
+	if err := closeTerminalRunAgentBinding(ctx, exec, current, normalized.Now); err != nil {
 		return taskpkg.Run{}, err
 	}
 	if current.IsTaskAnchored() {

--- a/internal/store/globaldb/global_db_task_claim_complete.go
+++ b/internal/store/globaldb/global_db_task_claim_complete.go
@@ -107,6 +107,9 @@ func (g *TaskRunRepo) completeRunLeaseWithExecutor(
 	if err := recordCompletedRunLoopOutput(ctx, exec, current, normalized, outputRef, resultPayload); err != nil {
 		return taskpkg.Run{}, err
 	}
+	if err := closeCompletedRunAgentBinding(ctx, exec, current, normalized.Now); err != nil {
+		return taskpkg.Run{}, err
+	}
 	if current.IsTaskAnchored() {
 		if err := clearTaskCurrentRunProjection(ctx, exec, current.TaskID, current.ID); err != nil {
 			return taskpkg.Run{}, err

--- a/internal/store/globaldb/global_db_task_coordinator.go
+++ b/internal/store/globaldb/global_db_task_coordinator.go
@@ -215,7 +215,7 @@ func (g *TaskRepo) finalizeCoordinatorGenerationWithExecutor(
 			return coordinatorBoundaryState{}, err
 		}
 	}
-	if err := applyCoordinatorGenerationSnapshotIntentsWithExecutor(
+	if err := g.applyCoordinatorGenerationSnapshotIntentsWithExecutor(
 		ctx,
 		exec,
 		loopRun,
@@ -426,7 +426,7 @@ func (g *TaskRepo) applyCoordinatorContinueBoundaryWithExecutor(
 		if err := finalizer.WriteGenerationSnapshot(ctx, exec, *postReserveSnapshot); err != nil {
 			return err
 		}
-		if err := applyCoordinatorGenerationSnapshotIntentsWithExecutor(
+		if err := g.applyCoordinatorGenerationSnapshotIntentsWithExecutor(
 			ctx,
 			exec,
 			loopRun,

--- a/internal/store/globaldb/global_db_task_coordinator_intents.go
+++ b/internal/store/globaldb/global_db_task_coordinator_intents.go
@@ -27,6 +27,9 @@ func applyCoordinatorGenerationSnapshotIntentsWithExecutor(
 	if snapshot.Generation <= 0 {
 		return fmt.Errorf("%w: generation snapshot generation must be positive", looppkg.ErrValidation)
 	}
+	if err := closeSettledRunAgentBindings(ctx, exec, payload, at); err != nil {
+		return err
+	}
 	var provenance looppkg.GenerationIntent
 	if generationSnapshotRequiresProvenance(payload, snapshot.Generation, run.Generation) {
 		provenance, err = persistGenerationProvenanceWithExecutor(ctx, exec, run, snapshot, payload, at)

--- a/internal/store/globaldb/global_db_task_coordinator_intents.go
+++ b/internal/store/globaldb/global_db_task_coordinator_intents.go
@@ -13,7 +13,7 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
-func applyCoordinatorGenerationSnapshotIntentsWithExecutor(
+func (g *TaskRepo) applyCoordinatorGenerationSnapshotIntentsWithExecutor(
 	ctx context.Context,
 	exec taskSQLExecutor,
 	run looppkg.Run,
@@ -27,7 +27,11 @@ func applyCoordinatorGenerationSnapshotIntentsWithExecutor(
 	if snapshot.Generation <= 0 {
 		return fmt.Errorf("%w: generation snapshot generation must be positive", looppkg.ErrValidation)
 	}
-	if err := closeSettledRunAgentBindings(ctx, exec, payload, at); err != nil {
+	if err := g.closeSettledRunAgentBindings(ctx, exec, runAgentSnapshotSettlement{
+		Payload:    payload,
+		Generation: snapshot.Generation,
+		TerminalAt: at,
+	}); err != nil {
 		return err
 	}
 	var provenance looppkg.GenerationIntent

--- a/internal/store/globaldb/global_db_task_coordinator_settlement.go
+++ b/internal/store/globaldb/global_db_task_coordinator_settlement.go
@@ -144,18 +144,24 @@ func (g *TaskRepo) terminalizeLoopTaskRunWithExecutor(
 		if err != nil {
 			return err
 		}
-		return updateTaskCurrentRunProjectionForRunUpdate(ctx, exec, current, updated)
+		if err := updateTaskCurrentRunProjectionForRunUpdate(ctx, exec, current, updated); err != nil {
+			return err
+		}
+		return closeTerminalRunAgentBinding(ctx, exec, updated, terminalAt)
 	}
 	next := current
 	next.Status = taskpkg.TaskRunStatusCanceled
 	next.EndedAt = terminalAt.UTC()
 	next.Error = terminalReason
-	_, err := g.transitionTerminalRunWithExecutor(
+	updated, err := g.transitionTerminalRunWithExecutor(
 		ctx,
 		exec,
 		taskpkg.NewTerminalRunMutation(current, next),
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	return closeTerminalRunAgentBinding(ctx, exec, updated, terminalAt)
 }
 
 func (g *TaskRepo) cancelLiveLoopTaskWithExecutor(

--- a/internal/store/globaldb/global_db_task_runagent_cleanup.go
+++ b/internal/store/globaldb/global_db_task_runagent_cleanup.go
@@ -1,0 +1,70 @@
+package globaldb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/loop/dsl"
+	"github.com/compozy/compozy/internal/loop/goal"
+	taskpkg "github.com/compozy/compozy/internal/task"
+)
+
+type completedRunAgentMetadata struct {
+	NodeKind      string `json:"node_kind"`
+	SessionHandle string `json:"session_handle"`
+	Epoch         int64  `json:"epoch"`
+}
+
+func closeCompletedRunAgentBinding(
+	ctx context.Context,
+	exec taskSQLExecutor,
+	run taskpkg.Run,
+	completedAt time.Time,
+) error {
+	if !run.IsLoopWorker() {
+		return nil
+	}
+	var metadata completedRunAgentMetadata
+	if err := json.Unmarshal(run.Metadata, &metadata); err != nil {
+		return fmt.Errorf("store: decode completed run-agent metadata: %w", err)
+	}
+	if dsl.ActionKind(strings.TrimSpace(metadata.NodeKind)) != dsl.ActionRunAgent {
+		return nil
+	}
+	metadata.SessionHandle = strings.TrimSpace(metadata.SessionHandle)
+	if metadata.SessionHandle == "" || metadata.Epoch < 0 || metadata.Epoch == math.MaxInt64 {
+		return fmt.Errorf("%w: completed run-agent binding identity is invalid", looppkg.ErrValidation)
+	}
+	key := goal.BindingKey{
+		WorkspaceID: looppkg.WorkspaceID(strings.TrimSpace(run.WorkspaceID)),
+		LoopRunID:   looppkg.RunID(strings.TrimSpace(run.LoopRunID)),
+		Handle:      metadata.SessionHandle,
+	}
+	if err := key.Validate(); err != nil {
+		return err
+	}
+	binding, found, err := findSessionBindingAttemptWithExecutor(ctx, exec, key, metadata.Epoch+1)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+	if binding.Ownership != goal.BindingOwnershipRunOwned {
+		return fmt.Errorf("%w: run-agent binding is not run-owned", looppkg.ErrTransitionConflict)
+	}
+	return closeGoalBindingWithCleanup(
+		ctx,
+		exec,
+		key,
+		binding.BindingEpoch,
+		binding.SessionID,
+		goal.SessionCleanupCauseTerminal,
+		completedAt,
+	)
+}

--- a/internal/store/globaldb/global_db_task_runagent_cleanup.go
+++ b/internal/store/globaldb/global_db_task_runagent_cleanup.go
@@ -61,7 +61,7 @@ func closeTerminalRunAgentBinding(
 		return nil
 	}
 	if binding.Ownership != goal.BindingOwnershipRunOwned {
-		return fmt.Errorf("%w: run-agent binding is not run-owned", looppkg.ErrTransitionConflict)
+		return nil
 	}
 	return closeGoalBindingWithCleanup(
 		ctx,
@@ -74,42 +74,55 @@ func closeTerminalRunAgentBinding(
 	)
 }
 
-func closeSettledRunAgentBindings(
+type runAgentSnapshotSettlement struct {
+	Payload    looppkg.GenerationSnapshotPayload
+	Generation int
+	TerminalAt time.Time
+}
+
+func (g *TaskRepo) closeSettledRunAgentBindings(
 	ctx context.Context,
 	exec taskSQLExecutor,
-	payload looppkg.GenerationSnapshotPayload,
-	terminalAt time.Time,
+	settlement runAgentSnapshotSettlement,
 ) error {
-	for _, attempt := range payload.Attempts {
+	for _, attempt := range settlement.Payload.Attempts {
 		if attempt.Disposition == looppkg.AttemptRetried || attempt.Disposition == looppkg.AttemptResumed {
 			continue
 		}
-		taskRunID := settledAttemptTaskRunID(payload.Outputs, attempt)
+		taskRunID := settledAttemptTaskRunID(settlement.Payload.Outputs, attempt, settlement.Generation)
 		if taskRunID == "" {
 			continue
 		}
-		run, err := (&TaskRepo{}).getTaskRunWithExecutor(ctx, exec, taskRunID)
+		run, err := g.getTaskRunWithExecutor(ctx, exec, taskRunID)
 		if err != nil {
 			return err
 		}
-		if err := closeTerminalRunAgentBinding(ctx, exec, run, terminalAt); err != nil {
+		if err := closeTerminalRunAgentBinding(ctx, exec, run, settlement.TerminalAt); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func settledAttemptTaskRunID(outputs []looppkg.GenerationOutput, attempt looppkg.NodeAttempt) string {
+func settledAttemptTaskRunID(
+	outputs []looppkg.GenerationOutput,
+	attempt looppkg.NodeAttempt,
+	snapshotGeneration int,
+) string {
 	for _, output := range outputs {
-		if output.NodeID == string(attempt.NodeID) && output.ItemIndex == attempt.ItemIndex &&
-			output.Attempt == attempt.Attempt {
+		outputGeneration := output.Generation
+		if outputGeneration == 0 {
+			outputGeneration = snapshotGeneration
+		}
+		if outputGeneration == attempt.Generation && output.NodeID == string(attempt.NodeID) &&
+			output.ItemIndex == attempt.ItemIndex && output.Attempt == attempt.Attempt {
 			return strings.TrimSpace(output.TaskRunID)
 		}
 	}
 	return ""
 }
 
-func closeCanceledRunAgentLaneBinding(
+func (g *TaskRepo) closeCanceledRunAgentLaneBinding(
 	ctx context.Context,
 	exec taskSQLExecutor,
 	mutation looppkg.CancellationMutation,
@@ -137,7 +150,7 @@ func closeCanceledRunAgentLaneBinding(
 	if !taskRunID.Valid {
 		return nil
 	}
-	run, err := (&TaskRepo{}).getTaskRunWithExecutor(ctx, exec, taskRunID.String)
+	run, err := g.getTaskRunWithExecutor(ctx, exec, taskRunID.String)
 	if err != nil {
 		return err
 	}

--- a/internal/store/globaldb/global_db_task_runagent_cleanup.go
+++ b/internal/store/globaldb/global_db_task_runagent_cleanup.go
@@ -2,7 +2,9 @@ package globaldb
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -14,31 +16,34 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
-type completedRunAgentMetadata struct {
+type runAgentBindingMetadata struct {
 	NodeKind      string `json:"node_kind"`
 	SessionHandle string `json:"session_handle"`
 	Epoch         int64  `json:"epoch"`
 }
 
-func closeCompletedRunAgentBinding(
+func closeTerminalRunAgentBinding(
 	ctx context.Context,
 	exec taskSQLExecutor,
 	run taskpkg.Run,
-	completedAt time.Time,
+	terminalAt time.Time,
 ) error {
 	if !run.IsLoopWorker() {
 		return nil
 	}
-	var metadata completedRunAgentMetadata
+	if len(run.Metadata) == 0 {
+		return nil
+	}
+	var metadata runAgentBindingMetadata
 	if err := json.Unmarshal(run.Metadata, &metadata); err != nil {
-		return fmt.Errorf("store: decode completed run-agent metadata: %w", err)
+		return fmt.Errorf("store: decode terminal run-agent metadata: %w", err)
 	}
 	if dsl.ActionKind(strings.TrimSpace(metadata.NodeKind)) != dsl.ActionRunAgent {
 		return nil
 	}
 	metadata.SessionHandle = strings.TrimSpace(metadata.SessionHandle)
 	if metadata.SessionHandle == "" || metadata.Epoch < 0 || metadata.Epoch == math.MaxInt64 {
-		return fmt.Errorf("%w: completed run-agent binding identity is invalid", looppkg.ErrValidation)
+		return fmt.Errorf("%w: terminal run-agent binding identity is invalid", looppkg.ErrValidation)
 	}
 	key := goal.BindingKey{
 		WorkspaceID: looppkg.WorkspaceID(strings.TrimSpace(run.WorkspaceID)),
@@ -65,6 +70,76 @@ func closeCompletedRunAgentBinding(
 		binding.BindingEpoch,
 		binding.SessionID,
 		goal.SessionCleanupCauseTerminal,
-		completedAt,
+		terminalAt,
 	)
+}
+
+func closeSettledRunAgentBindings(
+	ctx context.Context,
+	exec taskSQLExecutor,
+	payload looppkg.GenerationSnapshotPayload,
+	terminalAt time.Time,
+) error {
+	for _, attempt := range payload.Attempts {
+		if attempt.Disposition == looppkg.AttemptRetried || attempt.Disposition == looppkg.AttemptResumed {
+			continue
+		}
+		taskRunID := settledAttemptTaskRunID(payload.Outputs, attempt)
+		if taskRunID == "" {
+			continue
+		}
+		run, err := (&TaskRepo{}).getTaskRunWithExecutor(ctx, exec, taskRunID)
+		if err != nil {
+			return err
+		}
+		if err := closeTerminalRunAgentBinding(ctx, exec, run, terminalAt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func settledAttemptTaskRunID(outputs []looppkg.GenerationOutput, attempt looppkg.NodeAttempt) string {
+	for _, output := range outputs {
+		if output.NodeID == string(attempt.NodeID) && output.ItemIndex == attempt.ItemIndex &&
+			output.Attempt == attempt.Attempt {
+			return strings.TrimSpace(output.TaskRunID)
+		}
+	}
+	return ""
+}
+
+func closeCanceledRunAgentLaneBinding(
+	ctx context.Context,
+	exec taskSQLExecutor,
+	mutation looppkg.CancellationMutation,
+	generation int,
+) error {
+	if mutation.ItemIndex == nil {
+		return fmt.Errorf("%w: run-agent lane cancellation requires item_index", looppkg.ErrValidation)
+	}
+	var taskRunID sql.NullString
+	err := exec.QueryRowContext(
+		ctx,
+		`SELECT task_run_id FROM loop_generation_outputs
+		 WHERE loop_run_id = ? AND generation = ? AND node_id = ? AND item_index = ?`,
+		mutation.RunID,
+		generation,
+		mutation.NodeID,
+		*mutation.ItemIndex,
+	).Scan(&taskRunID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("store: load canceled run-agent lane task run: %w", err)
+	}
+	if !taskRunID.Valid {
+		return nil
+	}
+	run, err := (&TaskRepo{}).getTaskRunWithExecutor(ctx, exec, taskRunID.String)
+	if err != nil {
+		return err
+	}
+	return closeTerminalRunAgentBinding(ctx, exec, run, mutation.RequestedAt)
 }

--- a/packages/site/content/docs/loops/dsl-reference.mdx
+++ b/packages/site/content/docs/loops/dsl-reference.mdx
@@ -166,6 +166,10 @@ The daemon validates the agent's exact structured result against that schema bef
 task and revalidates it before publishing node success. A mismatch fails with `invalid_output`.
 Large results keep the same structured value when stored by content reference. The bound agent
 session may heartbeat its task, but only the owning daemon can complete or fail it.
+Each managed `run-agent` cell owns a system session. A session-started Loop records the nearest
+origin session as informational parent lineage without borrowing it. Successful cell settlement
+closes the binding and queues a durable stop; retries keep the binding active until a terminal
+boundary.
 Cross-generation references keep the same authored shape on every pass. On generation 1,
 `previous.generation` is `0`; before a best candidate exists, `best.generation` is `0`. Authored
 node outputs use zero values from their declared schemas and verdict lists are empty, so a valid

--- a/packages/site/content/docs/loops/dsl-reference.mdx
+++ b/packages/site/content/docs/loops/dsl-reference.mdx
@@ -167,9 +167,9 @@ task and revalidates it before publishing node success. A mismatch fails with `i
 Large results keep the same structured value when stored by content reference. The bound agent
 session may heartbeat its task, but only the owning daemon can complete or fail it.
 Each managed `run-agent` cell owns a system session. A session-started Loop records the nearest
-origin session as informational parent lineage without borrowing it. Successful cell settlement
-closes the binding and queues a durable stop; retries keep the binding active until a terminal
-boundary.
+origin session as informational parent lineage without borrowing it. Terminal cell settlement
+closes the binding and queues a durable stop. A failure scheduled for retry keeps the binding active
+until the cell reaches a terminal boundary.
 Cross-generation references keep the same authored shape on every pass. On generation 1,
 `previous.generation` is `0`; before a best candidate exists, `best.generation` is `0`. Authored
 node outputs use zero values from their declared schemas and verdict lists are empty, so a valid

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -416,9 +416,9 @@ settles the task and again before node success is published. A mismatch fails wi
 session may call `compozy__task_run_heartbeat`, but only the owning daemon may call the terminal
 complete or fail operations for that task.
 Each managed `run-agent` cell owns a system session. A session-started Loop records the nearest
-origin session as informational parent lineage without borrowing it. Successful cell settlement
-closes the binding and queues a durable stop; retries keep the binding active until a terminal
-boundary.
+origin session as informational parent lineage without borrowing it. Terminal cell settlement
+closes the binding and queues a durable stop. A failure scheduled for retry keeps the binding active
+until the cell reaches a terminal boundary.
 A gate's
 `verdict_policy: revise_until_clean` requires an `agent-judge` or `human` criterion. For a command
 criterion with `expect: stdout_contains`, set the typed `contains` field to the required stdout

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -415,6 +415,10 @@ settles the task and again before node success is published. A mismatch fails wi
 `invalid_output`; content-addressed storage preserves the exact structured value. The bound agent
 session may call `compozy__task_run_heartbeat`, but only the owning daemon may call the terminal
 complete or fail operations for that task.
+Each managed `run-agent` cell owns a system session. A session-started Loop records the nearest
+origin session as informational parent lineage without borrowing it. Successful cell settlement
+closes the binding and queues a durable stop; retries keep the binding active until a terminal
+boundary.
 A gate's
 `verdict_policy: revise_until_clean` requires an `agent-judge` or `human` criterion. For a command
 criterion with `expect: stdout_contains`, set the typed `contains` field to the required stdout


### PR DESCRIPTION
## Summary

- preserve the nearest originating session as informational parent lineage for managed `run-agent` workers without borrowing the origin session
- close run-owned worker bindings and enqueue durable terminal cleanup atomically when a Loop cell completes successfully
- keep the same worker session active across retryable output failures until terminal settlement
- document the lifecycle contract and record the live Batuta QA walk
- align the release workflow test with the `releasepr@v0.0.29` version already used by `main`

## Context

Both lifecycle bugs were reproduced against the latest official beta, `v0.3.0-beta.18`. The implementation does not change a public API, schema, migration, or configuration key.

## Verification

- `make gate-full` passed on fingerprint `11baee9612c24e2c73aac8227c3a1fdc3dca1afc`: 23,510 tests passed, 3 platform-specific tests skipped, Go build passed, and package boundaries passed
- live isolated Batuta QA passed for parent/root lineage, terminal worker stop, origin-session preservation, and retry reuse
- first run: `looprun-1a2ab03c08ad6304`, worker `sess_62bf080f2cf6a8a485d838696aa4062c`
- retry run: `looprun-8855dfa795404c0e`, worker `sess_387ba71836d94d1d913c28b5aaf0c3ff`
- strict QA evidence audit passed; teardown recorded `clean: true` with no surviving lab processes

## Compozy Impact Audit

- **Native tools:** no tool IDs, toolsets, descriptors, schemas, digests, risk flags, or capability gates changed. Existing Loop and session reads now expose corrected persisted lineage and terminal state; checked `compozy__loop_run`, Loop status, and session CLI/HTTP reads.
- **Extensibility and hooks:** reserved `run-agent` lifecycle behavior changed only. Extensions, hooks, capability registries, bridge SDKs, MCP sidecars, and configuration lifecycle were checked and are unchanged; custom actions remain unaffected.
- **Workspace data isolation:** cleanup resolves the exact workspace/run/handle binding key and fenced epoch. Provenance continues through existing workspace-guarded lookup paths; no list, cache, SSE, event, or cross-workspace contract changed.
- **Official Compozy skill:** updated `skills/compozy/references/loops.md` with the managed worker ownership, lineage, retry, and cleanup contract.
- **Web/Docs impact:** no Web component or route change is required because existing projections consume the corrected stored state. The Loop DSL site documentation and QA journey were updated.
- **Config lifecycle:** no `config.toml` key, default, validation rule, or documentation entry was added, changed, or removed.

Fixes #444
Fixes #445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session provenance tracking for managed run-agent actions.
  * Ensured completed, canceled, and terminally failed run-agent tasks close associated session bindings.
  * Preserved originating session relationships while creating managed child sessions.
  * Kept session bindings active for retryable failures and prevented duplicate cleanup.

* **Tests**
  * Added integration coverage for run-agent completion, cancellation, retries, and session-binding cleanup.
  * Expanded verification of policy and session provenance propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->