### PR TITLE
fix: include sessions route in packaged web assets

### DIFF
--- a/docs/qa/reports/2026-08-31-session-final-delete-route.md
+++ b/docs/qa/reports/2026-08-31-session-final-delete-route.md
@@ -1,0 +1,78 @@
+# QA Run Report — 2026-08-31 — session-final-delete-route
+
+- **Scope:** Packaged web-assets synchronization for the empty Sessions route reached after deleting the final session
+- **Cadence tier:** targeted
+- **Build:** `98e4aa7c81f0726916c01c4a08d153d6b924be69` with local web-assets pin fix · **Environment:** isolated production-bundle daemon and Chromium
+- **Started:** 2026-08-31T18:55:00-03:00 · **Status:** closed at 2026-08-31T19:24:40-03:00
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Théo | Power User | desktop / wifi-fast / en-US | CH-untested-016-15-theo |
+
+## Flows in Scope
+
+- `J-15` — A returning session user deletes the final session and remains in a usable empty Sessions window (`../journeys/J-15-operate-session-via-cli-api.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-untested-016-15-theo | J-15 / RT-014 | Théo | Feature Tour | Pass | compozy/compozy#511 | this change |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-untested-016-15-theo — Théo
+
+- **Ran:** 2026-08-31T18:55:00-03:00 → 2026-08-31T19:00:00-03:00 (box respected: yes)
+- **Findings:** The corrected production bundle kept the user inside the Sessions window after deleting the final session. No new finding was observed.
+- **Bugs filed/updated:** The pre-existing product finding is tracked in `compozy/compozy#511`; no new QA-registry symptom was found during this walk.
+- **Scenarios settled:** RT-014 → pass
+- **Paper cuts:** None.
+- **Surprises:** The bootstrap did not detect the ephemeral `npx agent-browser` fallback, but Chromium executed the required Web journey and produced evidence successfully.
+- **Suggested next charter:** Re-run the existing session catalog charter when the next packaged release candidate is available.
+
+## What Was Fixed
+
+### compozy/compozy#511: Packaged UI omitted the empty Sessions route
+
+- **Symptom:** Deleting the final session navigated to `/sessions`, where the packaged UI rendered `Page not found`.
+- **Root cause:** `go.mod` pinned `compozy-web-assets@v0.0.190`, generated before `web/src/routes/_app/sessions.tsx` existed.
+- **Fix:** Update the pin to `v0.0.196`, the published deterministic bundle for source commit `98e4aa7c81f0726916c01c4a08d153d6b924be69`.
+- **Regression test:** `webAssetsCheck` failed before the pin update with digest `e2b1ac…` versus `3c929e…`, then passed after the update. The daemon-served browser replay also passed after deletion and refresh.
+- **Retested:** RT-014 in a fresh isolated daemon plus the adjacent empty-catalog read through CLI and HTTP.
+
+## Paper Cuts
+
+None.
+
+## Runtime Errors Observed
+
+The expected pre-fix `webAssetsCheck` digest mismatch was captured during the red phase. No runtime or browser error appeared in the corrected walk.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The navigation coordinator and source route were already correct; release-bundle coherence was the responsible boundary.
+- The existing full-bundle digest check is stronger and less brittle than a new assertion against minified JavaScript text.
+- Production-parity deviation: `agent-browser` ran through `npx` because the CLI is not installed globally; it used the host-provided `/bin/google-chrome` and did not download a browser.
+
+## Final Status
+
+- **Exit gate (full automated suite):** PASS — `make gate`; `go-lint` and `go-test -race ./...` have current evidence records for the finalized report tree.
+- **Gate log:** `/home/francisross/tmp-builds/compozy-session-final-delete-route-20260831-215333-848220-lab/qa-artifacts/qa/logs/final-make-verify.log`.
+- **Additional frontend evidence:** PASS — `make bun-lint`, `make bun-typecheck`, and `make bun-test`.
+- **Embedded boundary evidence:** PASS — `webAssetsCheck` and `CGO_ENABLED=1 go test -race ./internal/api/httpapi -run '^TestStaticRoutesServeEmbedded(IndexForRootAndDeepLinks|Assets)$' -count=1`.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 journeys walked; Web, CLI, and HTTP surfaces confirmed. UDS is represented by the installed CLI transport against the isolated socket.
+- **Verdict:** PASS — ready for review; the corrected packaged bundle resolves `/sessions` after the final session is deleted.

--- a/docs/qa/scenarios/RT-014.md
+++ b/docs/qa/scenarios/RT-014.md
@@ -11,8 +11,8 @@ bug_ids: BUG-20260826-session-delete-return-race
 fix_status: fixed
 retest_status: pass
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-session-empty-dock-20260827-165738-773687-lab/qa-artifacts/qa/journey-log.jsonl;/Users/pedronauck/dev/qa-labs/compozy-session-empty-dock-20260827-165738-773687-lab/qa-artifacts/qa/logs/http-delete.txt;/Users/pedronauck/dev/qa-labs/compozy-session-empty-dock-20260827-165738-773687-lab/qa-artifacts/qa/logs/uds-delete.txt;/Users/pedronauck/dev/qa-labs/compozy-session-empty-dock-20260827-165738-773687-lab/qa-artifacts/qa/logs/http-windows-after.json;/Users/pedronauck/dev/qa-labs/compozy-session-empty-dock-20260827-165738-773687-lab/qa-artifacts/qa/screenshots/delete-keeps-empty-tab.png
-last_report: docs/qa/reports/2026-08-27-session-empty-dock.md
+evidence: /home/francisross/tmp-builds/compozy-session-final-delete-route-20260831-215333-848220-lab/qa-artifacts/qa/journey-log.jsonl;/home/francisross/tmp-builds/compozy-session-final-delete-route-20260831-215333-848220-lab/qa-artifacts/qa/logs/web-final-delete.md;/home/francisross/tmp-builds/compozy-session-final-delete-route-20260831-215333-848220-lab/qa-artifacts/qa/logs/cli-session-list.json;/home/francisross/tmp-builds/compozy-session-final-delete-route-20260831-215333-848220-lab/qa-artifacts/qa/logs/api-session-reads.txt;/home/francisross/tmp-builds/compozy-session-final-delete-route-20260831-215333-848220-lab/qa-artifacts/qa/screenshots/final-session-empty-route.png
+last_report: docs/qa/reports/2026-08-31-session-final-delete-route.md
 overlaps: RT-session-delete-keeps-empty-tab
 ---
 
@@ -71,3 +71,13 @@ matching window stayed on `/sessions` with the tasks stack sibling intact; reope
 the deleted session. UDS `session remove` retargeted its own window the same way. Web overflow
 delete landed on `/sessions` with "No session selected" and the sidebar; Cancel kept Cancel
 preserve. Verdict: pass.
+
+QA impact 2026-08-31: packaged runtimes pinned a web-assets bundle from before the `/sessions`
+route existed, so deleting the final session landed on the root not-found screen. Reset for a
+production-bundle Web walk plus an independent session-catalog read after synchronizing the embedded
+bundle.
+
+QA execution 2026-08-31: Théo deleted the only session from a daemon-served production bundle.
+The browser landed on `/sessions` with `No session selected`, retained that state after refresh, and
+never rendered the root not-found screen. CLI and HTTP independently reported an empty catalog, and
+the deleted session returned 404. The embedded-bundle digest check and `make gate` passed.

--- a/docs/qa/scenarios/RT-017.md
+++ b/docs/qa/scenarios/RT-017.md
@@ -41,3 +41,9 @@ from committed state, retains the authoritative transcript epoch through recover
 concurrent Stop/RequestStop from the finalization window. Keep `blocked-verify`; the next public walk
 must prove clear/reload persistence, committed-manifest recovery, and Stop/Clear convergence in a
 fresh isolated lab with mandatory clean teardown.
+
+QA impact 2026-09-01: Clear now commits the fresh event-store generation before opening the
+replacement recorder, preventing the restarted session from invalidating its own clear manifest.
+The affected browser/API path passed 100 consecutive isolated Playwright repetitions, including
+cancel, clear, reload, empty-transcript, and delete assertions. Keep `blocked-verify` because the
+pending UDS and optimistic rollback portions still require a fresh public walk and clean teardown.

--- a/docs/qa/scenarios/RT-session-lifecycle-affordances.md
+++ b/docs/qa/scenarios/RT-session-lifecycle-affordances.md
@@ -32,4 +32,11 @@ the title and marker.
 QA impact 2026-08-03: removed obsolete interrupt-salvage expectations. RT-019 now owns durable,
 fenced interrupt and steer replacements; this scenario retains only title and file-verifier behavior.
 
+QA impact 2026-08-31: terminal session events now persist and publish only after the unresolved
+file-mutation marker, so a live Web stream cannot close before receiving the marker. The focused
+browser regression passed 20/20 repetitions against a production daemon build, and the session
+manager regression failed before the ordering fix and passed afterward. The browser harness uses a
+simulated provider, so this scenario remains `blocked-verify` until the same failed-edit journey is
+walked with a real provider and confirmed after refresh through an independent event read.
+
 src: .compozy/tasks/hermes-comparison/_user_stories.md#us-004-compaction-under-pressure-crash-safe

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/compozy/compozy-web-assets v0.0.190
+	github.com/compozy/compozy-web-assets v0.0.196
 	github.com/compozy/compozy/sdk/go v0.0.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/dave/jennifer v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/compozy/acp-go-sdk v0.13.5-compozy.2 h1:jrgwxoL6DBHrjzQPVs8LO6rUAyJFiTT3u1qdxcOlbMk=
 github.com/compozy/acp-go-sdk v0.13.5-compozy.2/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
-github.com/compozy/compozy-web-assets v0.0.190 h1:nE9Cfx6X1e1crZu5qBiy1XciMLZ3xfvvWIGYQNNn19o=
-github.com/compozy/compozy-web-assets v0.0.190/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
+github.com/compozy/compozy-web-assets v0.0.196 h1:q1XCw750tni1WpCqGGrI0NimDcZiCJilrQxc3zKcfCs=
+github.com/compozy/compozy-web-assets v0.0.196/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 h1:8h5+bWd7R6AYUslN6c6iuZWTKsKxUFDlpnmilO6R2n0=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/internal/session/manager_clear.go
+++ b/internal/session/manager_clear.go
@@ -76,6 +76,13 @@ func (m *Manager) restartClearedConversation(
 	dbPath string,
 	clearGeneration string,
 ) (_ *Session, err error) {
+	targetEpoch, err := m.nextTranscriptEpoch(ctx, nil, target)
+	if err != nil {
+		return nil, err
+	}
+	if commitErr := commitSessionDBClear(dbPath, clearGeneration, targetEpoch); commitErr != nil {
+		return nil, fmt.Errorf("session: commit cleared event store for %q: %w", target, commitErr)
+	}
 	session, err := m.startSession(ctx, spec)
 	if err != nil {
 		return nil, err
@@ -88,13 +95,6 @@ func (m *Manager) restartClearedConversation(
 			err = errors.Join(err, fmt.Errorf("session: rollback failed clear restart for %q: %w", target, rollbackErr))
 		}
 	}()
-	targetEpoch, err := m.nextTranscriptEpoch(ctx, session, target)
-	if err != nil {
-		return nil, err
-	}
-	if commitErr := commitSessionDBClear(dbPath, clearGeneration, targetEpoch); commitErr != nil {
-		return nil, fmt.Errorf("session: commit cleared event store for %q: %w", target, commitErr)
-	}
 	if _, err := m.ensureTranscriptEpoch(ctx, session, target, targetEpoch); err != nil {
 		return nil, err
 	}

--- a/internal/session/manager_clear_test.go
+++ b/internal/session/manager_clear_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -101,6 +102,36 @@ func TestClearConversationRestartsSameSessionWithFreshContext(t *testing.T) {
 				t.Fatalf("stored event content still contains cleared prompt: %s", event.Content)
 			}
 		}
+	})
+
+	t.Run("Should commit the clear before opening the replacement event store", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		var openCount atomic.Int32
+		h.manager = newManagerWithHarness(
+			t,
+			h,
+			WithStore(func(ctx context.Context, owner store.SessionDBOwner, path string) (EventRecorder, error) {
+				if openCount.Add(1) == 2 {
+					if _, err := os.Stat(sessionDBClearCommitPath(path)); err != nil {
+						return nil, fmt.Errorf("clear commit must precede replacement store open: %w", err)
+					}
+				}
+				return sessiondb.OpenSessionDB(ctx, owner, path)
+			}),
+		)
+
+		session := createSession(t, h)
+		cleared, err := h.manager.ClearConversation(testutil.Context(t), session.ID)
+		if err != nil {
+			t.Fatalf("ClearConversation() error = %v", err)
+		}
+		t.Cleanup(func() {
+			if err := h.manager.Stop(testutil.Context(t), cleared.ID); err != nil {
+				t.Errorf("Stop(cleared session cleanup) error = %v", err)
+			}
+		})
 	})
 
 	t.Run("Should wait for active stored readers before replacing the event store", func(t *testing.T) {

--- a/internal/session/manager_prompt_event_observation.go
+++ b/internal/session/manager_prompt_event_observation.go
@@ -24,11 +24,11 @@ func (m *Manager) observeRecordAndNotifyPromptEvent(
 	if loop.activity != nil && !runtimeEvent {
 		loop.activity.observeEvent(normalized)
 	}
+	m.emitFileMutationMarkerBeforeTerminalNotification(ctx, session, turnState, loop, normalized)
 	if err := m.recordEvent(ctx, session, normalized); err != nil {
 		return fmt.Errorf("session: record prompt event: %w", err)
 	}
 	loop.fileMutations.Observe(normalized)
-	m.emitFileMutationMarkerBeforeTerminalNotification(ctx, session, turnState, loop, normalized)
 	m.notifyManagedPromptEvent(ctx, session, turnState, normalized)
 	m.scheduleCompactionFromUsage(session, normalized)
 	if kind, summary, evidence, ok := promptTranscriptMarker(normalized); ok {

--- a/internal/session/manager_prompt_lifetime_test.go
+++ b/internal/session/manager_prompt_lifetime_test.go
@@ -619,6 +619,8 @@ func TestPromptFileMutationVerifier(t *testing.T) {
 				t.Fatalf("Events() error = %v", err)
 			}
 			markers := 0
+			markerSequence := int64(0)
+			terminalSequence := int64(0)
 			persistedEditKind := false
 			for _, storedEvent := range stored {
 				event, unmarshalErr := transcript.UnmarshalAgentEvent(storedEvent.Content)
@@ -631,9 +633,13 @@ func TestPromptFileMutationVerifier(t *testing.T) {
 				marker, ok := transcript.ParseMarker(event.Raw)
 				if ok && marker.Kind == transcript.MarkerFileMutationUnverified {
 					markers++
+					markerSequence = storedEvent.Sequence
 					if got := marker.Evidence["failure_count"]; got != float64(1) && got != 1 {
 						t.Fatalf("marker failure_count = %#v, want 1", got)
 					}
+				}
+				if event.Type == terminal {
+					terminalSequence = storedEvent.Sequence
 				}
 			}
 			if markers != tc.wantMarker {
@@ -643,6 +649,14 @@ func TestPromptFileMutationVerifier(t *testing.T) {
 				t.Fatal("persisted edit tool kind = false, want canonical edit evidence")
 			}
 			if tc.wantMarker > 0 {
+				if markerSequence == 0 || terminalSequence == 0 || markerSequence >= terminalSequence {
+					t.Fatalf(
+						"persisted marker sequence = %d, terminal sequence = %d, want marker before %q",
+						markerSequence,
+						terminalSequence,
+						terminal,
+					)
+				}
 				assertFileMutationMarkerNotifiedBeforeTerminal(t, h.notifier.eventsForSession(sess.ID), terminal)
 			}
 		})


### PR DESCRIPTION
## What & why

Fixes #511.

The daemon embedded `compozy-web-assets@v0.0.190`, which predates the `/sessions` route already present in the frontend source. After deleting the final session, the UI correctly navigated to `/sessions`, but the packaged bundle rendered the root not-found page.

This updates the embedded web-assets module to `v0.0.196`, the deterministic bundle published from the current source commit. No routing code changes are needed.

The first PR run also exposed an existing event-ordering race in the session runtime: the terminal event was persisted and published before the unresolved file-mutation marker. Because the Web live tail closes on a terminal event, the marker could be lost from the live view. The follow-up commit now persists and publishes the marker first, with the invariant covered in the canonical session manager suite.

The next exact-head CI run exposed a second existing race in Clear conversation. The replacement recorder could open and mutate the fresh SQLite database before the clear transaction committed its manifest. The commit now happens while the fresh database is still closed, before the replacement agent starts, so the restart cannot invalidate its own manifest.

Codex co-wrote this change; I verified the result through the packaged UI, CLI, HTTP, focused browser stress coverage, and repository gates.

## How you verified it

- `make gate`: `go-lint` and `go-test -race ./...` passed for fingerprint `459916436d25b00ae640c5b8408eb7779f6b5eb8`.
- `make lint` passed with zero warnings and zero errors.
- `CGO_ENABLED=1 go test -race ./internal/session/...` passed: 1,037 tests across two packages.
- The focused clear ordering regression failed before the fix and passed afterward; all 17 `TestClearConversation` cases passed.
- The focused Web E2E for cancel → clear → reload → empty transcript → delete passed 100/100 repetitions against a freshly built daemon. The unfixed version reproduced the HTTP 500 race in smaller runs at repetitions 16 and 49.
- The focused Web E2E for the generated title and file-mutation marker passed 20/20 repetitions against a freshly built daemon.
- `make bun-lint`, `make bun-typecheck`, and `make bun-test` passed for the packaged-route change.
- `webAssetsCheck` failed against the old pin and passed after the update.
- `CGO_ENABLED=1 go test -race ./internal/api/httpapi -run "^TestStaticRoutesServeEmbedded(IndexForRootAndDeepLinks|Assets)$" -count=1` passed.
- RT-014 passed in an isolated daemon: deleting the only session landed on `/sessions`, showed `No session selected`, remained correct after refresh, and CLI/HTTP independently reported an empty catalog.
- The strict QA evidence auditor passed with no blockers or warnings; teardown recorded `clean: true`.
- RT-017 records the clear-ordering regression evidence and remains `blocked-verify` for its pending UDS and optimistic rollback public walk.
- RT-session-lifecycle-affordances remains `blocked-verify` for a real-provider walk; the automated browser harness uses a simulated provider and is recorded only as regression evidence.

## Impact

- Web: fixes the packaged `/sessions` deep link and final-session deletion destination; no frontend source changed.
- Runtime: unresolved file-mutation markers persist and publish before terminal events from the same turn; Clear commits its fresh event-store generation before opening the replacement recorder.
- CLI, HTTP, and UDS: no public contract changes.
- `config.toml`: no keys, defaults, or lifecycle changes.
- `packages/site`: no documentation update; the intended route, marker, and Clear behavior already exist.

Compozy Impact Audit:

- Native tools: no impact; checked tool IDs, descriptors, schemas, digests, risk flags, and capability gates are unchanged.
- Extensibility and hooks: no public impact; extensions, hooks, skills/capabilities, registries, bridge SDKs, MCP sidecars, and config lifecycle are unchanged. Only internal transcript-event and clear-transaction ordering changed.
- Workspace data isolation: no data-scope change; events and clear artifacts remain session-scoped under the existing workspace owner, and `workspace_id`, cache, SSE routing, and cross-workspace filters are unchanged.
- Official Compozy skill: no impact; public CLI paths, tool IDs, hooks, capabilities, config, and documented runtime semantics are unchanged.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation clearing so reset state is committed before a replacement session begins.
  * Improved event sequencing to ensure file-change information is recorded before terminal notifications.
  * Updated web assets to the latest available version.

* **Tests**
  * Added coverage confirming conversation resets complete in the correct order.
  * Added validation that file-change markers are persisted before terminal events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->