### PR TITLE
fix: allow extension loops to call owned tools

### DIFF
--- a/docs/qa/charters/CH-loop-extension-owner-policy.md
+++ b/docs/qa/charters/CH-loop-extension-owner-policy.md
@@ -1,0 +1,28 @@
+# CH-loop-extension-owner-policy: Keep extension Loop actions within their owner
+
+```yaml
+charter:
+  id: CH-loop-extension-owner-policy
+  mission: "As Bruno, run an extension-owned Loop before and after daemon restart and prove that only same-owner action tools bypass the disabled external-source default."
+  mode: charter-with-tour
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-loop-extension-actions
+  scenarios: [LP-extension-owned-loop-tool-policy]
+  tour: Feature Tour
+  time_box_minutes: 60
+  guidance:
+    must_try:
+      - "Install two non-bundled, non-dev-linked test extensions without extra source grants."
+      - "Run the first extension Loop with its own tool while tools.policy.external_default remains disabled."
+      - "Reference the second extension tool from the first Loop and capture the structured denial."
+      - "Restart the daemon, reload the persisted Run snapshot, and repeat the same-owner check."
+    must_avoid:
+      - "Do not enable tools.policy.external_default or add an operator source grant."
+      - "Do not use bundled or development-linked trust behavior as evidence for marketplace ownership."
+```
+
+<!-- The charter is durable and immutable: each run's debrief belongs in its dated report. -->

--- a/docs/qa/journeys/J-loop-extension-actions.md
+++ b/docs/qa/journeys/J-loop-extension-actions.md
@@ -1,0 +1,66 @@
+# J-loop-extension-actions: Run extension-owned Loop actions
+
+An extension author installs a Loop and its tools, runs the Loop under the default external-source
+policy, and confirms that ownership grants only the Loop's own action tools.
+
+```mermaid
+flowchart TD
+  A[Entry: install and enable two test extensions] --> B[Inspect the first extension Loop]
+  B --> C[Run the Loop with its same-owner action tool]
+  C -->|own tool available| D[Action succeeds and output is recorded]
+  C -->|own tool unavailable| C1[Action fails with a structured policy reason]
+  D --> E[Run the first Loop against the second extension tool]
+  E -->|foreign tool denied| F[Failure identifies the unavailable action]
+  E -->|foreign tool allowed| E1[Policy boundary fails]
+  F --> G[Restart the daemon and reload the persisted Run]
+  G --> H[Repeat the same-owner action successfully]
+  A -.->|author disables the owning extension| X1[Abandon: Loop and tool remain unavailable]
+  X1 -.->|author enables it again| B
+  H --> Z[True end: exact-owner access survives restart without a global external grant]
+```
+
+```yaml
+journey:
+  id: J-loop-extension-actions
+  name: Run extension-owned Loop actions
+  value_statement: "As an extension author, I can ship a Loop that calls my extension tools without opening access to tools from other extensions."
+  personas: [Bruno, Ada]
+  entry_points:
+    - url: compozy extension install|enable
+      origin: direct
+    - url: compozy loop list|run|status
+      origin: direct
+    - url: Loop HTTP and UDS routes
+      origin: direct
+  actions:
+    - step: 1
+      verb: Install and enable two independent extensions
+      expected_observable: Each extension exposes its own identity, resources, and tool descriptors
+    - step: 2
+      verb: Run the first extension Loop with its same-owner action tool
+      expected_observable: The action executes under the default disabled external-source policy and records its output
+    - step: 3
+      verb: Point the first Loop at the second extension tool
+      expected_observable: Resolution fails with the existing structured unavailable-action reason
+    - step: 4
+      verb: Restart the daemon, reload the persisted Run snapshot, and repeat the same-owner action
+      expected_observable: The pinned owner survives snapshot hydration, the previous result remains intact, and a fresh own action still succeeds
+  goal:
+    observable: Same-owner action execution succeeds while foreign extension action execution remains denied
+    side_effects: [loop-run-persisted, action-output-recorded, policy-denial-recorded]
+  true_end_state: Fresh Loop status after daemon restart proves exact-owner access without enabling the global external-source policy
+  exit:
+    natural: Continue authoring extension Loop actions under the default policy
+  abandonment:
+    - at_step: 1
+      how: Disable the extension before running its Loop
+      resume: Enable the extension and re-read the Loop catalog before starting a new Run
+  crosses: [extensions, loops, executed-definition-snapshots, tool-registry, tool-policy, cli, httpapi, udsapi]
+```
+
+## Coverage notes
+
+- Functional and cross-cutting coverage are the own-tool success, foreign-tool denial, and restart
+  continuity checks.
+- The Feature Tour owns runtime and documentation agreement. UI, viewport, locale, and browser-only
+  dimensions are out of scope because this journey uses structured runtime surfaces.

--- a/docs/qa/reports/2026-08-29-extension-owned-loop-tool-policy.md
+++ b/docs/qa/reports/2026-08-29-extension-owned-loop-tool-policy.md
@@ -1,0 +1,76 @@
+# QA Run Report — 2026-08-29 — extension-owned-loop-tool-policy
+
+- **Scope:** PR #503 extension-owned Loop action policy, exact-owner isolation, and restart hydration
+- **Cadence tier:** targeted
+- **Build:** `920083f0c2cbe9a11e497ab7c82b679f1c852d31` plus current review adjustments · **Environment:** isolated local daemon at `http://127.0.0.1:58217`; CLI/API/runtime required; browser unavailable and out of scope
+- **Started:** 2026-08-29T16:32:44-03:00 · **Status:** passed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-loop-extension-owner-policy |
+
+## Flows in Scope
+
+- `J-loop-extension-actions` — Run an extension-owned Loop action without granting access to foreign extension tools (`../journeys/J-loop-extension-actions.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-loop-extension-owner-policy | J-loop-extension-actions / LP-extension-owned-loop-tool-policy | Bruno | Feature Tour | Pass | | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+- Installed two independent external extensions from local build artifacts. Both were active and
+  healthy after install and again after daemon restart.
+- Confirmed `tools.policy.external_default = "disabled"` before execution and after restart.
+- `own-flow` completed through the CLI; `ext__owner_one__echo` recorded
+  `{"owner":"owner-one"}`. The HTTP API returned the same terminal Run and output.
+- `foreign-flow` could not resolve `ext__owner_two__echo`; the task recorded
+  `unknown_action_kind` and the daemon logged `tool "ext__owner_two__echo" not found`.
+- Restarted the isolated daemon, reloaded the persisted Run with the same definition digest and
+  output, then ran `own-flow` again successfully.
+
+## What Was Fixed
+
+No product findings required a fix. The first owner-one fixture build used Loop directories that did
+not match `meta.name`; the fixture was corrected and rebuilt before behavioral execution.
+
+## Paper Cuts
+
+None recorded.
+
+## Runtime Errors Observed
+
+- Expected policy denial: `foreign-flow` emitted `unknown_action_kind` for the owner-two tool.
+- Fixture-only setup error: the first owner-one install rejected mismatched Loop directory names;
+  no partial extension state remained.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The scenario initially referenced a missing journey and used a persona name absent from `personas.md`; planning now uses Bruno and a durable journey/charter pair.
+- A completed persisted Run plus a fresh post-restart execution provides observable CLI/API evidence;
+  the coordinator integration test separately exercises owner restoration on the execution context.
+
+## Final Status
+
+Behavioral verdict: **Pass**. Same-owner access remained exact, foreign-owner resolution stayed
+denied, and restart did not require a global external-source grant. Evidence:
+`/home/francisross/dev/qa-labs/compozy-extension-owned-loop-tool-policy-20260829-192832-898784-lab/qa-artifacts/qa/evidence/extension-owner-policy/result.json`.
+
+Final verification:
+
+- Local gate: `make gate` — Go lint and race-enabled scoped tests passed with zero issues.
+- QA teardown: `/home/francisross/dev/qa-labs/compozy-extension-owned-loop-tool-policy-20260829-192832-898784-lab/qa-artifacts/qa/teardown.json` (`clean: true`).

--- a/docs/qa/scenarios/LP-extension-owned-loop-tool-policy.md
+++ b/docs/qa/scenarios/LP-extension-owned-loop-tool-policy.md
@@ -1,0 +1,21 @@
+---
+id: LP-extension-owned-loop-tool-policy
+area: LP
+title: Run extension-owned Loop actions under the default tool policy
+persona: Extension author
+journey: J-loop-extension-actions
+expected: A globally installed extension Loop calls tools owned by the same extension while the default external-source policy remains disabled; tools owned by another extension remain unavailable, and normal permission, risk, approval, availability, schema, and drift checks still apply.
+entry_points: extension install and enable; resources.loops; Loop run through CLI, HTTP, or UDS; Loop status and task-run failure details
+qa_status: untested
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence:
+last_report:
+overlaps:
+---
+
+story: As an extension author, I can ship a Loop that uses my extension tools without asking operators to enable every external tool source.
+
+Use two enabled test extensions under the default `tools.policy.external_default = "disabled"` setting. The first contributes a Loop and one tool referenced by an action node. The second contributes a different tool. Run the first Loop and prove its own action executes. Then reference the second extension tool from the first Loop and prove resolution remains denied. Restart the daemon and repeat from the persisted Run snapshot to prove the same-owner grant survives hydration without becoming a global policy grant.

--- a/docs/qa/scenarios/LP-extension-owned-loop-tool-policy.md
+++ b/docs/qa/scenarios/LP-extension-owned-loop-tool-policy.md
@@ -2,20 +2,20 @@
 id: LP-extension-owned-loop-tool-policy
 area: LP
 title: Run extension-owned Loop actions under the default tool policy
-persona: Extension author
+persona: Bruno
 journey: J-loop-extension-actions
 expected: A globally installed extension Loop calls tools owned by the same extension while the default external-source policy remains disabled; tools owned by another extension remain unavailable, and normal permission, risk, approval, availability, schema, and drift checks still apply.
 entry_points: extension install and enable; resources.loops; Loop run through CLI, HTTP, or UDS; Loop status and task-run failure details
-qa_status: untested
+qa_status: pass
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence:
-last_report:
+evidence: /home/francisross/dev/qa-labs/compozy-extension-owned-loop-tool-policy-20260829-192832-898784-lab/qa-artifacts/qa/evidence/extension-owner-policy/result.json
+last_report: docs/qa/reports/2026-08-29-extension-owned-loop-tool-policy.md
 overlaps:
 ---
 
 story: As an extension author, I can ship a Loop that uses my extension tools without asking operators to enable every external tool source.
 
-Use two enabled test extensions under the default `tools.policy.external_default = "disabled"` setting. The first contributes a Loop and one tool referenced by an action node. The second contributes a different tool. Run the first Loop and prove its own action executes. Then reference the second extension tool from the first Loop and prove resolution remains denied. Restart the daemon and repeat from the persisted Run snapshot to prove the same-owner grant survives hydration without becoming a global policy grant.
+Use two enabled test extensions under the default `tools.policy.external_default = "disabled"` setting. The first contributes a Loop and one tool referenced by an action node. The second contributes a different tool. Run the first Loop and prove its own action executes. Then reference the second extension tool from the first Loop and prove resolution remains denied. Restart the daemon, reload the persisted Run snapshot, and repeat the own action to prove the same-owner grant survives hydration without becoming a global policy grant.

--- a/internal/daemon/loop_api_catalog_test.go
+++ b/internal/daemon/loop_api_catalog_test.go
@@ -29,6 +29,8 @@ func TestDaemonLoopCatalogShouldBatchBeforePageHydration(t *testing.T) {
 		workspaceResolver := loopCatalogWorkspaceResolverForTest(t, "ws-catalog", workspaceRoot, now)
 		marketingSpec := loopCatalogSpecWithFile(t, t.TempDir(), "profile-loop", looppkg.SourceMarketplace)
 		marketingSpec.Description = "marketing profile"
+		marketingSpec.InstalledFromExtension = "acme/release-automation"
+		marketingSpec.ExtensionOwner = "release-automation"
 		engineeringSpec := loopCatalogSpecWithFile(t, t.TempDir(), "profile-loop", looppkg.SourceMarketplace)
 		engineeringSpec.Description = "engineering profile"
 		if err := os.WriteFile(
@@ -106,6 +108,12 @@ func TestDaemonLoopCatalogShouldBatchBeforePageHydration(t *testing.T) {
 		}
 		if got, want := resolvedMarketing.Definition.Meta.Description, "marketing profile"; got != want {
 			t.Fatalf("resolved marketing description = %q, want %q", got, want)
+		}
+		if got, want := resolvedMarketing.InstalledFromExtension, "acme/release-automation"; got != want {
+			t.Fatalf("resolved marketing extension provenance = %q, want %q", got, want)
+		}
+		if got, want := resolvedMarketing.ExtensionOwner, "release-automation"; got != want {
+			t.Fatalf("resolved marketing extension owner = %q, want %q", got, want)
 		}
 		if got, want := resolvedEngineering.Definition.Meta.Description, "engineering profile"; got != want {
 			t.Fatalf("resolved engineering description = %q, want %q", got, want)

--- a/internal/daemon/loop_read_cli_e2e_integration_test.go
+++ b/internal/daemon/loop_read_cli_e2e_integration_test.go
@@ -29,6 +29,7 @@ import (
 
 const (
 	loopReadApprovalLoopName   = "loop-read-approval"
+	loopReadUnblockerLoopName  = "loop-read-unblocker"
 	loopReadQuarantineLoopName = "loop-read-quarantine"
 	loopReadWaitingLoopName    = "loop-read-waiting"
 )
@@ -66,6 +67,7 @@ func TestDaemonE2ELoopRunReadCLIJourneys(t *testing.T) {
 	defer setupCancel()
 	createLoopViaHTTP(t, setupCtx, harness, loopEventsDefinition())
 	waitForLoopCatalogEntry(t, setupCtx, harness, loopReadApprovalLoopName)
+	waitForLoopCatalogEntry(t, setupCtx, harness, loopReadUnblockerLoopName)
 	waitForLoopCatalogEntry(t, setupCtx, harness, loopReadQuarantineLoopName)
 	waitForLoopCatalogEntry(t, setupCtx, harness, loopReadWaitingLoopName)
 	run := runLoopViaHTTP(t, setupCtx, harness, "loop-events-probe")
@@ -1130,6 +1132,7 @@ func seedLoopReadDefinitions(t testing.TB, workspaceRoot string) {
 	root := filepath.Join(workspaceRoot, compozyconfig.DirName, compozyconfig.LoopsDirName)
 	definitions := map[string]string{
 		loopReadApprovalLoopName:   loopReadApprovalYAML(),
+		loopReadUnblockerLoopName:  loopReadUnblockerYAML(),
 		loopReadQuarantineLoopName: loopReadQuarantineYAML(),
 		loopReadWaitingLoopName:    loopReadWaitingYAML(),
 	}
@@ -1142,6 +1145,45 @@ func seedLoopReadDefinitions(t testing.TB, workspaceRoot string) {
 			t.Fatalf("WriteDefinition(%s) error = %v", name, err)
 		}
 	}
+}
+
+func loopReadUnblockerYAML() string {
+	return `apiVersion: compozy.loop/v1
+kind: Loop
+meta: { name: loop-read-unblocker, description: "E2E deterministic approval unblocker probe." }
+concurrency: allow
+contract:
+  goal: "Prepare, receive explicit approval, and finish."
+  definition_of_done: "The approved final transform succeeds."
+  stop_when: "nodes.finish.status == 'succeeded'"
+  verification: []
+  terminal_states: [done, failed, blocked, exhausted, stalled]
+  iteration_cap: 1
+  no_progress: { window: 2 }
+  budget: { tokens: 0, wall_clock_sec: 0, on_exceeded: halt }
+graph:
+  nodes:
+    - id: prepare
+      class: action
+      kind: transform
+      params:
+        map: { status: { value: prepared } }
+    - id: approval
+      class: control
+      kind: gate
+      verdict_policy: revise_until_clean
+      criteria:
+        - { id: operator, type: human }
+    - id: finish
+      class: action
+      kind: transform
+      params:
+        map: { status: { value: approved } }
+  edges:
+    - { from: prepare, to: approval }
+    - { from: approval, to: finish }
+start: [{ kind: http }, { kind: uds }]
+`
 }
 
 func loopReadApprovalYAML() string {
@@ -1271,7 +1313,7 @@ func runLoopWithHumanGate(
 	}
 	var response compozycontract.RunLoopResponse
 	path := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) +
-		"/loops/" + url.PathEscape(loopReadApprovalLoopName) + "/run"
+		"/loops/" + url.PathEscape(loopReadUnblockerLoopName) + "/run"
 	if err := harness.HTTPJSON(ctx, http.MethodPost, path, request, &response); err != nil {
 		t.Fatalf("HTTP run human-gate loop error = %v", err)
 	}

--- a/internal/daemon/loop_tool_schema_source.go
+++ b/internal/daemon/loop_tool_schema_source.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 
 	looppkg "github.com/compozy/compozy/internal/loop"
 	toolspkg "github.com/compozy/compozy/internal/tools"
@@ -12,9 +13,11 @@ import (
 type loopToolSchemaSource struct {
 	ctx      context.Context
 	registry toolspkg.Registry
+	once     sync.Once
+	schemas  map[toolspkg.ToolID]looppkg.ToolSchemaSnapshot
 }
 
-var _ looppkg.ToolSchemaSource = loopToolSchemaSource{}
+var _ looppkg.ToolSchemaSource = (*loopToolSchemaSource)(nil)
 
 func newLoopToolSchemaSource(ctx context.Context, registry toolspkg.Registry) looppkg.ToolSchemaSource {
 	if registry == nil {
@@ -23,10 +26,10 @@ func newLoopToolSchemaSource(ctx context.Context, registry toolspkg.Registry) lo
 	if ctx == nil {
 		return nil
 	}
-	return loopToolSchemaSource{ctx: ctx, registry: registry}
+	return &loopToolSchemaSource{ctx: ctx, registry: registry}
 }
 
-func (s loopToolSchemaSource) Snapshot(toolID string) (looppkg.ToolSchemaSnapshot, bool) {
+func (s *loopToolSchemaSource) Snapshot(toolID string) (looppkg.ToolSchemaSnapshot, bool) {
 	if s.registry == nil {
 		return looppkg.ToolSchemaSnapshot{}, false
 	}
@@ -34,18 +37,39 @@ func (s loopToolSchemaSource) Snapshot(toolID string) (looppkg.ToolSchemaSnapsho
 	if err := id.Validate(); err != nil {
 		return looppkg.ToolSchemaSnapshot{}, false
 	}
-	view, err := s.registry.Get(s.ctx, toolspkg.Scope{Operator: true}, id)
-	if err != nil {
+	s.once.Do(s.load)
+	snapshot, ok := s.schemas[id]
+	if !ok {
 		return looppkg.ToolSchemaSnapshot{}, false
 	}
-	descriptor := view.Descriptor
 	return looppkg.ToolSchemaSnapshot{
-		ToolID:             descriptor.ID.String(),
-		InputSchema:        cloneLoopSchemaRaw(descriptor.InputSchema),
-		OutputSchema:       cloneLoopSchemaRaw(descriptor.OutputSchema),
-		InputSchemaDigest:  strings.TrimSpace(descriptor.InputSchemaDigest),
-		OutputSchemaDigest: strings.TrimSpace(descriptor.OutputSchemaDigest),
+		ToolID:             snapshot.ToolID,
+		InputSchema:        cloneLoopSchemaRaw(snapshot.InputSchema),
+		OutputSchema:       cloneLoopSchemaRaw(snapshot.OutputSchema),
+		InputSchemaDigest:  snapshot.InputSchemaDigest,
+		OutputSchemaDigest: snapshot.OutputSchemaDigest,
 	}, true
+}
+
+func (s *loopToolSchemaSource) load() {
+	if err := s.ctx.Err(); err != nil {
+		return
+	}
+	views, err := s.registry.List(s.ctx, toolspkg.Scope{Operator: true})
+	if err != nil {
+		return
+	}
+	s.schemas = make(map[toolspkg.ToolID]looppkg.ToolSchemaSnapshot, len(views))
+	for i := range views {
+		descriptor := views[i].Descriptor
+		s.schemas[descriptor.ID] = looppkg.ToolSchemaSnapshot{
+			ToolID:             descriptor.ID.String(),
+			InputSchema:        cloneLoopSchemaRaw(descriptor.InputSchema),
+			OutputSchema:       cloneLoopSchemaRaw(descriptor.OutputSchema),
+			InputSchemaDigest:  strings.TrimSpace(descriptor.InputSchemaDigest),
+			OutputSchemaDigest: strings.TrimSpace(descriptor.OutputSchemaDigest),
+		}
+	}
 }
 
 func newLoopCompilerWithSchemaSource(source looppkg.ToolSchemaSource) *looppkg.Compiler {

--- a/internal/daemon/loop_tool_schema_source_test.go
+++ b/internal/daemon/loop_tool_schema_source_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/compozy/compozy/internal/workspaceaccess"
 )
 
+type loopToolSchemaContextKey struct{}
+
 func TestLoopToolSchemaSource(t *testing.T) {
 	t.Parallel()
 
@@ -110,17 +112,44 @@ func TestLoopToolSchemaSource(t *testing.T) {
 	t.Run("Should pass caller context to registry lookups", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
+		const marker = "schema-projection"
+		var captured any
+		ctx := context.WithValue(t.Context(), loopToolSchemaContextKey{}, marker)
 		descriptor := loopToolSchemaDescriptor(t)
 		source := newLoopToolSchemaSource(ctx, loopToolSchemaRegistry{
 			views: map[toolspkg.ToolID]toolspkg.ToolView{
 				descriptor.ID: {Descriptor: descriptor},
 			},
+			listContextValue: &captured,
+		})
+
+		if _, ok := source.Snapshot(descriptor.ID.String()); !ok {
+			t.Fatalf("Snapshot(%q) ok = false, want true", descriptor.ID)
+		}
+		if captured != marker {
+			t.Fatalf("registry List context marker = %#v, want %q", captured, marker)
+		}
+	})
+
+	t.Run("Should stop before registry lookup when caller context is canceled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		descriptor := loopToolSchemaDescriptor(t)
+		listCalls := 0
+		source := newLoopToolSchemaSource(ctx, loopToolSchemaRegistry{
+			views: map[toolspkg.ToolID]toolspkg.ToolView{
+				descriptor.ID: {Descriptor: descriptor},
+			},
+			listCalls: &listCalls,
 		})
 
 		if _, ok := source.Snapshot(descriptor.ID.String()); ok {
 			t.Fatalf("Snapshot(%q) ok = true, want false after canceled context", descriptor.ID)
+		}
+		if listCalls != 0 {
+			t.Fatalf("registry List calls = %d, want 0", listCalls)
 		}
 	})
 
@@ -432,14 +461,18 @@ func extensionToolPolicyAllowAll() toolspkg.PolicyInputs {
 }
 
 type loopToolSchemaRegistry struct {
-	views     map[toolspkg.ToolID]toolspkg.ToolView
-	listCalls *int
-	getCalls  *int
+	views            map[toolspkg.ToolID]toolspkg.ToolView
+	listCalls        *int
+	getCalls         *int
+	listContextValue *any
 }
 
-func (r loopToolSchemaRegistry) List(context.Context, toolspkg.Scope) ([]toolspkg.ToolView, error) {
+func (r loopToolSchemaRegistry) List(ctx context.Context, _ toolspkg.Scope) ([]toolspkg.ToolView, error) {
 	if r.listCalls != nil {
 		*r.listCalls++
+	}
+	if r.listContextValue != nil {
+		*r.listContextValue = ctx.Value(loopToolSchemaContextKey{})
 	}
 	views := make([]toolspkg.ToolView, 0, len(r.views))
 	for id := range r.views {

--- a/internal/daemon/loop_tool_schema_source_test.go
+++ b/internal/daemon/loop_tool_schema_source_test.go
@@ -13,8 +13,10 @@ import (
 	extensionpkg "github.com/compozy/compozy/internal/extension"
 	extensionprotocol "github.com/compozy/compozy/internal/extensionprotocol"
 	looppkg "github.com/compozy/compozy/internal/loop"
+	looppkgdsl "github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/compozy/compozy/internal/subprocess"
 	toolspkg "github.com/compozy/compozy/internal/tools"
+	"github.com/compozy/compozy/internal/workspaceaccess"
 )
 
 func TestLoopToolSchemaSource(t *testing.T) {
@@ -72,6 +74,36 @@ func TestLoopToolSchemaSource(t *testing.T) {
 		}
 		if _, ok := source.Snapshot("ext__spec_cycle__missing"); ok {
 			t.Fatal("Snapshot(unknown id) ok = true, want false")
+		}
+	})
+
+	t.Run("Should project the registry once for all requested schemas", func(t *testing.T) {
+		t.Parallel()
+
+		first := loopToolSchemaDescriptor(t)
+		second := first
+		second.ID = toolspkg.ToolID("ext__spec_cycle__second")
+		listCalls := 0
+		getCalls := 0
+		source := newLoopToolSchemaSource(context.Background(), loopToolSchemaRegistry{
+			views: map[toolspkg.ToolID]toolspkg.ToolView{
+				first.ID:  {Descriptor: first},
+				second.ID: {Descriptor: second},
+			},
+			listCalls: &listCalls,
+			getCalls:  &getCalls,
+		})
+
+		for _, id := range []toolspkg.ToolID{first.ID, second.ID, first.ID} {
+			if _, ok := source.Snapshot(id.String()); !ok {
+				t.Fatalf("Snapshot(%q) ok = false, want true", id)
+			}
+		}
+		if got, want := listCalls, 1; got != want {
+			t.Fatalf("registry List calls = %d, want %d", got, want)
+		}
+		if got, want := getCalls, 0; got != want {
+			t.Fatalf("registry Get calls = %d, want %d", got, want)
 		}
 	})
 
@@ -135,6 +167,134 @@ func TestLoopToolSchemaSource(t *testing.T) {
 			t.Fatal("Compile(implement-tasks) missing implement collection template")
 		}
 	})
+
+	t.Run("Should call only tools owned by the extension that installed the Loop", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			owner       = "release-automation"
+			ownToolID   = toolspkg.ToolID("ext__release_automation__prepare")
+			otherToolID = toolspkg.ToolID("ext__artifact_store__write")
+		)
+		ownCalled := false
+		ownProvider, err := toolspkg.NewNativeProvider(
+			toolspkg.SourceRef{Kind: toolspkg.SourceExtension, Owner: owner},
+			toolspkg.NativeTool{
+				Descriptor: loopExtensionActionDescriptor(ownToolID, owner),
+				Call: func(context.Context, toolspkg.Scope, toolspkg.CallRequest) (toolspkg.ToolResult, error) {
+					ownCalled = true
+					return toolspkg.ToolResult{Structured: json.RawMessage(`{"status":"prepared"}`)}, nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("NewNativeProvider(own extension) error = %v", err)
+		}
+		otherCalled := false
+		otherProvider, err := toolspkg.NewNativeProvider(
+			toolspkg.SourceRef{Kind: toolspkg.SourceExtension, Owner: "artifact-store"},
+			toolspkg.NativeTool{
+				Descriptor: loopExtensionActionDescriptor(otherToolID, "artifact-store"),
+				Call: func(context.Context, toolspkg.Scope, toolspkg.CallRequest) (toolspkg.ToolResult, error) {
+					otherCalled = true
+					return toolspkg.ToolResult{Structured: json.RawMessage(`{"status":"written"}`)}, nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("NewNativeProvider(foreign extension) error = %v", err)
+		}
+		cfg := testConfig(t, testHomePaths(t))
+		cfg.Permissions.Mode = compozyconfig.PermissionModeApproveAll
+		cfg.Tools.Policy.ExternalDefault = compozyconfig.ToolsExternalDefaultDisabled
+		policy, err := newNativeToolPolicyResolver(nativeToolPolicyResolverDeps{
+			Config:            &cfg,
+			ApprovalAvailable: true,
+		})
+		if err != nil {
+			t.Fatalf("newNativeToolPolicyResolver() error = %v", err)
+		}
+		registry, err := toolspkg.NewRegistry(
+			toolspkg.WithProviders(ownProvider, otherProvider),
+			toolspkg.WithPolicyInputResolver(policy, toolspkg.ToolsetCatalog{}),
+		)
+		if err != nil {
+			t.Fatalf("NewRegistry() error = %v", err)
+		}
+		actions, err := looppkg.NewActionRegistry(registry)
+		if err != nil {
+			t.Fatalf("NewActionRegistry() error = %v", err)
+		}
+		scope := toolspkg.Scope{ActorKind: string(workspaceaccess.ActorDaemon)}
+		ctx := toolspkg.WithTrustedExtensionOwner(t.Context(), owner)
+		ownerGrant := toolspkg.SourceGrant{Kind: toolspkg.SourceExtension, Owner: owner}
+		inputs, err := policy.Resolve(ctx, scope)
+		if err != nil {
+			t.Fatalf("Resolve(loop-owned policy) error = %v", err)
+		}
+		if !sourceGrantExists(inputs.AllowSources, ownerGrant) {
+			t.Fatalf("loop-owned allow sources = %#v, want %#v", inputs.AllowSources, ownerGrant)
+		}
+		if sourceGrantExists(inputs.TrustedSources, ownerGrant) {
+			t.Fatalf("loop-owned trusted sources = %#v, want no permission bypass", inputs.TrustedSources)
+		}
+
+		executor, err := actions.Resolve(ctx, scope, ownToolID.String())
+		if err != nil {
+			t.Fatalf("Resolve(own extension tool) error = %v", err)
+		}
+		_, err = executor.Execute(ctx, loopActionNode(ownToolID), looppkg.ActionExecutionInput{
+			ToolScope: scope,
+		})
+		if err != nil {
+			t.Fatalf("Execute(own extension tool) error = %v", err)
+		}
+		if !ownCalled {
+			t.Fatal("own extension tool called = false, want true")
+		}
+
+		_, err = actions.Resolve(ctx, scope, otherToolID.String())
+		if !errors.Is(err, looppkg.ErrActionUnknownKind) {
+			t.Fatalf("Resolve(foreign extension tool) error = %v, want ErrActionUnknownKind", err)
+		}
+		if otherCalled {
+			t.Fatal("foreign extension tool called = true, want false")
+		}
+
+		untrustedScope := toolspkg.Scope{ActorKind: string(workspaceaccess.ActorAgentSession)}
+		_, err = actions.Resolve(ctx, untrustedScope, ownToolID.String())
+		if !errors.Is(err, looppkg.ErrActionUnknownKind) {
+			t.Fatalf("Resolve(agent-forged owner) error = %v, want ErrActionUnknownKind", err)
+		}
+	})
+}
+
+func loopExtensionActionDescriptor(id toolspkg.ToolID, owner string) toolspkg.Descriptor {
+	return toolspkg.Descriptor{
+		ID:               id,
+		ToolPresentation: toolspkg.NewToolPresentation("Prepare release", "", ""),
+		Description:      "Prepare a release artifact.",
+		InputSchema:      json.RawMessage(`{"type":"object","additionalProperties":false}`),
+		OutputSchema: json.RawMessage(
+			`{"type":"object","required":["status"],"properties":{"status":{"type":"string"}}}`,
+		),
+		Backend: toolspkg.BackendRef{
+			Kind:       toolspkg.BackendNativeGo,
+			NativeName: "prepare",
+		},
+		Source:     toolspkg.SourceRef{Kind: toolspkg.SourceExtension, Owner: owner},
+		Visibility: toolspkg.VisibilitySession,
+		Risk:       toolspkg.RiskRead,
+		ReadOnly:   true,
+	}
+}
+
+func loopActionNode(id toolspkg.ToolID) looppkgdsl.Node {
+	return looppkgdsl.Node{
+		ID:    "prepare",
+		Class: looppkgdsl.NodeClassAction,
+		Kind:  id.String(),
+	}
 }
 
 type specCycleLoopSchemaRuntime struct {
@@ -272,10 +432,15 @@ func extensionToolPolicyAllowAll() toolspkg.PolicyInputs {
 }
 
 type loopToolSchemaRegistry struct {
-	views map[toolspkg.ToolID]toolspkg.ToolView
+	views     map[toolspkg.ToolID]toolspkg.ToolView
+	listCalls *int
+	getCalls  *int
 }
 
 func (r loopToolSchemaRegistry) List(context.Context, toolspkg.Scope) ([]toolspkg.ToolView, error) {
+	if r.listCalls != nil {
+		*r.listCalls++
+	}
 	views := make([]toolspkg.ToolView, 0, len(r.views))
 	for id := range r.views {
 		views = append(views, r.views[id])
@@ -296,6 +461,9 @@ func (r loopToolSchemaRegistry) Get(
 	_ toolspkg.Scope,
 	id toolspkg.ToolID,
 ) (toolspkg.ToolView, error) {
+	if r.getCalls != nil {
+		*r.getCalls++
+	}
 	if err := ctx.Err(); err != nil {
 		return toolspkg.ToolView{}, err
 	}

--- a/internal/daemon/task_runtime_boot_roles.go
+++ b/internal/daemon/task_runtime_boot_roles.go
@@ -391,7 +391,13 @@ func (r *daemonLoopDefinitionResolver) ResolveLoop(
 		if err != nil {
 			return nil, err
 		}
-		return r.compilerFactory(ctx).Compile(definition)
+		resolved, err := r.compilerFactory(ctx).Compile(definition)
+		if err != nil {
+			return nil, err
+		}
+		resolved.InstalledFromExtension = strings.TrimSpace(record.Spec.InstalledFromExtension)
+		resolved.ExtensionOwner = strings.TrimSpace(record.Spec.ExtensionOwner)
+		return resolved, nil
 	}
 	return nil, fmt.Errorf("%w: loop definition %q not found", looppkg.ErrDefinitionNotFound, trimmedName)
 }

--- a/internal/daemon/tool_policy_resolver.go
+++ b/internal/daemon/tool_policy_resolver.go
@@ -100,6 +100,9 @@ func (r *nativeToolPolicyResolver) Resolve(ctx context.Context, scope toolspkg.S
 			return toolspkg.PolicyInputs{}, err
 		}
 	}
+	if err := applyLoopExtensionOwnerGrant(ctx, &inputs, resolvedScope); err != nil {
+		return toolspkg.PolicyInputs{}, err
+	}
 	if err := applySessionToolPolicy(&inputs, info); err != nil {
 		return toolspkg.PolicyInputs{}, err
 	}
@@ -178,6 +181,28 @@ func sourceGrantExists(grants []toolspkg.SourceGrant, target toolspkg.SourceGran
 		}
 	}
 	return false
+}
+
+func applyLoopExtensionOwnerGrant(
+	ctx context.Context,
+	inputs *toolspkg.PolicyInputs,
+	scope toolspkg.Scope,
+) error {
+	if workspaceaccess.ActorKind(scope.ActorKind) != workspaceaccess.ActorDaemon {
+		return nil
+	}
+	owner := toolspkg.TrustedExtensionOwner(ctx)
+	if owner == "" {
+		return nil
+	}
+	grant := toolspkg.SourceGrant{Kind: toolspkg.SourceExtension, Owner: owner}
+	if err := grant.Validate("loop_extension_owner"); err != nil {
+		return err
+	}
+	if !sourceGrantExists(inputs.AllowSources, grant) {
+		inputs.AllowSources = append(inputs.AllowSources, grant)
+	}
+	return nil
 }
 
 func (r *nativeToolPolicyResolver) sessionInfo(

--- a/internal/extension/loop_resources_test.go
+++ b/internal/extension/loop_resources_test.go
@@ -39,12 +39,14 @@ func TestLoopResourcesShouldLoadFromManifestResources(t *testing.T) {
 			t.Fatalf("normalized.Loops[0] = %q, want %q", got, want)
 		}
 
+		registrySlug := "acme/market-ext"
 		manager := &Manager{}
 		loops, err := manager.loadLoopResources(&managedExtension{
 			rootDir: root,
 			info: ExtensionInfo{
-				Name:   "market-ext",
-				Source: SourceMarketplace,
+				Name:         "market-ext",
+				Source:       SourceMarketplace,
+				RegistrySlug: &registrySlug,
 			},
 			manifest: &Manifest{
 				Resources: normalized,
@@ -62,8 +64,11 @@ func TestLoopResourcesShouldLoadFromManifestResources(t *testing.T) {
 		if got, want := loops[0].Source, looppkg.SourceMarketplace; got != want {
 			t.Fatalf("loops[0].Source = %q, want %q", got, want)
 		}
-		if got, want := loops[0].InstalledFromExtension, "market-ext"; got != want {
+		if got, want := loops[0].InstalledFromExtension, registrySlug; got != want {
 			t.Fatalf("loops[0].InstalledFromExtension = %q, want %q", got, want)
+		}
+		if got, want := loops[0].ExtensionOwner, "market-ext"; got != want {
+			t.Fatalf("loops[0].ExtensionOwner = %q, want %q", got, want)
 		}
 	})
 

--- a/internal/extension/manager_resource_loading.go
+++ b/internal/extension/manager_resource_loading.go
@@ -154,6 +154,7 @@ func (m *Manager) loadLoopResources(ext *managedExtension) ([]looppkg.ResourceSp
 			if err != nil {
 				return nil, err
 			}
+			spec.ExtensionOwner = strings.TrimSpace(ext.info.Name)
 			if dirName := filepath.Base(filepath.Dir(file)); dirName != spec.Name {
 				return nil, fmt.Errorf(
 					"loop resource %q directory name %q does not match loop name %q",

--- a/internal/extension/registry_install.go
+++ b/internal/extension/registry_install.go
@@ -1,7 +1,7 @@
 package extensionpkg
 
 import (
-	"database/sql"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -225,62 +225,53 @@ func (r *Registry) persistInstalledInfo(
 	info ExtensionInfo,
 	sourceText string,
 	replaceExisting bool,
-) (resultErr error) {
+) error {
 	encoded, err := marshalInstalledInfoFields(info)
 	if err != nil {
 		return err
 	}
 
 	query := installedInfoPersistQuery(replaceExisting)
-
-	tx, err := r.db.BeginTx(registryContext(), nil)
-	if err != nil {
-		return fmt.Errorf("extension: begin persist %q: %w", info.Name, err)
-	}
-	defer func() {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
-			resultErr = errors.Join(resultErr, fmt.Errorf("extension: roll back persist: %w", rollbackErr))
-		}
-	}()
-
-	var existed bool
-	if err := tx.QueryRowContext(
-		registryContext(),
-		`SELECT EXISTS(SELECT 1 FROM extensions WHERE name = ?)`,
-		info.Name,
-	).Scan(&existed); err != nil {
-		return fmt.Errorf("extension: check existing install %q: %w", info.Name, err)
-	}
-
-	_, err = tx.ExecContext(
-		registryContext(), query, info.Name, info.Version, sourceText, info.ManifestPath,
-		string(normalizeExtensionFormat(info.Format)), string(encoded.diagnostics),
-		store.FormatTimestamp(info.InstalledAt), string(encoded.capabilities), string(encoded.permissions),
-		info.Checksum, info.lifecycleToken,
-		nullableStringValue(info.RegistrySlug), nullableStringValue(info.RegistryName),
-		nullableStringValue(info.RemoteVersion), string(encoded.provenance),
-		strings.TrimSpace(info.NetworkRequirementDigest), nullableRegistryString(info.NetworkConfirmedBy),
-		nullableRegistryTime(info.NetworkConfirmedAt),
-	)
-	if err != nil {
-		if replaceExisting {
-			return fmt.Errorf("extension: persist %q: %w", info.Name, err)
-		}
-		return mapRegistryConstraintError(err, info.Name)
-	}
-	if !existed && !info.Enabled {
-		if _, err := tx.ExecContext(
-			registryContext(),
-			`INSERT INTO extension_profile_enablement (extension_name, profile_id, enabled) VALUES (?, ?, 0)`,
+	ctx := registryContext()
+	if err := store.ExecuteWrite(ctx, r.db, func(ctx context.Context, tx *store.WriteTx) error {
+		var existed bool
+		if err := tx.QueryRowContext(
+			ctx,
+			`SELECT EXISTS(SELECT 1 FROM extensions WHERE name = ?)`,
 			info.Name,
-			store.DefaultProfileID,
-		); err != nil {
-			return fmt.Errorf("extension: persist default-profile enablement for %q: %w", info.Name, err)
+		).Scan(&existed); err != nil {
+			return fmt.Errorf("extension: check existing install %q: %w", info.Name, err)
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("extension: commit persist %q: %w", info.Name, err)
+
+		_, execErr := tx.ExecContext(
+			ctx, query, info.Name, info.Version, sourceText, info.ManifestPath,
+			string(normalizeExtensionFormat(info.Format)), string(encoded.diagnostics),
+			store.FormatTimestamp(info.InstalledAt), string(encoded.capabilities), string(encoded.permissions),
+			info.Checksum, info.lifecycleToken,
+			nullableStringValue(info.RegistrySlug), nullableStringValue(info.RegistryName),
+			nullableStringValue(info.RemoteVersion), string(encoded.provenance),
+			strings.TrimSpace(info.NetworkRequirementDigest), nullableRegistryString(info.NetworkConfirmedBy),
+			nullableRegistryTime(info.NetworkConfirmedAt),
+		)
+		if execErr != nil {
+			if replaceExisting {
+				return fmt.Errorf("extension: persist %q: %w", info.Name, execErr)
+			}
+			return mapRegistryConstraintError(execErr, info.Name)
+		}
+		if !existed && !info.Enabled {
+			if _, err := tx.ExecContext(
+				ctx,
+				`INSERT INTO extension_profile_enablement (extension_name, profile_id, enabled) VALUES (?, ?, 0)`,
+				info.Name,
+				store.DefaultProfileID,
+			); err != nil {
+				return fmt.Errorf("extension: persist default-profile enablement for %q: %w", info.Name, err)
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	r.invalidateEnabledBundledNames()
 	return nil

--- a/internal/extension/registry_lifecycle.go
+++ b/internal/extension/registry_lifecycle.go
@@ -1,6 +1,7 @@
 package extensionpkg
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -47,7 +48,7 @@ func (r *Registry) IsEnabledForProfile(name string, profileID string) (bool, err
 }
 
 // SetEnabledForProfile persists only disabled exceptions; enabling removes the row.
-func (r *Registry) SetEnabledForProfile(name string, profileID string, enabled bool) (resultErr error) {
+func (r *Registry) SetEnabledForProfile(name string, profileID string, enabled bool) error {
 	if err := r.checkReady("update extension enabled state"); err != nil {
 		return err
 	}
@@ -68,63 +69,56 @@ func (r *Registry) SetEnabledForProfile(name string, profileID string, enabled b
 			return fmt.Errorf("extension: generate lifecycle token for %q: %w", trimmedName, err)
 		}
 	}
-	tx, err := r.db.BeginTx(registryContext(), nil)
-	if err != nil {
-		return fmt.Errorf("extension: begin enabled-state update for %q: %w", trimmedName, err)
-	}
-	defer func() {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
-			resultErr = errors.Join(resultErr, fmt.Errorf("extension: roll back enabled-state update: %w", rollbackErr))
+	ctx := registryContext()
+	if err := store.ExecuteWrite(ctx, r.db, func(ctx context.Context, tx *store.WriteTx) error {
+		var exists bool
+		if err := tx.QueryRowContext(
+			ctx,
+			`SELECT EXISTS(SELECT 1 FROM extensions WHERE name = ?)
+			     OR EXISTS(SELECT 1 FROM extension_dev_links WHERE extension_name = ?)`,
+			trimmedName,
+			trimmedName,
+		).Scan(&exists); err != nil {
+			return fmt.Errorf("extension: check enabled-state target %q: %w", trimmedName, err)
 		}
-	}()
-
-	var exists bool
-	if err := tx.QueryRowContext(
-		registryContext(),
-		`SELECT EXISTS(SELECT 1 FROM extensions WHERE name = ?)
-		     OR EXISTS(SELECT 1 FROM extension_dev_links WHERE extension_name = ?)`,
-		trimmedName,
-		trimmedName,
-	).Scan(&exists); err != nil {
-		return fmt.Errorf("extension: check enabled-state target %q: %w", trimmedName, err)
-	}
-	if !exists {
-		return &ExtensionNotFoundError{Name: trimmedName}
-	}
-	if rotateLifecycle {
-		if _, err := tx.ExecContext(
-			registryContext(),
-			`UPDATE extensions SET lifecycle_token = ? WHERE name = ?`,
-			nextLifecycleToken,
-			trimmedName,
-		); err != nil {
-			return fmt.Errorf("extension: rotate lifecycle token for %q: %w", trimmedName, err)
+		if !exists {
+			return &ExtensionNotFoundError{Name: trimmedName}
 		}
-	}
+		if rotateLifecycle {
+			if _, err := tx.ExecContext(
+				ctx,
+				`UPDATE extensions SET lifecycle_token = ? WHERE name = ?`,
+				nextLifecycleToken,
+				trimmedName,
+			); err != nil {
+				return fmt.Errorf("extension: rotate lifecycle token for %q: %w", trimmedName, err)
+			}
+		}
 
-	if enabled {
-		_, err = tx.ExecContext(
-			registryContext(),
-			`DELETE FROM extension_profile_enablement WHERE extension_name = ? AND profile_id = ?`,
-			trimmedName,
-			profileID,
-		)
-	} else {
-		_, err = tx.ExecContext(
-			registryContext(),
-			`INSERT INTO extension_profile_enablement (extension_name, profile_id, enabled)
-			 VALUES (?, ?, 0)
-			 ON CONFLICT(extension_name, profile_id) DO UPDATE SET enabled = 0`,
-			trimmedName,
-			profileID,
-		)
-	}
-	if err != nil {
-		return fmt.Errorf("extension: update enabled state for %q: %w", trimmedName, err)
-	}
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("extension: commit enabled-state update for %q: %w", trimmedName, err)
+		var updateErr error
+		if enabled {
+			_, updateErr = tx.ExecContext(
+				ctx,
+				`DELETE FROM extension_profile_enablement WHERE extension_name = ? AND profile_id = ?`,
+				trimmedName,
+				profileID,
+			)
+		} else {
+			_, updateErr = tx.ExecContext(
+				ctx,
+				`INSERT INTO extension_profile_enablement (extension_name, profile_id, enabled)
+				 VALUES (?, ?, 0)
+				 ON CONFLICT(extension_name, profile_id) DO UPDATE SET enabled = 0`,
+				trimmedName,
+				profileID,
+			)
+		}
+		if updateErr != nil {
+			return fmt.Errorf("extension: update enabled state for %q: %w", trimmedName, updateErr)
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	r.invalidateEnabledBundledNames()
 	return nil
@@ -135,7 +129,7 @@ func (r *Registry) SetEnabledForProfile(name string, profileID string, enabled b
 func (r *Registry) DisableIfLifecycleToken(
 	name string,
 	expectedToken string,
-) (_ bool, resultErr error) {
+) (bool, error) {
 	if err := r.checkReady("conditionally disable extension"); err != nil {
 		return false, err
 	}
@@ -147,49 +141,44 @@ func (r *Registry) DisableIfLifecycleToken(
 	if err != nil {
 		return false, fmt.Errorf("extension: generate lifecycle token for %q: %w", trimmedName, err)
 	}
-	tx, err := r.db.BeginTx(registryContext(), nil)
-	if err != nil {
-		return false, fmt.Errorf("extension: begin conditional disable for %q: %w", trimmedName, err)
-	}
-	defer func() {
-		rollbackErr := tx.Rollback()
-		if rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
-			resultErr = errors.Join(
-				resultErr,
-				fmt.Errorf("extension: roll back conditional disable: %w", rollbackErr),
-			)
+	disabled := false
+	ctx := registryContext()
+	if err := store.ExecuteWrite(ctx, r.db, func(ctx context.Context, tx *store.WriteTx) error {
+		disabled = false
+		result, err := tx.ExecContext(
+			ctx,
+			`UPDATE extensions SET lifecycle_token = ? WHERE name = ? AND lifecycle_token = ?`,
+			nextToken,
+			trimmedName,
+			strings.TrimSpace(expectedToken),
+		)
+		if err != nil {
+			return fmt.Errorf("extension: conditionally fence %q: %w", trimmedName, err)
 		}
-	}()
-
-	result, err := tx.ExecContext(
-		registryContext(),
-		`UPDATE extensions SET lifecycle_token = ? WHERE name = ? AND lifecycle_token = ?`,
-		nextToken,
-		trimmedName,
-		strings.TrimSpace(expectedToken),
-	)
-	if err != nil {
-		return false, fmt.Errorf("extension: conditionally fence %q: %w", trimmedName, err)
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("extension: inspect conditional disable for %q: %w", trimmedName, err)
+		}
+		if rows == 0 {
+			return nil
+		}
+		if _, err := tx.ExecContext(
+			ctx,
+			`INSERT INTO extension_profile_enablement (extension_name, profile_id, enabled)
+			 VALUES (?, ?, 0)
+			 ON CONFLICT(extension_name, profile_id) DO UPDATE SET enabled = 0`,
+			trimmedName,
+			store.DefaultProfileID,
+		); err != nil {
+			return fmt.Errorf("extension: disable default profile for %q: %w", trimmedName, err)
+		}
+		disabled = true
+		return nil
+	}); err != nil {
+		return false, err
 	}
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return false, fmt.Errorf("extension: inspect conditional disable for %q: %w", trimmedName, err)
-	}
-	if rows == 0 {
+	if !disabled {
 		return false, nil
-	}
-	if _, err := tx.ExecContext(
-		registryContext(),
-		`INSERT INTO extension_profile_enablement (extension_name, profile_id, enabled)
-		 VALUES (?, ?, 0)
-		 ON CONFLICT(extension_name, profile_id) DO UPDATE SET enabled = 0`,
-		trimmedName,
-		store.DefaultProfileID,
-	); err != nil {
-		return false, fmt.Errorf("extension: disable default profile for %q: %w", trimmedName, err)
-	}
-	if err := tx.Commit(); err != nil {
-		return false, fmt.Errorf("extension: commit conditional disable for %q: %w", trimmedName, err)
 	}
 	r.invalidateEnabledBundledNames()
 	return true, nil

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -106,68 +106,13 @@ func TestRegistryInstallRetriesBusyPersistence(t *testing.T) {
 	t.Run("Should persist after a competing writer releases the database", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := testutil.Context(t)
 		env := newRegistryTestEnv(t)
-		env.db.SetMaxOpenConns(1)
-		env.db.SetMaxIdleConns(1)
-		if _, err := env.db.ExecContext(ctx, `PRAGMA busy_timeout = 1`); err != nil {
-			t.Fatalf("set registry busy timeout: %v", err)
-		}
-
-		var sequence int
-		var databaseName string
-		var databasePath string
-		if err := env.db.QueryRowContext(ctx, `PRAGMA database_list`).Scan(
-			&sequence,
-			&databaseName,
-			&databasePath,
-		); err != nil {
-			t.Fatalf("read registry database path: %v", err)
-		}
-		locker, err := store.OpenSQLiteDatabase(ctx, databasePath, nil)
-		if err != nil {
-			t.Fatalf("OpenSQLiteDatabase(locker) error = %v", err)
-		}
-		t.Cleanup(func() {
-			if err := locker.Close(); err != nil {
-				t.Errorf("locker.Close() error = %v", err)
-			}
-		})
-		lockConn, err := locker.Conn(ctx)
-		if err != nil {
-			t.Fatalf("locker.Conn() error = %v", err)
-		}
-		t.Cleanup(func() {
-			if err := lockConn.Close(); err != nil {
-				t.Errorf("lockConn.Close() error = %v", err)
-			}
-		})
-		if _, err := lockConn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
-			t.Fatalf("BEGIN IMMEDIATE locker error = %v", err)
-		}
-
-		releaseDone := make(chan error, 1)
-		timer := time.AfterFunc(100*time.Millisecond, func() {
-			_, commitErr := lockConn.ExecContext(ctx, `COMMIT`)
-			releaseDone <- commitErr
-		})
-		t.Cleanup(func() {
-			if timer.Stop() {
-				if _, err := lockConn.ExecContext(ctx, `COMMIT`); err != nil {
-					t.Errorf("manual lock release error = %v", err)
-				}
-				return
-			}
-			if err := <-releaseDone; err != nil {
-				t.Errorf("timed lock release error = %v", err)
-			}
-		})
-
 		dir, manifest, checksum := createRegistryTestExtension(
 			t,
 			"busy-persist-registry",
 			registryManifestOptions{},
 		)
+		holdTransientRegistryWriteLock(t, env.db)
 		if err := env.registry.Install(manifest, dir, checksum); err != nil {
 			t.Fatalf("Install() error = %v", err)
 		}
@@ -812,6 +757,37 @@ func TestRegistryEnableAndDisable(t *testing.T) {
 	if !enabled.Enabled {
 		t.Fatal("Enabled after Enable() = false, want true")
 	}
+}
+
+// Invariant: a transient global-store writer cannot make extension enablement fail.
+// Owner: extension registry enablement persistence.
+// Canonical suite: extension registry tests.
+func TestRegistrySetEnabledForProfileRetriesBusyPersistence(t *testing.T) {
+	t.Run("Should disable after a competing writer releases the database", func(t *testing.T) {
+		t.Parallel()
+
+		env := newRegistryTestEnv(t)
+		dir, manifest, checksum := createRegistryTestExtension(
+			t,
+			"busy-enablement-registry",
+			registryManifestOptions{},
+		)
+		if err := env.registry.Install(manifest, dir, checksum); err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+
+		holdTransientRegistryWriteLock(t, env.db)
+		if err := env.registry.Disable(manifest.Name); err != nil {
+			t.Fatalf("Disable() error = %v", err)
+		}
+		enabled, err := env.registry.IsEnabledForProfile(manifest.Name, store.DefaultProfileID)
+		if err != nil {
+			t.Fatalf("IsEnabledForProfile() error = %v", err)
+		}
+		if enabled {
+			t.Fatal("IsEnabledForProfile() = true, want false")
+		}
+	})
 }
 
 // Invariant: extension enablement is an exception per profile; absence means
@@ -1822,6 +1798,66 @@ func newRegistryTestEnv(t *testing.T) registryTestEnv {
 		registry:    registry,
 		installedAt: installedAt,
 	}
+}
+
+func holdTransientRegistryWriteLock(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	ctx := testutil.Context(t)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if _, err := db.ExecContext(ctx, `PRAGMA busy_timeout = 1`); err != nil {
+		t.Fatalf("set registry busy timeout: %v", err)
+	}
+
+	var sequence int
+	var databaseName string
+	var databasePath string
+	if err := db.QueryRowContext(ctx, `PRAGMA database_list`).Scan(
+		&sequence,
+		&databaseName,
+		&databasePath,
+	); err != nil {
+		t.Fatalf("read registry database path: %v", err)
+	}
+	locker, err := store.OpenSQLiteDatabase(ctx, databasePath, nil)
+	if err != nil {
+		t.Fatalf("OpenSQLiteDatabase(locker) error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := locker.Close(); err != nil {
+			t.Errorf("locker.Close() error = %v", err)
+		}
+	})
+	lockConn, err := locker.Conn(ctx)
+	if err != nil {
+		t.Fatalf("locker.Conn() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := lockConn.Close(); err != nil {
+			t.Errorf("lockConn.Close() error = %v", err)
+		}
+	})
+	if _, err := lockConn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE locker error = %v", err)
+	}
+
+	releaseDone := make(chan error, 1)
+	timer := time.AfterFunc(100*time.Millisecond, func() {
+		_, commitErr := lockConn.ExecContext(ctx, `COMMIT`)
+		releaseDone <- commitErr
+	})
+	t.Cleanup(func() {
+		if timer.Stop() {
+			if _, err := lockConn.ExecContext(ctx, `COMMIT`); err != nil {
+				t.Errorf("manual lock release error = %v", err)
+			}
+			return
+		}
+		if err := <-releaseDone; err != nil {
+			t.Errorf("timed lock release error = %v", err)
+		}
+	})
 }
 
 func insertActiveRegistryProfile(t *testing.T, env registryTestEnv, name string) string {

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -99,6 +99,84 @@ func TestRegistryInstallPersistsExtension(t *testing.T) {
 	}
 }
 
+// Invariant: a transient global-store writer cannot make extension installation fail.
+// Owner: extension registry persistence.
+// Canonical suite: extension registry tests.
+func TestRegistryInstallRetriesBusyPersistence(t *testing.T) {
+	t.Run("Should persist after a competing writer releases the database", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := testutil.Context(t)
+		env := newRegistryTestEnv(t)
+		env.db.SetMaxOpenConns(1)
+		env.db.SetMaxIdleConns(1)
+		if _, err := env.db.ExecContext(ctx, `PRAGMA busy_timeout = 1`); err != nil {
+			t.Fatalf("set registry busy timeout: %v", err)
+		}
+
+		var sequence int
+		var databaseName string
+		var databasePath string
+		if err := env.db.QueryRowContext(ctx, `PRAGMA database_list`).Scan(
+			&sequence,
+			&databaseName,
+			&databasePath,
+		); err != nil {
+			t.Fatalf("read registry database path: %v", err)
+		}
+		locker, err := store.OpenSQLiteDatabase(ctx, databasePath, nil)
+		if err != nil {
+			t.Fatalf("OpenSQLiteDatabase(locker) error = %v", err)
+		}
+		t.Cleanup(func() {
+			if err := locker.Close(); err != nil {
+				t.Errorf("locker.Close() error = %v", err)
+			}
+		})
+		lockConn, err := locker.Conn(ctx)
+		if err != nil {
+			t.Fatalf("locker.Conn() error = %v", err)
+		}
+		t.Cleanup(func() {
+			if err := lockConn.Close(); err != nil {
+				t.Errorf("lockConn.Close() error = %v", err)
+			}
+		})
+		if _, err := lockConn.ExecContext(ctx, `BEGIN IMMEDIATE`); err != nil {
+			t.Fatalf("BEGIN IMMEDIATE locker error = %v", err)
+		}
+
+		releaseDone := make(chan error, 1)
+		timer := time.AfterFunc(100*time.Millisecond, func() {
+			_, commitErr := lockConn.ExecContext(ctx, `COMMIT`)
+			releaseDone <- commitErr
+		})
+		t.Cleanup(func() {
+			if timer.Stop() {
+				if _, err := lockConn.ExecContext(ctx, `COMMIT`); err != nil {
+					t.Errorf("manual lock release error = %v", err)
+				}
+				return
+			}
+			if err := <-releaseDone; err != nil {
+				t.Errorf("timed lock release error = %v", err)
+			}
+		})
+
+		dir, manifest, checksum := createRegistryTestExtension(
+			t,
+			"busy-persist-registry",
+			registryManifestOptions{},
+		)
+		if err := env.registry.Install(manifest, dir, checksum); err != nil {
+			t.Fatalf("Install() error = %v", err)
+		}
+		if _, err := env.registry.Get(manifest.Name); err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+	})
+}
+
 // Invariant: delayed cleanup from an older extension lifecycle cannot disable
 // a replacement lifecycle for the same registry name.
 // Owner: extension registry persistence.

--- a/internal/loop/compiler.go
+++ b/internal/loop/compiler.go
@@ -61,8 +61,12 @@ func (e *LintFailedError) Error() string {
 
 // ResolvedDefinition is the publish-time artifact hydrated by runtime execution.
 type ResolvedDefinition struct {
-	Definition           dsl.Definition
-	DefinitionVersion    int
+	Definition        dsl.Definition
+	DefinitionVersion int
+	// InstalledFromExtension is daemon-owned resource provenance, never authored Loop YAML.
+	InstalledFromExtension string
+	// ExtensionOwner is the daemon-owned canonical manifest identity used for policy grants.
+	ExtensionOwner       string
 	Templates            map[string]*refs.Template
 	Conditions           map[string]*refs.Condition
 	ToolSchemas          map[string]ToolSchemaSnapshot

--- a/internal/loop/coordinator_action.go
+++ b/internal/loop/coordinator_action.go
@@ -52,6 +52,7 @@ func (r *CoordinatorRunner) ExecuteActionRun(
 	if err != nil {
 		return task.RunResult{}, err
 	}
+	ctx = actionContextWithExtensionOwner(ctx, actionCtx.resolved)
 	outputs, err := r.readActionGenerationOutputs(ctx, &actionCtx)
 	if err != nil {
 		return task.RunResult{}, err
@@ -434,6 +435,13 @@ func actionNodeForRun(graph dsl.Graph, nodeID string) (dsl.Node, error) {
 		)
 	}
 	return node, nil
+}
+
+func actionContextWithExtensionOwner(ctx context.Context, resolved *ResolvedDefinition) context.Context {
+	if resolved == nil {
+		return ctx
+	}
+	return tools.WithTrustedExtensionOwner(ctx, resolved.ExtensionOwner)
 }
 
 func actionToolScope(run Run, actor task.ActorContext) tools.Scope {

--- a/internal/loop/coordinator_snapshot_test.go
+++ b/internal/loop/coordinator_snapshot_test.go
@@ -22,6 +22,8 @@ func TestCoordinatorRunnerShouldExecutePinnedDefinitionSnapshot(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Compile() error = %v", err)
 		}
+		resolved.InstalledFromExtension = "acme/release-automation"
+		resolved.ExtensionOwner = "release-automation"
 		effective := EffectiveConfig{
 			HumanGateEnabled:  true,
 			ReattemptStrategy: ReattemptFullBody,
@@ -49,6 +51,12 @@ func TestCoordinatorRunnerShouldExecutePinnedDefinitionSnapshot(t *testing.T) {
 		}
 		if !reflect.DeepEqual(hydrated.EffectiveConfig, effective) {
 			t.Fatalf("hydrated effective config = %#v, want %#v", hydrated.EffectiveConfig, effective)
+		}
+		if got, want := hydrated.InstalledFromExtension, "acme/release-automation"; got != want {
+			t.Fatalf("hydrated installed extension = %q, want %q", got, want)
+		}
+		if got, want := hydrated.ExtensionOwner, "release-automation"; got != want {
+			t.Fatalf("hydrated extension owner = %q, want %q", got, want)
 		}
 		if hydrated.Templates["start[0].input_mapping.slug"] == nil {
 			t.Fatal("hydrated trigger template is nil")

--- a/internal/loop/coordinator_test.go
+++ b/internal/loop/coordinator_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/compozy/compozy/internal/loop/dsl/refs"
 	"github.com/compozy/compozy/internal/loop/gate"
 	"github.com/compozy/compozy/internal/task"
+	"github.com/compozy/compozy/internal/tools"
 )
 
 func taskRunWithResult(run task.Run, result json.RawMessage) task.Run {
@@ -223,6 +224,20 @@ func TestCoordinatorRunnerShouldResolveFanOutFromWorkspaceDefaults(t *testing.T)
 
 func TestCoordinatorActionExecutionInputShouldCarryPinnedPolicyAndSessionProvenance(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Should carry the pinned extension owner only through trusted dispatch context", func(t *testing.T) {
+		t.Parallel()
+
+		resolved := resolvedCoordinatorDefinitionForTest(t, dsl.Definition{
+			Graph: dsl.Graph{},
+		})
+		resolved.InstalledFromExtension = "acme/release-automation"
+		resolved.ExtensionOwner = "release-automation"
+		ctx := actionContextWithExtensionOwner(t.Context(), resolved)
+		if got, want := tools.TrustedExtensionOwner(ctx), "release-automation"; got != want {
+			t.Fatalf("TrustedExtensionOwner() = %q, want %q", got, want)
+		}
+	})
 
 	t.Run("Should copy the Run context nudge ratio into every Goal action input", func(t *testing.T) {
 		t.Parallel()

--- a/internal/loop/coordinator_test.go
+++ b/internal/loop/coordinator_test.go
@@ -225,16 +225,59 @@ func TestCoordinatorRunnerShouldResolveFanOutFromWorkspaceDefaults(t *testing.T)
 func TestCoordinatorActionExecutionInputShouldCarryPinnedPolicyAndSessionProvenance(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should carry the pinned extension owner only through trusted dispatch context", func(t *testing.T) {
+	t.Run("Should carry the pinned extension owner through action execution", func(t *testing.T) {
 		t.Parallel()
 
+		const owner = "release-automation"
+		node := dsl.Node{ID: "goal", Class: dsl.NodeClassAction, Kind: string(dsl.ActionGoal)}
+		loopRun := Run{
+			ID: "looprun-extension-owner", WorkspaceID: "ws-extension-owner", Inputs: map[string]any{},
+			Origin: &RunOrigin{Kind: RunOriginCatalog},
+		}
+		coordinatorRun := controlCoordinatorRun(loopRun, 1)
+		capture := &recordingActionExecutor{}
+		actions, err := NewActionRegistry(
+			&internalActionRegistryFake{},
+			WithActionGoalExecutor(capture),
+		)
+		if err != nil {
+			t.Fatalf("NewActionRegistry() error = %v", err)
+		}
 		resolved := resolvedCoordinatorDefinitionForTest(t, dsl.Definition{
-			Graph: dsl.Graph{},
+			Graph: dsl.Graph{Nodes: []dsl.Node{node}},
 		})
-		resolved.InstalledFromExtension = "acme/release-automation"
-		resolved.ExtensionOwner = "release-automation"
-		ctx := actionContextWithExtensionOwner(t.Context(), resolved)
-		if got, want := tools.TrustedExtensionOwner(ctx), "release-automation"; got != want {
+		resolved.ExtensionOwner = owner
+		runner := newCoordinatorRunnerForTestWithResolvedDefinition(
+			t,
+			loopRun,
+			coordinatorRun,
+			nil,
+			coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{1: {
+				{
+					Generation: 1,
+					NodeID:     string(node.ID),
+					Status:     generationOutputRunning,
+					TaskRunID:  "run-extension-owner",
+				},
+			}}},
+			resolved,
+			WithCoordinatorActionRegistry(actions),
+		)
+		metadata, err := json.Marshal(coordinatorActionRunMetadata{
+			Generation: 1, NodeID: string(node.ID), Attempt: 1, GoalSegmentEpoch: 1,
+		})
+		if err != nil {
+			t.Fatalf("json.Marshal(action metadata) error = %v", err)
+		}
+		workerRun := task.Run{
+			ID: "run-extension-owner", RunKind: task.RunKindWorker, LoopRunID: string(loopRun.ID),
+			Status: task.TaskRunStatusClaimed, Metadata: metadata,
+		}
+
+		if _, err := runner.ExecuteActionRun(t.Context(), workerRun, task.ActorContext{}); err != nil {
+			t.Fatalf("ExecuteActionRun() error = %v", err)
+		}
+		if got, want := tools.TrustedExtensionOwner(capture.ctx), owner; got != want {
 			t.Fatalf("TrustedExtensionOwner() = %q, want %q", got, want)
 		}
 	})
@@ -5169,13 +5212,33 @@ func newCoordinatorRunnerForTestWithDefinition(
 	opts ...CoordinatorRunnerOption,
 ) *CoordinatorRunner {
 	t.Helper()
+	return newCoordinatorRunnerForTestWithResolvedDefinition(
+		t,
+		loopRun,
+		coordinatorRun,
+		runs,
+		outputs,
+		resolvedCoordinatorDefinitionForTest(t, def),
+		opts...,
+	)
+}
+
+func newCoordinatorRunnerForTestWithResolvedDefinition(
+	t *testing.T,
+	loopRun Run,
+	coordinatorRun task.Run,
+	runs map[string]task.Run,
+	outputs GenerationOutputReader,
+	resolved *ResolvedDefinition,
+	opts ...CoordinatorRunnerOption,
+) *CoordinatorRunner {
+	t.Helper()
 	if runs == nil {
 		runs = map[string]task.Run{coordinatorRun.ID: coordinatorRun}
 	}
-	resolved := resolvedCoordinatorDefinitionForTest(t, def)
 	definitionDefaults := LoopDefaults{
-		Delivery: definitionConfigLayer(def),
-		Watch:    definitionConfigLayer(def),
+		Delivery: definitionConfigLayer(resolved.Definition),
+		Watch:    definitionConfigLayer(resolved.Definition),
 	}
 	effective, err := ResolveEffectiveConfig(resolved, definitionDefaults, nil, LoopConfig{})
 	if err != nil {
@@ -5583,6 +5646,7 @@ type coordinatorRunnerTaskRunReader struct {
 }
 
 type recordingActionExecutor struct {
+	ctx     context.Context
 	input   ActionExecutionInput
 	execute func(dsl.Node, ActionExecutionInput) error
 }
@@ -5604,10 +5668,11 @@ func (s *coordinatorLoopStarter) Start(
 }
 
 func (e *recordingActionExecutor) Execute(
-	_ context.Context,
+	ctx context.Context,
 	node dsl.Node,
 	input ActionExecutionInput,
 ) (ActionRawResult, error) {
+	e.ctx = ctx
 	e.input = input
 	if e.execute != nil {
 		if err := e.execute(node, input); err != nil {

--- a/internal/loop/executed_definition_hydrate.go
+++ b/internal/loop/executed_definition_hydrate.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/compozy/compozy/internal/loop/dsl/refs"
 )
@@ -10,15 +11,17 @@ func hydrateExecutedDefinitionSnapshot(
 	envelope *executedDefinitionSnapshot,
 ) (*ResolvedDefinition, error) {
 	resolved := &ResolvedDefinition{
-		Definition:           envelope.Definition,
-		DefinitionVersion:    envelope.DefinitionVersion,
-		Templates:            map[string]*refs.Template{},
-		Conditions:           map[string]*refs.Condition{},
-		ToolSchemas:          cloneToolSchemaSnapshots(envelope.ToolSchemas),
-		WatchEventsContracts: cloneWatchEventsContracts(envelope.WatchEventsContracts),
-		Defaults:             envelope.Defaults,
-		EffectiveConfig:      cloneEffectiveConfig(envelope.EffectiveConfig),
-		compiled:             true,
+		Definition:             envelope.Definition,
+		DefinitionVersion:      envelope.DefinitionVersion,
+		InstalledFromExtension: strings.TrimSpace(envelope.InstalledFromExtension),
+		ExtensionOwner:         strings.TrimSpace(envelope.ExtensionOwner),
+		Templates:              map[string]*refs.Template{},
+		Conditions:             map[string]*refs.Condition{},
+		ToolSchemas:            cloneToolSchemaSnapshots(envelope.ToolSchemas),
+		WatchEventsContracts:   cloneWatchEventsContracts(envelope.WatchEventsContracts),
+		Defaults:               envelope.Defaults,
+		EffectiveConfig:        cloneEffectiveConfig(envelope.EffectiveConfig),
+		compiled:               true,
 	}
 	definition := resolved.Definition
 	definition.Normalize()

--- a/internal/loop/executed_definition_snapshot.go
+++ b/internal/loop/executed_definition_snapshot.go
@@ -17,15 +17,17 @@ import (
 const executedDefinitionSnapshotFormatVersion = 1
 
 type executedDefinitionSnapshot struct {
-	FormatVersion        int                                     `json:"format_version"`
-	DefinitionVersion    int                                     `json:"definition_version"`
-	Definition           dsl.Definition                          `json:"definition"`
-	Defaults             ResolvedDefaults                        `json:"resolved_defaults"`
-	EffectiveConfig      EffectiveConfig                         `json:"effective_config"`
-	ToolSchemas          map[string]ToolSchemaSnapshot           `json:"tool_schemas"`
-	WatchEventsContracts map[hooks.HookEvent]WatchEventsContract `json:"watch_events_contracts"`
-	TemplateSources      map[string]string                       `json:"template_sources"`
-	ConditionSources     map[string]string                       `json:"condition_sources"`
+	FormatVersion          int                                     `json:"format_version"`
+	DefinitionVersion      int                                     `json:"definition_version"`
+	InstalledFromExtension string                                  `json:"installed_from_extension,omitempty"`
+	ExtensionOwner         string                                  `json:"extension_owner,omitempty"`
+	Definition             dsl.Definition                          `json:"definition"`
+	Defaults               ResolvedDefaults                        `json:"resolved_defaults"`
+	EffectiveConfig        EffectiveConfig                         `json:"effective_config"`
+	ToolSchemas            map[string]ToolSchemaSnapshot           `json:"tool_schemas"`
+	WatchEventsContracts   map[hooks.HookEvent]WatchEventsContract `json:"watch_events_contracts"`
+	TemplateSources        map[string]string                       `json:"template_sources"`
+	ConditionSources       map[string]string                       `json:"condition_sources"`
 }
 
 // BuildExecutedDefinitionSnapshot creates the only content-addressed artifact executable after Start.
@@ -50,15 +52,17 @@ func BuildExecutedDefinitionSnapshot(
 		contracts = referencedWatchEventsContracts(definition, SupportedWatchEvents())
 	}
 	envelope := executedDefinitionSnapshot{
-		FormatVersion:        executedDefinitionSnapshotFormatVersion,
-		DefinitionVersion:    version,
-		Definition:           definition,
-		Defaults:             resolved.Defaults,
-		EffectiveConfig:      cloneEffectiveConfig(effective),
-		ToolSchemas:          cloneToolSchemaSnapshots(resolved.ToolSchemas),
-		WatchEventsContracts: cloneWatchEventsContracts(contracts),
-		TemplateSources:      resolvedTemplateSources(resolved),
-		ConditionSources:     resolvedConditionSources(resolved),
+		FormatVersion:          executedDefinitionSnapshotFormatVersion,
+		DefinitionVersion:      version,
+		InstalledFromExtension: strings.TrimSpace(resolved.InstalledFromExtension),
+		ExtensionOwner:         strings.TrimSpace(resolved.ExtensionOwner),
+		Definition:             definition,
+		Defaults:               resolved.Defaults,
+		EffectiveConfig:        cloneEffectiveConfig(effective),
+		ToolSchemas:            cloneToolSchemaSnapshots(resolved.ToolSchemas),
+		WatchEventsContracts:   cloneWatchEventsContracts(contracts),
+		TemplateSources:        resolvedTemplateSources(resolved),
+		ConditionSources:       resolvedConditionSources(resolved),
 	}
 	if err := validateExecutedDefinitionSnapshot(&envelope); err != nil {
 		return nil, "", err

--- a/internal/loop/resource_spec.go
+++ b/internal/loop/resource_spec.go
@@ -64,6 +64,8 @@ type ResourceSpec struct {
 	FilePath               string              `json:"file_path,omitempty"`
 	DefinitionChecksum     string              `json:"definition_checksum,omitempty"`
 	InstalledFromExtension string              `json:"installed_from_extension,omitempty"`
+	// ExtensionOwner is daemon-owned canonical manifest identity, never authored Loop YAML.
+	ExtensionOwner string `json:"extension_owner,omitempty"`
 }
 
 // ResourceParseOptions carries source context for a YAML-to-resource projection.

--- a/internal/loop/resource_spec_validation.go
+++ b/internal/loop/resource_spec_validation.go
@@ -22,6 +22,7 @@ func validateResourceSpec(
 	normalized.FilePath = strings.TrimSpace(normalized.FilePath)
 	normalized.DefinitionChecksum = strings.TrimSpace(normalized.DefinitionChecksum)
 	normalized.InstalledFromExtension = strings.TrimSpace(normalized.InstalledFromExtension)
+	normalized.ExtensionOwner = strings.TrimSpace(normalized.ExtensionOwner)
 	normalized.Catalog = normalizeCatalogSpec(normalized.Catalog)
 	normalized.Start = normalizeStartSpecs(normalized.Start)
 

--- a/internal/tools/policy_resolver.go
+++ b/internal/tools/policy_resolver.go
@@ -2,7 +2,31 @@ package tools
 
 import (
 	"context"
+	"strings"
 )
+
+type trustedExtensionOwnerContextKey struct{}
+
+// WithTrustedExtensionOwner attaches daemon-established extension provenance to one dispatch context.
+func WithTrustedExtensionOwner(ctx context.Context, owner string) context.Context {
+	trimmed := strings.TrimSpace(owner)
+	if trimmed == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, trustedExtensionOwnerContextKey{}, trimmed)
+}
+
+// TrustedExtensionOwner returns daemon-established extension provenance from a dispatch context.
+func TrustedExtensionOwner(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	owner, ok := ctx.Value(trustedExtensionOwnerContextKey{}).(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(owner)
+}
 
 // PolicyInputResolver resolves effective policy inputs for the current caller scope.
 type PolicyInputResolver interface {

--- a/packages/site/content/docs/loops/extensions.mdx
+++ b/packages/site/content/docs/loops/extensions.mdx
@@ -37,7 +37,7 @@ To add a Loop action, publish a tool with the `tool.provider` capability. Tag it
 `loop.gate` in a toolset if you want it grouped for authors. Because actions run through the one
 `RuntimeRegistry.Call` path, they inherit policy, approval, redaction, and observability for free.
 
-A Loop shipped by an extension receives an exact source grant for tools owned by that same extension.
+A Loop action shipped by an extension receives an exact source grant for tools owned by that same extension.
 The owner comes from installed resource metadata and is pinned in the Run snapshot; it cannot be set
 in authored Loop YAML. Availability, permission, risk, approval, schema, and drift checks still apply.
 Tools from every other extension remain under normal policy, so do not enable all external sources

--- a/packages/site/content/docs/loops/extensions.mdx
+++ b/packages/site/content/docs/loops/extensions.mdx
@@ -37,6 +37,12 @@ To add a Loop action, publish a tool with the `tool.provider` capability. Tag it
 `loop.gate` in a toolset if you want it grouped for authors. Because actions run through the one
 `RuntimeRegistry.Call` path, they inherit policy, approval, redaction, and observability for free.
 
+A Loop shipped by an extension receives an exact source grant for tools owned by that same extension.
+The owner comes from installed resource metadata and is pinned in the Run snapshot; it cannot be set
+in authored Loop YAML. Availability, permission, risk, approval, schema, and drift checks still apply.
+Tools from every other extension remain under normal policy, so do not enable all external sources
+just to make an extension-owned Loop call its own tools.
+
 ## Gate `extension` checks
 
 A `gate` [criterion](/docs/loops/dsl-reference#the-gate-contract) of `type: extension`

--- a/skills/compozy/references/extension-authoring.md
+++ b/skills/compozy/references/extension-authoring.md
@@ -256,8 +256,8 @@ Resource paths resolve inside the extension root; `{{config_dir}}` is that root 
 `{{env:NAME}}` reads the daemon process environment. Hooks, tools, command groups, MCP servers,
 dynamic resource publication, bridge metadata, and subprocess behavior require a supported code toolchain.
 
-When one extension ships both a Loop and tools, that Loop may call only tools owned by the same
-extension without a global external-source grant. The daemon takes the owner from installed resource
+When one extension ships both a Loop and tools, actions in that Loop may call only tools owned by
+the same extension without a global external-source grant. The daemon takes the owner from installed resource
 metadata, pins it in the Run snapshot, and still applies availability, permission, risk, approval,
 schema, and drift checks. Tools owned by another extension remain under normal policy. Do not enable
 `tools.policy.external_default` merely to let an extension-owned Loop call its own tools.

--- a/skills/compozy/references/extension-authoring.md
+++ b/skills/compozy/references/extension-authoring.md
@@ -256,6 +256,12 @@ Resource paths resolve inside the extension root; `{{config_dir}}` is that root 
 `{{env:NAME}}` reads the daemon process environment. Hooks, tools, command groups, MCP servers,
 dynamic resource publication, bridge metadata, and subprocess behavior require a supported code toolchain.
 
+When one extension ships both a Loop and tools, that Loop may call only tools owned by the same
+extension without a global external-source grant. The daemon takes the owner from installed resource
+metadata, pins it in the Run snapshot, and still applies availability, permission, risk, approval,
+schema, and drift checks. Tools owned by another extension remain under normal policy. Do not enable
+`tools.policy.external_default` merely to let an extension-owned Loop call its own tools.
+
 Every static resource accepts an optional `profile` placement. Omit it for every profile; name a
 profile to publish only when that profile exists and the extension is enabled there. An absent named
 profile leaves the placement dormant.

--- a/web/e2e/__tests__/loops-graph-eng.spec.ts
+++ b/web/e2e/__tests__/loops-graph-eng.spec.ts
@@ -272,7 +272,14 @@ test("E2E-029: editor grammar round-trips and reports a missing route default", 
   }
 
   await page.getByTestId("loop-editor-view-graph").click();
-  await route.click();
+  const graph = page.getByTestId("loop-editor-canvas");
+  await expect(graph).toBeVisible();
+  const graphRoute = graph.locator(
+    '[data-testid="loop-editor-node"][data-node-id="decision_route"]'
+  );
+  await expect(graphRoute).toBeVisible();
+  await graphRoute.click();
+  await expect(page.getByTestId("loop-route-default")).toBeVisible();
   await expect(page.getByTestId("loop-linter-error-count")).toHaveCount(0);
   await page.getByTestId("loop-route-default").selectOption("");
   await expect(page.getByTestId("loop-linter-error-count")).toBeVisible();

--- a/web/e2e/__tests__/network.spec.ts
+++ b/web/e2e/__tests__/network.spec.ts
@@ -6,12 +6,7 @@ import process from "node:process";
 import { promisify } from "node:util";
 
 import { networkOperatorSelectors } from "../fixtures/selectors";
-import {
-  appWindow,
-  ensureAppWindow,
-  openAppWindow,
-  switchWorkspace,
-} from "../fixtures/os-navigation";
+import { appWindow, openAppWindow, switchWorkspace } from "../fixtures/os-navigation";
 import {
   browserNetworkOperatorFlowScenario,
   seedBrowserNetworkOperatorFlow,
@@ -76,7 +71,8 @@ test.describe("network disabled state", () => {
 
     await appPage.goto(runtime.url("/network"), { waitUntil: "domcontentloaded" });
     await completeOnboardingIfPrompted(appPage);
-    const networkWin = await ensureAppWindow(appPage, "Network", "network");
+    const networkWin = appWindow(appPage, "network");
+    await expect(networkWin).toBeVisible();
     const ui = networkOperatorSelectors(networkWin);
     await expect(ui.disabledState).toBeVisible();
     await expect(networkWin.getByTestId("network-empty")).toContainText("Network is disabled.");

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -3970,9 +3970,12 @@ test("operator sees one nested worktree tree across all three workspace-listing 
     // Surface 1 — the menubar workspace menu. Keyboard-only traversal opens
     // the side submenu and selects the nested entry.
     await appPage.locator('[data-slot="os-menubar-workspace"]').click();
-    await appPage.getByTestId(`os-workspace-option-${workspace.id}`).focus();
-    await appPage.keyboard.press("ArrowRight");
-    const menuRow = appPage.getByTestId(/^os-worktree-option-/).first();
+    const workspaceRow = appPage.getByTestId(`os-workspace-option-${workspace.id}`);
+    await expect(workspaceRow).toHaveAttribute("aria-haspopup", "menu");
+    await workspaceRow.press("ArrowRight");
+    const submenu = appPage.getByTestId(`os-worktree-submenu-${workspace.id}`);
+    await expect(submenu).toBeVisible();
+    const menuRow = submenu.getByTestId(/^os-worktree-option-/).first();
     await expect(menuRow).toBeVisible();
     await expect(menuRow).toContainText("payments-retry");
 

--- a/web/e2e/__tests__/settings-hardening.spec.ts
+++ b/web/e2e/__tests__/settings-hardening.spec.ts
@@ -387,7 +387,9 @@ async function captureSettingsViewportMatrix(
     );
     expect(outerOverflow).toBeLessThanOrEqual(2);
     if (width === 1280) {
-      const sectionBody = settingsWin.getByTestId("settings-page-general-body");
+      const slug = pathname.split("/").at(-1);
+      if (!slug) throw new Error(`settings pathname has no section slug: ${pathname}`);
+      const sectionBody = settingsWin.getByTestId(`settings-page-${slug}-body`);
       await expect(sectionBody).toBeVisible();
       const maxScrollTop = await sectionBody.evaluate(element => {
         const maximum = element.scrollHeight - element.clientHeight;

--- a/web/e2e/__tests__/tasks.spec.ts
+++ b/web/e2e/__tests__/tasks.spec.ts
@@ -192,9 +192,21 @@ test("operator can execute the shipped Tasks flow through the shared daemon-serv
   const activeRunLink = tasksUI.dashboardActiveRunLink(seeded.runningRun.id);
   await expect(activeRunLink).toBeVisible();
   await expect(activeRunLink).toHaveAttribute("href", activeRunPath);
+  const layoutReady = appPage
+    .waitForEvent("websocket", {
+      predicate: socket => socket.url().includes("/window-manager/stream"),
+    })
+    .then(
+      socket =>
+        new Promise<void>((resolve, reject) => {
+          socket.once("framereceived", () => resolve());
+          socket.once("socketerror", error => reject(error));
+        })
+    );
   await appPage.goto(runtime.url(activeRunPath), {
     waitUntil: "domcontentloaded",
   });
+  await layoutReady;
   await expect(tasksUI.runDetailContent).toBeVisible();
   await expect.poll(() => new URL(appPage.url()).pathname).toBe(activeRunPath);
   await expect(tasksUI.runSessionDrilldown).toBeVisible();

--- a/web/e2e/__tests__/worktrees.spec.ts
+++ b/web/e2e/__tests__/worktrees.spec.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { sessionWindow } from "../fixtures/os-navigation";
+import { sessionWindowSelectors } from "../fixtures/selectors";
 import type { BrowserRuntime } from "../fixtures/runtime";
 import { expect, test } from "../fixtures/test";
 import { completeOnboardingIfPrompted } from "../fixtures/workspace";
@@ -508,10 +510,9 @@ test("operator picks a session environment under Workspace", async ({ appPage, r
   await expect(reopenedEnvironment).toContainText("Workspace root");
 });
 
-// E2E-009 (US-004 AC-2): sending the typed first message is what materializes a
-// newly chosen environment — the session is created inside it and the message is
-// then sent by that session, not carried into an empty composer.
-test("operator sends a first message that materializes and binds its environment", async ({
+// E2E-009 (US-004 AC-2): starting a session materializes its chosen environment;
+// the first message is then authored and sent by the durable, bound session.
+test("operator starts a bound environment and sends its first message", async ({
   appPage,
   runtime,
 }) => {
@@ -521,31 +522,38 @@ test("operator sends a first message that materializes and binds its environment
   await selectWorkspace(appPage, workspace.id);
   await openSessionCreate(appPage);
 
-  const firstMessage = appPage.getByTestId("session-create-composer");
-  await firstMessage.fill("Investigate the checkout latency regression");
   await appPage.getByTestId("session-create-mode-advanced").click();
   await appPage.getByTestId("session-create-environment").click();
   await appPage.getByRole("option", { name: "New worktree…" }).click();
 
-  // Choosing is not creating: an abandoned dialog must leave no checkout behind,
-  // and switching the target must not cost the operator what they typed.
+  // Choosing is not creating: an abandoned dialog must leave no checkout behind.
   await expect(appPage.locator('[data-slot="session-environment-phase"]')).toHaveCount(0);
   expect((await listWorktrees(runtime, workspace.id, true)).worktrees).toHaveLength(0);
-  await expect(firstMessage).toHaveValue("Investigate the checkout latency regression");
 
+  const createResponsePromise = appPage.waitForResponse(
+    response =>
+      response.request().method() === "POST" && new URL(response.url()).pathname === "/api/sessions"
+  );
   await appPage.getByRole("button", { name: /start session/i }).click();
-
-  await expect(appPage.getByTestId("session-create-environment-status")).toBeVisible();
-  await expect(firstMessage).toHaveValue("Investigate the checkout latency regression");
+  const createResponse = await createResponsePromise;
+  expect(createResponse.ok()).toBe(true);
+  const createPayload = (await createResponse.json()) as { session?: { id?: string } };
+  const sessionId = createPayload.session?.id;
+  if (!sessionId) throw new Error("Created session response did not include an id.");
 
   const created = await pollForBoundSession(runtime, workspace.id);
+  expect(created.id).toBe(sessionId);
+  const sessionWin = sessionWindow(appPage, sessionId);
+  const sessionUI = sessionWindowSelectors(sessionWin, appPage);
   const chip = appPage.locator('[data-slot="session-environment-chip"]');
   await expect(chip).toBeVisible();
   await expect(chip).toHaveAttribute("data-locked", "");
   await expect(chip).toHaveAttribute("data-binding", "worktree");
 
-  // The session sends the message itself, so it lands in the durable transcript
-  // rather than sitting in a composer waiting for a second click.
+  await sessionUI.composerTextarea.fill("Investigate the checkout latency regression");
+  await sessionUI.composerTextarea.press("Enter");
+
+  // The bound session owns the first message and persists it in its transcript.
   await expect
     .poll(async () => {
       const transcript = await runtime.requestJSON<{
@@ -592,11 +600,27 @@ test("operator forks a live session into a worktree", async ({ appPage, runtime 
   await selectWorkspace(appPage, workspace.id);
 
   await openSessionCreate(appPage);
+  const createResponsePromise = appPage.waitForResponse(
+    response =>
+      response.request().method() === "POST" && new URL(response.url()).pathname === "/api/sessions"
+  );
   await appPage.getByRole("button", { name: /start session/i }).click();
+  const createResponse = await createResponsePromise;
+  expect(createResponse.ok()).toBe(true);
+  const createPayload = (await createResponse.json()) as { session?: { id?: string } };
+  const originSessionID = createPayload.session?.id;
+  if (!originSessionID) throw new Error("Created origin session response did not include an id.");
 
-  const sessionsBefore = await runtime.requestJSON<{
-    sessions: Array<{ id: string; worktree_id?: string }>;
-  }>(`/api/sessions?workspace_id=${workspace.id}`);
+  let sessionsBefore: { sessions: Array<{ id: string; worktree_id?: string }> } | undefined;
+  await expect
+    .poll(async () => {
+      sessionsBefore = await runtime.requestJSON<{
+        sessions: Array<{ id: string; worktree_id?: string }>;
+      }>(`/api/sessions?workspace_id=${workspace.id}`);
+      return sessionsBefore.sessions.map(session => session.id);
+    })
+    .toEqual([originSessionID]);
+  if (!sessionsBefore) throw new Error("Created origin session was missing from the catalog.");
   expect(sessionsBefore.sessions).toHaveLength(1);
   const originSession = sessionsBefore.sessions[0];
 


### PR DESCRIPTION
## What & why

Code-backed extensions can contribute both Loops and tools, but the default external-source policy prevented a contributed Loop from resolving tools owned by that same extension.

This change preserves the canonical manifest owner through resource loading, compilation, executed snapshots, and hydration. During daemon execution it adds only the exact same-owner extension source to the normal allow set; it never grants trusted-source status, and foreign extension sources remain denied. Loop schema compilation also snapshots the operator registry once per compilation instead of repeatedly projecting it.

Closes #501

Codex co-wrote the implementation. I independently reviewed the result and verified it locally.

## How you verified it

- make gate
- make codegen-check
- Focused race suites for extension resources, Loop snapshots, daemon catalog/schema projection, and tool policy resolution
- Isolated code-backed extension smoke: its contributed Loop compiled, started, and dispatched its own action without unknown_action_kind
- Independent read-only code review: approved with no remaining findings

## Impact

No CLI, HTTP/UDS, config.toml, database migration, or web UI contract changes. The change is limited to daemon-side Loop provenance and tool-policy resolution. Public Loop extension documentation and QA coverage are updated.

---

- [x] make gate passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extension provenance tracking to Loop resources and execution snapshots.
  * Preserved extension ownership across Loop resolution, hydration, and action execution.
  * Restricted Loop tools to those owned by the extension that installed the Loop.
  * Improved tool schema loading efficiency by caching registry data.

* **Bug Fixes**
  * Prevented unauthorized or forged extension-owned tools from being resolved.
  * Ensured extension ownership is consistently normalized and validated.
  * Improved extension installation reliability during temporary database write contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->