### PR TITLE
fix: scope Loop extension tools to worktrees

### DIFF
--- a/docs/qa/charters/CH-loop-web-environment-authoring.md
+++ b/docs/qa/charters/CH-loop-web-environment-authoring.md
@@ -1,0 +1,26 @@
+# CH-loop-web-environment-authoring: Web narrows choices without losing config
+
+```yaml
+charter:
+  id: CH-loop-web-environment-authoring
+  mission: "As Bruno, edit Loop environments in Web and prove advanced values created through the API or CLI remain visible and unchanged."
+  mode: scenario-based
+  persona:
+    name: Bruno
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-isolated-task-loop-execution
+  scenarios: [LP-worktree-web-loop-environment]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Confirm configure, run, and node controls offer only Inherit, Workspace root, and Named worktree for new choices."
+      - "Load directory and per-run values created through a structured surface; confirm their read-only labels and exact values."
+      - "Save or publish an unrelated edit, reload through an independent read, and confirm the advanced environment value is byte-for-byte unchanged."
+    must_avoid:
+      - "Treating optimistic UI state or component-test mocks as saved-state evidence."
+```
+
+<!-- The charter is durable and immutable: re-run it in later cycles; each run's debrief goes in that run's report (Session Debriefs), never here. -->

--- a/docs/qa/charters/CH-loop-worktree-tool-root.md
+++ b/docs/qa/charters/CH-loop-worktree-tool-root.md
@@ -1,0 +1,26 @@
+# CH-loop-worktree-tool-root: Loop tools use the selected checkout
+
+```yaml
+charter:
+  id: CH-loop-worktree-tool-root
+  mission: "As Ada, run a Loop whose task pack exists only in a ready Worktree and prove its extension action uses that checkout."
+  mode: scenario-based
+  persona:
+    name: Ada
+    device: desktop
+    network: wifi-fast
+    locale: en-US
+  journey: J-isolated-task-loop-execution
+  scenarios: [LP-loop-environment-resolution]
+  tour: Feature Tour
+  time_box_minutes: 30
+  guidance:
+    must_try:
+      - "Create the task pack only in a ready Worktree, configure a Loop extension action with that worktree id, and start it through structured CLI output."
+      - "Read the Loop output through CLI, API, and Web; it must name the task path under the selected Worktree."
+      - "Use a root-scoped run or direct extension action as a canary; it must not see the worktree-only task pack."
+    must_avoid:
+      - "Using database reads, copied files in the parent checkout, or test-only fixtures as behavior evidence."
+```
+
+<!-- The charter is durable and immutable: re-run it in later cycles; each run's debrief goes in that run's report (Session Debriefs), never here. -->

--- a/docs/qa/journeys/J-isolated-task-loop-execution.md
+++ b/docs/qa/journeys/J-isolated-task-loop-execution.md
@@ -21,10 +21,13 @@ flowchart TD
     K -->|worktree| L[Resolve the ready worktree]
     K -->|per_run| M[Materialize one checkout per node instance]
     K -->|directory| N[Render and contain the directory under the workspace root]
-    L --> O[Start the node session at the resolved root]
+    L --> L1{Agent or extension tool}
+    L1 -->|agent| O[Start the node session at the resolved root]
+    L1 -->|extension tool| O1[Resolve workspace-relative resources from the same checkout]
     M --> O
     N --> O
     O --> P[Reach the Loop node and run terminal state]
+    O1 --> P
     I --> Q[Fresh reads show the same run, session, and worktree identities]
     P --> Q
     Q --> R{Retained worktree?}
@@ -59,7 +62,7 @@ journey:
       expected_observable: "Task runs retain the enqueue-time policy snapshot, and every per-run task or Loop node instance receives its own worktree identity."
     - step: 3
       verb: "Let the worker or node execute"
-      expected_observable: "The session runs from the resolved worktree or contained directory, with no fallback to the parent root and no sibling checkout leakage."
+      expected_observable: "The session and workspace-relative extension tools use the resolved worktree or contained directory, with no fallback to the parent root and no sibling checkout leakage."
     - step: 4
       verb: "Complete, cancel, or observe a denied materialization"
       expected_observable: "Successful and canceled worktrees remain inspectable with run attribution; a pre-create denial fails only its run and leaves no orphan."
@@ -72,7 +75,7 @@ journey:
   goal:
     observable: "Task and Loop work runs in the selected isolated environment and remains attributable after completion."
     side_effects: [policy-snapshotted, worktree-created, session-bound, run-attributed, terminal-state-persisted]
-  true_end_state: "Fresh structured reads show each run and session bound to the same durable worktree or contained directory used for execution; retained worktrees remain manageable through the ordinary exit flow, and denied creation has no Git, registry, or event residue."
+  true_end_state: "Fresh structured reads show each run, session, and workspace-relative extension action using the same durable worktree or contained directory selected for execution; retained worktrees remain manageable through the ordinary exit flow, and denied creation has no Git, registry, or event residue."
   exit:
     natural: "The operator inspects or removes retained worktrees after the task or Loop reaches a terminal state."
   abandonment:
@@ -86,7 +89,7 @@ journey:
 
 coverage:
   journeys: "Task profile through terminal run, designated fan-out, and Loop node execution all reach a durable end state."
-  functional: "Snapshot authority, distinct per-run roots, directory containment, hook denial cleanup, and cross-surface parity are in scope."
+  functional: "Snapshot authority, extension-tool root propagation, distinct per-run roots, directory containment, hook denial cleanup, and cross-surface parity are in scope."
   experiential: "Structured output must make the selected mode, resulting binding, and recoverable failure clear without requiring database or Git inspection."
   edge_error_empty: "Post-enqueue profile edits, invalid refs, explicit hook denial, cancellation, and empty fan-out attribution are covered by the walk."
   cross_cutting: "Workspace isolation, event correlation, config lifecycle, and agent-manageability are checked across task and Loop consumers."

--- a/docs/qa/reports/2026-09-01-issue-512-loop-worktree-tools.md
+++ b/docs/qa/reports/2026-09-01-issue-512-loop-worktree-tools.md
@@ -1,0 +1,89 @@
+# QA Run Report — 2026-09-01 — issue-512-loop-worktree-tools
+
+- **Scope:** Issue 512 — selected Loop Worktrees scope extension tools and Web authors only root/worktree without losing API/CLI values
+- **Cadence tier:** targeted
+- **Build:** `1881a9f54` + working tree · **Environment:** isolated lab, `http://127.0.0.1:62770`
+- **Started:** 2026-09-01T13:33:55Z · **Status:** PASS
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | Power User | desktop / wifi-fast / en-US | CH-loop-worktree-tool-root |
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-loop-web-environment-authoring |
+
+## Flows in Scope
+
+- `J-isolated-task-loop-execution` — Run task and Loop work in isolated environments (`../journeys/J-isolated-task-loop-execution.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-loop-worktree-tool-root | J-isolated-task-loop-execution / LP-loop-environment-resolution | Ada | Feature Tour | Pass | | |
+| 2 | CH-loop-web-environment-authoring | J-isolated-task-loop-execution / LP-worktree-web-loop-environment | Bruno | Feature Tour | Pass | | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-loop-worktree-tool-root — Ada
+
+- **Ran:** 2026-09-01T13:41Z → 13:45Z (box respected: yes)
+- **Findings:** A root-scoped canary returned `No task set matched`; after selecting ready Worktree
+  `wt_d7e6c291e8cae07e`, the same extension action completed and returned the sole task from
+  `project-worktree/.compozy/tasks/issue-512-qa/task_01.md`. CLI, HTTP, Web, and runtime records
+  agreed for `looprun-4047102765205c5a`, including after reload.
+- **Bugs filed/updated:** none
+- **Scenarios settled:** LP-loop-environment-resolution → pass
+
+### CH-loop-web-environment-authoring — Bruno
+
+- **Ran:** 2026-09-01T13:43Z → 13:48Z (box respected: yes)
+- **Findings:** The Run form offered only Inherit, Workspace root, and Named worktree. A
+  CLI-authored directory rendered as `Directory (read-only)`, its input had the browser
+  `readOnly` property, and saving the unrelated Human approval gate preserved the exact directory.
+  A CLI-authored per-run value then rendered as `Per-run (read-only)`.
+- **Bugs filed/updated:** none
+- **Scenarios settled:** LP-worktree-web-loop-environment → pass
+
+## What Was Fixed
+
+No QA findings fixed in this run.
+
+## Paper Cuts
+
+None.
+
+## Runtime Errors Observed
+
+- The first-run wizard remained on `Loading Continue` within the session patience window after the
+  default Codex model was selected. The session ended without retries; the supported
+  `compozy onboarding complete` command established the precondition for a fresh browser session.
+  This did not recur in either in-scope Loop journey.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- A one-action Loop is the cleanest behavioral probe for this regression: it isolates extension
+  workspace resolution from provider availability while still using the published Loop, CLI,
+  HTTP, Web, and extension subprocess surfaces.
+- The strongest preservation proof pairs the read-only Web control with a structured CLI read
+  after an unrelated Web save.
+
+## Final Status
+
+- **Behavioral sessions:** PASS — 2/2 targeted scenarios passed.
+- **Evidence:** `docs/qa/evidence/2026-09-01-issue-512-loop-worktree-tools/` plus the isolated lab's
+  `qa/evidence/issue-512-loop-worktree-tools/` structured CLI/API reads.
+- **Evidence audit:** PASS — strict audit reported 0 blockers and 0 warnings.
+- **Local gate:** PASS — all classified Go and Web lanes completed successfully.
+- **Teardown:** PASS — `qa/teardown.json` records `"clean": true` with no surviving lab processes.
+- **QA verdict:** PASS — exact-head PR CI remains the repository delivery gate outside this QA run.

--- a/docs/qa/reports/2026-09-01-pr-519-review-fixes.md
+++ b/docs/qa/reports/2026-09-01-pr-519-review-fixes.md
@@ -1,0 +1,59 @@
+# QA Run Report — 2026-09-01 — PR 519 review fixes
+
+- **Scope:** Worktree removal during Loop extension calls and read-only advanced Web environments
+- **Cadence tier:** targeted
+- **Build:** working tree for PR 519 · **Environment:** isolated lab, daemon `http://127.0.0.1:57779`, Web `http://localhost:3000`
+- **Started:** 2026-09-01T15:11:10Z · **Status:** PASS
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Session |
+|---|---|---|---|
+| Ada | Power User | desktop / wifi-fast / en-US | CH-loop-worktree-tool-root |
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-loop-web-environment-authoring |
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Tour | Status |
+|---|---|---|---|---|
+| 1 | CH-loop-worktree-tool-root | J-isolated-task-loop-execution / LP-loop-environment-resolution | Feature Tour | Pass |
+| 2 | CH-loop-web-environment-authoring | J-isolated-task-loop-execution / LP-worktree-web-loop-environment | Feature Tour | Pass |
+
+## Session Debriefs
+
+### CH-loop-worktree-tool-root — Ada
+
+- A real one-action Loop claimed `run.loop.looprun-c6a1c35ff80474c8.g1.node.load_tasks.0` and held
+  `ext__spec_cycle__import_tasks` open against ready Worktree `wt_6a764ac4712021cf`.
+- Concurrent structured CLI removal returned exit 65 and `worktree_operation_in_progress`.
+- The tool then completed with the task path under the selected Worktree; removal succeeded only
+  after the tool released its lease.
+- Scenario settled: LP-loop-environment-resolution → pass.
+
+### CH-loop-web-environment-authoring — Bruno
+
+- The live configure form continued to offer only Inherit, Workspace root, and Named worktree for
+  authored choices.
+- CLI-authored directory and per-run values rendered as disabled read-only buttons on fresh loads.
+- The directory textbox preserved its exact absolute value.
+- Scenario settled: LP-worktree-web-loop-environment → pass.
+
+## Paper Cuts
+
+None in scope.
+
+## Runtime Errors Observed
+
+- Deliberately blocked FIFO probes caused two earlier extension-host health timeouts before the
+  final timestamped run. They were lab-probe artifacts, not product findings; the final run
+  released normally and completed through the same public runtime path.
+
+## Final Status
+
+- **Behavioral sessions:** PASS — 2/2 affected scenarios passed.
+- **Evidence:** repository screenshots plus structured artifacts under the isolated lab.
+- **Local gate:** PASS — `make gate` completed the scoped Go lint, Go race-test, and Web
+  lint/typecheck/test lanes with zero failures.
+- **Teardown:** PASS — `qa/teardown.json` records `"clean": true` and no survivors.
+- **QA verdict:** PASS — the worktree lease blocks removal for the complete tool call, and advanced
+  Web environment values remain visible but non-interactive.

--- a/docs/qa/scenarios/LP-loop-environment-resolution.md
+++ b/docs/qa/scenarios/LP-loop-environment-resolution.md
@@ -11,8 +11,8 @@ bug_ids:
 fix_status:
 retest_status: pass
 fix_commits:
-evidence: docs/qa/evidence/2026-09-01-issue-512-loop-worktree-tools/web-run-done-after-reload.png
-last_report: docs/qa/reports/2026-09-01-issue-512-loop-worktree-tools.md
+evidence: qa-lab pr-519-review-fixes worktree-removal-blocked.json; tool-run-completed.json; worktree-removed-after-tool.json
+last_report: docs/qa/reports/2026-09-01-pr-519-review-fixes.md
 overlaps:
 ---
 
@@ -25,3 +25,7 @@ CLI-started run and a Web-started run with ready Worktree `wt_d7e6c291e8cae07e` 
 extension action and returned the task path under `project-worktree`. CLI, HTTP, Web, and runtime
 evidence agreed after a fresh Web reload. The real-worktree integration suite separately verifies
 that implement-tasks worker sessions retain the same Worktree id.
+
+QA follow-up 2026-09-01: while the real extension task run was claimed and blocked inside
+`ext__spec_cycle__import_tasks`, CLI removal returned `worktree_operation_in_progress`. After the
+tool completed with the worktree-only task path, the same CLI removal succeeded.

--- a/docs/qa/scenarios/LP-loop-environment-resolution.md
+++ b/docs/qa/scenarios/LP-loop-environment-resolution.md
@@ -4,18 +4,24 @@ area: LP
 title: Resolve each Loop node into its declared environment
 persona: Ada
 journey: J-isolated-task-loop-execution
-expected: A Loop node overrides the loop default, resolves a ready worktree or contained directory, creates a distinct worktree for every per-run fan-out instance, and fails before session start when the environment cannot be resolved.
-entry_points: compozy loop create|validate --file; compozy loop configure --file|--set; compozy loop run --config-file; HTTP/UDS Loop definition, config, and run routes; compozy__loop_create|configure|run.environment
+expected: A Loop node resolves every agent session and workspace-relative extension action from its ready worktree, while root, directory, per-run, precedence, and invalid-environment behavior remain unchanged.
+entry_points: compozy loop create|validate --file; compozy loop configure --file|--set; compozy loop run --config-file; HTTP/UDS Loop definition, config, and run routes; compozy__loop_create|configure|run.environment; ext__spec-cycle__import_tasks
 qa_status: pass
 bug_ids:
 fix_status:
-retest_status:
+retest_status: pass
 fix_commits:
-evidence: internal/daemon/loop_action_environment_integration_test.go; internal/loop/action_test.go
-last_report: docs/qa/reports/2026-08-13-worktree-support.md
+evidence: docs/qa/evidence/2026-09-01-issue-512-loop-worktree-tools/web-run-done-after-reload.png
+last_report: docs/qa/reports/2026-09-01-issue-512-loop-worktree-tools.md
 overlaps:
 ---
 
-QA impact: Task 04 replaces Loop `params.cwd` with the closed `environment` contract for run-agent
-and goal nodes. The Phase C walk must cover root, worktree, per_run fan-out, and a templated directory,
-plus the retired `cwd` validation message and run-loop inheritance.
+QA impact: Issue 512 makes a named Loop worktree authoritative for workspace-relative extension
+actions as well as agent sessions. The targeted walk must load a task pack that exists only in the
+worktree, verify worker-session attribution, and retain root/manual-call behavior as a canary.
+
+QA completion 2026-09-01: the root-scoped canary could not see the worktree-only task pack. Both a
+CLI-started run and a Web-started run with ready Worktree `wt_d7e6c291e8cae07e` completed the same
+extension action and returned the task path under `project-worktree`. CLI, HTTP, Web, and runtime
+evidence agreed after a fresh Web reload. The real-worktree integration suite separately verifies
+that implement-tasks worker sessions retain the same Worktree id.

--- a/docs/qa/scenarios/LP-worktree-web-loop-environment.md
+++ b/docs/qa/scenarios/LP-worktree-web-loop-environment.md
@@ -11,8 +11,8 @@ bug_ids:
 fix_status:
 retest_status: pass
 fix_commits:
-evidence: docs/qa/evidence/2026-09-01-issue-512-loop-worktree-tools/directory-preserved-after-save.png
-last_report: docs/qa/reports/2026-09-01-issue-512-loop-worktree-tools.md
+evidence: docs/qa/evidence/2026-09-01-pr-519-review-fixes/directory-read-only-disabled.png; docs/qa/evidence/2026-09-01-pr-519-review-fixes/per-run-read-only-disabled.png
+last_report: docs/qa/reports/2026-09-01-pr-519-review-fixes.md
 overlaps: LP-loop-environment-resolution
 ---
 
@@ -24,3 +24,6 @@ QA completion 2026-09-01: the live Run form offered only Inherit, Workspace root
 worktree, then completed against the selected ready Worktree. A CLI-authored directory remained
 read-only and byte-for-byte unchanged after an unrelated Human approval gate save and a fresh CLI
 read. A subsequent CLI-authored per-run value rendered as `Per-run (read-only)`.
+
+QA follow-up 2026-09-01: fresh Web loads rendered both CLI-authored `Directory (read-only)` and
+`Per-run (read-only)` controls as disabled while preserving the directory value exactly.

--- a/docs/qa/scenarios/LP-worktree-web-loop-environment.md
+++ b/docs/qa/scenarios/LP-worktree-web-loop-environment.md
@@ -2,18 +2,25 @@
 id: LP-worktree-web-loop-environment
 area: LP
 title: Declare loop and node execution environments in the builder
-persona: Ada
+persona: Bruno
 journey: J-isolated-task-loop-execution
-expected: The loop configure dialog sets a loop-level environment default that survives an unrelated save, and agent-executing nodes expose exactly one Environment control with the locked mode vocabulary. Switching a mode writes only the companion key that mode allows. The retired working-directory field is gone from every node, and a definition still carrying it fails validation with the daemon's migration reason on the offending node.
+expected: Loop configure, run, and node Environment controls author only root or a named worktree, while API/CLI-authored directory and per-run values remain visible, read-only, and byte-for-byte preserved by unrelated saves or publishes.
 entry_points: S12 Loop configure dialog -> Environment default; S13 loop builder -> node inspector -> Environment
 qa_status: pass
 bug_ids:
 fix_status:
-retest_status:
+retest_status: pass
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-worktree-support-terminal-rewalk-20260813-150834-409343-lab/qa-artifacts/qa/screenshots/loop-node-named-worktree.png; web/src/systems/loops/components/__tests__/loop-editor.test.tsx
-last_report: docs/qa/reports/2026-08-13-worktree-support.md
+evidence: docs/qa/evidence/2026-09-01-issue-512-loop-worktree-tools/directory-preserved-after-save.png
+last_report: docs/qa/reports/2026-09-01-issue-512-loop-worktree-tools.md
 overlaps: LP-loop-environment-resolution
 ---
 
-QA impact: Task 07 adds the loop environment default, the node Environment descriptor, and the hard cut of params.cwd from the builder.
+QA impact: Issue 512 removes directory and per-run from Web authoring without removing those API/CLI
+contracts. The walk must prove both the reduced choice set and lossless preservation of a loaded
+read-only value.
+
+QA completion 2026-09-01: the live Run form offered only Inherit, Workspace root, and Named
+worktree, then completed against the selected ready Worktree. A CLI-authored directory remained
+read-only and byte-for-byte unchanged after an unrelated Human approval gate save and a fresh CLI
+read. A subsequent CLI-authored per-run value rendered as `Per-run (read-only)`.

--- a/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
+++ b/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/compozy/compozy/internal/speed"
 	"github.com/compozy/compozy/internal/testutil/acpmock"
 	e2etest "github.com/compozy/compozy/internal/testutil/e2e"
+	worktreepkg "github.com/compozy/compozy/internal/worktree"
 )
 
 const (
@@ -51,6 +52,50 @@ func TestDaemonE2EImplementTasksShouldCompleteTaskJourney(t *testing.T) {
 		})
 		assertImplementTasksPerTaskRuntimes(t, detail)
 		assertImplementTasksRoute(t, detail, "orchestrate", "route_not_taken:select_delivery")
+	})
+
+	t.Run("Should import a worktree-only task pack and bind its workers to that worktree", func(t *testing.T) {
+		t.Parallel()
+
+		workspaceRoot := initWorktreeE2ERepository(t)
+		harness, ctx := startImplementTasksE2EHarnessAt(t, implementTasksImplementer, workspaceRoot)
+		runWorktreeE2EGit(t, ctx, workspaceRoot, "add", ".")
+		runWorktreeE2EGit(t, ctx, workspaceRoot, "commit", "-m", "seed implement-tasks pack")
+
+		created := createWorktreeE2E(t, ctx, harness, harness.WorkspaceID, "Issue 512")
+		ready := waitForWorktreeE2EState(
+			t, ctx, harness, harness.WorkspaceID, created.ID, worktreepkg.StateReady,
+		)
+		mainTaskPack := filepath.Join(workspaceRoot, ".compozy", "tasks", implementTasksE2ESlug)
+		if err := os.RemoveAll(mainTaskPack); err != nil {
+			t.Fatalf("RemoveAll(main task pack) error = %v", err)
+		}
+		if _, err := os.Stat(mainTaskPack); !os.IsNotExist(err) {
+			t.Fatalf("Stat(main task pack) error = %v, want not exist", err)
+		}
+		worktreeTask := filepath.Join(
+			ready.Worktree.Path,
+			".compozy",
+			"tasks",
+			implementTasksE2ESlug,
+			"task_01.md",
+		)
+		if _, err := os.Stat(worktreeTask); err != nil {
+			t.Fatalf("Stat(worktree task) error = %v", err)
+		}
+
+		configPath := filepath.Join(t.TempDir(), "worktree-config.yaml")
+		configBody := fmt.Sprintf(
+			"environment:\n  mode: worktree\n  worktree_ref: %s\n",
+			quotedYAMLString(ready.Worktree.ID),
+		)
+		if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+			t.Fatalf("WriteFile(worktree config) error = %v", err)
+		}
+
+		detail := runImplementTasksE2E(t, ctx, harness, []string{"--config-file", configPath})
+		assertImplementTasksRoute(t, detail, "orchestrate", "route_not_taken:select_delivery")
+		assertImplementTasksWorkerWorktree(t, ctx, harness, detail, ready.Worktree.ID)
 	})
 
 	t.Run("Should complete orchestrated mode and stop every category worker", func(t *testing.T) {
@@ -95,11 +140,22 @@ func startImplementTasksE2EHarness(
 	orchestratedImplementer string,
 ) (*e2etest.RuntimeHarness, context.Context) {
 	t.Helper()
+	return startImplementTasksE2EHarnessAt(t, orchestratedImplementer, "")
+}
+
+func startImplementTasksE2EHarnessAt(
+	t testing.TB,
+	orchestratedImplementer string,
+	workspaceRoot string,
+) (*e2etest.RuntimeHarness, context.Context) {
+	t.Helper()
 
 	driverPath := acpmock.RequireDriver(t)
 	binaryPath := e2etest.BuildCompozyBinary(t)
 	homePaths := e2etest.NewHomePaths(t)
-	workspaceRoot := filepath.Join(t.TempDir(), "implement-tasks-workspace")
+	if strings.TrimSpace(workspaceRoot) == "" {
+		workspaceRoot = filepath.Join(t.TempDir(), "implement-tasks-workspace")
+	}
 	fixturePath := materializeImplementTasksFixture(
 		t,
 		mockFixturePath(t, "implement_tasks_fixture.json"),
@@ -590,6 +646,42 @@ func assertImplementTasksSpawnedWorkerRuntimes(
 		}
 		if len(live.Sessions) != 0 {
 			t.Fatalf("spawned implement-tasks workers remain %s: %#v", state, live.Sessions)
+		}
+	}
+}
+
+func assertImplementTasksWorkerWorktree(
+	t testing.TB,
+	ctx context.Context,
+	harness *e2etest.RuntimeHarness,
+	detail contract.LoopRunResponse,
+	wantWorktreeID string,
+) {
+	t.Helper()
+
+	sessionIDs := make([]string, 0, 3)
+	for _, generation := range detail.Generations {
+		for _, output := range generation.Outputs {
+			if strings.HasPrefix(output.NodeID, "execute_") && output.SessionID != "" {
+				sessionIDs = append(sessionIDs, output.SessionID)
+			}
+		}
+	}
+	if len(sessionIDs) != 3 {
+		t.Fatalf("implement-tasks worker session ids = %#v, want three sessions", sessionIDs)
+	}
+	for _, sessionID := range sessionIDs {
+		worker, err := harness.GetSession(ctx, sessionID)
+		if err != nil {
+			t.Fatalf("GetSession(%q) error = %v", sessionID, err)
+		}
+		if worker.WorktreeID != wantWorktreeID {
+			t.Fatalf(
+				"spawned worker %q worktree = %q, want %q",
+				worker.Name,
+				worker.WorktreeID,
+				wantWorktreeID,
+			)
 		}
 	}
 }

--- a/internal/daemon/execution_worktrees.go
+++ b/internal/daemon/execution_worktrees.go
@@ -12,6 +12,7 @@ import (
 // adapter resolves the current service at call time.
 type executionWorktreeService interface {
 	Get(context.Context, string, string) (*worktree.Worktree, error)
+	AcquireUsage(context.Context, string, string) (*worktree.Worktree, func(), error)
 	MaterializeForRun(context.Context, string, worktree.RunWorktreeRequest) (*worktree.Worktree, error)
 	RollbackRunMaterialization(context.Context, string, string, string) error
 }
@@ -34,6 +35,18 @@ func (r daemonExecutionWorktrees) service() executionWorktreeService {
 		return nil
 	}
 	return r.lookup()
+}
+
+func (r daemonExecutionWorktrees) AcquireUsage(
+	ctx context.Context,
+	workspaceID string,
+	ref string,
+) (*worktree.Worktree, func(), error) {
+	service := r.service()
+	if service == nil {
+		return nil, nil, fmt.Errorf("daemon: worktree service is unavailable: %w", worktree.ErrNotFound)
+	}
+	return service.AcquireUsage(ctx, workspaceID, ref)
 }
 
 func (r daemonExecutionWorktrees) Get(

--- a/internal/daemon/loop_action_environment.go
+++ b/internal/daemon/loop_action_environment.go
@@ -15,7 +15,7 @@ import (
 )
 
 type loopActionWorktrees interface {
-	Get(context.Context, string, string) (*worktree.Worktree, error)
+	loopActionWorktreeReader
 	MaterializeForRun(context.Context, string, worktree.RunWorktreeRequest) (*worktree.Worktree, error)
 	RollbackRunMaterialization(context.Context, string, string, string) error
 }
@@ -69,27 +69,14 @@ func (b *loopActionSessionBinder) applyLoopActionEnvironment(
 	case dsl.EnvironmentRoot, dsl.EnvironmentDirectory:
 		return nil, nil
 	case dsl.EnvironmentWorktree:
-		if b.worktrees == nil {
-			return nil, fmt.Errorf("%w: loop worktree service is unavailable", worktree.ErrNotFound)
-		}
-		item, getErr := b.worktrees.Get(
+		item, getErr := resolveReadyLoopActionWorktree(
 			ctx,
+			b.worktrees,
 			strings.TrimSpace(string(req.WorkspaceID)),
 			environment.WorktreeRef,
 		)
 		if getErr != nil {
 			return nil, getErr
-		}
-		if item == nil {
-			return nil, fmt.Errorf("%w: loop worktree %q", worktree.ErrNotFound, environment.WorktreeRef)
-		}
-		if item.State != worktree.StateReady {
-			return nil, fmt.Errorf(
-				"%w: loop worktree %q is %q",
-				worktree.ErrNotReady,
-				environment.WorktreeRef,
-				item.State,
-			)
 		}
 		opts.Worktree = item.ID
 		opts.CWD = item.Path

--- a/internal/daemon/loop_action_registry_boot.go
+++ b/internal/daemon/loop_action_registry_boot.go
@@ -17,15 +17,19 @@ func newBootLoopActionRegistry(
 	gateEvaluator gate.GateEvaluator,
 	judgeExecutions *loopJudgeExecutionRegistry,
 ) (*looppkg.ActionRegistry, error) {
+	worktrees := executionWorktreesForState(state)
 	actionBinder := &loopActionSessionBinder{
 		sessions:            state.sessions,
 		globalWorkspacePath: globalWorkspacePath,
 		policyGate:          policyGate,
-		worktrees:           executionWorktreesForState(state),
+		worktrees:           worktrees,
 	}
 	actionOptions := []looppkg.ActionRegistryOption{
 		looppkg.WithActionDefaultMaxResultBytes(state.cfg.Tools.DefaultMaxResultBytes),
 		looppkg.WithActionSessionBinder(actionBinder),
+		looppkg.WithActionToolWorkspaceRootResolver(&loopActionToolWorkspaceRootResolver{
+			worktrees: worktrees,
+		}),
 		looppkg.WithActionLoopStarter(lazyLoopStarter{current: func() looppkg.ActionLoopStarter {
 			if state == nil {
 				return nil
@@ -45,7 +49,7 @@ func newBootLoopActionRegistry(
 			policyGate,
 			time.Now,
 			state.logger,
-			executionWorktreesForState(state),
+			worktrees,
 		)
 		actionOptions[1] = looppkg.WithActionSessionBinder(goalRuntime)
 		goalOption, err := composeLoopGoalExecutor(

--- a/internal/daemon/loop_action_tool_workspace.go
+++ b/internal/daemon/loop_action_tool_workspace.go
@@ -14,29 +14,51 @@ type loopActionWorktreeReader interface {
 	Get(context.Context, string, string) (*worktree.Worktree, error)
 }
 
+type loopActionWorktreeUsage interface {
+	AcquireUsage(context.Context, string, string) (*worktree.Worktree, func(), error)
+}
+
 type loopActionToolWorkspaceRootResolver struct {
-	worktrees loopActionWorktreeReader
+	worktrees loopActionWorktreeUsage
 }
 
 var _ looppkg.ActionToolWorkspaceRootResolver = (*loopActionToolWorkspaceRootResolver)(nil)
 
-func (r *loopActionToolWorkspaceRootResolver) ResolveActionToolWorkspaceRoot(
+func (r *loopActionToolWorkspaceRootResolver) AcquireActionToolWorkspaceRoot(
 	ctx context.Context,
 	req looppkg.ActionToolWorkspaceRootRequest,
-) (string, error) {
+) (string, func(), error) {
 	if req.Environment.Mode != dsl.EnvironmentWorktree {
-		return "", nil
+		return "", nil, nil
 	}
-	item, err := resolveReadyLoopActionWorktree(
+	if r.worktrees == nil {
+		return "", nil, fmt.Errorf("%w: loop worktree service is unavailable", worktree.ErrNotFound)
+	}
+	item, release, err := r.worktrees.AcquireUsage(
 		ctx,
-		r.worktrees,
 		strings.TrimSpace(string(req.WorkspaceID)),
 		req.Environment.WorktreeRef,
 	)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return item.Path, nil
+	if release == nil {
+		return "", nil, fmt.Errorf("%w: loop worktree usage lease has no release function", worktree.ErrNotReady)
+	}
+	if item == nil {
+		release()
+		return "", nil, fmt.Errorf("%w: loop worktree %q", worktree.ErrNotFound, req.Environment.WorktreeRef)
+	}
+	if item.State != worktree.StateReady || strings.TrimSpace(item.Path) == "" {
+		release()
+		return "", nil, fmt.Errorf(
+			"%w: loop worktree %q is %q",
+			worktree.ErrNotReady,
+			req.Environment.WorktreeRef,
+			item.State,
+		)
+	}
+	return item.Path, release, nil
 }
 
 func resolveReadyLoopActionWorktree(

--- a/internal/daemon/loop_action_tool_workspace.go
+++ b/internal/daemon/loop_action_tool_workspace.go
@@ -1,0 +1,63 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/loop/dsl"
+	"github.com/compozy/compozy/internal/worktree"
+)
+
+type loopActionWorktreeReader interface {
+	Get(context.Context, string, string) (*worktree.Worktree, error)
+}
+
+type loopActionToolWorkspaceRootResolver struct {
+	worktrees loopActionWorktreeReader
+}
+
+var _ looppkg.ActionToolWorkspaceRootResolver = (*loopActionToolWorkspaceRootResolver)(nil)
+
+func (r *loopActionToolWorkspaceRootResolver) ResolveActionToolWorkspaceRoot(
+	ctx context.Context,
+	req looppkg.ActionToolWorkspaceRootRequest,
+) (string, error) {
+	if req.Environment.Mode != dsl.EnvironmentWorktree {
+		return "", nil
+	}
+	item, err := resolveReadyLoopActionWorktree(
+		ctx,
+		r.worktrees,
+		strings.TrimSpace(string(req.WorkspaceID)),
+		req.Environment.WorktreeRef,
+	)
+	if err != nil {
+		return "", err
+	}
+	return item.Path, nil
+}
+
+func resolveReadyLoopActionWorktree(
+	ctx context.Context,
+	worktrees loopActionWorktreeReader,
+	workspaceID string,
+	worktreeRef string,
+) (*worktree.Worktree, error) {
+	ref := strings.TrimSpace(worktreeRef)
+	if worktrees == nil {
+		return nil, fmt.Errorf("%w: loop worktree service is unavailable", worktree.ErrNotFound)
+	}
+	item, err := worktrees.Get(ctx, strings.TrimSpace(workspaceID), ref)
+	if err != nil {
+		return nil, err
+	}
+	if item == nil {
+		return nil, fmt.Errorf("%w: loop worktree %q", worktree.ErrNotFound, ref)
+	}
+	if item.State != worktree.StateReady || strings.TrimSpace(item.Path) == "" {
+		return nil, fmt.Errorf("%w: loop worktree %q is %q", worktree.ErrNotReady, ref, item.State)
+	}
+	return item, nil
+}

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -97,6 +97,77 @@ func TestLoopCancellationSessionControllerShouldTreatMissingSessionsAsStopped(t 
 	}
 }
 
+func TestLoopActionToolWorkspaceRootResolverShouldRequireReadyWorktrees(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should resolve a ready worktree in the requested workspace", func(t *testing.T) {
+		t.Parallel()
+
+		worktrees := &recordingTaskBridgeWorktrees{getItem: &worktreepkg.Worktree{
+			ID: "wt-ready", WorkspaceID: "ws-loop", Path: "/worktrees/ready", State: worktreepkg.StateReady,
+		}}
+		resolver := &loopActionToolWorkspaceRootResolver{worktrees: worktrees}
+
+		root, err := resolver.ResolveActionToolWorkspaceRoot(t.Context(), looppkg.ActionToolWorkspaceRootRequest{
+			WorkspaceID: "ws-loop",
+			Environment: dsl.EnvironmentSpec{Mode: dsl.EnvironmentWorktree, WorktreeRef: "ready-ref"},
+		})
+		if err != nil {
+			t.Fatalf("ResolveActionToolWorkspaceRoot() error = %v", err)
+		}
+		if got, want := root, "/worktrees/ready"; got != want {
+			t.Fatalf("ResolveActionToolWorkspaceRoot() = %q, want %q", got, want)
+		}
+		if len(worktrees.getCalls) != 1 || worktrees.getCalls[0] != (taskBridgeWorktreeGetCall{
+			workspaceID: "ws-loop", ref: "ready-ref",
+		}) {
+			t.Fatalf("Get() calls = %#v, want workspace-scoped ready-ref", worktrees.getCalls)
+		}
+	})
+
+	t.Run("Should preserve typed missing and non-ready worktree errors", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name      string
+			worktrees *recordingTaskBridgeWorktrees
+			wantErr   error
+		}{
+			{
+				name:      "Should preserve a missing worktree lookup error",
+				worktrees: &recordingTaskBridgeWorktrees{getErr: worktreepkg.ErrNotFound},
+				wantErr:   worktreepkg.ErrNotFound,
+			},
+			{
+				name: "Should reject a worktree that is not ready",
+				worktrees: &recordingTaskBridgeWorktrees{getItem: &worktreepkg.Worktree{
+					ID: "wt-pending", WorkspaceID: "ws-loop", State: worktreepkg.StatePending,
+				}},
+				wantErr: worktreepkg.ErrNotReady,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				resolver := &loopActionToolWorkspaceRootResolver{worktrees: tt.worktrees}
+				_, err := resolver.ResolveActionToolWorkspaceRoot(
+					t.Context(),
+					looppkg.ActionToolWorkspaceRootRequest{
+						WorkspaceID: "ws-loop",
+						Environment: dsl.EnvironmentSpec{
+							Mode: dsl.EnvironmentWorktree, WorktreeRef: "pending-ref",
+						},
+					},
+				)
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("ResolveActionToolWorkspaceRoot() error = %v, want %v", err, tt.wantErr)
+				}
+			})
+		}
+	})
+}
+
 func TestLoopActionSessionBinderShouldApplyPolicyGate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -108,20 +108,28 @@ func TestLoopActionToolWorkspaceRootResolverShouldRequireReadyWorktrees(t *testi
 		}}
 		resolver := &loopActionToolWorkspaceRootResolver{worktrees: worktrees}
 
-		root, err := resolver.ResolveActionToolWorkspaceRoot(t.Context(), looppkg.ActionToolWorkspaceRootRequest{
-			WorkspaceID: "ws-loop",
-			Environment: dsl.EnvironmentSpec{Mode: dsl.EnvironmentWorktree, WorktreeRef: "ready-ref"},
-		})
+		root, release, err := resolver.AcquireActionToolWorkspaceRoot(
+			t.Context(),
+			looppkg.ActionToolWorkspaceRootRequest{
+				WorkspaceID: "ws-loop",
+				Environment: dsl.EnvironmentSpec{Mode: dsl.EnvironmentWorktree, WorktreeRef: "ready-ref"},
+			},
+		)
 		if err != nil {
-			t.Fatalf("ResolveActionToolWorkspaceRoot() error = %v", err)
+			t.Fatalf("AcquireActionToolWorkspaceRoot() error = %v", err)
 		}
+		t.Cleanup(release)
 		if got, want := root, "/worktrees/ready"; got != want {
-			t.Fatalf("ResolveActionToolWorkspaceRoot() = %q, want %q", got, want)
+			t.Fatalf("AcquireActionToolWorkspaceRoot() = %q, want %q", got, want)
 		}
-		if len(worktrees.getCalls) != 1 || worktrees.getCalls[0] != (taskBridgeWorktreeGetCall{
+		if len(worktrees.usageCalls) != 1 || worktrees.usageCalls[0] != (taskBridgeWorktreeUsageCall{
 			workspaceID: "ws-loop", ref: "ready-ref",
 		}) {
-			t.Fatalf("Get() calls = %#v, want workspace-scoped ready-ref", worktrees.getCalls)
+			t.Fatalf("AcquireUsage() calls = %#v, want workspace-scoped ready-ref", worktrees.usageCalls)
+		}
+		release()
+		if worktrees.usageReleases != 1 {
+			t.Fatalf("usage releases = %d, want 1", worktrees.usageReleases)
 		}
 	})
 
@@ -151,7 +159,7 @@ func TestLoopActionToolWorkspaceRootResolverShouldRequireReadyWorktrees(t *testi
 				t.Parallel()
 
 				resolver := &loopActionToolWorkspaceRootResolver{worktrees: tt.worktrees}
-				_, err := resolver.ResolveActionToolWorkspaceRoot(
+				_, _, err := resolver.AcquireActionToolWorkspaceRoot(
 					t.Context(),
 					looppkg.ActionToolWorkspaceRootRequest{
 						WorkspaceID: "ws-loop",
@@ -161,7 +169,7 @@ func TestLoopActionToolWorkspaceRootResolverShouldRequireReadyWorktrees(t *testi
 					},
 				)
 				if !errors.Is(err, tt.wantErr) {
-					t.Fatalf("ResolveActionToolWorkspaceRoot() error = %v, want %v", err, tt.wantErr)
+					t.Fatalf("AcquireActionToolWorkspaceRoot() error = %v, want %v", err, tt.wantErr)
 				}
 			})
 		}

--- a/internal/daemon/native_extension_tool_provider.go
+++ b/internal/daemon/native_extension_tool_provider.go
@@ -173,21 +173,11 @@ func (h *daemonExtensionToolHandle) workspaceScopedImportTasksCallRequest(
 	ctx context.Context,
 	req toolspkg.CallRequest,
 ) (toolspkg.CallRequest, error) {
-	if h.workspaceResolver == nil {
-		return toolspkg.CallRequest{}, importTasksScopeError(
-			req.ToolID,
-			fmt.Sprintf("tool %q has no workspace resolver", req.ToolID),
-			toolspkg.ErrToolInvalidInput,
-		)
+	scoped, err := h.attachTrustedWorkspace(ctx, req)
+	if err != nil {
+		return toolspkg.CallRequest{}, err
 	}
-	workspaceID := strings.TrimSpace(req.WorkspaceID)
-	if workspaceID == "" {
-		return toolspkg.CallRequest{}, importTasksScopeError(
-			req.ToolID,
-			fmt.Sprintf("tool %q requires workspace scope", req.ToolID),
-			toolspkg.ErrToolInvalidInput,
-		)
-	}
+	req = scoped
 	var input struct {
 		Pattern string `json:"pattern"`
 	}
@@ -215,7 +205,7 @@ func (h *daemonExtensionToolHandle) workspaceScopedImportTasksCallRequest(
 			fmt.Errorf("%w: absolute pattern %q", toolspkg.ErrToolInvalidInput, pattern),
 		)
 	}
-	absolute, err := h.resolveImportTasksPattern(ctx, req.ToolID, workspaceID, pattern)
+	absolute, err := h.resolveImportTasksPattern(req.ToolID, req.TrustedWorkspaceRoot, pattern)
 	if err != nil {
 		return toolspkg.CallRequest{}, err
 	}
@@ -255,7 +245,10 @@ func (h *daemonExtensionToolHandle) attachTrustedWorkspace(
 			fmt.Errorf("resolve workspace: %w", err),
 		)
 	}
-	root := strings.TrimSpace(resolved.RootDir)
+	root := strings.TrimSpace(req.TrustedWorkspaceRoot)
+	if root == "" {
+		root = strings.TrimSpace(resolved.RootDir)
+	}
 	if root == "" {
 		return toolspkg.CallRequest{}, extensionWorkspaceScopeError(
 			req.ToolID,
@@ -276,31 +269,10 @@ func (h *daemonExtensionToolHandle) attachTrustedWorkspace(
 }
 
 func (h *daemonExtensionToolHandle) resolveImportTasksPattern(
-	ctx context.Context,
 	toolID toolspkg.ToolID,
-	workspaceID string,
+	root string,
 	pattern string,
 ) (string, error) {
-	resolved, err := h.workspaceResolver.Resolve(ctx, workspaceID)
-	if err != nil {
-		return "", toolspkg.NewToolError(
-			toolspkg.ErrorCodeInvalidInput,
-			toolID,
-			fmt.Sprintf("tool %q workspace %q is invalid", toolID, workspaceID),
-			fmt.Errorf("%w: resolve workspace: %w", toolspkg.ErrToolInvalidInput, err),
-			toolspkg.ReasonScopeMismatch,
-		)
-	}
-	root := strings.TrimSpace(resolved.RootDir)
-	if root == "" {
-		return "", toolspkg.NewToolError(
-			toolspkg.ErrorCodeInvalidInput,
-			toolID,
-			fmt.Sprintf("tool %q workspace %q has no root directory", toolID, workspaceID),
-			toolspkg.ErrToolInvalidInput,
-			toolspkg.ReasonScopeMismatch,
-		)
-	}
 	absolute, err := workspaceRelativePattern(root, pattern)
 	if err != nil {
 		return "", toolspkg.NewToolError(

--- a/internal/daemon/native_extension_tool_provider_test.go
+++ b/internal/daemon/native_extension_tool_provider_test.go
@@ -215,6 +215,56 @@ func TestDaemonExtensionToolProvider(t *testing.T) {
 		}
 	})
 
+	t.Run("Should anchor spec-cycle import task patterns to the trusted worktree root", func(t *testing.T) {
+		t.Parallel()
+
+		workspaceRoot := t.TempDir()
+		worktreeRoot := t.TempDir()
+		inner := &daemonExtensionProviderStub{handle: &daemonExtensionHandleStub{}}
+		resolver := &daemonExtensionWorkspaceResolverStub{
+			resolved: workspacepkg.ResolvedWorkspace{
+				Workspace:   workspacepkg.Workspace{ID: "ws-1", RootDir: workspaceRoot},
+				WorkspaceID: "ws-1",
+			},
+		}
+		provider := newDaemonScopedExtensionToolProvider(inner, resolver)
+		handle, ok, err := provider.Resolve(
+			t.Context(),
+			toolspkg.Scope{WorkspaceID: "ws-1"},
+			specCycleImportTasksToolID,
+		)
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+		if !ok {
+			t.Fatal("Resolve() ok = false, want true")
+		}
+
+		_, err = handle.Call(t.Context(), toolspkg.CallRequest{
+			ToolID:               specCycleImportTasksToolID,
+			WorkspaceID:          "ws-1",
+			TrustedWorkspaceRoot: worktreeRoot,
+			Input:                json.RawMessage(`{"pattern":".compozy/tasks/example/task_*.md"}`),
+		})
+		if err != nil {
+			t.Fatalf("Call() error = %v", err)
+		}
+
+		var input struct {
+			Pattern string `json:"pattern"`
+		}
+		if err := json.Unmarshal(inner.handle.request.Input, &input); err != nil {
+			t.Fatalf("Unmarshal(patched input) error = %v", err)
+		}
+		want := filepath.Join(worktreeRoot, ".compozy", "tasks", "example", "task_*.md")
+		if input.Pattern != want {
+			t.Fatalf("patched pattern = %q, want trusted worktree pattern %q", input.Pattern, want)
+		}
+		if got := inner.handle.request.TrustedWorkspaceRoot; got != worktreeRoot {
+			t.Fatalf("TrustedWorkspaceRoot = %q, want %q", got, worktreeRoot)
+		}
+	})
+
 	t.Run("Should reject relative spec-cycle import task patterns that escape the workspace root", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/task_runtime_test.go
+++ b/internal/daemon/task_runtime_test.go
@@ -1299,16 +1299,35 @@ type taskBridgeWorktreeGetCall struct {
 	ref         string
 }
 
+type taskBridgeWorktreeUsageCall struct {
+	workspaceID string
+	ref         string
+}
+
 type recordingTaskBridgeWorktrees struct {
 	getItem          *worktreepkg.Worktree
 	getErr           error
 	getCalls         []taskBridgeWorktreeGetCall
+	usageCalls       []taskBridgeWorktreeUsageCall
+	usageReleases    int
 	materialized     *worktreepkg.Worktree
 	materializeFn    func(string, worktreepkg.RunWorktreeRequest) (*worktreepkg.Worktree, error)
 	materializeErr   error
 	materializeCalls []taskBridgeWorktreeMaterializeCall
 	rollbackErr      error
 	rollbackCalls    []taskBridgeWorktreeRollbackCall
+}
+
+func (w *recordingTaskBridgeWorktrees) AcquireUsage(
+	_ context.Context,
+	workspaceID string,
+	ref string,
+) (*worktreepkg.Worktree, func(), error) {
+	w.usageCalls = append(w.usageCalls, taskBridgeWorktreeUsageCall{workspaceID: workspaceID, ref: ref})
+	if w.getErr != nil {
+		return nil, nil, w.getErr
+	}
+	return w.getItem, sync.OnceFunc(func() { w.usageReleases++ }), nil
 }
 
 func (w *recordingTaskBridgeWorktrees) Get(

--- a/internal/loop/action.go
+++ b/internal/loop/action.go
@@ -22,6 +22,7 @@ type actionRegistryConfig struct {
 	eventReader    ActionEventRangeReader
 	channel        ChannelResultHarvester
 	channelStore   ChannelResultConversationStore
+	toolWorkspace  ActionToolWorkspaceRootResolver
 	maxResultBytes int64
 }
 
@@ -60,6 +61,13 @@ func WithActionGoalExecutor(executor ActionExecutor) ActionRegistryOption {
 func WithActionSessionBinder(binder ActionSessionBinder) ActionRegistryOption {
 	return func(cfg *actionRegistryConfig) {
 		cfg.sessionBinder = binder
+	}
+}
+
+// WithActionToolWorkspaceRootResolver wires trusted workspace roots for registry-backed tool actions.
+func WithActionToolWorkspaceRootResolver(resolver ActionToolWorkspaceRootResolver) ActionRegistryOption {
+	return func(cfg *actionRegistryConfig) {
+		cfg.toolWorkspace = resolver
 	}
 }
 
@@ -107,6 +115,7 @@ type ActionRegistry struct {
 	goal           ActionExecutor
 	events         ActionEventRangeReader
 	channel        ChannelResultHarvester
+	toolWorkspace  ActionToolWorkspaceRootResolver
 	maxResultBytes int64
 }
 
@@ -162,6 +171,7 @@ func NewActionRegistry(runtime tools.Registry, opts ...ActionRegistryOption) (*A
 		goal:           cfg.goal,
 		events:         cfg.eventReader,
 		channel:        cfg.channel,
+		toolWorkspace:  cfg.toolWorkspace,
 		maxResultBytes: cfg.maxResultBytes,
 	}, nil
 }
@@ -224,10 +234,11 @@ func (r *ActionRegistry) resolve(
 		}
 	}
 	return &ToolCallActionExecutor{
-		runtime:     r.runtime,
-		toolID:      id,
-		eventReader: r.events,
-		channel:     r.channel,
+		runtime:               r.runtime,
+		toolID:                id,
+		eventReader:           r.events,
+		channel:               r.channel,
+		workspaceRootResolver: r.toolWorkspace,
 		maxResultBytes: tools.EffectiveResultLimit(
 			view.Descriptor.MaxResultBytes,
 			r.maxResultBytes,

--- a/internal/loop/action_test.go
+++ b/internal/loop/action_test.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -230,11 +231,16 @@ func TestToolCallActionExecutorShouldExecuteAndHarvestToolResults(t *testing.T) 
 		t.Parallel()
 
 		toolID := tools.ToolID("ext__spec_cycle__import_tasks")
+		resolver := &fakeActionToolWorkspaceRootResolver{root: "/worktrees/feature-512"}
 		registry := &fakeActionToolRegistry{
 			views:      map[tools.ToolID]tools.ToolView{toolID: {}},
 			callResult: tools.ToolResult{Structured: json.RawMessage(`{"ok":true}`)},
+			onCall: func() {
+				if !resolver.leaseHeld.Load() {
+					t.Error("workspace usage lease was released before RuntimeRegistry.Call")
+				}
+			},
 		}
-		resolver := &fakeActionToolWorkspaceRootResolver{root: "/worktrees/feature-512"}
 		actions := newActionRegistryForTest(
 			t,
 			registry,
@@ -265,6 +271,55 @@ func TestToolCallActionExecutorShouldExecuteAndHarvestToolResults(t *testing.T) 
 		request := resolver.mustSingleRequest(t)
 		if request.WorkspaceID != "ws-1" || request.Environment.WorktreeRef != "feature-512" {
 			t.Fatalf("workspace root request = %#v, want workspace and worktree propagated", request)
+		}
+		if resolver.leaseHeld.Load() || resolver.releaseCount.Load() != 1 {
+			t.Fatalf(
+				"workspace usage lease after Execute = held:%t releases:%d, want released once",
+				resolver.leaseHeld.Load(),
+				resolver.releaseCount.Load(),
+			)
+		}
+	})
+
+	t.Run("Should release the worktree usage lease when tool dispatch fails", func(t *testing.T) {
+		t.Parallel()
+
+		toolID := tools.ToolID("ext__spec_cycle__import_tasks")
+		callErr := errors.New("extension call failed")
+		resolver := &fakeActionToolWorkspaceRootResolver{root: "/worktrees/feature-512"}
+		registry := &fakeActionToolRegistry{
+			views:   map[tools.ToolID]tools.ToolView{toolID: {}},
+			callErr: callErr,
+		}
+		actions := newActionRegistryForTest(
+			t,
+			registry,
+			loop.WithActionToolWorkspaceRootResolver(resolver),
+		)
+		executor, err := actions.Resolve(t.Context(), tools.Scope{}, toolID.String())
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+
+		_, err = executor.Execute(t.Context(), dsl.Node{
+			ID: "load_tasks", Class: dsl.NodeClassAction, Kind: toolID.String(),
+		}, loop.ActionExecutionInput{
+			WorkspaceID: "ws-1",
+			Environment: &dsl.EnvironmentSpec{
+				Mode:        dsl.EnvironmentWorktree,
+				WorktreeRef: "feature-512",
+			},
+			Actor: mustDaemonActor(t),
+		})
+		if !errors.Is(err, callErr) {
+			t.Fatalf("Execute() error = %v, want %v", err, callErr)
+		}
+		if resolver.leaseHeld.Load() || resolver.releaseCount.Load() != 1 {
+			t.Fatalf(
+				"workspace usage lease after failure = held:%t releases:%d, want released once",
+				resolver.leaseHeld.Load(),
+				resolver.releaseCount.Load(),
+			)
 		}
 	})
 
@@ -1608,6 +1663,7 @@ type fakeActionToolRegistry struct {
 	getErr     error
 	callResult tools.ToolResult
 	callErr    error
+	onCall     func()
 	gets       []tools.ToolID
 	calls      []tools.CallRequest
 }
@@ -1657,6 +1713,9 @@ func (r *fakeActionToolRegistry) Call(
 	defer r.mu.Unlock()
 
 	r.calls = append(r.calls, req)
+	if r.onCall != nil {
+		r.onCall()
+	}
 	if r.callErr != nil {
 		return tools.ToolResult{}, r.callErr
 	}
@@ -1696,24 +1755,31 @@ type fakeActionEventReader struct {
 }
 
 type fakeActionToolWorkspaceRootResolver struct {
-	mu       sync.Mutex
-	root     string
-	err      error
-	requests []loop.ActionToolWorkspaceRootRequest
+	mu           sync.Mutex
+	root         string
+	err          error
+	requests     []loop.ActionToolWorkspaceRootRequest
+	leaseHeld    atomic.Bool
+	releaseCount atomic.Int64
 }
 
-func (r *fakeActionToolWorkspaceRootResolver) ResolveActionToolWorkspaceRoot(
+func (r *fakeActionToolWorkspaceRootResolver) AcquireActionToolWorkspaceRoot(
 	_ context.Context,
 	req loop.ActionToolWorkspaceRootRequest,
-) (string, error) {
+) (string, func(), error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.requests = append(r.requests, req)
 	if r.err != nil {
-		return "", r.err
+		return "", nil, r.err
 	}
-	return r.root, nil
+	r.leaseHeld.Store(true)
+	release := sync.OnceFunc(func() {
+		r.leaseHeld.Store(false)
+		r.releaseCount.Add(1)
+	})
+	return r.root, release, nil
 }
 
 func (r *fakeActionToolWorkspaceRootResolver) mustSingleRequest(
@@ -1724,7 +1790,7 @@ func (r *fakeActionToolWorkspaceRootResolver) mustSingleRequest(
 	defer r.mu.Unlock()
 
 	if len(r.requests) != 1 {
-		t.Fatalf("ResolveActionToolWorkspaceRoot calls = %d, want 1", len(r.requests))
+		t.Fatalf("AcquireActionToolWorkspaceRoot calls = %d, want 1", len(r.requests))
 	}
 	return r.requests[0]
 }

--- a/internal/loop/action_test.go
+++ b/internal/loop/action_test.go
@@ -226,6 +226,105 @@ func TestActionRegistryShouldResolveReservedKindsBeforeRuntimeAndRejectUnknownKi
 func TestToolCallActionExecutorShouldExecuteAndHarvestToolResults(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should propagate the selected worktree as the trusted workspace root", func(t *testing.T) {
+		t.Parallel()
+
+		toolID := tools.ToolID("ext__spec_cycle__import_tasks")
+		registry := &fakeActionToolRegistry{
+			views:      map[tools.ToolID]tools.ToolView{toolID: {}},
+			callResult: tools.ToolResult{Structured: json.RawMessage(`{"ok":true}`)},
+		}
+		resolver := &fakeActionToolWorkspaceRootResolver{root: "/worktrees/feature-512"}
+		actions := newActionRegistryForTest(
+			t,
+			registry,
+			loop.WithActionToolWorkspaceRootResolver(resolver),
+		)
+		executor, err := actions.Resolve(t.Context(), tools.Scope{}, toolID.String())
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+
+		_, err = executor.Execute(t.Context(), dsl.Node{
+			ID: "load_tasks", Class: dsl.NodeClassAction, Kind: toolID.String(),
+		}, loop.ActionExecutionInput{
+			WorkspaceID: "ws-1",
+			Environment: &dsl.EnvironmentSpec{
+				Mode:        dsl.EnvironmentWorktree,
+				WorktreeRef: "feature-512",
+			},
+			Actor: mustDaemonActor(t),
+		})
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+		call := registry.mustSingleCall(t)
+		if got, want := call.TrustedWorkspaceRoot, "/worktrees/feature-512"; got != want {
+			t.Fatalf("TrustedWorkspaceRoot = %q, want %q", got, want)
+		}
+		request := resolver.mustSingleRequest(t)
+		if request.WorkspaceID != "ws-1" || request.Environment.WorktreeRef != "feature-512" {
+			t.Fatalf("workspace root request = %#v, want workspace and worktree propagated", request)
+		}
+	})
+
+	t.Run("Should stop before tool dispatch when worktree resolution fails", func(t *testing.T) {
+		t.Parallel()
+
+		toolID := tools.ToolID("ext__spec_cycle__import_tasks")
+		resolveErr := errors.New("worktree is not ready")
+		registry := &fakeActionToolRegistry{views: map[tools.ToolID]tools.ToolView{toolID: {}}}
+		actions := newActionRegistryForTest(
+			t,
+			registry,
+			loop.WithActionToolWorkspaceRootResolver(&fakeActionToolWorkspaceRootResolver{err: resolveErr}),
+		)
+		executor, err := actions.Resolve(t.Context(), tools.Scope{}, toolID.String())
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+
+		_, err = executor.Execute(t.Context(), dsl.Node{
+			ID: "load_tasks", Class: dsl.NodeClassAction, Kind: toolID.String(),
+		}, loop.ActionExecutionInput{
+			WorkspaceID: "ws-1",
+			Environment: &dsl.EnvironmentSpec{Mode: dsl.EnvironmentWorktree, WorktreeRef: "pending"},
+			Actor:       mustDaemonActor(t),
+		})
+		if !errors.Is(err, resolveErr) {
+			t.Fatalf("Execute() error = %v, want resolver error", err)
+		}
+		if got := registry.callCount(); got != 0 {
+			t.Fatalf("RuntimeRegistry.Call calls = %d, want 0", got)
+		}
+	})
+
+	t.Run("Should fail closed when a worktree action has no root resolver", func(t *testing.T) {
+		t.Parallel()
+
+		toolID := tools.ToolID("ext__spec_cycle__import_tasks")
+		registry := &fakeActionToolRegistry{views: map[tools.ToolID]tools.ToolView{toolID: {}}}
+		actions := newActionRegistryForTest(t, registry)
+		executor, err := actions.Resolve(t.Context(), tools.Scope{}, toolID.String())
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+
+		_, err = executor.Execute(t.Context(), dsl.Node{
+			ID: "load_tasks", Class: dsl.NodeClassAction, Kind: toolID.String(),
+		}, loop.ActionExecutionInput{
+			WorkspaceID: "ws-1",
+			Environment: &dsl.EnvironmentSpec{Mode: dsl.EnvironmentWorktree, WorktreeRef: "feature-512"},
+			Actor:       mustDaemonActor(t),
+		})
+		if !errors.Is(err, loop.ErrActionDependencyMissing) {
+			t.Fatalf("Execute() error = %v, want ErrActionDependencyMissing", err)
+		}
+		if got := registry.callCount(); got != 0 {
+			t.Fatalf("RuntimeRegistry.Call calls = %d, want 0", got)
+		}
+	})
+
 	t.Run("Should execute RuntimeRegistry call and sync harvest structured output", func(t *testing.T) {
 		t.Parallel()
 
@@ -1571,6 +1670,13 @@ func (r *fakeActionToolRegistry) getCount() int {
 	return len(r.gets)
 }
 
+func (r *fakeActionToolRegistry) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return len(r.calls)
+}
+
 func (r *fakeActionToolRegistry) mustSingleCall(t *testing.T) tools.CallRequest {
 	t.Helper()
 	r.mu.Lock()
@@ -1587,6 +1693,40 @@ type fakeActionEventReader struct {
 	last   loop.ActionEventRangeRequest
 	result loop.ActionEventRangeResult
 	err    error
+}
+
+type fakeActionToolWorkspaceRootResolver struct {
+	mu       sync.Mutex
+	root     string
+	err      error
+	requests []loop.ActionToolWorkspaceRootRequest
+}
+
+func (r *fakeActionToolWorkspaceRootResolver) ResolveActionToolWorkspaceRoot(
+	_ context.Context,
+	req loop.ActionToolWorkspaceRootRequest,
+) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.requests = append(r.requests, req)
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.root, nil
+}
+
+func (r *fakeActionToolWorkspaceRootResolver) mustSingleRequest(
+	t *testing.T,
+) loop.ActionToolWorkspaceRootRequest {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(r.requests) != 1 {
+		t.Fatalf("ResolveActionToolWorkspaceRoot calls = %d, want 1", len(r.requests))
+	}
+	return r.requests[0]
 }
 
 func (r *fakeActionEventReader) ReadActionEventRange(

--- a/internal/loop/action_tool_workspace.go
+++ b/internal/loop/action_tool_workspace.go
@@ -8,6 +8,8 @@ import (
 	"github.com/compozy/compozy/internal/loop/dsl"
 )
 
+const toolWorkspaceRootResolverDependency = "tool_workspace_root_resolver"
+
 // ActionToolWorkspaceRootRequest identifies the effective workspace root for one tool action.
 type ActionToolWorkspaceRootRequest struct {
 	WorkspaceID WorkspaceID
@@ -16,38 +18,46 @@ type ActionToolWorkspaceRootRequest struct {
 
 // ActionToolWorkspaceRootResolver resolves trusted roots outside the Loop package.
 type ActionToolWorkspaceRootResolver interface {
-	ResolveActionToolWorkspaceRoot(context.Context, ActionToolWorkspaceRootRequest) (string, error)
+	AcquireActionToolWorkspaceRoot(context.Context, ActionToolWorkspaceRootRequest) (string, func(), error)
 }
 
-func (e *ToolCallActionExecutor) trustedWorkspaceRoot(
+func (e *ToolCallActionExecutor) acquireTrustedWorkspaceRoot(
 	ctx context.Context,
 	in ActionExecutionInput,
-) (string, error) {
+) (string, func(), error) {
 	environment := in.EnvironmentValue()
 	if environment.Mode != dsl.EnvironmentWorktree {
-		return "", nil
+		return "", nil, nil
 	}
 	if e.workspaceRootResolver == nil {
-		return "", reasonError(
+		return "", nil, reasonError(
 			ReasonCodeActionDependencyMissing,
 			ErrActionDependencyMissing,
-			map[string]string{actionDependencyMetaKey: "tool_workspace_root_resolver"},
+			map[string]string{actionDependencyMetaKey: toolWorkspaceRootResolverDependency},
 		)
 	}
-	root, err := e.workspaceRootResolver.ResolveActionToolWorkspaceRoot(ctx, ActionToolWorkspaceRootRequest{
+	root, release, err := e.workspaceRootResolver.AcquireActionToolWorkspaceRoot(ctx, ActionToolWorkspaceRootRequest{
 		WorkspaceID: in.WorkspaceID,
 		Environment: environment,
 	})
 	if err != nil {
-		return "", fmt.Errorf("resolve action tool workspace root: %w", err)
+		return "", nil, fmt.Errorf("acquire action tool workspace root: %w", err)
+	}
+	if release == nil {
+		return "", nil, reasonError(
+			ReasonCodeActionDependencyMissing,
+			fmt.Errorf("%w: tool workspace root resolver returned no release function", ErrActionDependencyMissing),
+			map[string]string{actionDependencyMetaKey: toolWorkspaceRootResolverDependency},
+		)
 	}
 	root = strings.TrimSpace(root)
 	if root == "" {
-		return "", reasonError(
+		release()
+		return "", nil, reasonError(
 			ReasonCodeActionDependencyMissing,
 			fmt.Errorf("%w: tool workspace root resolver returned an empty root", ErrActionDependencyMissing),
-			map[string]string{actionDependencyMetaKey: "tool_workspace_root_resolver"},
+			map[string]string{actionDependencyMetaKey: toolWorkspaceRootResolverDependency},
 		)
 	}
-	return root, nil
+	return root, release, nil
 }

--- a/internal/loop/action_tool_workspace.go
+++ b/internal/loop/action_tool_workspace.go
@@ -1,0 +1,53 @@
+package loop
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/compozy/compozy/internal/loop/dsl"
+)
+
+// ActionToolWorkspaceRootRequest identifies the effective workspace root for one tool action.
+type ActionToolWorkspaceRootRequest struct {
+	WorkspaceID WorkspaceID
+	Environment dsl.EnvironmentSpec
+}
+
+// ActionToolWorkspaceRootResolver resolves trusted roots outside the Loop package.
+type ActionToolWorkspaceRootResolver interface {
+	ResolveActionToolWorkspaceRoot(context.Context, ActionToolWorkspaceRootRequest) (string, error)
+}
+
+func (e *ToolCallActionExecutor) trustedWorkspaceRoot(
+	ctx context.Context,
+	in ActionExecutionInput,
+) (string, error) {
+	environment := in.EnvironmentValue()
+	if environment.Mode != dsl.EnvironmentWorktree {
+		return "", nil
+	}
+	if e.workspaceRootResolver == nil {
+		return "", reasonError(
+			ReasonCodeActionDependencyMissing,
+			ErrActionDependencyMissing,
+			map[string]string{actionDependencyMetaKey: "tool_workspace_root_resolver"},
+		)
+	}
+	root, err := e.workspaceRootResolver.ResolveActionToolWorkspaceRoot(ctx, ActionToolWorkspaceRootRequest{
+		WorkspaceID: in.WorkspaceID,
+		Environment: environment,
+	})
+	if err != nil {
+		return "", fmt.Errorf("resolve action tool workspace root: %w", err)
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return "", reasonError(
+			ReasonCodeActionDependencyMissing,
+			fmt.Errorf("%w: tool workspace root resolver returned an empty root", ErrActionDependencyMissing),
+			map[string]string{actionDependencyMetaKey: "tool_workspace_root_resolver"},
+		)
+	}
+	return root, nil
+}

--- a/internal/loop/action_toolcall.go
+++ b/internal/loop/action_toolcall.go
@@ -12,11 +12,12 @@ import (
 
 // ToolCallActionExecutor adapts a ToolID action to RuntimeRegistry.Call.
 type ToolCallActionExecutor struct {
-	runtime        tools.Registry
-	toolID         tools.ToolID
-	eventReader    ActionEventRangeReader
-	channel        ChannelResultHarvester
-	maxResultBytes int64
+	runtime               tools.Registry
+	toolID                tools.ToolID
+	eventReader           ActionEventRangeReader
+	channel               ChannelResultHarvester
+	workspaceRootResolver ActionToolWorkspaceRootResolver
+	maxResultBytes        int64
 }
 
 // Execute calls RuntimeRegistry.Call with rendered action params.
@@ -50,16 +51,21 @@ func (e *ToolCallActionExecutor) Execute(
 	if err != nil {
 		return ActionRawResult{}, fmt.Errorf("marshal action params for %q: %w", node.ID, err)
 	}
+	trustedWorkspaceRoot, err := e.trustedWorkspaceRoot(callCtx, in)
+	if err != nil {
+		return ActionRawResult{}, err
+	}
 	scope := normalizeActionToolScope(in)
 	result, err := e.runtime.Call(callCtx, scope, tools.CallRequest{
-		ToolID:        e.toolID,
-		ToolCallID:    actionToolCallID(node, in),
-		SessionID:     scope.SessionID,
-		WorkspaceID:   scope.WorkspaceID,
-		AgentName:     scope.AgentName,
-		ActorKind:     scope.ActorKind,
-		CorrelationID: in.CorrelationID,
-		Input:         input,
+		ToolID:               e.toolID,
+		ToolCallID:           actionToolCallID(node, in),
+		SessionID:            scope.SessionID,
+		WorkspaceID:          scope.WorkspaceID,
+		AgentName:            scope.AgentName,
+		ActorKind:            scope.ActorKind,
+		CorrelationID:        in.CorrelationID,
+		Input:                input,
+		TrustedWorkspaceRoot: trustedWorkspaceRoot,
 	})
 	if err != nil {
 		return ActionRawResult{}, fmt.Errorf("call action tool %q: %w", e.toolID, err)

--- a/internal/loop/action_toolcall.go
+++ b/internal/loop/action_toolcall.go
@@ -51,9 +51,12 @@ func (e *ToolCallActionExecutor) Execute(
 	if err != nil {
 		return ActionRawResult{}, fmt.Errorf("marshal action params for %q: %w", node.ID, err)
 	}
-	trustedWorkspaceRoot, err := e.trustedWorkspaceRoot(callCtx, in)
+	trustedWorkspaceRoot, releaseWorkspaceRoot, err := e.acquireTrustedWorkspaceRoot(callCtx, in)
 	if err != nil {
 		return ActionRawResult{}, err
+	}
+	if releaseWorkspaceRoot != nil {
+		defer releaseWorkspaceRoot()
 	}
 	scope := normalizeActionToolScope(in)
 	result, err := e.runtime.Call(callCtx, scope, tools.CallRequest{

--- a/internal/worktree/remove.go
+++ b/internal/worktree/remove.go
@@ -51,6 +51,25 @@ func (s *Service) Remove(
 	if item.State != StateReady {
 		return nil, ErrNotReady
 	}
+	releaseUsage, acquired := s.usage.tryAcquireExclusive(worktreeUsageKey(item.WorkspaceID, item.ID))
+	if !acquired {
+		return nil, ErrOperationInProgress
+	}
+	defer releaseUsage()
+
+	item, err = s.store.Get(ctx, workspaceID, item.ID)
+	if errors.Is(err, ErrNotFound) || item == nil {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("worktree: reread removal target: %w", err)
+	}
+	if item.State == StateRemoved {
+		return nil, nil
+	}
+	if item.State != StateReady {
+		return nil, ErrNotReady
+	}
 	if _, err := s.capability.Check(ctx); err != nil {
 		return nil, err
 	}

--- a/internal/worktree/remove_test.go
+++ b/internal/worktree/remove_test.go
@@ -192,6 +192,37 @@ func TestServiceRemoveAndRecover(t *testing.T) {
 		}
 	})
 
+	t.Run("Should block removal while a tool holds a usage lease", func(t *testing.T) {
+		t.Parallel()
+		fixture := newRemovalTestFixture(t)
+		item, release, err := fixture.service.AcquireUsage(
+			t.Context(), fixture.workspace.ID, fixture.item.ID,
+		)
+		if err != nil {
+			t.Fatalf("AcquireUsage() error = %v", err)
+		}
+		if item == nil || item.ID != fixture.item.ID {
+			t.Fatalf("AcquireUsage() item = %#v, want %q", item, fixture.item.ID)
+		}
+		t.Cleanup(release)
+
+		if _, err := fixture.service.Remove(
+			t.Context(), fixture.workspace.ID, fixture.item.ID, true,
+		); !errors.Is(err, ErrOperationInProgress) {
+			t.Fatalf("Remove(active usage) error = %v, want ErrOperationInProgress", err)
+		}
+		if got := fixture.mustItem(t).State; got != StateReady {
+			t.Fatalf("active usage state = %q, want ready", got)
+		}
+
+		release()
+		if _, err := fixture.service.Remove(
+			t.Context(), fixture.workspace.ID, fixture.item.ID, true,
+		); err != nil {
+			t.Fatalf("Remove(after release) error = %v", err)
+		}
+	})
+
 	t.Run("Should preserve the fence when session and status safety checks fail", func(t *testing.T) {
 		t.Parallel()
 		sessionFailure := newRemovalTestFixture(t)

--- a/internal/worktree/service.go
+++ b/internal/worktree/service.go
@@ -34,6 +34,7 @@ type Service struct {
 	resolver   WorkspaceResolver
 	sessions   SessionGuard
 	locks      *RepositoryLocks
+	usage      *worktreeUsageLocks
 	hooks      HookDispatcher
 	events     EventSink
 	forge      ForgeProvider
@@ -62,6 +63,7 @@ func NewService(store Store, runner GitRunner, opts ...Option) *Service {
 	s := &Service{
 		store: store, runner: runner, capability: NewCapabilityGate(runner),
 		locks: NewRepositoryLocks(8), now: time.Now, newID: generateID, getenv: os.Getenv, environ: os.Environ,
+		usage:  newWorktreeUsageLocks(),
 		logger: slog.Default(), discovery: make(map[string]discoveryCacheEntry),
 		catalog: newCatalogBroadcaster(), creates: make(map[string]*createOperation),
 		exits: make(map[string]*exitOperationControl),

--- a/internal/worktree/usage.go
+++ b/internal/worktree/usage.go
@@ -1,0 +1,108 @@
+package worktree
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+)
+
+const exclusiveWorktreeUsageWeight = int64(math.MaxInt64)
+
+type worktreeUsageLock struct {
+	semaphore *semaphore.Weighted
+	refs      int
+}
+
+type worktreeUsageLocks struct {
+	mu      sync.Mutex
+	entries map[string]*worktreeUsageLock
+}
+
+func newWorktreeUsageLocks() *worktreeUsageLocks {
+	return &worktreeUsageLocks{entries: make(map[string]*worktreeUsageLock)}
+}
+
+func (l *worktreeUsageLocks) acquire(ctx context.Context, key string) (func(), error) {
+	entry := l.reserve(key)
+	if err := entry.semaphore.Acquire(ctx, 1); err != nil {
+		l.releaseRef(key, entry)
+		return nil, err
+	}
+	return sync.OnceFunc(func() {
+		entry.semaphore.Release(1)
+		l.releaseRef(key, entry)
+	}), nil
+}
+
+func (l *worktreeUsageLocks) tryAcquireExclusive(key string) (func(), bool) {
+	entry := l.reserve(key)
+	if !entry.semaphore.TryAcquire(exclusiveWorktreeUsageWeight) {
+		l.releaseRef(key, entry)
+		return nil, false
+	}
+	return sync.OnceFunc(func() {
+		entry.semaphore.Release(exclusiveWorktreeUsageWeight)
+		l.releaseRef(key, entry)
+	}), true
+}
+
+func (l *worktreeUsageLocks) reserve(key string) *worktreeUsageLock {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry := l.entries[key]
+	if entry == nil {
+		entry = &worktreeUsageLock{semaphore: semaphore.NewWeighted(exclusiveWorktreeUsageWeight)}
+		l.entries[key] = entry
+	}
+	entry.refs++
+	return entry
+}
+
+func (l *worktreeUsageLocks) releaseRef(key string, entry *worktreeUsageLock) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry.refs--
+	if entry.refs == 0 {
+		delete(l.entries, key)
+	}
+}
+
+func worktreeUsageKey(workspaceID string, worktreeID string) string {
+	return strings.TrimSpace(workspaceID) + "\x00" + strings.TrimSpace(worktreeID)
+}
+
+// AcquireUsage keeps a ready worktree available until the returned release function runs.
+func (s *Service) AcquireUsage(
+	ctx context.Context,
+	workspaceID string,
+	ref string,
+) (*Worktree, func(), error) {
+	item, err := s.Get(ctx, workspaceID, ref)
+	if err != nil {
+		return nil, nil, err
+	}
+	if item.State != StateReady || strings.TrimSpace(item.Path) == "" {
+		return nil, nil, ErrNotReady
+	}
+
+	release, err := s.usage.acquire(ctx, worktreeUsageKey(item.WorkspaceID, item.ID))
+	if err != nil {
+		return nil, nil, fmt.Errorf("worktree: acquire usage lease: %w", err)
+	}
+	current, err := s.Get(ctx, item.WorkspaceID, item.ID)
+	if err != nil {
+		release()
+		return nil, nil, err
+	}
+	if current.State != StateReady || strings.TrimSpace(current.Path) == "" {
+		release()
+		return nil, nil, ErrNotReady
+	}
+	return current, release, nil
+}

--- a/packages/site/content/docs/worktrees/index.mdx
+++ b/packages/site/content/docs/worktrees/index.mdx
@@ -41,8 +41,10 @@ A failed `setup_command` is different from lifecycle `failed`: the checkout stay
   first prompt. Changing the environment later creates a new session; it never moves a live one.
 - A Task policy resolves to the workspace root, one named Worktree, or a fresh Worktree per run.
   The resolved choice is saved on the run and does not change after enqueue.
-- A Loop agent action resolves `root`, `worktree`, `per_run`, or `directory`. A node value wins over
-  the Loop default; `run-loop` forwards the parent environment unless the child resolves its own.
+- A Loop agent or extension-tool action resolves `root`, `worktree`, `per_run`, or `directory`. A
+  node value wins over the Loop default; `run-loop` forwards the parent environment unless the child
+  resolves its own. A named Worktree scopes both the agent's current directory and
+  workspace-relative extension resources to that checkout.
 
 ## In this section
 

--- a/packages/site/content/docs/worktrees/loop-environments.mdx
+++ b/packages/site/content/docs/worktrees/loop-environments.mdx
@@ -19,6 +19,15 @@ An explicit node environment wins over the Loop default. If neither exists, exec
 `run-loop` forwards the parent environment unless the child resolves its own default. Only
 `run-agent` and `goal` accept node environments.
 
+With `worktree`, both agent sessions and workspace-relative extension tool actions use the selected
+ready Worktree. For example, the `spec-cycle` extension's `import_tasks` action reads a task pack
+from that Worktree. A direct extension-tool call without a Loop Worktree context still resolves from
+the workspace root.
+
+Web authoring offers `root` and `worktree`, plus Inherit to remove an override. The API and CLI still
+accept `directory` and `per_run`. When either value is loaded in Web, it is shown read-only and is
+preserved by unrelated saves or publishes until you replace it with a Web-supported choice.
+
 ## Set a Loop default
 
 ### 1. Write a config file

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -488,6 +488,10 @@ in-body direct target written as `{route: node_id}`. The old `branch` action is 
 `worktree` requires `worktree_ref`, `directory` requires a contained `directory`, and `per_run`
 creates one worktree per execution instance, including each fan-out branch. `run-loop` forwards the
 parent environment unless the child resolves its own default. Other node kinds reject `environment`.
+In `worktree` mode, agent sessions and workspace-relative extension tool actions use the same ready
+Worktree; a direct extension-tool call without that Loop context stays at the workspace root.
+Web authors only `root` and `worktree`; API/CLI-authored `directory` and `per_run` values remain
+visible and unchanged in Web until replaced.
 The retired `params.cwd` fails validation; migrate it to
 `params.environment: {mode: directory, directory: <path>}`.
 

--- a/web/src/systems/loops/components/__tests__/loop-configure-dialog.test.tsx
+++ b/web/src/systems/loops/components/__tests__/loop-configure-dialog.test.tsx
@@ -214,10 +214,11 @@ describe("LoopConfigureDialog", () => {
       },
     });
     const modes = await screen.findByTestId("loop-configure-environment-mode");
-    expect(within(modes).getByRole("button", { name: "Directory (read-only)" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
+    const readOnlyDirectory = within(modes).getByRole("button", {
+      name: "Directory (read-only)",
+    });
+    expect(readOnlyDirectory).toHaveAttribute("aria-pressed", "true");
+    expect(readOnlyDirectory).toBeDisabled();
     expect(within(modes).queryByRole("button", { name: "Per-run" })).not.toBeInTheDocument();
     const directory = screen.getByLabelText("Directory");
     expect(directory).toHaveValue("packages/api");

--- a/web/src/systems/loops/components/__tests__/loop-configure-dialog.test.tsx
+++ b/web/src/systems/loops/components/__tests__/loop-configure-dialog.test.tsx
@@ -206,20 +206,30 @@ describe("LoopConfigureDialog", () => {
     expect(screen.getByTestId("loop-configure-limit-input-iteration_cap")).toHaveValue(16);
   });
 
-  it("Should collect the directory required by the loop environment default", async () => {
-    renderSheet({ config: null });
+  it("Should preserve an API-authored directory while editing another setting", async () => {
+    renderSheet({
+      config: {
+        ...loopConfigFixture,
+        environment: { mode: "directory", directory: "packages/api" },
+      },
+    });
     const modes = await screen.findByTestId("loop-configure-environment-mode");
-
-    fireEvent.click(within(modes).getByRole("button", { name: "Directory" }));
+    expect(within(modes).getByRole("button", { name: "Directory (read-only)" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(within(modes).queryByRole("button", { name: "Per-run" })).not.toBeInTheDocument();
     const directory = screen.getByLabelText("Directory");
-    expect(directory).toHaveValue("");
+    expect(directory).toHaveValue("packages/api");
+    expect(directory).toHaveAttribute("readonly");
 
-    fireEvent.change(directory, { target: { value: "packages/api" } });
+    fireEvent.click(rowSwitch("loop-configure-human-gate"));
     fireEvent.click(screen.getByTestId("loop-configure-save"));
 
     await waitFor(() => expect(putBodies).toHaveLength(1));
     expect(putBodies[0].config).toMatchObject({
       environment: { mode: "directory", directory: "packages/api" },
+      human_gate_enabled: false,
     });
   });
 

--- a/web/src/systems/loops/components/__tests__/loop-editor.test.tsx
+++ b/web/src/systems/loops/components/__tests__/loop-editor.test.tsx
@@ -837,26 +837,41 @@ describe("LoopEditor", () => {
     expect(onPublished.mock.calls[0][0].version).toBe(1);
   });
 
-  it("Should show per-mode environment hints and the directory companion in the inspector", async () => {
-    renderEditor();
+  it("Should preserve an API-authored directory as read-only through an unrelated publish", async () => {
+    const { captured, handler } = capturePublish();
+    renderEditor("quality-gate-demo", [
+      handler,
+      detailHandler(
+        withExecuteTaskParams({
+          environment: { mode: "directory", directory: "packages/{{ .inputs.slug }}" },
+        })
+      ),
+    ]);
     await screen.findByTestId("loop-editor");
     await waitFor(() => expect(screen.getAllByTestId("loop-editor-node")).toHaveLength(8));
     fireEvent.click(nodeCard("execute_task"));
     await screen.findByTestId("loop-field-environment");
-    expect(
-      screen.queryByText("Runs at the workspace root. Part of the session binding key.")
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Directory (read-only)" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(screen.queryByRole("button", { name: "Per-run" })).not.toBeInTheDocument();
+    const directory = screen.getByTestId("loop-field-environment-directory");
+    expect(directory).toHaveValue("packages/{{ .inputs.slug }}");
+    expect(directory).toHaveAttribute("readonly");
 
-    fireEvent.click(screen.getByRole("button", { name: "Workspace root" }));
-    expect(
-      screen.getByText("Runs at the workspace root. Part of the session binding key.")
-    ).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Directory" }));
-    expect(
-      screen.getByText("Resolved when the run starts. Type {{ to autocomplete references.")
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("loop-field-environment-directory")).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("loop-field-deadline"), {
+      target: { value: "4h" },
+    });
+    await waitFor(() => expect(screen.getByTestId("loop-editor-publish")).not.toBeDisabled());
+    fireEvent.click(screen.getByTestId("loop-editor-publish"));
+    await waitFor(() => expect(captured.definition).not.toBeNull());
+    expect(publishedNode(captured, "execute_task")).toMatchObject({
+      deadline: "4h",
+      params: {
+        environment: { mode: "directory", directory: "packages/{{ .inputs.slug }}" },
+      },
+    });
   });
 
   it("Should pick a ready worktree for a node environment override", async () => {

--- a/web/src/systems/loops/components/__tests__/loop-run-form.test.tsx
+++ b/web/src/systems/loops/components/__tests__/loop-run-form.test.tsx
@@ -16,6 +16,7 @@ import { buildLocalNetworkParticipationFixture } from "@/test/network-participat
 import { storyWorkspaceIds } from "@/storybook/fintech-scenario";
 import { LoopRunForm } from "../run-form/loop-run-form";
 import { handlers } from "../../mocks";
+import { worktreeBehindFixture } from "@/systems/workspace/mocks";
 import { worktreeHandlers } from "@/systems/workspace/mocks/worktree-handlers";
 import { loopDetailByName, loopEffectiveConfigFixture } from "../../mocks/fixtures";
 import type { LoopEffectiveConfig } from "../../types";
@@ -404,13 +405,20 @@ describe("LoopRunForm", () => {
     });
   });
 
-  it("Should send the selected environment as a per-run override", async () => {
+  it("Should offer only Web-supported environment overrides", async () => {
     renderForm();
     openSection(/Environment/);
-    const perRun = screen.getByRole("button", { name: "Per-run" });
-    await waitFor(() => expect(perRun).toBeEnabled());
-    fireEvent.click(perRun);
-    await waitFor(() => expect(perRun).toHaveAttribute("aria-pressed", "true"));
+    expect(screen.queryByRole("button", { name: "Directory" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Per-run" })).not.toBeInTheDocument();
+    const worktree = screen.getByRole("button", { name: "Named worktree" });
+    await waitFor(() => expect(worktree).toBeEnabled());
+    fireEvent.click(worktree);
+    await waitFor(() => expect(worktree).toHaveAttribute("aria-pressed", "true"));
+    const picker = await screen.findByTestId("loop-run-environment-ref");
+    fireEvent.click(picker);
+    fireEvent.click(
+      await screen.findByRole("option", { name: new RegExp(worktreeBehindFixture.name) })
+    );
     expect(screen.getByTestId("loop-run-overrides-badge")).toHaveTextContent("overrides set");
     fireEvent.change(screen.getByTestId("loop-run-field-input-slug"), {
       target: { value: "billing-webhooks" },
@@ -418,7 +426,9 @@ describe("LoopRunForm", () => {
     fireEvent.click(screen.getByTestId("loop-run-submit-button"));
     await waitFor(() => expect(fetchMock).toHaveBeenCalled());
     await expect(runRequestBody()).resolves.toMatchObject({
-      config_overrides: { environment: { mode: "per_run" } },
+      config_overrides: {
+        environment: { mode: "worktree", worktree_ref: worktreeBehindFixture.id },
+      },
     });
   });
 });

--- a/web/src/systems/loops/components/configure/loop-worktree-section.tsx
+++ b/web/src/systems/loops/components/configure/loop-worktree-section.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldError, FieldLabel, FormSection, Input, PillGroup } from "@compozy/ui";
+import { Field, FieldLabel, FormSection, Input, PillGroup } from "@compozy/ui";
 
 import { WorktreeRefSelect, type WorktreePayload } from "@/systems/workspace";
 
@@ -20,7 +20,6 @@ interface LoopWorktreeSectionProps {
 
 const MODE_HINTS: Partial<Record<LoopEnvironmentChoice, string>> = {
   [INHERIT_ENVIRONMENT]: "No loop default declared — nodes choose their own environment.",
-  per_run: "Fresh worktree per run.",
 };
 
 /**
@@ -38,9 +37,8 @@ export function LoopWorktreeSection({
   onChange,
 }: LoopWorktreeSectionProps) {
   const mode: LoopEnvironmentChoice = value?.mode ?? INHERIT_ENVIRONMENT;
-  const items = loopEnvironmentItems(gitBacked, disabled);
+  const items = loopEnvironmentItems(gitBacked, disabled, mode);
   const hint = MODE_HINTS[mode];
-  const invalidDirectory = value?.mode === "directory" && !value.directory?.trim();
 
   function handleModeChange(next: LoopEnvironmentChoice) {
     onChange(environmentSpecForChoice(next, value));
@@ -70,18 +68,14 @@ export function LoopWorktreeSection({
           </div>
         ) : null}
         {value?.mode === "directory" ? (
-          <Field className="mt-3" data-invalid={invalidDirectory ? "" : undefined}>
+          <Field className="mt-3">
             <FieldLabel htmlFor="loop-configure-environment-directory">Directory</FieldLabel>
             <Input
               disabled={disabled}
               id="loop-configure-environment-directory"
-              onChange={event => onChange({ mode: "directory", directory: event.target.value })}
-              placeholder="packages/api"
+              readOnly
               value={value.directory ?? ""}
             />
-            {invalidDirectory ? (
-              <FieldError>Enter a directory inside the workspace.</FieldError>
-            ) : null}
           </Field>
         ) : null}
         {hint ? <p className="mt-2 text-form-hint leading-relaxed text-subtle">{hint}</p> : null}

--- a/web/src/systems/loops/components/editor/loop-editor-environment-field.tsx
+++ b/web/src/systems/loops/components/editor/loop-editor-environment-field.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from "react";
 
-import { Field, FieldError, FieldLabel, PillGroup, cn } from "@compozy/ui";
+import { Field, FieldError, FieldLabel, Input, PillGroup, cn } from "@compozy/ui";
 
 import { WorktreeRefSelect, type WorktreePayload } from "@/systems/workspace";
 
@@ -19,9 +19,7 @@ import {
   type EnvironmentFieldSpec,
   type FieldPath,
 } from "../../lib/loop-node-schema-types";
-import type { LoopReferenceSuggestion } from "../../lib/loop-references";
 import type { LoopEnvironmentSpec, LoopValidationIssue } from "../../types";
-import { LoopReferenceInput } from "./loop-reference-input";
 
 const UNSET_MODE_VALUE = "";
 
@@ -31,7 +29,6 @@ interface LoopEditorEnvironmentFieldProps extends Omit<ComponentProps<"div">, "o
   disabled: boolean;
   onChangeFields: (edits: NodeFieldEdit[]) => void;
   onChange: (path: FieldPath, value: unknown) => void;
-  suggestions: readonly LoopReferenceSuggestion[];
   worktrees?: readonly WorktreePayload[];
   gitBacked?: boolean;
   loopDefaultEnvironment?: LoopEnvironmentSpec;
@@ -53,7 +50,6 @@ export function LoopEditorEnvironmentField({
   disabled,
   onChangeFields,
   onChange,
-  suggestions,
   worktrees = [],
   gitBacked = true,
   loopDefaultEnvironment,
@@ -63,14 +59,17 @@ export function LoopEditorEnvironmentField({
 }: LoopEditorEnvironmentFieldProps) {
   const cwdIssue = lintIssues.find(issue => issue.code === ENVIRONMENT_CWD_REMOVED_CODE);
   const invalidCwd = Boolean(cwdIssue) || hasRetiredCwd(raw);
-  const items = loopEnvironmentItems(gitBacked, disabled).map(item =>
+  const mode = field.mode ?? INHERIT_ENVIRONMENT;
+  const items = loopEnvironmentItems(gitBacked, disabled, mode).map(item =>
     item.value === INHERIT_ENVIRONMENT ? { ...item, label: field.inheritLabel } : item
   );
   const selectedRef = String(getAtPath(raw, [...field.basePath, "worktree_ref"]) ?? "");
   const referenced = worktrees.find(worktree => worktree.id === selectedRef);
   const readyWorktrees = worktrees.filter(worktree => worktree.state === "ready");
   const directory = String(getAtPath(raw, [...field.basePath, "directory"]) ?? "");
-  const hint = invalidCwd ? undefined : environmentHint(field.mode, loopDefaultEnvironment);
+  const readOnlyMode = field.mode === "directory" || field.mode === "per_run";
+  const hint =
+    invalidCwd || readOnlyMode ? undefined : environmentHint(field.mode, loopDefaultEnvironment);
 
   function handleChange(next: string) {
     if (next === UNSET_MODE_VALUE) return;
@@ -117,15 +116,13 @@ export function LoopEditorEnvironmentField({
       ) : null}
       {field.mode === "directory" && !invalidCwd ? (
         <div className="mt-3">
-          <FieldLabel>Directory</FieldLabel>
-          <LoopReferenceInput
-            ariaLabel="Directory"
+          <FieldLabel htmlFor="loop-field-environment-directory">Directory</FieldLabel>
+          <Input
             disabled={disabled}
-            mono
-            onChange={value => onChange([...field.basePath, "directory"], value)}
-            placeholder="packages/{{ .inputs.slug }}"
-            suggestions={suggestions}
-            testId="loop-field-environment-directory"
+            id="loop-field-environment-directory"
+            readOnly
+            className="font-mono"
+            data-testid="loop-field-environment-directory"
             value={directory}
           />
         </div>

--- a/web/src/systems/loops/components/editor/loop-editor-field.tsx
+++ b/web/src/systems/loops/components/editor/loop-editor-field.tsx
@@ -323,7 +323,6 @@ export function LoopEditorField(props: LoopEditorFieldProps) {
         onChange={props.onChange}
         onChangeFields={props.onChangeFields}
         raw={raw as RawLoopNode}
-        suggestions={props.suggestions}
         worktrees={props.worktrees}
       />
     );

--- a/web/src/systems/loops/components/run-form/loop-run-environment.tsx
+++ b/web/src/systems/loops/components/run-form/loop-run-environment.tsx
@@ -32,8 +32,7 @@ export function LoopRunEnvironment({
 }: LoopRunEnvironmentProps) {
   const choice = value?.mode ?? INHERIT_ENVIRONMENT;
   const invalidWorktree = value?.mode === "worktree" && !value.worktree_ref?.trim();
-  const invalidDirectory = value?.mode === "directory" && !value.directory?.trim();
-  const items = loopEnvironmentItems(gitBacked, disabled);
+  const items = loopEnvironmentItems(gitBacked, disabled, choice);
 
   function handleModeChange(next: LoopEnvironmentChoice) {
     onChange(environmentSpecForChoice(next, value));
@@ -69,18 +68,14 @@ export function LoopRunEnvironment({
           </Field>
         ) : null}
         {value?.mode === "directory" ? (
-          <Field className="mt-3" data-invalid={invalidDirectory ? "" : undefined}>
+          <Field className="mt-3">
             <FieldLabel htmlFor="loop-run-environment-directory">Directory</FieldLabel>
             <Input
               disabled={disabled}
               id="loop-run-environment-directory"
-              onChange={event => onChange({ mode: "directory", directory: event.target.value })}
-              placeholder="packages/api"
+              readOnly
               value={value.directory ?? ""}
             />
-            {invalidDirectory ? (
-              <FieldError>Enter a directory inside the workspace.</FieldError>
-            ) : null}
           </Field>
         ) : null}
       </div>

--- a/web/src/systems/loops/components/stories/loop-editor.stories.tsx
+++ b/web/src/systems/loops/components/stories/loop-editor.stories.tsx
@@ -349,27 +349,29 @@ export const NodeEnvironmentDirectory: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = await revealNodeEnvironment(canvasElement, ["loop-field-environment-directory"]);
-    await canvas.findByRole("combobox", { name: "Directory" });
-    await expect(canvas.getByTestId("loop-field-environment-directory")).toHaveValue(
-      "packages/{{ .inputs.slug }}"
+    await expect(canvas.getByRole("button", { name: "Directory (read-only)" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
     );
+    const directory = canvas.getByTestId("loop-field-environment-directory");
+    await expect(directory).toHaveAttribute("readonly");
+    await expect(directory).toHaveValue("packages/{{ .inputs.slug }}");
   },
 };
 
-export const NodeEnvironmentReadout: Story = {
+export const NodeEnvironmentPerRunReadOnly: Story = {
   args: { workspaceId: WS, name: "implement-tasks" },
   parameters: {
     msw: {
-      handlers: [
-        compozyApiMock.get("/api/workspaces/{workspace_id}/loops/{name}/config", () =>
-          HttpResponse.json({
-            config: { ...loopConfigFixture, environment: { mode: "per_run" } },
-            effective_config: { ...loopEffectiveConfigFixture, environment: { mode: "per_run" } },
-          })
-        ),
-        ...editorHandlers(nodeEnvironmentDetail(null)),
-      ],
+      handlers: editorHandlers(nodeEnvironmentDetail({ mode: "per_run" })),
     },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = await revealNodeEnvironment(canvasElement);
+    await expect(canvas.getByRole("button", { name: "Per-run (read-only)" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
   },
 };
 

--- a/web/src/systems/loops/components/stories/loop-worktree-environment.stories.tsx
+++ b/web/src/systems/loops/components/stories/loop-worktree-environment.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof LoopWorktreeSection> = {
     docs: {
       description: {
         component:
-          "The loop-level environment default. Inherit is the rendering of an absent key — choosing it clears the stored default rather than writing a placeholder mode — and a node override always wins over whatever is set here. The per-node control is captured on the LoopEditor inspector (VC-31..VC-35).",
+          "The loop-level environment default. Web authors choose Inherit, Workspace root, or Named worktree. Directory and Per-run values created through the API or CLI remain visible as read-only values.",
       },
     },
   },
@@ -53,8 +53,8 @@ export const LoopDefaultNamedWorktree: Story = {
   ),
 };
 
-/** VC-30 — per-run: a fresh worktree for each run of the loop. */
-export const LoopDefaultPerRun: Story = {
+/** VC-30 — an API-authored per-run value remains visible but cannot be edited in Web. */
+export const LoopDefaultPerRunReadOnly: Story = {
   args: { ...LoopDefaultUnset.args, value: { mode: "per_run" } },
   render: () => <SectionHarness initial={{ mode: "per_run" }} />,
 };

--- a/web/src/systems/loops/lib/loop-environment-choice.ts
+++ b/web/src/systems/loops/lib/loop-environment-choice.ts
@@ -1,18 +1,38 @@
-import { LOOP_ENVIRONMENT_MODE_LABELS, LOOP_ENVIRONMENT_MODES } from "./loop-node-schema-types";
+import { LOOP_ENVIRONMENT_MODE_LABELS } from "./loop-node-schema-types";
 import type { LoopEnvironmentMode, LoopEnvironmentSpec } from "../types";
 
 export const INHERIT_ENVIRONMENT = "__inherit__";
 export type LoopEnvironmentChoice = LoopEnvironmentMode | typeof INHERIT_ENVIRONMENT;
 
-export function loopEnvironmentItems(gitBacked: boolean, disabled: boolean) {
-  return [
+const WEB_EDITABLE_ENVIRONMENT_MODES = ["root", "worktree"] as const;
+
+function isReadOnlyWebMode(
+  mode: LoopEnvironmentChoice
+): mode is Extract<LoopEnvironmentMode, "directory" | "per_run"> {
+  return mode === "directory" || mode === "per_run";
+}
+
+export function loopEnvironmentItems(
+  gitBacked: boolean,
+  disabled: boolean,
+  current: LoopEnvironmentChoice
+) {
+  const items = [
     { value: INHERIT_ENVIRONMENT as LoopEnvironmentChoice, label: "Inherit", disabled },
-    ...LOOP_ENVIRONMENT_MODES.map(mode => ({
+    ...WEB_EDITABLE_ENVIRONMENT_MODES.map(mode => ({
       value: mode as LoopEnvironmentChoice,
       label: LOOP_ENVIRONMENT_MODE_LABELS[mode],
-      disabled: disabled || (!gitBacked && (mode === "worktree" || mode === "per_run")),
+      disabled: disabled || (!gitBacked && mode === "worktree"),
     })),
   ];
+  if (isReadOnlyWebMode(current)) {
+    items.push({
+      value: current,
+      label: `${LOOP_ENVIRONMENT_MODE_LABELS[current]} (read-only)`,
+      disabled,
+    });
+  }
+  return items;
 }
 
 export function environmentSpecForChoice(

--- a/web/src/systems/loops/lib/loop-environment-choice.ts
+++ b/web/src/systems/loops/lib/loop-environment-choice.ts
@@ -29,7 +29,7 @@ export function loopEnvironmentItems(
     items.push({
       value: current,
       label: `${LOOP_ENVIRONMENT_MODE_LABELS[current]} (read-only)`,
-      disabled,
+      disabled: true,
     });
   }
   return items;


### PR DESCRIPTION
## Summary

- resolve Loop extension tools against the selected ready worktree without changing direct or root-scoped calls
- restrict Web Loop environment authoring to inherit, workspace root, and named worktree while preserving API/CLI directory and per-run values read-only
- update the official Compozy skill, public docs, canonical tests, and QA tracker

## Verification

- make gate — PASS after rebase (fingerprint 733c93061233f1557175d2d6a309ae6011b152ee)
- React Doctor — 100/100, no issues
- strict QA evidence audit — PASS, 0 blockers, 0 warnings
- isolated real-user QA — 2/2 scenarios PASS; clean teardown with no survivors

## Compozy Impact Audit

- Native tools: no tool IDs, descriptors, schemas, digests, risk flags, or capability gates changed; the existing hidden trusted-root call context now carries the resolved Loop worktree.
- Extensibility and hooks: extension tool actions use the selected ready worktree root; hooks, capabilities, MCP contracts, registries, and config keys are unchanged.
- Workspace data isolation: worktrees are resolved by workspace ID and worktree ref, must be ready, and add no persisted data, cache, SSE, or event changes.
- Official Compozy skill: Loop environment guidance updated in skills/compozy/references/loops.md.

Closes #512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tool actions now use the trusted root of the selected worktree, improving workspace isolation.
  - Worktree-based task runs are supported when only the worktree task pack is available.
  - Missing or unavailable worktrees are clearly rejected before execution.

- **Bug Fixes**
  - Directory-based loop configurations remain read-only and are preserved when other settings change.
  - Loop environment options now prevent unsupported directory and per-run overrides while allowing named worktree selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->