### PR TITLE
fix: honor route skips within a planning pass

### DIFF
--- a/docs/qa/bugs/BUG-20260901-unselected-route-gate-executes.md
+++ b/docs/qa/bugs/BUG-20260901-unselected-route-gate-executes.md
@@ -1,0 +1,42 @@
+# BUG-20260901-unselected-route-gate-executes: An unselected route gate still executes
+
+- **Status:** verified
+- **Impact (user-side):** Blocks-Completion
+- **Severity:** High · **Priority:** P1
+- **Persona Affected:** Bruno
+- **Journey Step:** J-complete-partial-loop, settle an exclusive route and inspect its history
+- **Scenarios:** LP-exclusive-route-history
+- **Found:** 2026-09-01 · **Report:** docs/qa/reports/2026-09-01-loop-route-selection.md
+
+## Summary
+
+After a route selected one path, a later gate on the unselected path could still execute during the same planning pass. That gate could stop the selected work or publish a verdict for a path the Loop never took.
+
+## Reproduction
+
+- **Charter:** CH-loop-partial-runtime · **Tour:** Interrupt Tour
+- **Environment:** desktop / wifi-fast / en-US; isolated runtime harness with real HTTP, UDS, CLI, and Loop runtime paths
+
+1. Publish a Loop whose route selects `quality` and whose mandatory default points to the lexically later `z_publish_guard` gate.
+2. Start the Loop through HTTP and wait for the selected `quality` path to settle.
+3. Read the run through `compozy loop status -o json` over UDS.
+
+**Expected:** Only `quality` has a verdict; `z_publish_guard` and its descendant remain `route_not_taken`.
+**Actual:** Before the fix, `z_publish_guard` could execute from a stale planning snapshot after the route had already marked it unselected.
+
+## Evidence
+
+- `internal/loop/coordinator_control_test.go` — focused planner regression.
+- `internal/daemon/loop_generation_feedback_e2e_integration_test.go` — HTTP start plus CLI/UDS read-back regression and adjacent runtime canaries.
+- `docs/qa/reports/2026-09-01-loop-route-selection.md` — commands, results, and parity limits.
+
+## Fix
+
+- **Root cause:** the planner iterated copied generation outputs and did not reload the canonical output after route selection changed later nodes in the same pass.
+- **Fix commit:** `304059507bbeff0213b1d516cccbd5be7939bb03`
+- **Regression test:** `TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate`; the daemon route-history case now exercises the same gate shape through HTTP and CLI/UDS.
+
+## Verification
+
+- **Retested:** 2026-09-02, same Bruno route-history journey · **Report:** docs/qa/reports/2026-09-01-loop-route-selection.md
+- **Result:** The focused race regression passed, and the full daemon feedback integration suite completed in 46.781 seconds. HTTP start plus CLI/UDS read-back showed no `z_publish_guard` verdict, kept the gate and its descendant `route_not_taken`, and settled the selected path `done`.

--- a/docs/qa/reports/2026-09-01-loop-route-selection.md
+++ b/docs/qa/reports/2026-09-01-loop-route-selection.md
@@ -1,0 +1,48 @@
+# QA Run Report — 2026-09-01 — Loop route selection
+
+- **Scope:** Honor same-pass route skips before evaluating later coordinator-owned gates or actions.
+- **Cadence tier:** targeted
+- **Build:** `4eb70b82202446ad9eb3ec7a9ea35734cb6c824a` · **Environment:** isolated integration harness using the real CLI, HTTP API, UDS, and Loop runtime with deterministic ACP fixtures
+- **Started:** 2026-09-01T20:00:00Z · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Developer/operator | Local isolated runtime / en-US | Exclusive route history |
+
+## Flows in Scope
+
+- Exclusive route selection and durable route history.
+
+## Session Matrix & Results
+
+| # | Journey / Scenario | Persona | Status | Issue | Fix commit |
+|---|---|---|---|---|---|
+| 1 | `LP-exclusive-route-history` | Bruno | Pass | Unselected gate executed after the selected route | `4eb70b82` |
+
+## Session Debriefs
+
+- The owning regression evaluates a selected `c_verify` gate before a lexically later unselected `z_reject` gate. Only `c_verify` ran, only the selected action was queued, and `z_reject` settled `route_not_taken`.
+- The public route-history E2E created and ran the Loop through HTTP, read it through CLI, observed only the selected route and gate causes, and settled `done`.
+
+## What Was Fixed
+
+- **Root cause:** the planner iterated stale cloned generation outputs after route selection had marked canonical outputs skipped.
+- **Fix:** reload each candidate from canonical state before deciding whether it remains pending.
+- **Regression:** `TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate`.
+
+## Runtime Errors Observed
+
+- None.
+
+## Human Verifications Needed
+
+- None.
+
+## Final Status
+
+- **Exit gate:** `make gate` passed; focused `go test -race ./internal/loop/...` passed; targeted public-path E2E passed.
+- **Issues:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 targeted Loop route journey.
+- **Verdict:** ready pending exact-head provider CI.

--- a/docs/qa/reports/2026-09-01-loop-route-selection.md
+++ b/docs/qa/reports/2026-09-01-loop-route-selection.md
@@ -2,7 +2,7 @@
 
 - **Scope:** Honor same-pass route skips before evaluating later coordinator-owned gates or actions.
 - **Cadence tier:** targeted
-- **Base:** `34208e9990622ee62e9a5cf114386273ae6abfa0` · **Build:** `30405950134c99f0feea2d97fb6acf81f357bc7e` · **Environment:** isolated integration harness using the real CLI, HTTP API, UDS, and Loop runtime with deterministic ACP fixtures
+- **Base:** `34208e9990622ee62e9a5cf114386273ae6abfa0` · **Build:** `304059507bbeff0213b1d516cccbd5be7939bb03` · **Environment:** isolated integration harness using the real CLI, HTTP API, UDS, and Loop runtime with deterministic ACP fixtures
 - **Started:** 2026-09-01T20:00:00Z · **Status:** closed
 
 ## Personas

--- a/docs/qa/reports/2026-09-01-loop-route-selection.md
+++ b/docs/qa/reports/2026-09-01-loop-route-selection.md
@@ -2,7 +2,7 @@
 
 - **Scope:** Honor same-pass route skips before evaluating later coordinator-owned gates or actions.
 - **Cadence tier:** targeted
-- **Build:** `4eb70b82202446ad9eb3ec7a9ea35734cb6c824a` · **Environment:** isolated integration harness using the real CLI, HTTP API, UDS, and Loop runtime with deterministic ACP fixtures
+- **Base:** `34208e9990622ee62e9a5cf114386273ae6abfa0` · **Build:** `30405950134c99f0feea2d97fb6acf81f357bc7e` · **Environment:** isolated integration harness using the real CLI, HTTP API, UDS, and Loop runtime with deterministic ACP fixtures
 - **Started:** 2026-09-01T20:00:00Z · **Status:** closed
 
 ## Personas
@@ -19,7 +19,7 @@
 
 | # | Journey / Scenario | Persona | Status | Issue | Fix commit |
 |---|---|---|---|---|---|
-| 1 | `LP-exclusive-route-history` | Bruno | Pass | Unselected gate executed after the selected route | `4eb70b82` |
+| 1 | `LP-exclusive-route-history` | Bruno | Pass | Unselected gate executed after the selected route | `30405950` |
 
 ## Session Debriefs
 

--- a/docs/qa/reports/2026-09-01-loop-route-selection.md
+++ b/docs/qa/reports/2026-09-01-loop-route-selection.md
@@ -19,22 +19,31 @@
 
 | # | Journey / Scenario | Persona | Status | Issue | Fix commit |
 |---|---|---|---|---|---|
-| 1 | `LP-exclusive-route-history` | Bruno | Pass | Unselected gate executed after the selected route | `30405950` |
+| 1 | `LP-exclusive-route-history` | Bruno | Fixed | [`BUG-20260901-unselected-route-gate-executes`](../bugs/BUG-20260901-unselected-route-gate-executes.md) | `30405950` |
 
 ## Session Debriefs
 
 - The owning regression evaluates a selected `c_verify` gate before a lexically later unselected `z_reject` gate. Only `c_verify` ran, only the selected action was queued, and `z_reject` settled `route_not_taken`.
-- The public route-history E2E created and ran the Loop through HTTP, read it through CLI, observed only the selected route and gate causes, and settled `done`.
+- The public route-history integration journey created and ran the Loop through HTTP, read it through CLI over UDS, observed no verdict for the unselected gate, preserved its `route_not_taken` output, and settled `done`.
+- The rest of `TestDaemonE2ELoopGenerationFeedbackShouldConvergeAndBound` ran as the adjacent runtime canary. The harness owned process cleanup and exited without a persistent QA lab or daemon.
 
 ## What Was Fixed
 
 - **Root cause:** the planner iterated stale cloned generation outputs after route selection had marked canonical outputs skipped.
 - **Fix:** reload each candidate from canonical state before deciding whether it remains pending.
-- **Regression:** `TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate`.
+- **Regression:** `TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate`; the daemon route-history integration case now proves the same gate shape across HTTP and CLI/UDS.
 
 ## Runtime Errors Observed
 
 - None.
+
+## Verification Refresh — 2026-09-02
+
+- `CGO_ENABLED=1 go test -race ./internal/loop/... -run '^TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate$' -count=1` — pass.
+- `CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2ELoopGenerationFeedbackShouldConvergeAndBound$' -count=1` — pass in 46.781 seconds; the route-history journey and its adjacent generation-feedback canaries all passed.
+- `bunx turbo run generate:content --filter=./packages/site` and `bunx turbo run typecheck --filter=./packages/site` — pass.
+- `bunx turbo run build --filter=./packages/site` — pass and prerendered `/docs/loops/dsl-reference`; it also repeated an existing Turbopack filesystem-tracing warning from `packages/site/lib/marketplace-bridges.ts`, outside this route change.
+- Public-path boundary: this refresh started the run over HTTP and read it independently through the CLI over UDS. Web and native-tool Loop status consume the unchanged run-detail contract; their adapters and schemas did not change in this fix.
 
 ## Human Verifications Needed
 
@@ -42,7 +51,7 @@
 
 ## Final Status
 
-- **Exit gate:** `make gate` passed; focused `go test -race ./internal/loop/...` passed; targeted public-path E2E passed.
-- **Issues:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Exit gate:** focused race, full daemon feedback integration, Fumadocs generation, site typecheck, site build, and the final scoped `make gate` passed.
+- **Issues:** Blocks-Completion 1 fixed and verified · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
 - **Coverage:** 1/1 targeted Loop route journey.
 - **Verdict:** ready pending exact-head provider CI.

--- a/docs/qa/scenarios/LP-exclusive-route-history.md
+++ b/docs/qa/scenarios/LP-exclusive-route-history.md
@@ -7,15 +7,15 @@ journey: J-complete-partial-loop
 expected: A route node takes the first matching direct forward edge or its mandatory default, skips every dominated non-selected path without failure, omits inactive-route Tasks so they cannot block the selected downstream work, and exposes the exact decision cause consistently through CLI, HTTP, native-tool status, and SSE replay; a gate object route follows the same durable history contract.
 entry_points: compozy loop validate|run|status; GET /loop-runs/:id over HTTP and UDS; compozy__loop_status; Loop SSE; web Loop editor and run detail; /docs/loops/dsl-reference; skills/compozy/references/loops.md
 qa_status: pass
-bug_ids:
+bug_ids: BUG-20260901-unselected-route-gate-executes
 fix_status: fixed
 retest_status: pass
 fix_commits: 304059507bbeff0213b1d516cccbd5be7939bb03
-evidence: go test -tags=integration ./internal/daemon -run TestDaemonE2ELoopGenerationFeedbackShouldConvergeAndBound/Should_route_classifier_output_and_expose_gate_reroute_causes_through_loop_status -count=1; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-runtime-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-task-catalog-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/http-independent-verdict.json
+evidence: docs/qa/reports/2026-09-01-loop-route-selection.md; docs/qa/bugs/BUG-20260901-unselected-route-gate-executes.md
 last_report: docs/qa/reports/2026-09-01-loop-route-selection.md
 overlaps:
 ---
 
 acceptance-walk: Publish a Loop with two ordered route conditions, a default, a downstream join, and a gate `on_result` object route. Run matching and default inputs. Confirm exactly one route runs each time, dominated nodes read as `route_not_taken`, inactive-route Tasks are absent from the Task catalog and do not block the selected downstream work, broken CEL fails instead of defaulting, and every structured read shows the same `route_causes` facts.
 
-2026-09-01: `pass` — the exact fix head passed the CoordinatorRunner regression, focused race suite, `make gate`, and the public CLI/API route-history E2E. The unselected gate stayed `route_not_taken`; only the selected gate/action path ran and the run settled `done`.
+2026-09-01: `pass` after fix — the focused planner regression and daemon integration journey confirmed that the unselected gate stayed `route_not_taken` with no verdict, while HTTP start and CLI/UDS read-back showed only the selected gate/action path and the run settled `done`.

--- a/docs/qa/scenarios/LP-exclusive-route-history.md
+++ b/docs/qa/scenarios/LP-exclusive-route-history.md
@@ -10,7 +10,7 @@ qa_status: pass
 bug_ids:
 fix_status: fixed
 retest_status: passed
-fix_commits: 4eb70b82202446ad9eb3ec7a9ea35734cb6c824a
+fix_commits: 30405950134c99f0feea2d97fb6acf81f357bc7e
 evidence: go test -tags=integration ./internal/daemon -run TestDaemonE2ELoopGenerationFeedbackShouldConvergeAndBound/Should_route_classifier_output_and_expose_gate_reroute_causes_through_loop_status -count=1; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-runtime-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-task-catalog-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/http-independent-verdict.json
 last_report: docs/qa/reports/2026-09-01-loop-route-selection.md
 overlaps:

--- a/docs/qa/scenarios/LP-exclusive-route-history.md
+++ b/docs/qa/scenarios/LP-exclusive-route-history.md
@@ -9,8 +9,8 @@ entry_points: compozy loop validate|run|status; GET /loop-runs/:id over HTTP and
 qa_status: pass
 bug_ids:
 fix_status: fixed
-retest_status: passed
-fix_commits: 30405950134c99f0feea2d97fb6acf81f357bc7e
+retest_status: pass
+fix_commits: 304059507bbeff0213b1d516cccbd5be7939bb03
 evidence: go test -tags=integration ./internal/daemon -run TestDaemonE2ELoopGenerationFeedbackShouldConvergeAndBound/Should_route_classifier_output_and_expose_gate_reroute_causes_through_loop_status -count=1; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-runtime-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-task-catalog-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/http-independent-verdict.json
 last_report: docs/qa/reports/2026-09-01-loop-route-selection.md
 overlaps:

--- a/docs/qa/scenarios/LP-exclusive-route-history.md
+++ b/docs/qa/scenarios/LP-exclusive-route-history.md
@@ -8,12 +8,14 @@ expected: A route node takes the first matching direct forward edge or its manda
 entry_points: compozy loop validate|run|status; GET /loop-runs/:id over HTTP and UDS; compozy__loop_status; Loop SSE; web Loop editor and run detail; /docs/loops/dsl-reference; skills/compozy/references/loops.md
 qa_status: pass
 bug_ids:
-fix_status:
-retest_status:
-fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-runtime-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-task-catalog-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/http-independent-verdict.json
-last_report: docs/qa/reports/2026-08-25-issue-479.md
+fix_status: fixed
+retest_status: passed
+fix_commits: 4eb70b82202446ad9eb3ec7a9ea35734cb6c824a
+evidence: go test -tags=integration ./internal/daemon -run TestDaemonE2ELoopGenerationFeedbackShouldConvergeAndBound/Should_route_classifier_output_and_expose_gate_reroute_causes_through_loop_status -count=1; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-runtime-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-task-catalog-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/http-independent-verdict.json
+last_report: docs/qa/reports/2026-09-01-loop-route-selection.md
 overlaps:
 ---
 
 acceptance-walk: Publish a Loop with two ordered route conditions, a default, a downstream join, and a gate `on_result` object route. Run matching and default inputs. Confirm exactly one route runs each time, dominated nodes read as `route_not_taken`, inactive-route Tasks are absent from the Task catalog and do not block the selected downstream work, broken CEL fails instead of defaulting, and every structured read shows the same `route_causes` facts.
+
+2026-09-01: `pass` — the exact fix head passed the CoordinatorRunner regression, focused race suite, `make gate`, and the public CLI/API route-history E2E. The unselected gate stayed `route_not_taken`; only the selected gate/action path ran and the run settled `done`.

--- a/internal/daemon/loop_generation_feedback_e2e_integration_test.go
+++ b/internal/daemon/loop_generation_feedback_e2e_integration_test.go
@@ -268,8 +268,16 @@ func TestDaemonE2ELoopGenerationFeedbackShouldConvergeAndBound(t *testing.T) {
 			causes[1].Cause != "gate_verdict:rejected" {
 			t.Fatalf("gate route cause = %#v, want rejected verdict reroute", causes[1])
 		}
+		if got := feedbackNodeOutputRef(t, cli.Generations[0], "z_publish_guard"); got != "route_not_taken:router" {
+			t.Fatalf("publish guard output_ref = %q, want route_not_taken:router", got)
+		}
 		if got := feedbackNodeOutputRef(t, cli.Generations[0], "publish"); got != "route_not_taken:router" {
 			t.Fatalf("publish output_ref = %q, want route_not_taken:router", got)
+		}
+		for _, verdict := range cli.Generations[0].Verdicts {
+			if verdict.GateID == "z_publish_guard" {
+				t.Fatalf("unselected publish guard verdict = %#v, want no evaluation", verdict)
+			}
 		}
 	})
 }
@@ -395,7 +403,7 @@ func feedbackRouteDefinition() compozycontract.LoopDefinitionDocument {
 					Routes: []dsl.RouteSpec{{
 						When: "nodes.classifier.output.bucket == 'revise'", To: "quality",
 					}},
-					Default: "publish",
+					Default: "z_publish_guard",
 				},
 				{
 					ID: "quality", Class: dsl.NodeClassControl, Kind: "gate",
@@ -406,6 +414,13 @@ func feedbackRouteDefinition() compozycontract.LoopDefinitionDocument {
 					OnResult: map[string]any{
 						"fail": map[string]any{"route": "revise"},
 					},
+				},
+				{
+					ID: "z_publish_guard", Class: dsl.NodeClassControl, Kind: "gate",
+					Criteria: []dsl.GateCriterion{{
+						ID: "ready_to_publish", Type: "command", Check: "exit 0", Expect: "exit_zero",
+					}},
+					VerdictPolicy: "fixed_passes",
 				},
 				{
 					ID: "revise", Class: dsl.NodeClassAction, Kind: "transform",
@@ -419,8 +434,9 @@ func feedbackRouteDefinition() compozycontract.LoopDefinitionDocument {
 			Edges: []dsl.Edge{
 				{From: "classifier", To: "router"},
 				{From: "router", To: "quality"},
-				{From: "router", To: "publish"},
+				{From: "router", To: "z_publish_guard"},
 				{From: "quality", To: "revise"},
+				{From: "z_publish_guard", To: "publish"},
 			},
 		},
 		DefinitionExtensionState: &dsl.DefinitionExtensionState{

--- a/internal/loop/control_plan.go
+++ b/internal/loop/control_plan.go
@@ -149,7 +149,13 @@ func advanceControlNodes(
 			return nil, err
 		}
 		indexes := generationOutputIndexMap(*outputs)
-		for _, output := range sortedGenerationOutputs(*outputs) {
+		for _, candidate := range sortedGenerationOutputs(*outputs) {
+			key := generationOutputKey{nodeID: candidate.NodeID, itemIndex: candidate.ItemIndex}
+			idx, ok := indexes[key]
+			if !ok {
+				continue
+			}
+			output := (*outputs)[idx]
 			if output.Status != generationOutputPending {
 				continue
 			}
@@ -181,10 +187,7 @@ func advanceControlNodes(
 				}
 				updated = materializationFailedOutput(output)
 			}
-			key := generationOutputKey{nodeID: output.NodeID, itemIndex: output.ItemIndex}
-			if idx, ok := indexes[key]; ok {
-				(*outputs)[idx] = updated
-			}
+			(*outputs)[idx] = updated
 			if terminal != nil {
 				if terminal.Status != string(StatusNeedsApproval) {
 					return terminal, nil

--- a/internal/loop/coordinator_control_test.go
+++ b/internal/loop/coordinator_control_test.go
@@ -1135,6 +1135,83 @@ func TestCoordinatorRunnerShouldRouteBranchCondition(t *testing.T) {
 	})
 }
 
+// Invariant: route selection settles every unselected path before any later
+// coordinator-owned node from the same planning pass can be evaluated.
+func TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate(t *testing.T) {
+	t.Parallel()
+
+	definition := dsl.Definition{Graph: dsl.Graph{
+		Nodes: []dsl.Node{
+			lifecycleNode("a_input"),
+			{
+				ID: "b_route", Class: dsl.NodeClassControl, Kind: string(dsl.ControlRoute),
+				Routes:  []dsl.RouteSpec{{When: "true", To: "c_verify"}},
+				Default: "z_reject",
+			},
+			testRouteGateNode("c_verify"),
+			lifecycleNode("d_accept"),
+			testRouteGateNode("z_reject"),
+		},
+		Edges: []dsl.Edge{
+			{From: "a_input", To: "b_route"},
+			{From: "b_route", To: "c_verify"},
+			{From: "b_route", To: "z_reject"},
+			{From: "c_verify", To: "d_accept"},
+		},
+	}}
+	loopRun := controlLoopRun("looprun-exclusive-route-gate", nil)
+	coordinatorRun := controlCoordinatorRun(loopRun, 1)
+	evaluated := make([]string, 0, 1)
+	runner := newCoordinatorRunnerForTestWithDefinition(
+		t,
+		loopRun,
+		coordinatorRun,
+		nil,
+		coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{1: {
+			{Generation: 1, NodeID: "a_input", Status: generationOutputSucceeded, Attempt: 1},
+			{Generation: 1, NodeID: "b_route", Status: generationOutputPending, Attempt: 1},
+			{Generation: 1, NodeID: "c_verify", Status: generationOutputPending, Attempt: 1},
+			{Generation: 1, NodeID: "d_accept", Status: generationOutputPending, Attempt: 1},
+			{Generation: 1, NodeID: "z_reject", Status: generationOutputPending, Attempt: 1},
+		}}},
+		definition,
+		WithCoordinatorGateEvaluator(gateEvaluatorFunc(
+			func(_ context.Context, runtimeGate gate.Gate, _ gate.GateInput) (gate.Verdict, error) {
+				evaluated = append(evaluated, runtimeGate.ID)
+				if runtimeGate.ID == "z_reject" {
+					return testRouteVerdict(gate.RouteHalt), nil
+				}
+				return gate.Verdict{
+					Outcome: gate.VerdictOutcomeApproved,
+					Criteria: []gate.CriterionResult{{
+						ID: "check", Type: dsl.CriterionCommand,
+						Outcome: gate.VerdictOutcomeApproved, Passed: true,
+					}},
+					Route: gate.RouteDecision{Placement: gate.PlacementInBody, Action: gate.RouteContinue},
+				}, nil
+			},
+		)),
+	)
+
+	plan, err := runner.Run(t.Context(), task.RunID(coordinatorRun.ID))
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if plan.Terminal != nil {
+		t.Fatalf("Terminal = %#v, want selected path to remain live", plan.Terminal)
+	}
+	if got, want := strings.Join(evaluated, ","), "c_verify"; got != want {
+		t.Fatalf("evaluated gates = %q, want %q", got, want)
+	}
+	if len(plan.NodeRuns) != 1 || plan.NodeRuns[0].TaskID != coordinatorNodeTaskID(loopRun.ID, 1, "d_accept", 0) {
+		t.Fatalf("node runs = %#v, want only selected-path accept action", plan.NodeRuns)
+	}
+	outputs := outputsByNodeAndItemForTest(coordinatorPostReservePayloadForTest(t, plan).Outputs)
+	if got, want := outputs["z_reject/0"].OutputRef, routeNotTakenOutputRef("b_route"); got != want {
+		t.Fatalf("unselected gate output_ref = %q, want %q", got, want)
+	}
+}
+
 func TestCoordinatorRunnerShouldExecuteSubLoopBody(t *testing.T) {
 	t.Run("Should enqueue nested body nodes before downstream work", func(t *testing.T) {
 		t.Parallel()

--- a/internal/loop/coordinator_control_test.go
+++ b/internal/loop/coordinator_control_test.go
@@ -1138,78 +1138,80 @@ func TestCoordinatorRunnerShouldRouteBranchCondition(t *testing.T) {
 // Invariant: route selection settles every unselected path before any later
 // coordinator-owned node from the same planning pass can be evaluated.
 func TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate(t *testing.T) {
-	t.Parallel()
+	t.Run("Should not evaluate an unselected route gate", func(t *testing.T) {
+		t.Parallel()
 
-	definition := dsl.Definition{Graph: dsl.Graph{
-		Nodes: []dsl.Node{
-			lifecycleNode("a_input"),
-			{
-				ID: "b_route", Class: dsl.NodeClassControl, Kind: string(dsl.ControlRoute),
-				Routes:  []dsl.RouteSpec{{When: "true", To: "c_verify"}},
-				Default: "z_reject",
+		definition := dsl.Definition{Graph: dsl.Graph{
+			Nodes: []dsl.Node{
+				lifecycleNode("a_input"),
+				{
+					ID: "b_route", Class: dsl.NodeClassControl, Kind: string(dsl.ControlRoute),
+					Routes:  []dsl.RouteSpec{{When: "true", To: "c_verify"}},
+					Default: "z_reject",
+				},
+				testRouteGateNode("c_verify"),
+				lifecycleNode("d_accept"),
+				testRouteGateNode("z_reject"),
 			},
-			testRouteGateNode("c_verify"),
-			lifecycleNode("d_accept"),
-			testRouteGateNode("z_reject"),
-		},
-		Edges: []dsl.Edge{
-			{From: "a_input", To: "b_route"},
-			{From: "b_route", To: "c_verify"},
-			{From: "b_route", To: "z_reject"},
-			{From: "c_verify", To: "d_accept"},
-		},
-	}}
-	loopRun := controlLoopRun("looprun-exclusive-route-gate", nil)
-	coordinatorRun := controlCoordinatorRun(loopRun, 1)
-	evaluated := make([]string, 0, 1)
-	runner := newCoordinatorRunnerForTestWithDefinition(
-		t,
-		loopRun,
-		coordinatorRun,
-		nil,
-		coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{1: {
-			{Generation: 1, NodeID: "a_input", Status: generationOutputSucceeded, Attempt: 1},
-			{Generation: 1, NodeID: "b_route", Status: generationOutputPending, Attempt: 1},
-			{Generation: 1, NodeID: "c_verify", Status: generationOutputPending, Attempt: 1},
-			{Generation: 1, NodeID: "d_accept", Status: generationOutputPending, Attempt: 1},
-			{Generation: 1, NodeID: "z_reject", Status: generationOutputPending, Attempt: 1},
-		}}},
-		definition,
-		WithCoordinatorGateEvaluator(gateEvaluatorFunc(
-			func(_ context.Context, runtimeGate gate.Gate, _ gate.GateInput) (gate.Verdict, error) {
-				evaluated = append(evaluated, runtimeGate.ID)
-				if runtimeGate.ID == "z_reject" {
-					return testRouteVerdict(gate.RouteHalt), nil
-				}
-				return gate.Verdict{
-					Outcome: gate.VerdictOutcomeApproved,
-					Criteria: []gate.CriterionResult{{
-						ID: "check", Type: dsl.CriterionCommand,
-						Outcome: gate.VerdictOutcomeApproved, Passed: true,
-					}},
-					Route: gate.RouteDecision{Placement: gate.PlacementInBody, Action: gate.RouteContinue},
-				}, nil
+			Edges: []dsl.Edge{
+				{From: "a_input", To: "b_route"},
+				{From: "b_route", To: "c_verify"},
+				{From: "b_route", To: "z_reject"},
+				{From: "c_verify", To: "d_accept"},
 			},
-		)),
-	)
+		}}
+		loopRun := controlLoopRun("looprun-exclusive-route-gate", nil)
+		coordinatorRun := controlCoordinatorRun(loopRun, 1)
+		evaluated := make([]string, 0, 1)
+		runner := newCoordinatorRunnerForTestWithDefinition(
+			t,
+			loopRun,
+			coordinatorRun,
+			nil,
+			coordinatorRunnerOutputs{outputs: map[int][]GenerationOutput{1: {
+				{Generation: 1, NodeID: "a_input", Status: generationOutputSucceeded, Attempt: 1},
+				{Generation: 1, NodeID: "b_route", Status: generationOutputPending, Attempt: 1},
+				{Generation: 1, NodeID: "c_verify", Status: generationOutputPending, Attempt: 1},
+				{Generation: 1, NodeID: "d_accept", Status: generationOutputPending, Attempt: 1},
+				{Generation: 1, NodeID: "z_reject", Status: generationOutputPending, Attempt: 1},
+			}}},
+			definition,
+			WithCoordinatorGateEvaluator(gateEvaluatorFunc(
+				func(_ context.Context, runtimeGate gate.Gate, _ gate.GateInput) (gate.Verdict, error) {
+					evaluated = append(evaluated, runtimeGate.ID)
+					if runtimeGate.ID == "z_reject" {
+						return testRouteVerdict(gate.RouteHalt), nil
+					}
+					return gate.Verdict{
+						Outcome: gate.VerdictOutcomeApproved,
+						Criteria: []gate.CriterionResult{{
+							ID: "check", Type: dsl.CriterionCommand,
+							Outcome: gate.VerdictOutcomeApproved, Passed: true,
+						}},
+						Route: gate.RouteDecision{Placement: gate.PlacementInBody, Action: gate.RouteContinue},
+					}, nil
+				},
+			)),
+		)
 
-	plan, err := runner.Run(t.Context(), task.RunID(coordinatorRun.ID))
-	if err != nil {
-		t.Fatalf("Run() error = %v", err)
-	}
-	if plan.Terminal != nil {
-		t.Fatalf("Terminal = %#v, want selected path to remain live", plan.Terminal)
-	}
-	if got, want := strings.Join(evaluated, ","), "c_verify"; got != want {
-		t.Fatalf("evaluated gates = %q, want %q", got, want)
-	}
-	if len(plan.NodeRuns) != 1 || plan.NodeRuns[0].TaskID != coordinatorNodeTaskID(loopRun.ID, 1, "d_accept", 0) {
-		t.Fatalf("node runs = %#v, want only selected-path accept action", plan.NodeRuns)
-	}
-	outputs := outputsByNodeAndItemForTest(coordinatorPostReservePayloadForTest(t, plan).Outputs)
-	if got, want := outputs["z_reject/0"].OutputRef, routeNotTakenOutputRef("b_route"); got != want {
-		t.Fatalf("unselected gate output_ref = %q, want %q", got, want)
-	}
+		plan, err := runner.Run(t.Context(), task.RunID(coordinatorRun.ID))
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+		if plan.Terminal != nil {
+			t.Fatalf("Terminal = %#v, want selected path to remain live", plan.Terminal)
+		}
+		if got, want := strings.Join(evaluated, ","), "c_verify"; got != want {
+			t.Fatalf("evaluated gates = %q, want %q", got, want)
+		}
+		if len(plan.NodeRuns) != 1 || plan.NodeRuns[0].TaskID != coordinatorNodeTaskID(loopRun.ID, 1, "d_accept", 0) {
+			t.Fatalf("node runs = %#v, want only selected-path accept action", plan.NodeRuns)
+		}
+		outputs := outputsByNodeAndItemForTest(coordinatorPostReservePayloadForTest(t, plan).Outputs)
+		if got, want := outputs["z_reject/0"].OutputRef, routeNotTakenOutputRef("b_route"); got != want {
+			t.Fatalf("unselected gate output_ref = %q, want %q", got, want)
+		}
+	})
 }
 
 func TestCoordinatorRunnerShouldExecuteSubLoopBody(t *testing.T) {

--- a/packages/site/content/docs/loops/dsl-reference.mdx
+++ b/packages/site/content/docs/loops/dsl-reference.mdx
@@ -307,6 +307,9 @@ authoring failure handled by the same policy.
 A `route` checks its CEL conditions in declaration order and takes the first match. If none match,
 it takes the mandatory `default`. Every destination must be a unique direct forward edge. A broken
 condition fails closed with `predicate_evaluation_failed`; it never falls through to the default.
+Nodes that belong only to a non-selected path settle as durable `route_not_taken` evidence and are
+not evaluated or scheduled, including gates. Shared downstream joins remain live. Inspect the
+decision through Loop status, the node roster, and `route_causes`.
 
 ```yaml
 - id: classify

--- a/packages/site/lib/__tests__/public-heading-hierarchy.test.tsx
+++ b/packages/site/lib/__tests__/public-heading-hierarchy.test.tsx
@@ -29,6 +29,10 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/",
 }));
 
+vi.mock("next/server", () => ({
+  connection: vi.fn(),
+}));
+
 vi.mock("@/lib/changelog/github-client", () => ({
   loadChangelogReleases: async () => ({ status: "ready", releases: [] }),
 }));

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -456,9 +456,12 @@ Node classes: `action` (open), `control` (closed), `source` (closed). Reserved *
 `goal`, `run-agent`, `run-loop`, `transform`; every other action kind is a literal tool ID
 (`compozy__*`/`ext__*`/`mcp__*`). Control kinds: `fan-out`, `collect`, `branch`, `route`, `gate`,
 `wait`, `sub-loop`. A `route` evaluates ordered `{when, to}` entries, takes the first match, and
-otherwise takes its mandatory `default`; every target is a unique direct forward edge. A `wait`
-declares exactly one of `for`, `until`, or `event`, with optional `expect`, `ahead_arrival`, and
-`expires`. Source kinds: `input`, `file-import`, `watch-source`, `watch-events`.
+otherwise takes its mandatory `default`; every target is a unique direct forward edge. Nodes that
+belong only to a non-selected path settle as durable `route_not_taken` evidence and are neither
+evaluated nor scheduled, including gates; shared downstream joins remain live. Inspect the decision
+through Loop status, the node roster, and `route_causes`. A `wait` declares exactly one of `for`,
+`until`, or `event`, with optional `expect`, `ahead_arrival`, and `expires`. Source kinds: `input`,
+`file-import`, `watch-source`, `watch-events`.
 A fan-out requires positive `max_fan_out`; logical lanes may exceed 64, while only its
 `max_parallel` window materializes at once.
 A `run-agent` result is validated against its pinned `output_schema` before the owning daemon


### PR DESCRIPTION
## What & why

Exclusive route selection updated canonical generation outputs, but the coordinator continued iterating a stale cloned output slice. A later gate or action on the dominated branch could therefore execute in the same planning pass.

The planner now reloads each candidate from canonical state before deciding whether it is still pending. The selected branch executes once; dominated gates/actions remain `route_not_taken`; durable route causes and ordering are unchanged.

Fixes #528

An AI coding agent co-wrote this change. The final diff and evidence were independently reviewed.

## How you verified it

- `make gate`
- `go test -race ./internal/loop/... -run 'TestCoordinatorRunnerShouldNotEvaluateUnselectedRouteGate|TestCoordinator' -count=1`
- Public Loop route-history integration through CLI and HTTP
- Integrated work-intake run: only `verify_workspace` and the selected workflow action executed; rejecting branches stayed `route_not_taken`

## Impact

- **Loops:** corrects coordinator scheduling only; route DSL, status payloads, and persisted route-cause shapes are unchanged.
- **Tasks/storage:** no schema or migration change; inactive work remains historical `route_not_taken` state.
- **Permissions/extensibility:** no tool, extension, Agent, or permission contract changes.
- **CLI/Web/config:** no surface or setting changes.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal processing of generated outputs without changing observable behavior.
* **Tests**
  * Added coverage confirming that unselected route gates are not evaluated.
  * Verified that only the selected route’s action is queued and no terminal result is produced.
  * Expanded end-to-end routing coverage to confirm unselected gates report the route-not-taken result and produce no verdict.
  * Improved heading hierarchy test reliability by isolating server connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->