### PR TITLE
fix: prevent session cancel and clear races

### DIFF
--- a/docs/qa/reports/2026-09-01-issue-521-522-session-cancel-clear.md
+++ b/docs/qa/reports/2026-09-01-issue-521-522-session-cancel-clear.md
@@ -1,0 +1,101 @@
+# QA Run Report — 2026-09-01 — Issue 521/522 Session Cancel and Clear
+
+- **Scope:** Request-scoped prompt cancellation, late-cancel idempotency, and atomic transcript reads during conversation clear.
+- **Cadence tier:** targeted
+- **Build:** `5ae7dbbfe` + working tree · **Environment:** isolated targeted lab, Codex provider, HTTP `127.0.0.1:53131`
+- **Started:** 2026-09-01T18:14:16Z · **Status:** QA pass; delivery CI pending
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | Agent / headless operator | desktop / wifi-fast / en-US | `CH-herdr-session-orchestration` |
+| Théo | Returning session operator | desktop / wifi-fast / en-US | `CH-untested-valid-005-14-theo`, `CH-stopped-session-prompt-continuity` |
+
+## Flows in Scope
+
+- `J-15` — cancel one prompt through structured surfaces while preserving the live session and its next turn ([journey](../journeys/J-15-operate-session-via-cli-api.md)).
+- `J-14` — clear a transcript and confirm the same session stays empty after a fresh read ([journey](../journeys/J-14-read-a-finished-transcript.md)).
+- `J-13` — adjacent canary: submit a later prompt and preserve one durable session identity ([journey](../journeys/J-13-follow-a-live-run.md)).
+
+Taxonomy coverage: the functional and journey contracts are the primary scope; interruption, repeat action, concurrent read, refresh, and error recovery cover edge and experiential dimensions; CLI/API/runtime parity covers cross-cutting consistency. Layout, locale, and mobile compatibility are deliberately out of scope because no UI layout or copy changed.
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | `CH-herdr-session-orchestration` | `J-15` / `RT-session-prompt-cancel` | Ada | Interrupt Tour | Pass | #522 | working tree |
+| 2 | `CH-untested-valid-005-14-theo` | `J-14` / `RT-017` | Théo | Feature Tour | Pass | #521 | working tree |
+| 3 | `CH-stopped-session-prompt-continuity` | `J-13` / `RT-018` | Théo | Interrupt Tour | Skipped | known `BUG-20260825-workspace-agent-unusable-for-sessions` | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### Ada — cancel one prompt, then continue
+
+- Started real Codex turn `turn-8a40d61cac8706d7` in session `sess-a63b87a64ffa9285` and canceled it through the CLI.
+- The stream ended with ACP request cancellation, while session status returned to healthy and idle.
+- Repeated cancellation through CLI, HTTP, and `compozy__session_prompt_cancel` returned `nothing-in-flight` without stopping the session.
+- A later prompt completed `NEXT_TURN_OK` on the same durable session and original ACP session ID.
+
+### Théo — clear and freshly read the same session
+
+- Confirmed the pre-clear transcript contained the canceled turn and the successful later turn.
+- `POST .../sessions/sess-a63b87a64ffa9285/clear` returned 200 with the same durable session and a restarted ACP context.
+- Independent HTTP and UDS reads returned an empty transcript at epoch 1; neither returned a transient missing-session result.
+- The restarted Codex session completed `CLEAR_NEXT_OK`, proving the session remained usable after database replacement.
+- A separate Web session rendered `WEB_CLEAR_READY`, completed the clear confirmation dialog, rendered an empty thread, and returned zero transcript entries on an independent API read.
+- The adjacent stop/resume canary could not run because workspace-profile agents hit the already-open `BUG-20260825-workspace-agent-unusable-for-sessions`; the in-scope clear and post-clear prompt completed before that independent boundary.
+
+## What Was Fixed
+
+### Issue #522: late prompt cancel could cancel the next turn
+
+- **Symptom:** A repeated or delayed prompt cancel emitted session-scoped ACP cancellation after the original turn had settled.
+- **Root cause:** `Driver.Cancel` fell back to `session/cancel`, and prompt-context cancellation also emitted the same session-scoped notification even though the ACP SDK supports request-scoped cancellation.
+- **Fix:** working tree.
+- **Regression test:** `internal/acp/client_process_lifecycle_test.go` failed before the fix by capturing one unwanted `session/cancel` for both active and late cancellation, then passed with next-turn integrity.
+- **Retested:** Pass. CLI, HTTP, native-tool, runtime, and real Codex-provider evidence is recorded under `/Users/pedronauck/dev/qa-labs/compozy-issue-521-522-session-cancel-clear-20260901-183338-907244-lab/qa-artifacts/qa`.
+
+### Issue #521: transcript read raced session clear
+
+- **Symptom:** A transcript poll returned `session not found` during clear and could interfere with the in-progress clear transaction, producing HTTP 500.
+- **Root cause:** recorder resolution ignored the conversation-finalization barrier and translated query-pool quiescence into a missing session while the database family was being replaced.
+- **Fix:** working tree.
+- **Regression test:** `internal/session/manager_clear_test.go` failed before the fix with `session: session not found` during deterministic query-pool quiescence, then passed by waiting for finalization.
+- **Retested:** Pass across Web, runtime, API, and UDS in the isolated lab: both clear requests returned 200, fresh reads returned epoch 1 with zero entries, the first durable session accepted a later prompt, and the Web session rendered an empty thread after confirmation. Exact-head PR E2E remains the delivery backstop.
+
+## Paper Cuts
+
+- The out-of-scope stopped-session canary reproduced existing `BUG-20260825-workspace-agent-unusable-for-sessions`: the catalog listed the workspace agent, but resume validation rejected it as unavailable. This did not affect active cancel, clear, fresh read, or the post-clear prompt.
+
+## Runtime Errors Observed
+
+- Recent `ci.yml` runs `33538539190`, `33535868025`, and `33528977779` reproduced issue #521 in Web E2E shard 3/4 at `session-hardening.spec.ts:314`: backup completed, a concurrent transcript read reported `session not found`, and clear returned HTTP 500.
+- Other recent E2E failures (Loops builder, OS shell performance, terminal locator, and Desktop teardown) have different logs and are outside this fix.
+- The local full Web E2E lane was intentionally stopped before completion; repository policy assigns the heavy E2E matrix to exact-head PR CI. Focused race-enabled regressions and `make gate` remain the local evidence.
+- The isolated QA environment was torn down after the strict evidence audit. Its `qa/teardown.json` records `"clean": true` with no surviving processes.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- ACP request cancellation already has an exact request identity; session-wide cancellation belongs only to whole-session stop.
+- A database replacement barrier must cover recovery and read-open paths, not only the writer performing the replacement.
+
+## Final Status
+
+- **Local gate:** PASS — `make gate` completed the affected `go-lint` and race-enabled `go-test` lanes with zero lint issues and zero test failures.
+- **Final verify log:** `/Users/pedronauck/dev/qa-labs/compozy-issue-521-522-session-cancel-clear-20260901-183338-907244-lab/qa-artifacts/qa/verify-gate.log`
+- **Exit gate (full automated suite):** Pending exact-head PR CI by repository policy.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 2/3 passed; 1/3 adjacent canary skipped on a known pre-existing bug.
+- Verdict: PASS — both changed behavior contracts passed their public-surface walks and strict evidence review.
+- Delivery: PENDING — the PR's exact-head E2E and required CI checks remain the completion authority.

--- a/docs/qa/scenarios/RT-017.md
+++ b/docs/qa/scenarios/RT-017.md
@@ -6,13 +6,13 @@ persona: Théo
 journey: J-14
 expected: `POST .../sessions/:sid/clear` → 200 session; clears persisted history + restarts ACP context; web optimistically empties transcript/history and rolls back on error.
 entry_points: HTTP+UDS; web clear control
-qa_status: blocked-verify
+qa_status: pass
 bug_ids:
-fix_status:
-retest_status:
+fix_status: fixed
+retest_status: pass
 fix_commits: 3e35bf90
-evidence: `handlers.go:599-611`; `use-session-actions.ts:196-253`; qa/evidence/batch-003-sessions/rt017-*; docs/qa/reports/2026-07-08-session-improvements.md;/Users/pedronauck/dev/qa-labs/compozy-qa-rt-current-source-20260730-20260730-061631-252740-lab/qa-artifacts/qa
-last_report: docs/qa/reports/2026-07-28-untested-full.md
+evidence: `handlers.go:599-611`; `use-session-actions.ts:196-253`; qa/evidence/batch-003-sessions/rt017-*; docs/qa/reports/2026-07-08-session-improvements.md;/Users/pedronauck/dev/qa-labs/compozy-qa-rt-current-source-20260730-20260730-061631-252740-lab/qa-artifacts/qa;docs/qa/reports/2026-09-01-issue-521-522-session-cancel-clear.md;/Users/pedronauck/dev/qa-labs/compozy-issue-521-522-session-cancel-clear-20260901-183338-907244-lab/qa-artifacts/qa
+last_report: docs/qa/reports/2026-09-01-issue-521-522-session-cancel-clear.md
 overlaps:
 ---
 
@@ -41,3 +41,14 @@ from committed state, retains the authoritative transcript epoch through recover
 concurrent Stop/RequestStop from the finalization window. Keep `blocked-verify`; the next public walk
 must prove clear/reload persistence, committed-manifest recovery, and Stop/Clear convergence in a
 fresh isolated lab with mandatory clean teardown.
+
+QA impact 2026-09-01: transcript readers now wait for the complete stop, backup, replacement, and
+restart transition instead of recovering or opening a quiescing session database mid-clear. Reset
+for cancel-then-clear, concurrent transcript read, same-id restart, empty reload, and adjacent prompt
+continuity in a fresh isolated lab.
+
+QA 2026-09-01: `POST .../sessions/sess-a63b87a64ffa9285/clear` returned 200, retained
+the same durable session, advanced the transcript epoch, and a fresh HTTP plus UDS read returned an
+empty transcript. The restarted Codex-backed runtime then completed `CLEAR_NEXT_OK`. A separate
+Codex-backed session populated with `WEB_CLEAR_READY` was cleared through the Web confirmation
+dialog; the thread rendered empty and an independent transcript read returned zero entries.

--- a/docs/qa/scenarios/RT-session-prompt-cancel.md
+++ b/docs/qa/scenarios/RT-session-prompt-cancel.md
@@ -8,11 +8,11 @@ expected: compozy session prompt-cancel and compozy__session_prompt_cancel use t
 entry_points: compozy session prompt-cancel; compozy__session_prompt_cancel; POST /api/workspaces/{workspace_id}/sessions/{session_id}/prompt/cancel over HTTP and UDS
 qa_status: pass
 bug_ids:
-fix_status:
-retest_status:
+fix_status: fixed
+retest_status: pass
 fix_commits:
-evidence: docs/qa/reports/2026-08-16-herdr-parity.md; /Users/pedronauck/dev/qa-labs/compozy-northstar-pay-20260816-141901-835450-lab/qa-artifacts/qa/bootstrap-manifest.json
-last_report: docs/qa/reports/2026-08-16-herdr-parity.md
+evidence: docs/qa/reports/2026-08-16-herdr-parity.md; /Users/pedronauck/dev/qa-labs/compozy-northstar-pay-20260816-141901-835450-lab/qa-artifacts/qa/bootstrap-manifest.json;docs/qa/reports/2026-09-01-issue-521-522-session-cancel-clear.md;/Users/pedronauck/dev/qa-labs/compozy-issue-521-522-session-cancel-clear-20260901-183338-907244-lab/qa-artifacts/qa
+last_report: docs/qa/reports/2026-09-01-issue-521-522-session-cancel-clear.md
 overlaps: RT-020; ET-web-session-transcript-calm-grammar
 ---
 
@@ -26,3 +26,11 @@ QA impact 2026-08-16: Task 04 added the prompt-cancel CLI verb and scoped native
 the existing route's single production cancellation path. Flag only; task_08 owns execution.
 
 QA 2026-08-16 Herdr parity: The full runtime E2E exercised the public HTTP, UDS, CLI, and native-tool paths, including matching persisted projections, restart recovery, scoped denials, bounded wait/notify/cancel/stop races, and stable negative outcomes (65/66/69/75/78, agent_scope_denied, and queue-full).
+
+QA impact 2026-09-01: ACP prompt cancellation is now request-scoped, while session-scoped cancellation
+is reserved for whole-session Stop. Reset for repeat-cancel and next-turn integrity across public
+HTTP, UDS, CLI, native-tool, and provider-backed runtime surfaces.
+
+QA 2026-09-01: Codex-backed session `sess-a63b87a64ffa9285` canceled active turn
+`turn-8a40d61cac8706d7`, returned `nothing-in-flight` for repeated CLI, HTTP, and native-tool
+requests, and completed `NEXT_TURN_OK` on the same durable session without a late session cancel.

--- a/internal/acp/client_control.go
+++ b/internal/acp/client_control.go
@@ -46,7 +46,7 @@ func (d *Driver) Prompt(ctx context.Context, proc *AgentProcess, req PromptReque
 	return active.events, nil
 }
 
-// Cancel cancels the local active prompt or falls back to ACP cooperative cancellation.
+// Cancel cancels only the active prompt and is an idempotent no-op once it settles.
 func (d *Driver) Cancel(ctx context.Context, proc *AgentProcess) error {
 	if ctx == nil {
 		return errors.New("acp: context is required")
@@ -63,9 +63,7 @@ func (d *Driver) Cancel(ctx context.Context, proc *AgentProcess) error {
 	if proc.cancelCurrentPrompt() {
 		return nil
 	}
-	return proc.conn.SendNotification(ctx, acpsdk.AgentMethodSessionCancel, acpsdk.CancelNotification{
-		SessionId: acpsdk.SessionId(proc.SessionID),
-	})
+	return nil
 }
 
 // Interrupt signals processes matching a scoped toolruntime selector.
@@ -174,7 +172,12 @@ func (d *Driver) cancelSessionForStop(ctx context.Context, proc *AgentProcess) [
 	cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
 	defer cancel()
 
-	if err := d.Cancel(cancelCtx, proc); err != nil && !errors.Is(err, context.Canceled) {
+	err := proc.conn.SendNotification(
+		cancelCtx,
+		acpsdk.AgentMethodSessionCancel,
+		acpsdk.CancelNotification{SessionId: acpsdk.SessionId(proc.SessionID)},
+	)
+	if err != nil && !errors.Is(err, context.Canceled) {
 		return []error{fmt.Errorf("acp: cancel session prompt: %w", err)}
 	}
 	return nil

--- a/internal/acp/client_process_lifecycle_test.go
+++ b/internal/acp/client_process_lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -234,6 +235,90 @@ func TestAgentProcessExitLifecycle(t *testing.T) {
 		}
 		if _, admitted := proc.beginChildTask(); admitted {
 			t.Fatal("beginChildTask() admitted work after Done()")
+		}
+	})
+}
+
+func TestDriverCancelPreservesTurnScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should leave a completed turn and the next turn untouched", func(t *testing.T) {
+		t.Parallel()
+
+		driver := New()
+		captureFile := filepath.Join(t.TempDir(), "late-cancel.jsonl")
+		proc := startHelperProcess(t, driver, "echo_prompt", "", StartOpts{
+			Env: helperEnvWithCapture("echo_prompt", "", captureFile),
+		})
+		t.Cleanup(func() {
+			stopProcess(t, driver, proc)
+		})
+
+		firstEvents, err := driver.Prompt(t.Context(), proc, PromptRequest{
+			TurnID:  "turn-before-late-cancel",
+			Message: "before late cancel",
+		})
+		if err != nil {
+			t.Fatalf("Prompt(first turn) error = %v", err)
+		}
+		collectEvents(t, firstEvents)
+
+		if err := driver.Cancel(t.Context(), proc); err != nil {
+			t.Fatalf("Cancel(after completed turn) error = %v", err)
+		}
+		if got := len(captureRequestParamsForMethod(t, captureFile, acpsdk.AgentMethodSessionCancel)); got != 0 {
+			t.Fatalf("session/cancel notifications after late cancel = %d, want 0", got)
+		}
+
+		secondEvents, err := driver.Prompt(t.Context(), proc, PromptRequest{
+			TurnID:  "turn-after-late-cancel",
+			Message: "after late cancel",
+		})
+		if err != nil {
+			t.Fatalf("Prompt(next turn) error = %v", err)
+		}
+		events := collectEvents(t, secondEvents)
+		if len(events) == 0 || events[0].Type != EventTypeAgentMessage || events[0].Text != "after late cancel" {
+			t.Fatalf("Prompt(next turn) events = %#v, want echoed agent message", events)
+		}
+	})
+
+	t.Run("Should cancel an active turn locally without canceling the session", func(t *testing.T) {
+		t.Parallel()
+
+		driver := New()
+		captureFile := filepath.Join(t.TempDir(), "active-cancel.jsonl")
+		proc := startHelperProcess(t, driver, "block_prompt_until_cancel", "", StartOpts{
+			Env: helperEnvWithCapture("block_prompt_until_cancel", "", captureFile),
+		})
+		t.Cleanup(func() {
+			stopProcess(t, driver, proc)
+		})
+
+		eventsCh, err := driver.Prompt(t.Context(), proc, PromptRequest{
+			TurnID:  "turn-active-cancel",
+			Message: "block until canceled",
+		})
+		if err != nil {
+			t.Fatalf("Prompt() error = %v", err)
+		}
+		startCtx, cancelStart := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancelStart()
+		select {
+		case event := <-eventsCh:
+			if event.Type != EventTypeAgentMessage || event.Text != "blocking" {
+				t.Fatalf("first prompt event = %#v, want blocking agent message", event)
+			}
+		case <-startCtx.Done():
+			t.Fatal("Prompt() did not start before test context expired")
+		}
+
+		if err := driver.Cancel(t.Context(), proc); err != nil {
+			t.Fatalf("Cancel(active turn) error = %v", err)
+		}
+		collectEvents(t, eventsCh)
+		if got := len(captureRequestParamsForMethod(t, captureFile, acpsdk.AgentMethodSessionCancel)); got != 0 {
+			t.Fatalf("session/cancel notifications after active cancel = %d, want 0", got)
 		}
 	})
 }

--- a/internal/acp/client_prompt.go
+++ b/internal/acp/client_prompt.go
@@ -24,14 +24,12 @@ func (d *Driver) runPrompt(ctx context.Context, proc *AgentProcess, active *acti
 	stopReporter := startPromptActivityReporter(ctx, req)
 	defer stopReporter()
 
-	stopCancellationNotifier := d.startPromptCancellationNotifier(ctx, proc, active)
-	defer stopCancellationNotifier()
-
 	promptRequest, err := buildWirePromptRequest(proc, req)
 	if err != nil {
 		emitPromptBuildError(proc, req, err)
 		return
 	}
+	// The SDK turns context cancellation into request-scoped $/cancel_request.
 	response, err := acpsdk.SendRequest[wirePromptResponse](
 		proc.conn,
 		ctx,
@@ -73,64 +71,6 @@ func (d *Driver) runPrompt(ctx context.Context, proc *AgentProcess, active *acti
 	}
 	d.waitForPromptQuiescence(active)
 	proc.emitPromptEvent(doneEvent)
-}
-
-func (d *Driver) startPromptCancellationNotifier(
-	ctx context.Context,
-	proc *AgentProcess,
-	active *activePromptState,
-) func() {
-	if ctx.Err() != nil {
-		d.sendPromptCancellationNotification(ctx, proc, active)
-		return func() {}
-	}
-
-	done := make(chan struct{})
-	stopped := make(chan struct{})
-	go func() {
-		defer close(stopped)
-		select {
-		case <-ctx.Done():
-			d.sendPromptCancellationNotification(ctx, proc, active)
-		case <-done:
-		}
-	}()
-	var stopOnce sync.Once
-	return func() {
-		stopOnce.Do(func() {
-			close(done)
-		})
-		<-stopped
-	}
-}
-
-func (d *Driver) sendPromptCancellationNotification(
-	ctx context.Context,
-	proc *AgentProcess,
-	active *activePromptState,
-) {
-	if strings.TrimSpace(proc.SessionID) == "" {
-		return
-	}
-	notifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Second)
-	defer cancel()
-	err := proc.conn.SendNotification(
-		notifyCtx,
-		acpsdk.AgentMethodSessionCancel,
-		acpsdk.CancelNotification{SessionId: acpsdk.SessionId(proc.SessionID)},
-	)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		d.logger.WarnContext(
-			notifyCtx,
-			"acp: send session cancel notification",
-			"session_id",
-			proc.SessionID,
-			"turn_id",
-			active.turnID,
-			"error",
-			err,
-		)
-	}
 }
 
 func buildWirePromptRequest(proc *AgentProcess, req PromptRequest) (acpsdk.PromptRequest, error) {

--- a/internal/acp/client_start_contract_test.go
+++ b/internal/acp/client_start_contract_test.go
@@ -522,8 +522,8 @@ func TestStopCancelsANonInspectionSession(t *testing.T) {
 		if err := driver.Stop(testutil.Context(t), proc); err != nil {
 			t.Fatalf("Stop() error = %v", err)
 		}
-		if !captureMethodExists(t, captureFile, acpsdk.AgentMethodSessionCancel) {
-			t.Fatal("session/cancel was not sent for a non-inspection session")
+		if got := len(captureRequestParamsForMethod(t, captureFile, acpsdk.AgentMethodSessionCancel)); got != 1 {
+			t.Fatalf("session/cancel notifications for a non-inspection session = %d, want 1", got)
 		}
 	})
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -203,6 +203,9 @@ func (m *Manager) endConversationFinalization(id string) {
 
 func (m *Manager) waitForConversationFinalization(ctx context.Context, id string) error {
 	target := strings.TrimSpace(id)
+	if ownsConversationOperation(ctx, target) {
+		return nil
+	}
 	m.mu.RLock()
 	done := m.conversationFinalizing[target]
 	m.mu.RUnlock()

--- a/internal/session/manager_clear.go
+++ b/internal/session/manager_clear.go
@@ -46,6 +46,10 @@ func (m *Manager) ClearConversation(ctx context.Context, id string) (_ *Session,
 	if m.isPending(target) {
 		return nil, fmt.Errorf("%w: %s", ErrSessionNotActive, target)
 	}
+	if err := m.beginConversationFinalization(target); err != nil {
+		return nil, err
+	}
+	defer m.endConversationFinalization(target)
 
 	if stopErr := m.stopActiveSessionForClear(ctx, target); stopErr != nil {
 		return nil, stopErr

--- a/internal/session/manager_clear_operation.go
+++ b/internal/session/manager_clear_operation.go
@@ -25,11 +25,6 @@ func (m *Manager) clearStoppedConversation(
 	sanitized store.SessionMeta,
 	spec *sessionStartSpec,
 ) (_ *Session, err error) {
-	if err := m.beginConversationFinalization(target); err != nil {
-		return nil, err
-	}
-	defer m.endConversationFinalization(target)
-
 	clearDisposition := sessionDBClearRollback
 	dbPath := store.SessionDBFile(filepath.Join(m.homePaths.SessionsDir, target))
 	familyLease, resumeQueries, err := m.acquireOwnedSessionDBFamily(

--- a/internal/session/manager_clear_test.go
+++ b/internal/session/manager_clear_test.go
@@ -155,6 +155,12 @@ func TestClearConversationRestartsSameSessionWithFreshContext(t *testing.T) {
 			t.Fatalf("ClearConversation() returned while stored reader was active: %v", result.err)
 		default:
 		}
+		readCtx, cancelRead := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		_, readErr := h.manager.TranscriptPage(readCtx, session.ID, transcript.PageQuery{})
+		cancelRead()
+		if !errors.Is(readErr, context.DeadlineExceeded) {
+			t.Fatalf("TranscriptPage(while clear quiesces store) error = %v, want context deadline exceeded", readErr)
+		}
 		if _, err := os.Stat(session.DBPath()); err != nil {
 			t.Fatalf("Stat(event store while clear quiesced) error = %v", err)
 		}

--- a/internal/session/manager_conversation_operation.go
+++ b/internal/session/manager_conversation_operation.go
@@ -55,6 +55,18 @@ func (m *Manager) lockConversationOperation(
 
 type conversationOperationOwnersContextKey struct{}
 
+func ownsConversationOperation(ctx context.Context, target string) bool {
+	if ctx == nil {
+		return false
+	}
+	owners, ok := ctx.Value(conversationOperationOwnersContextKey{}).(conversationOperationOwners)
+	if !ok {
+		return false
+	}
+	_, owned := owners[strings.TrimSpace(target)]
+	return owned
+}
+
 func addConversationOperationOwner(ctx context.Context, target string) conversationOperationOwners {
 	owners := make(conversationOperationOwners)
 	if current, ok := ctx.Value(conversationOperationOwnersContextKey{}).(conversationOperationOwners); ok {

--- a/internal/session/manager_session_db_family.go
+++ b/internal/session/manager_session_db_family.go
@@ -78,6 +78,9 @@ func (m *Manager) recoverOwnedSessionDBClear(
 	owner store.SessionDBOwner,
 	dbPath string,
 ) error {
+	if err := m.waitForConversationFinalization(ctx, owner.SessionID); err != nil {
+		return err
+	}
 	pending, err := sessionDBClearRecoveryPending(dbPath)
 	if err != nil {
 		return err

--- a/internal/session/query_recorder.go
+++ b/internal/session/query_recorder.go
@@ -27,21 +27,30 @@ func (m *Manager) openQueryRecorder(ctx context.Context, id string) (EventReadCl
 	if m.openQueryStore == nil {
 		return nil, nil, errors.New("session: query recorder opener is required")
 	}
-	target, err := m.resolveRecorderOpenTarget(ctx, id, true)
-	if err != nil {
-		return nil, nil, err
-	}
-	if target.active != nil {
-		return target.active, func() error { return nil }, nil
-	}
-	if target.stored == nil {
-		return nil, nil, errors.New("session: resolved query recorder target is empty")
-	}
-	reader, err := m.openQueryStore(ctx, target.stored.owner, target.stored.dbPath)
-	if err != nil {
+	for attempt := range 2 {
+		target, err := m.resolveRecorderOpenTarget(ctx, id, true)
+		if err != nil {
+			return nil, nil, err
+		}
+		if target.active != nil {
+			return target.active, func() error { return nil }, nil
+		}
+		if target.stored == nil {
+			return nil, nil, errors.New("session: resolved query recorder target is empty")
+		}
+		reader, err := m.openQueryStore(ctx, target.stored.owner, target.stored.dbPath)
+		if err == nil {
+			return reader, m.eventStoreCleanup(reader), nil
+		}
+		if attempt == 0 && errors.Is(err, sessiondb.ErrReadOnlyPoolQuiescing) {
+			if waitErr := m.waitForConversationFinalization(ctx, target.stored.owner.SessionID); waitErr != nil {
+				return nil, nil, waitErr
+			}
+			continue
+		}
 		return nil, nil, normalizeRecorderOpenError(target.stored.owner.SessionID, err)
 	}
-	return reader, m.eventStoreCleanup(reader), nil
+	return nil, nil, errors.New("session: query recorder retry exhausted")
 }
 
 func (m *Manager) openMutationRecorder(ctx context.Context, id string) (EventRecorder, func() error, error) {
@@ -77,6 +86,9 @@ func (m *Manager) resolveRecorderOpenTarget(
 	target := strings.TrimSpace(id)
 	if target == "" {
 		return recorderOpenTarget{}, errors.New("session: session id is required")
+	}
+	if err := m.waitForConversationFinalization(ctx, target); err != nil {
+		return recorderOpenTarget{}, err
 	}
 
 	waited, err := m.waitForSessionFinalization(ctx, target)


### PR DESCRIPTION
## What & why

Fixes #521.
Fixes #522.

This PR removes two timing-dependent session failures that meet in the same operator flow: cancel an active prompt, clear the conversation, and continue using the durable session.

### #522 — a late prompt cancel could cancel the next turn

`Driver.Cancel` previously had two different cancellation behaviors:

1. while a prompt was active, it canceled the prompt's local context; and
2. after that prompt had already settled, it fell back to ACP `session/cancel`.

That fallback was unsafe because `session/cancel` belongs to the whole ACP session rather than one request. A delayed or repeated cancel could therefore arrive after turn A settled and cancel turn B. Prompt-context cancellation also started a second notifier that emitted the same session-scoped notification, even though the ACP SDK already maps context cancellation to request-scoped `$/cancel_request`.

The fix makes prompt cancellation own only the active request:

- `Driver.Cancel` cancels the active prompt context and becomes an idempotent no-op after settlement;
- the redundant session-scoped prompt notifier is removed;
- the existing ACP SDK request cancellation remains the transport for an active prompt; and
- whole-session Stop sends exactly one `session/cancel` directly from `cancelSessionForStop`.

The owning ACP lifecycle suite now proves all four issue invariants: active cancellation still works, no session-scoped notification is sent for active or late prompt cancellation, Stop sends exactly one session-scoped cancel, and the next turn completes after a settled late cancel.

### #521 — transcript reads could enter the clear replacement window

Conversation clear already serialized its writer and quiesced the per-session SQLite family, but it published `conversationFinalizing` too late: only after stopping the active runtime and inside the database replacement operation. A transcript reader could resolve the stored recorder immediately before quiescence, fail its read-only open with `ErrReadOnlyPoolQuiescing`, normalize that temporary state to `session not found`, and enter recovery while clear was replacing the database family.

That is the same sequence recorded in recent `ci.yml` Web E2E failures: backup completed, a concurrent transcript read reported `session not found`, then the clear endpoint returned HTTP 500.

The fix makes the clear transition atomic to readers:

- publish the conversation-finalization barrier immediately after acquiring the serialized conversation-operation lock, before Stop;
- keep that barrier active through Stop, backup, database replacement, and runtime restart;
- let only the context that owns that exact conversation operation bypass its own barrier, preventing Clear → Stop self-deadlock;
- make query recorder resolution and clear-recovery paths wait for finalization; and
- retry one read-only store open after `ErrReadOnlyPoolQuiescing`, using the canonical resolved session ID.

The existing clear suite owns the regression. Its deterministic quiescence hook now proves that a transcript read waits for clear instead of returning a transient missing-session error.

### CI correlation

The #521 race is directly correlated with the repeated `E2E web (shard 3/4)` failure at `web/e2e/__tests__/session-hardening.spec.ts:314` in recent main runs:

- run `33538539190` / job `99958871506`;
- run `33535868025` / job `99950062419`; and
- run `33528977779` / job `99927127061`.

#522 is adjacent to the same cancel → clear scenario and explains flaky prompt-cancel/next-turn behavior, but it is not the source of the clear endpoint's recorded HTTP 500. Other recent E2E failures involving the Loops builder, OS shell performance, terminal locators, and Desktop teardown have different failure signatures and are deliberately outside this PR.

## How you verified it

### Focused regressions

- `go test -race ./internal/acp -run 'TestDriverCancelPreservesTurnScope|TestStopCancelsANonInspectionSession' -count=1`
  - 5 tests passed.
- `go test -race ./internal/session -run 'TestClearConversationRestartsSameSessionWithFreshContext' -count=1`
  - 3 tests passed.
- Both regressions also passed 10 consecutive race-enabled repetitions during development.
- Full race-enabled `internal/acp` and `internal/session` package suites passed before the final scoped gate.
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./internal/acp ./internal/session`
  - passed, covering the ACP subprocess changes on Windows.

### Required local gate

- `make gate`
  - affected scopes: `./internal/acp/...` and `./internal/session/...`;
  - Go source policies: pass;
  - golangci-lint: 0 issues;
  - race-enabled tests: all pass;
  - current gate fingerprint: `d992f081f6a9cdd0e1107f6f9070e02061112897`.

Per repository policy, I did not run `make gate-full` or the full Web E2E matrix locally. The exact-head PR CI run owns those heavy lanes.

### Public-surface QA

The targeted isolated lab used a real Codex provider and exercised CLI, HTTP, UDS, native-tool, runtime, and Web surfaces.

- Active CLI prompt cancellation returned `canceled` for turn `turn-8a40d61cac8706d7`.
- Repeated CLI, HTTP, and `compozy__session_prompt_cancel` calls returned `nothing-in-flight`.
- The same durable session completed `NEXT_TURN_OK` after the canceled turn.
- Clear returned HTTP 200, preserved the durable session ID, advanced the transcript epoch, and fresh HTTP plus UDS reads returned zero entries.
- The restarted provider session completed `CLEAR_NEXT_OK` after clear.
- A separate populated Web session completed the Clear conversation confirmation flow, rendered an empty thread, and independently returned zero transcript entries.
- `RT-session-prompt-cancel` and `RT-017` now record `qa_status: pass`.
- The strict QA evidence audit reports zero blockers and zero warnings.
- Mandatory teardown records `"clean": true` with no surviving processes.

The adjacent stopped-session canary encountered the already-open `BUG-20260825-workspace-agent-unusable-for-sessions`. That known workspace-profile agent resolution defect occurs after the in-scope clear and post-clear prompt have completed and is not changed here.

Authorship: Codex implemented and co-wrote this change; I inspected the final diff and verified it through the commands and public-surface walks above.

## Impact

- **CLI:** no command or output-schema change. `compozy session prompt-cancel` keeps the existing `canceled` / `nothing-in-flight` contract and becomes reliably turn-scoped.
- **HTTP/UDS:** no route or schema change. Existing prompt-cancel and clear endpoints keep their public shapes; clear no longer exposes the transient database replacement window to readers.
- **Web:** no Web source change. The existing optimistic clear flow and rollback behavior remain intact; the targeted Web walk passed, and `session-hardening.spec.ts` remains the full E2E backstop in PR CI.
- **Configuration:** no `config.toml` key, default, lifecycle, or Settings surface changes. Searches across runtime config and Settings found no cancellation or clear setting to update or remove.
- **Docs:** no `packages/site` product-doc change is needed because the existing lifecycle and orchestration docs already state the intended public behavior: prompt cancel preserves the session and repeat cancellation is safe. The living QA scenarios and run report are updated with fresh evidence.
- **Storage:** no schema or migration change. The existing per-session database family and clear protocol are unchanged on disk; only the synchronization boundary and read retry behavior change.

### Compozy Impact Audit

- **Native tools:** `compozy__session_prompt_cancel` keeps the same tool ID, toolset membership, descriptor, input/output schemas, digests, risk flags, availability gates, and CLI/API fallbacks. Its existing production path now inherits the corrected request-scoped runtime behavior. Verified through descriptor inspection and live invocation.
- **Extensibility and hooks:** no extension manifest, hook event, skill/capability, resource, registry, bridge SDK, MCP sidecar, or config-lifecycle change. The ACP provider transport is corrected below those stable extension surfaces.
- **Workspace data isolation:** changed data remains session-scoped. No new datum, cache, SSE frame, or event type is introduced. Existing workspace/session ownership continues through CLI/HTTP/UDS → session manager → session database family; the new waits key off the already-resolved session owner and cannot cross workspace boundaries.
- **Official Compozy skill:** no update required. Checked `skills/compozy/references/runtime-operations.md`, `skills/compozy/references/native-tools.md`, and their bundled mirrors; they already document idempotent prompt cancellation, session preservation, and whole-session Stop separately.

### Risk and rollback

The main risk is deadlock or over-serialization around conversation replacement. The operation-owner marker limits barrier bypass to the context holding the exact session's conversation lock, while independent readers still obey caller cancellation. Race-enabled package tests, deterministic clear quiescence, real provider QA, and the Web walk cover those boundaries.

There is no migration or compatibility bridge to roll back. Reverting this single commit restores the previous behavior, though it would also restore both races.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt cancellation so it only affects the active turn and no longer interrupts subsequent turns.
  * Ensured session cancellation notifications are sent consistently when stopping sessions.
  * Prevented conversation clearing and transcript access from racing with finalization.
  * Improved recovery and retry handling while session data is temporarily unavailable.
* **Tests**
  * Added coverage for turn-scoped cancellation, session stop notifications, and transcript access during conversation clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->