### PR TITLE
fix: preserve sparse fan-out roster rows

### DIFF
--- a/docs/qa/bugs/BUG-20260901-filtered-fanout-phantom-rows.md
+++ b/docs/qa/bugs/BUG-20260901-filtered-fanout-phantom-rows.md
@@ -1,0 +1,46 @@
+# BUG-20260901-filtered-fanout-phantom-rows: Successful filtered fan-out looks unfinished
+
+- **Status:** verified
+- **Impact (user-side):** Trust-Damage
+- **Severity:** High · **Priority:** P1
+- **Persona Affected:** Bruno
+- **Journey Step:** J-complete-partial-loop, step 3
+- **Scenarios:** LP-fan-out-filtering; LP-run-read-agent-journey; LP-runs-roster-server-ordering; LP-web-run-operator-register
+- **Found:** 2026-09-01 · **Report:** docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
+- **Origin:**
+
+## Summary
+
+A filtered fan-out can finish successfully while the roster invents pending workers for source
+positions rejected by the filter. Progress, rollups, run summaries, and the Web Inspect view then
+show unfinished work that never existed.
+
+## Reproduction
+
+- **Charter:** CH-loop-graph-runtime-safety · **Tour:** Feature Tour
+- **Environment:** desktop / wifi-fast / en-US
+
+1. Validate and run a fan-out over three source items with a filter that retains only source index 2.
+2. Wait for the run to succeed.
+3. Read the roster and fan-out rollup through the CLI, then compare HTTP, UDS, native-tool, and Web reads.
+
+**Expected:** The roster contains only worker index 2 and reports progress `1/1`.
+**Actual:** The roster contains indexes 0, 1, and 2, leaves 0 and 1 pending, and reports progress `1/3`.
+
+## Evidence
+
+- GitHub issue `compozy/compozy#506` records the public-surface reproduction.
+- `go test -race ./internal/loop -run '^TestRosterContract$/^Should_preserve_sparse_fanout_item_indexes_without_inventing_pending_rows$' -count=1` failed with indexes `[0 1 2 3 4 5]` instead of `[2 5]` before the fix.
+
+## Fix
+
+- **Root cause:** The roster indexed outputs by their maximum item index, then projected every integer from zero through that maximum instead of the exact persisted identities.
+- **Fix commit:** e96962c
+- **Regression test:** `internal/loop.TestRosterContract/Should preserve only materialized fanout item indexes` failed before the production change and passes after it.
+
+## Verification
+
+- **Retested:** 2026-09-01 · **Report:** docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
+- **Result:** Passed. A one-worker run exposed only index `2`; a second run exposed only indexes
+  `2` and `4`. CLI, HTTP, UDS, and native reads agreed, and Web Inspect showed `2 of 2 done`
+  before and after reload. Evidence is indexed from the report.

--- a/docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
+++ b/docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
@@ -1,0 +1,97 @@
+# QA Run Report — 2026-09-01 — Issue 506 filtered fan-out roster
+
+- **Scope:** Correct sparse filtered/batched fan-out roster rows and their derived progress across run-read surfaces.
+- **Cadence tier:** targeted
+- **Build:** e96962c + QA/test working tree · **Environment:** isolated targeted lab
+- **Started:** 2026-09-01T13:08:59Z · **Status:** complete; delivery CI pending
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-loop-graph-runtime-safety |
+| Ada | Power User | desktop / flaky / en-US | CH-loop-legibility-run-read-resume |
+| Dora | Power User | desktop / wifi-fast / en-US | CH-loop-legibility-operator-register |
+
+## Flows in Scope
+
+- `J-complete-partial-loop` — run a filtered fan-out and trust that only materialized lanes exist (`../journeys/J-complete-partial-loop.md`).
+- `J-operate-loop-run-headless` — read the same roster and progress through structured surfaces (`../journeys/J-operate-loop-run-headless.md`).
+- `J-diagnose-loop-run-operator` — inspect the fan-out and its server-owned rollup in Web (`../journeys/J-diagnose-loop-run-operator.md`).
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-loop-graph-runtime-safety | J-complete-partial-loop / LP-fan-out-filtering | Bruno | Feature Tour | Fixed | BUG-20260901-filtered-fanout-phantom-rows | e96962c |
+| 2 | CH-loop-legibility-run-read-resume | J-operate-loop-run-headless / LP-run-read-agent-journey; LP-runs-roster-server-ordering | Ada | Network Tour | Fixed | BUG-20260901-filtered-fanout-phantom-rows | e96962c |
+| 3 | CH-loop-legibility-operator-register | J-diagnose-loop-run-operator / LP-web-run-operator-register | Dora | Interrupt Tour | Fixed | BUG-20260901-filtered-fanout-phantom-rows | e96962c |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-loop-graph-runtime-safety · Bruno
+
+- Ran a real Loop whose filter retained only source index `2`.
+- The terminal CLI roster contained exactly one `process_record[2]` row and no phantom pending row.
+- Goal reached: yes. True end state: confirmed by a fresh terminal roster read.
+
+### CH-loop-legibility-run-read-resume · Ada
+
+- Ran a second Loop whose filter retained sparse indexes `2` and `4`.
+- CLI, HTTP, and UDS returned those exact identities and the same `2/2` rollup; the runs list and
+  `compozy__loop_runs` reported complete `3/3` progress.
+- Goal reached: yes. True end state: confirmed across four public read paths.
+
+### CH-loop-legibility-operator-register · Dora
+
+- Opened a live sparse run in headed Chrome, selected the workspace through the public picker, and
+  inspected Graph and Nodes.
+- Graph showed `2 of 2 done`; the two worker record links ended in `.2` and `.4`.
+- Reload preserved `2 of 2 done`, then the pending answer was submitted and the run reached Done.
+- Goal reached: yes. True end state: confirmed by Web reload and a fresh CLI roster read.
+
+## What Was Fixed
+
+### BUG-20260901-filtered-fanout-phantom-rows: Successful filtered fan-out looks unfinished
+
+- **Symptom:** A successful filtered fan-out reports pending rows and an unclosable progress fraction.
+- **Root cause:** Roster projection expands from zero through the maximum output index instead of projecting exact output identities.
+- **Fix:** e96962c
+- **Regression test:** `internal/loop.TestRosterContract/Should preserve only materialized fanout item indexes` — red before, green after.
+- **Retested:** all three isolated sessions passed.
+
+## Paper Cuts
+
+None.
+
+## Runtime Errors Observed
+
+None.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- A hidden headless tab intentionally disables live Web reads, so Web evidence used headed Chrome.
+  This is a test-driver condition, not a product defect; normal desktop visibility was confirmed.
+- The focused Web pass covered system status, literal state words, keyboard workspace selection,
+  refresh recovery, and the server-owned rollup. Responsive QA remains out of scope because Inspect
+  is desktop-only by product decision.
+
+## Final Status
+
+- **Exit gate (scoped pre-push):** `make gate` passed — Go lint/race tests and Web lint/typecheck/tests.
+- **Delivery gate:** exact-head draft PR CI pending.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 3/3 journeys walked; CLI, HTTP, UDS, native tool, and Web covered.
+- **Evidence:** `/Users/pedronauck/dev/qa-labs/compozy-issue-506-filtered-fanout-roster-20260901-131013-477371-lab/qa-artifacts/qa/`.
+- **Teardown:** `qa/teardown.json` reports `clean: true` with no survivors.
+- **Verdict:** not ready for merge until exact-head required CI is green; local implementation and QA are ready.

--- a/docs/qa/scenarios/LP-fan-out-filtering.md
+++ b/docs/qa/scenarios/LP-fan-out-filtering.md
@@ -7,13 +7,19 @@ journey: J-complete-partial-loop
 expected: A fan-out filter can read item, source index, and authored aliases; only matching elements are batched, and max_fan_out counts the resulting lanes.
 entry_points: compozy loop validate; compozy loop run; compozy loop status; /docs/loops/dsl-reference; skills/compozy/references/loops.md
 qa_status: pass
-bug_ids:
-fix_status:
-retest_status:
-fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-loop-runtime-graph-fixes-20260819-234724-890442-lab/qa-artifacts/qa/logs/bruno-filter-success-status.json; /Users/pedronauck/dev/qa-labs/compozy-loop-runtime-graph-fixes-20260819-234724-890442-lab/qa-artifacts/qa/logs/bruno-zero-filter-status.json; /Users/pedronauck/dev/qa-labs/compozy-loop-runtime-graph-fixes-20260819-234724-890442-lab/qa-artifacts/qa/logs/bruno-filter-error-exit-status.json; /Users/pedronauck/dev/qa-labs/compozy-loop-runtime-graph-fixes-20260819-234724-890442-lab/qa-artifacts/qa/logs/bruno-terminal-drain-v2-proof.json
-last_report: docs/qa/reports/2026-08-19-loop-runtime-graph-fixes.md
+bug_ids: BUG-20260901-filtered-fanout-phantom-rows
+fix_status: fixed
+retest_status: pass
+fix_commits: e96962c
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-506-filtered-fanout-roster-20260901-131013-477371-lab/qa-artifacts/qa/logs/cli-single-worker-roster.json
+last_report: docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
 overlaps:
 ---
 
 acceptance-walk: Validate and run a Loop whose fan-out uses bind_as and index_as in a filter, has batch_size 2, and would exceed max_fan_out before filtering. Confirm validation succeeds, excluded source elements create no worker lanes, matching elements retain order in the batch, and an invalid predicate follows the authored on_eval_error policy.
+
+QA impact 2026-09-01: reset after sparse fan-out roster projection changed. The re-walk must prove
+filtered source gaps create no phantom pending rows and every public read reports the same denominator.
+
+QA result 2026-09-01: passed. A real filtered fan-out retained source index `2`; the terminal
+roster exposed that worker only and no pending row for rejected indexes `0` or `1`.

--- a/docs/qa/scenarios/LP-run-read-agent-journey.md
+++ b/docs/qa/scenarios/LP-run-read-agent-journey.md
@@ -7,12 +7,12 @@ journey: J-operate-loop-run-headless
 expected: The briefing, complete node roster, and durable timeline agree on current run truth over HTTP, UDS, and CLI; unblocker commands execute verbatim, attempt history survives recovery, timeline resume has no gaps or duplicates, and foreign positions fail deterministically.
 entry_points: compozy loop why <run-id>; compozy loop nodes --run <run-id> --all; compozy loop events <run-id> --after <seq> --follow --view <notable|all>; GET /api/workspaces/:workspace_id/loop-runs/:run_id/{briefing,nodes,timeline}; skills/compozy/references/loops.md; /docs/cli/loop/why; /docs/cli/loop/nodes; /docs/cli/loop/events
 qa_status: pass
-bug_ids: BUG-20260719-autonomous-progress-unobservable; BUG-20260821-loop-unblocker-invalid-json; BUG-20260821-loop-timeline-head-omitted
+bug_ids: BUG-20260719-autonomous-progress-unobservable; BUG-20260821-loop-unblocker-invalid-json; BUG-20260821-loop-timeline-head-omitted; BUG-20260901-filtered-fanout-phantom-rows
 fix_status: fixed
-retest_status: pass — public-read observer matched the independent Task catalog through eight durable transitions and 11 terminal Tasks
-fix_commits: a53f470; b0eaf22; 37c101d
-evidence: /Users/pedronauck/dev/qa-labs/compozy-loop-unblocker-operator-input-20260821-20260821-124157-149087-lab/qa-artifacts/qa/request-unblocker-required-schema-rewalk.md; /Users/pedronauck/dev/qa-labs/compozy-loop-task-legibility-runtime-20260821-1126-20260821-112711-004724-lab/qa-artifacts/qa/headless/read-parity.sha256; /Users/pedronauck/dev/qa-labs/compozy-loop-task-legibility-runtime-20260821-1126-20260821-112711-004724-lab/qa-artifacts/qa/observation-summary.json
-last_report: docs/qa/reports/2026-08-21-loop-task-legibility.md
+retest_status: pass
+fix_commits: a53f470; b0eaf22; 37c101d; e96962c
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-506-filtered-fanout-roster-20260901-131013-477371-lab/qa-artifacts/qa/logs/parity-summary.json
+last_report: docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
 overlaps: LP-runs-roster-server-ordering; LP-terminal-loop-settlement
 ---
 
@@ -56,3 +56,9 @@ kept its durable winner metadata, superseded coordinator snapshots did not fail 
 Runs reached their expected states. Commands:
 `go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2ELoopRunReadCLIJourneys$/.*(IT-022|IT-027|IT-032)$' -count=10 -failfast` and
 `go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2ELoopRunReadCLIJourneys$' -count=5 -failfast`.
+
+QA impact 2026-09-01: reset because sparse roster rows change briefing, node, and progress values on
+CLI, HTTP, UDS, and native reads. The targeted re-walk must compare one persisted run across them.
+
+QA result 2026-09-01: passed. CLI, HTTP, and UDS returned the same sparse worker indexes `2,4`
+and fan-out rollup `2/2`; native `compozy__loop_runs` reported the same completed run progress.

--- a/docs/qa/scenarios/LP-runs-roster-server-ordering.md
+++ b/docs/qa/scenarios/LP-runs-roster-server-ordering.md
@@ -7,12 +7,12 @@ journey: J-operate-loop-run-headless
 expected: Every runs-list read returns needs-you runs first, then active, then terminal, with the ordering applied before pagination so a run that needs a human never falls off page one; each item carries progress (round, steps done, steps total) always and an attention object (kind, count, since) only when something is actually waiting; CLI columns, HTTP and UDS responses agree on the same persisted state, a malformed cursor is a field-addressed 400 invalid_cursor, and a run id from another workspace resolves to 404 rather than an empty success.
 entry_points: compozy loop runs; compozy loop runs --loop <loop-name> --status <status> -o json; GET /api/workspaces/:workspace_id/loop-runs over HTTP and UDS; /docs/cli/loop/runs
 qa_status: pass
-bug_ids: BUG-20260719-autonomous-progress-unobservable
+bug_ids: BUG-20260719-autonomous-progress-unobservable; BUG-20260901-filtered-fanout-phantom-rows
 fix_status: fixed
-retest_status: pass — runtime-owned observer followed catalog advancement and matched all 11 terminal Tasks
-fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-loop-task-legibility-task07-final-web-20260822-131622-550786-lab/qa-artifacts/qa/task07-scenario-walks.md; .compozy/tasks/loop-task-legibility/evidence/visual/task_05/VC-33
-last_report: docs/qa/reports/2026-08-21-loop-task-legibility.md
+retest_status: pass
+fix_commits: e96962c
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-506-filtered-fanout-roster-20260901-131013-477371-lab/qa-artifacts/qa/logs/cli-runs.json
+last_report: docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
 overlaps: LP-run-read-agent-journey; LP-web-runs-roster-rerank; LP-web-runs-breadcrumb; GL-016
 ---
 
@@ -41,3 +41,9 @@ this resolves the row's only blocked decision and the scenario now passes. Evide
 QA impact 2026-08-21: reset because the degraded-read age presentation changed after the prior
 walk. The fresh task_07 lab must re-walk ordering, paging, attention omission, progress, and the
 updated degraded age before restoring a verdict.
+
+QA impact 2026-09-01: reset because runs-list progress inherits sparse roster denominators. The
+targeted re-walk must confirm server-owned progress excludes non-materialized fan-out source indexes.
+
+QA result 2026-09-01: passed. The sparse run settled with server-owned progress `3/3`; rejected
+source indexes did not enlarge the denominator, and the native runs read agreed.

--- a/docs/qa/scenarios/LP-web-run-operator-register.md
+++ b/docs/qa/scenarios/LP-web-run-operator-register.md
@@ -7,12 +7,12 @@ journey: J-diagnose-loop-run-operator
 expected: "Inspect" is a single in-column disclosure — never a sheet and never a route change — holding four lanes over one read model: Graph, Nodes, Generations, Events. Graph is the default lane and renders the authored topology with per-node icon+text state chips, fan-out drawn as one entity with a rollup and one lane per worker, edge liveness toward the running node, and `pending` (reachable, dashed outline) visually and semantically distinct from `not_taken` (route evidence, neutral-dim). The lane auto-centres on whatever needs a human and says so in its foot. A node opens a panel carrying every recorded attempt (including a single one), next-retry, error class, cancellation cause and actor, plus Open session / Open record / View child run — all valid after the run ends, with a session retention has removed degrading to "Session no longer available" and a never-taken node offering no links at all. Nodes lists every node × round including healthy ones, follows the run's current round by default and shows a Round column under "All rounds"; a step that started and has not ended reads "in progress" with its elapsed clock and never "not started", and usage reads tokens beside a cost the column header labels an estimate. Generations shows per-round outcomes in plain words with no raw verdict enum, the round's own tokens and labelled estimated cost, a truthful still-running / partly-settled / interrupted state, and scores only where the loop defines them; Compare and Fork stay on every round. When the run holds more steps than one read returns, every roster-derived surface says so and offers both "Read the rest" and the exact `compozy loop nodes --run <run id> --all`. Under prefers-reduced-motion the edge pulse is unmounted, not paused.
 entry_points: web /loop-runs/:id Inspect; GET /loop-runs/:id/nodes; GET /loop-runs/:id/timeline
 qa_status: pass
-bug_ids: BUG-20260719-autonomous-progress-unobservable
-fix_status: pending
+bug_ids: BUG-20260719-autonomous-progress-unobservable; BUG-20260901-filtered-fanout-phantom-rows
+fix_status: fixed
 retest_status: pass
-fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-loop-task-legibility-task07-final-web-20260822-131622-550786-lab/qa-artifacts/qa/task07-scenario-walks.md; .compozy/tasks/loop-task-legibility/evidence/visual/task_05/VC-17; .compozy/tasks/loop-task-legibility/evidence/visual/task_05/VC-25
-last_report: docs/qa/reports/2026-08-21-loop-task-legibility.md
+fix_commits: e96962c
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-506-filtered-fanout-roster-20260901-131013-477371-lab/qa-artifacts/qa/screenshots/web-sparse-roster-refresh.png
+last_report: docs/qa/reports/2026-09-01-issue-506-filtered-fanout.md
 overlaps: LP-web-detail-inventory-contract;LP-web-timeline-graph-rows;LP-quarantine-diagnose-requeue;LP-web-attention-loop-rows
 ---
 
@@ -33,3 +33,9 @@ steps:
 8. Open a node whose session retention has removed and confirm the panel says "Session no longer available" instead of offering a link that 404s.
 9. On a run larger than one roster read, confirm the truncation is stated on both the default read's progress panel and the Inspect foot, and that "Read the rest" loads more.
 10. Re-run steps 2-3 with prefers-reduced-motion enabled and confirm the edge pulse is absent from the DOM.
+
+QA impact 2026-09-01: reset because the Inspect fan-out band consumes the daemon's roster and rollup.
+The targeted re-walk must show only materialized workers and the same completed fraction after reload.
+
+QA result 2026-09-01: passed in headed Chrome. Inspect showed six real rows, a `2 of 2 done`
+fan-out, and worker record links ending in `.2` and `.4`; refresh preserved the same fraction.

--- a/internal/loop/roster.go
+++ b/internal/loop/roster.go
@@ -178,7 +178,7 @@ func ProjectRoster(source *RosterSource, query RosterQuery) (RosterPage, error) 
 		}
 	}
 	generations := rosterGenerations(source)
-	outputs, maxOutputItems := indexOutputs(source.Outputs)
+	outputs, outputItemIndexes := indexOutputs(source.Outputs)
 	attempts := indexAttempts(source.Attempts)
 	controls := indexControls(source.Controls)
 	waits := indexWaits(source.Waits)
@@ -196,7 +196,7 @@ func ProjectRoster(source *RosterSource, query RosterQuery) (RosterPage, error) 
 		for _, node := range graphNodes {
 			key := rosterKey(generation, node.ID, 0)
 			items := rosterItems(
-				source.Run.ID, generation, node, outputs, maxOutputItems,
+				source.Run.ID, generation, node, outputs, outputItemIndexes,
 				attempts, controls, waits, routeExcluded,
 			)
 			if len(items) == 0 {

--- a/internal/loop/roster_helpers.go
+++ b/internal/loop/roster_helpers.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"fmt"
+	"slices"
 )
 
 func rosterKey(generation int, nodeID NodeID, itemIndex int) string {
@@ -12,18 +13,19 @@ func rosterNodeKey(generation int, nodeID NodeID) string {
 	return fmt.Sprintf("%d/%s", generation, nodeID)
 }
 
-func indexOutputs(items []GenerationOutput) (map[string]*GenerationOutput, map[string]int) {
+func indexOutputs(items []GenerationOutput) (map[string]*GenerationOutput, map[string][]int) {
 	indexed := map[string]*GenerationOutput{}
-	maxItems := map[string]int{}
+	itemIndexes := map[string][]int{}
 	for index := range items {
 		item := &items[index]
 		indexed[rosterKey(item.Generation, NodeID(item.NodeID), item.ItemIndex)] = item
 		key := rosterNodeKey(item.Generation, NodeID(item.NodeID))
-		if current, ok := maxItems[key]; !ok || item.ItemIndex > current {
-			maxItems[key] = item.ItemIndex
-		}
+		itemIndexes[key] = append(itemIndexes[key], item.ItemIndex)
 	}
-	return indexed, maxItems
+	for key := range itemIndexes {
+		slices.Sort(itemIndexes[key])
+	}
+	return indexed, itemIndexes
 }
 
 func indexAttempts(items []NodeAttempt) map[string][]NodeAttempt {

--- a/internal/loop/roster_projection.go
+++ b/internal/loop/roster_projection.go
@@ -1,7 +1,7 @@
 package loop
 
 import (
-	"sort"
+	"slices"
 
 	"github.com/compozy/compozy/internal/loop/dsl"
 )
@@ -14,7 +14,7 @@ func rosterGenerations(source *RosterSource) []int {
 	for _, item := range source.Generations {
 		generations = append(generations, int(item.Generation))
 	}
-	sort.Ints(generations)
+	slices.Sort(generations)
 	return generations
 }
 
@@ -23,18 +23,18 @@ func rosterItems(
 	generation int,
 	node dsl.Node,
 	outputs map[string]*GenerationOutput,
-	maxOutputItems map[string]int,
+	outputItemIndexes map[string][]int,
 	attempts map[string][]NodeAttempt,
 	controls map[NodeID]*NodeControl,
 	waits map[string]*NodeWait,
 	excluded map[string]bool,
 ) []RosterNode {
-	maxItem, ok := maxOutputItems[rosterNodeKey(generation, node.ID)]
-	if !ok || maxItem < 1 {
+	itemIndexes := outputItemIndexes[rosterNodeKey(generation, node.ID)]
+	if len(itemIndexes) == 0 {
 		return nil
 	}
-	items := make([]RosterNode, 0, maxItem+1)
-	for itemIndex := 0; itemIndex <= maxItem; itemIndex++ {
+	items := make([]RosterNode, 0, len(itemIndexes))
+	for _, itemIndex := range itemIndexes {
 		key := rosterKey(generation, node.ID, itemIndex)
 		items = append(items, newRosterNode(
 			runID, generation, node, itemIndex, outputs[key], attempts[key],

--- a/internal/loop/roster_test.go
+++ b/internal/loop/roster_test.go
@@ -214,6 +214,70 @@ func TestRosterContract(t *testing.T) {
 			t.Fatalf("page = %#v", page)
 		}
 	})
+	t.Run("Should preserve only materialized fanout item indexes", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name        string
+			outputs     []GenerationOutput
+			wantIndexes []int
+			wantRollups []FanoutRollup
+		}{
+			{
+				name: "Should preserve a lone nonzero worker index",
+				outputs: []GenerationOutput{
+					{Generation: 1, NodeID: "worker", ItemIndex: 2, Status: generationOutputSucceeded},
+				},
+				wantIndexes: []int{2},
+				wantRollups: []FanoutRollup{},
+			},
+			{
+				name: "Should sort sparse worker indexes without filling gaps",
+				outputs: []GenerationOutput{
+					{Generation: 1, NodeID: "worker", ItemIndex: 5, Status: generationOutputSucceeded},
+					{Generation: 1, NodeID: "worker", ItemIndex: 2, Status: generationOutputSucceeded},
+				},
+				wantIndexes: []int{2, 5},
+				wantRollups: []FanoutRollup{{Generation: 1, NodeID: "fan", Done: 2, Total: 2}},
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+				source := RosterSource{
+					Run: Run{ID: "r", LoopName: "fan", Generation: 1},
+					Graph: dsl.Graph{
+						Nodes: []dsl.Node{
+							{ID: "fan", Class: dsl.NodeClassControl, Kind: string(dsl.ControlFanOut)},
+							{ID: "worker", Class: dsl.NodeClassAction},
+						},
+						Edges: []dsl.Edge{{From: "fan", To: "worker"}},
+					},
+					Outputs: test.outputs,
+				}
+
+				page, err := ProjectRoster(&source, RosterQuery{})
+				if err != nil {
+					t.Fatalf("ProjectRoster() error = %v", err)
+				}
+				gotIndexes := make([]int, 0, len(test.wantIndexes))
+				for _, node := range page.Nodes {
+					if node.NodeID == "worker" {
+						gotIndexes = append(gotIndexes, node.ItemIndex)
+					}
+				}
+				if !slices.Equal(gotIndexes, test.wantIndexes) {
+					t.Fatalf("worker item indexes = %v, want %v", gotIndexes, test.wantIndexes)
+				}
+				if !slices.Equal(page.FanoutRollups, test.wantRollups) {
+					t.Fatalf("fanout rollups = %#v, want %#v", page.FanoutRollups, test.wantRollups)
+				}
+				progress := ProgressFromRoster(page, 1)
+				if progress.StepsDone != len(test.wantIndexes) || progress.StepsTotal != len(test.wantIndexes) {
+					t.Fatalf("progress = %#v, want %d/%d", progress, len(test.wantIndexes), len(test.wantIndexes))
+				}
+			})
+		}
+	})
 	t.Run("Should name a fanout rollup after its authored container", func(t *testing.T) {
 		t.Parallel()
 		source := RosterSource{

--- a/packages/site/content/docs/loops/running.mdx
+++ b/packages/site/content/docs/loops/running.mdx
@@ -192,6 +192,10 @@ The roster covers one run's nodes across generations. `--generation` narrows it 
 `--all` pages the whole roster in a single call, which is why `--all` and `--cursor` are mutually
 exclusive. Both `--all` and `--generation` require `--run`.
 
+Fan-out workers keep the source item indexes that created them. Filtering or batching can leave gaps
+such as `2, 5`; missing indexes are not pending workers. Roster progress and `fanout_rollups` count
+only the worker rows that exist.
+
 Structured rows in either mode carry the exact run, generation, node, and item identity needed by
 the node verbs. See
 [Failure handling](/docs/loops/failure-handling#inspect-and-recover-nodes) for the command forms.

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -83,6 +83,9 @@ attempt ledger, and `compozy loop events <run> --view notable|all -o jsonl` for 
 `all|running|queued|waiting|retrying|paused|quarantined|succeeded|failed|canceled|not_taken` and pages 50
 by default up to 500; without `--run` the same verb reads the workspace exception inventory, where
 `--state` is required, closed to `waiting|quarantined|attention|retrying`, and pages 50 by default up to 200.
+Fan-out roster indexes preserve source positions, so filtering or batching can make them sparse. Treat
+only returned rows as workers; never infer missing indexes or include them in progress or rollup
+denominators. `not_taken` is reserved for durable route evidence, not filter rejects.
 `events --after <seq> --follow` resumes at a plain per-run sequence; HTTP timeline pagination instead
 uses an opaque run-bound cursor. Follow attaches after the first page's `head_seq`, so the durable/live
 handoff does not duplicate or skip events. A plain sequence beyond the current history returns the

--- a/web/src/systems/loops/lib/loop-run-fanout-band.ts
+++ b/web/src/systems/loops/lib/loop-run-fanout-band.ts
@@ -20,8 +20,8 @@ import {
  */
 
 /**
- * The shared lane/segment vocabulary. `never` is a branch a filter skipped: it
- * leaves the denominator and stays neutral, because absence is calm.
+ * The shared lane/segment vocabulary. `never` is durable evidence that a route
+ * branch was not taken. It is resolved work and stays visually neutral.
  */
 export type LoopProgressSegment =
   | "clean"


### PR DESCRIPTION
## What & why

Fixes #506.

Fan-out roster projection treated the highest persisted item index as a contiguous range. When only item `2`, or items `2` and `5`, existed, CompozyOS invented rows for the missing indexes and left them pending. This change projects only the exact persisted item indexes, so roster rows, rollups, and run progress describe the workers that actually exist.

The change also documents sparse-index behavior in the Loop running guide and the official Compozy skill, and corrects the stale Web source comment about `not_taken`.

After rebasing onto the current `main`, exact-head CI exposed a base regression: `scripts/sync-emojibase.mjs` resolves its data through `web/package.json`, but the required Web development dependency had been removed. This PR restores the pinned dependency so clean installs can execute the repository's codegen contract.

## How you verified it

- `make gate` passed on the rebased diff with fresh Go lint, Go race-test, and all-workspace JS records.
- `go test -race -cover ./internal/loop -count=1` passed all 1,086 tests. Changed functions have 89.2%-100% coverage.
- The canonical `internal/loop.TestRosterContract` regression first reproduced the bug (`[0 1 2 3 4 5]` instead of `[2 5]`) and now passes for both lone and non-contiguous sparse indexes.
- Isolated real-scenario QA passed across CLI, HTTP, UDS, `compozy__loop_runs`, and the headed Web UI. The observed worker indexes were exactly `2` and `2,4`; rollup was `2/2`; run-list progress was `3/3`; Web refresh preserved the result.
- The strict QA evidence audit passed, and teardown finished with `clean: true` and no surviving processes.
- A fresh clone of base `main` reproduced the Emojibase resolution error. A fresh clone of this branch passed `bun install --frozen-lockfile` followed by `make codegen-check`.

OpenAI Codex co-wrote this change. I reviewed the diff and verified the result locally.

## Impact

- CLI/HTTP/UDS: response shapes and routes are unchanged. Existing roster and progress reads now return correct sparse fan-out results.
- Web: no component contract changed; the UI consumes the corrected server rollup. The stale `not_taken` source comment was updated, and the pinned codegen data dependency was restored.
- Docs: updated `packages/site/content/docs/loops/running.mdx` and `skills/compozy/references/loops.md`.
- Config: no `config.toml` key, default, or lifecycle changed.
- Native tools: no tool IDs, toolsets, descriptors, schemas, digests, risk flags, availability diagnostics, or capability gates changed. `compozy__loop_runs` inherits the corrected shared roster projection.
- Extensibility and hooks: no extensions, hooks, capabilities, registries, bridge SDKs, MCP sidecars, or resource contracts changed.
- Workspace data isolation: no datum ownership or `workspace_id` propagation changed. Loop outputs remain workspace-scoped through CLI, HTTP, UDS, core, store, Web, events, and cache reads.
- Official Compozy skill: updated the Loop reference with sparse-index semantics and clarified that `not_taken` requires durable route evidence.
- QA tracker: the affected Loop scenarios were re-walked and recorded as passing. Restoring the build-only dependency has no user-visible QA scenario impact.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved exact fan-out item indexes in roster projections, including sparse indexes without filling gaps.
  * Improved fan-out rollups and progress totals for more accurate loop status reporting.

* **Documentation**
  * Clarified that unselected route branches represent durable, visually neutral evidence of unresolved work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->