### PR TITLE
fix: resolve changelog releases by tag when the cached list lags

### DIFF
--- a/.release-notes/acp-runtime-catalogs-1788306269.md
+++ b/.release-notes/acp-runtime-catalogs-1788306269.md
@@ -1,0 +1,15 @@
+---
+title: Runtime selection reads live model catalogs
+type: feature
+---
+
+Model discovery and runtime configuration are rebuilt around logical model identities and live provider catalogs, so what you pick in CompozyOS matches what the provider actually offers. (#498)
+
+- Authored model IDs are separate from the transport aliases a provider expects, so a Loop or Agent keeps working when a provider renames its wire identifier.
+- Catalogs are discovered and stored with a five-minute freshness window, refreshed on a timer and on read, and fall back to the last successful result when a provider is unreachable.
+- Cursor launch aliases resolve before the process starts, including the Grok 4.5 and 4.6 Reasoning and Fast combinations. Opus 5 is visible offline while live discovery stays authoritative.
+- Hermes is treated as a discoverable ACP agent with handshake readiness diagnostics. OpenClaw stays described as a provider-managed bridge instead of showing model, Reasoning, or Fast controls it does not have.
+- Speed and typed `acp_options` are available on Agent definitions, session and prompt overrides, roles, Loops, Tasks, the CLI, HTTP, UDS, native tools, extension contracts, OpenAPI, and the SDKs. The shared Runtime Selector is wired into Agent, session, role, Loop, Task, and onboarding surfaces.
+- The New Session dialog no longer carries a first-message box. Create the session, then send the first prompt from the composer. This was a Web-only field; no API payload changed.
+
+This ships database migration `00097` and regenerated contract output.

--- a/.release-notes/child-loop-config-overrides-1788306270.md
+++ b/.release-notes/child-loop-config-overrides-1788306270.md
@@ -1,0 +1,11 @@
+---
+title: A parent Loop can reconfigure one child run
+type: feature
+---
+
+The reserved `run-loop` action accepts an optional `params.config_overrides` object, so a parent Loop can give one child run its own iteration limits, budgets, environment, reattempt behavior, and runtime selection without touching the child's stored configuration. (#494)
+
+- Works with both `await` and `detach`.
+- Exact node-output references stay typed, and unknown literal fields are rejected before the child starts.
+- Override values can be filled from templates.
+- The Loop editor exposes the overrides as JSON, and malformed JSON, unknown settings, wrong types, or trailing data block the run instead of failing mid-flight.

--- a/.release-notes/desktop-app-status-liveness-1788306279.md
+++ b/.release-notes/desktop-app-status-liveness-1788306279.md
@@ -1,0 +1,9 @@
+---
+title: App status asks the app instead of guessing from the process
+type: fix
+---
+
+`compozy app status` and `compozy app open` decided whether the desktop app was running by matching a recorded process ID and its start timestamp. When that timestamp comparison did not line up, a perfectly healthy app was reported as not running, and `app open` refused to reuse it. Both commands now probe the app's own control socket and take its answer. (#494)
+
+- A control channel that reports not running, or is unavailable, still resolves to "not running" instead of failing the command.
+- Any other probe failure is surfaced as an error rather than silently read as a stopped app.

--- a/.release-notes/extension-loops-call-owned-tools-1788306274.md
+++ b/.release-notes/extension-loops-call-owned-tools-1788306274.md
@@ -1,0 +1,9 @@
+---
+title: An extension Loop can call the tools its own extension ships
+type: fix
+---
+
+A code-backed extension can contribute both Loops and tools, but the external-source policy stopped a contributed Loop from resolving a tool owned by that same extension, so the action failed with `unknown_action_kind`. The manifest owner is now preserved through resource loading, compilation, executed snapshots, and hydration, and execution adds exactly that same-owner extension source to the normal allow set. (#503)
+
+- Trusted-source status is never granted, and tools from other extensions stay denied.
+- Loop schema compilation snapshots the operator registry once per compilation instead of reprojecting it repeatedly.

--- a/.release-notes/externalized-loop-action-results-1788306271.md
+++ b/.release-notes/externalized-loop-action-results-1788306271.md
@@ -1,0 +1,13 @@
+---
+title: Large Loop action results survive instead of breaking the run
+type: feature
+---
+
+A Loop action can now return a payload larger than the task-run envelope without losing coordinator restart safety. Results up to 16 KiB stay inline; anything larger is stored in the existing Loop blob store and read back byte for byte through a workspace-authorized paging resource. A result above the action budget fails with the typed `action_result_too_large` error before the task completes, so the lease is released instead of the run stalling. (#510)
+
+- Adds `compozy task run result`, task-run result paging over HTTP and UDS, the Host API `tasks/runs/result` resource, and the `compozy__task_run_result` native tool.
+- `compozy__tool_list` now returns deterministic pages so the global tool-result limit stays enforceable; `compozy__tool_info` still returns full descriptors.
+- The Task UI shows and copies bounded results.
+- Spec-cycle Task fan-out is a hard cut from embedded bodies to `path` plus `body_ref`.
+
+No `config.toml` key was added or removed — the existing tool-result budget remains the source of truth.

--- a/.release-notes/forced-loop-cancel-replaces-kill-1788306268.md
+++ b/.release-notes/forced-loop-cancel-replaces-kill-1788306268.md
@@ -1,0 +1,16 @@
+---
+title: Cancel now stops a Loop run for real, and Kill is gone
+type: breaking
+---
+
+Loop cancellation commits the terminal state before cleanup and stops every session that run owns, so a canceled run leaves nothing alive. Because cancel is now forceful, the separate Kill operation is removed everywhere. (#509)
+
+- Removed CLI commands: `compozy loop kill` and `compozy loop node kill`.
+- Removed HTTP and UDS routes: `POST /workspaces/{workspace_id}/loop-runs/{run_id}/kill` and `POST /workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/kill`.
+- Removed native tools: `compozy__loop_kill` and `compozy__loop_node_kill`.
+- Removed vocabulary: the run transition cause `operator_kill` and the run event kind `node_killed`. Only `operator_cancel` remains.
+- Removed Loop DSL value: `on_parent_close: cancel`. The authored parent-close vocabulary is now `terminate` and `abandon`.
+- `compozy__loop_cancel` and `compozy__loop_node_cancel` — and their CLI, HTTP, UDS, and Web equivalents — now terminalize immediately instead of requesting cooperative cancellation.
+- Sessions the run only borrowed are left running, workspace isolation is preserved, and a cleanup that fails is retried durably.
+
+Callers still using a Kill route, command, or tool must move to the matching cancel surface; there is no alias.

--- a/.release-notes/loop-extension-tools-worktrees-1788306275.md
+++ b/.release-notes/loop-extension-tools-worktrees-1788306275.md
@@ -1,0 +1,10 @@
+---
+title: Loop extension tools run in the worktree the Loop selected
+type: fix
+---
+
+Extension tools invoked from a Loop now resolve against the selected ready worktree instead of the workspace root, so work stays where the run was pointed. Direct and root-scoped calls are unchanged. (#519)
+
+- Web Loop environment authoring is limited to inherit, workspace root, and a named worktree; directory and per-run values set through the API or CLI remain visible and read-only.
+- A worktree is resolved by workspace ID and worktree ref and must be ready before it is used.
+- Removing a worktree now takes an exclusive usage lease, so `compozy worktree remove` and the matching delete route report that an operation is in progress while a Loop action is holding that worktree, instead of pulling it out from under the run.

--- a/.release-notes/managed-session-prompts-1788306272.md
+++ b/.release-notes/managed-session-prompts-1788306272.md
@@ -1,0 +1,11 @@
+---
+title: You can talk to managed sessions again
+type: fix
+---
+
+The Web composer now follows prompt authority instead of lifecycle ownership, so `user`, `system`, `coordinator`, and `spawned` sessions can all be prompted while active or stopped. An active session exposes Queue, Steer, Interrupt, and Stop generation; a stopped managed session resumes under the same durable session ID and transcript. (#517)
+
+- The composer's stop control now cancels the current turn instead of stopping the whole session, so you can interrupt one answer and keep going.
+- Managed sessions still cannot be renamed, cleared, attached, archived, deleted, or stopped as a whole.
+- Dream, maintenance, archived, transitional, and unrecoverable sessions stay read-only.
+- Session lifecycle docs and the official CompozyOS skill describe the new prompt boundary.

--- a/.release-notes/orchestrated-implementer-honored-1788306273.md
+++ b/.release-notes/orchestrated-implementer-honored-1788306273.md
@@ -1,0 +1,10 @@
+---
+title: Orchestrated task delivery uses the implementer you picked
+type: fix
+---
+
+`implement-tasks` running in `mode=orchestrated` replaced your selected `implementer` Agent with `code_implementer`. The typed Agent input now flows through the orchestrated objective, the conductor skill, and `compozy spawn`, so every worker runs as the Agent you chose and keeps its identity, Agent-local Skills, permissions, provider defaults, and category runtime overrides. (#502)
+
+- `code_implementer` is still the default, so omitting the input behaves as before.
+- A recovered session whose Agent does not match fails closed instead of being adopted silently.
+- Settlement still requires completed Task frontmatter and zero live workers created by the conductor.

--- a/.release-notes/profile-scoped-extension-agent-skills-1788306276.md
+++ b/.release-notes/profile-scoped-extension-agent-skills-1788306276.md
@@ -1,0 +1,10 @@
+---
+title: Profile-scoped extension Agents keep their own Skills
+type: fix
+---
+
+An extension Agent scoped to one Profile leaked into `default`, and Agent-local Skill lookup could read the wrong Agent definition. CompozyOS now publishes the already-projected Agent set and resolves Agent-scoped Skill queries through the selected global, Profile, or Workspace lens, passing the concrete Agent definition to the Skill registry. (#516)
+
+- Two Agents with the same name in different Profiles stay isolated, and `skill list|where|view --for-agent` returns each one's own Skill body.
+- Profile-only scope keeps both the Profile ID and the Profile name.
+- No command, flag, route, or payload shape changed — existing reads simply return the correctly scoped resources.

--- a/.release-notes/session-cancel-clear-races-1788306278.md
+++ b/.release-notes/session-cancel-clear-races-1788306278.md
@@ -1,0 +1,10 @@
+---
+title: Canceling a prompt and clearing a conversation no longer collide
+type: fix
+---
+
+Two timing failures met in the same flow — cancel an active prompt, clear the conversation, keep using the session. Both are fixed. (#523)
+
+- A late prompt cancel could cancel the next turn. Prompt cancellation now owns only the active request and becomes a no-op once that prompt has settled; the whole-session `session/cancel` is sent exactly once, and only by Stop.
+- Because of that, an ACP agent process no longer receives a `session/cancel` notification when a single prompt is canceled — only the SDK's request-scoped `$/cancel_request`. An agent that aborted a turn by listening for `session/cancel` must handle the request-scoped cancellation instead.
+- A transcript read could land inside the conversation-clear replacement window, report `session not found`, and drive the clear endpoint to HTTP 500. The finalization barrier is now published as soon as the conversation-operation lock is taken and held through stop, backup, database replacement, and restart, so readers wait for the clear instead of seeing a session that appears to be missing.

--- a/.release-notes/sparse-fanout-roster-rows-1788306277.md
+++ b/.release-notes/sparse-fanout-roster-rows-1788306277.md
@@ -1,0 +1,9 @@
+---
+title: A fan-out roster shows only the workers that exist
+type: fix
+---
+
+Fan-out roster projection treated the highest stored item index as a contiguous range, so a run holding only item `2`, or items `2` and `5`, invented rows for the missing indexes and left them pending forever. Roster rows, rollups, and run progress now project the exact stored item indexes. (#518)
+
+- Response shapes and routes are unchanged across CLI, HTTP, UDS, `compozy__loop_runs`, and Web; the same reads now return correct results.
+- The Loop running guide and the official CompozyOS skill document sparse-index behavior, and clarify that `not_taken` requires durable route evidence.

--- a/packages/site/app/changelog/[version]/page.tsx
+++ b/packages/site/app/changelog/[version]/page.tsx
@@ -8,9 +8,17 @@ import { ReleaseDetailRail } from "@/components/blog/release-detail-rail";
 import { ReleaseEvidence } from "@/components/blog/release-evidence";
 import { ReleaseMarkdown } from "@/components/blog/release-markdown";
 import { MonoBadge } from "@/components/blog/mono-badge";
-import { loadChangelogReleases, loadReleasePullRequests } from "@/lib/changelog/github-client";
+import {
+  loadChangelogReleaseByTag,
+  loadChangelogReleases,
+  loadReleasePullRequests,
+} from "@/lib/changelog/github-client";
 import { compareReleaseTags } from "@/lib/changelog/release-markdown";
-import { COMPOZY_REPOSITORY, type ChangelogRelease } from "@/lib/changelog/types";
+import {
+  COMPOZY_REPOSITORY,
+  type ChangelogRelease,
+  type ChangelogReleaseLookup,
+} from "@/lib/changelog/types";
 import { createPageMetadata } from "@/lib/site-config";
 
 export const revalidate = 300;
@@ -31,10 +39,22 @@ function findPredecessor(
   }, undefined);
 }
 
+async function resolveRelease(
+  releases: readonly ChangelogRelease[],
+  version: string
+): Promise<ChangelogReleaseLookup> {
+  const cached = releases.find(item => item.version === version);
+  if (cached) return { status: "found", release: cached };
+  return loadChangelogReleaseByTag(version);
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const [{ version }, result] = await Promise.all([params, loadChangelogReleases()]);
-  const release =
-    result.status === "ready" ? result.releases.find(item => item.version === version) : undefined;
+  const lookup =
+    result.status === "ready"
+      ? await resolveRelease(result.releases, version)
+      : ({ status: "missing" } as const);
+  const release = lookup.status === "found" ? lookup.release : undefined;
   return createPageMetadata({
     title: release ? `${release.version} Changelog` : "Release not found",
     description: release?.summary ?? "Published CompozyOS release notes.",
@@ -47,8 +67,12 @@ export default async function ChangelogReleasePage({ params }: PageProps) {
   if (result.status === "unavailable") {
     throw new Error(`GitHub changelog is unavailable: ${result.error.message}`);
   }
-  const release = result.releases.find(item => item.version === version);
-  if (!release) notFound();
+  const lookup = await resolveRelease(result.releases, version);
+  if (lookup.status === "unavailable") {
+    throw new Error(`GitHub changelog is unavailable: ${lookup.error.message}`);
+  }
+  if (lookup.status === "missing") notFound();
+  const release = lookup.release;
   const predecessor = findPredecessor(result.releases, release.version);
   const comparison = predecessor
     ? {

--- a/packages/site/lib/__tests__/github-changelog.test.ts
+++ b/packages/site/lib/__tests__/github-changelog.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadChangelogReleases, loadReleasePullRequests } from "../changelog/github-client";
+import {
+  loadChangelogReleaseByTag,
+  loadChangelogReleases,
+  loadReleasePullRequests,
+} from "../changelog/github-client";
 
 const releaseFixture = {
   tag_name: "v0.3.0-beta.3",
@@ -92,6 +96,45 @@ describe("GitHub changelog boundary", () => {
     expect(result).toEqual({
       status: "unavailable",
       error: expect.objectContaining({ kind: "invalid-response" }),
+    });
+  });
+
+  it("resolves a release by tag when the cached release list has not caught up yet", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(releaseFixture));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const lookup = await loadChangelogReleaseByTag("v0.3.0-beta.3");
+
+    expect(lookup).toEqual({
+      status: "found",
+      release: expect.objectContaining({
+        version: "v0.3.0-beta.3",
+        body: releaseFixture.body,
+        pullRequestNumbers: [123],
+      }),
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/compozy/compozy/releases/tags/v0.3.0-beta.3",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("separates a missing release by tag from a GitHub outage it must not hide", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ message: "Not Found" }, 404));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect(await loadChangelogReleaseByTag("v0.3.0-beta.99")).toEqual({ status: "missing" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    expect(await loadChangelogReleaseByTag("v0.2.9")).toEqual({ status: "missing" });
+    expect(await loadChangelogReleaseByTag("  ")).toEqual({ status: "missing" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ message: "boom" }, 500)));
+
+    expect(await loadChangelogReleaseByTag("v0.3.0-beta.3")).toEqual({
+      status: "unavailable",
+      error: expect.objectContaining({ kind: "github-response", status: 500 }),
     });
   });
 

--- a/packages/site/lib/changelog/github-client.ts
+++ b/packages/site/lib/changelog/github-client.ts
@@ -1,6 +1,7 @@
 import {
   githubGraphqlResponseSchema,
   githubReleaseListSchema,
+  githubReleaseSchema,
   type GitHubPullRequestPayload,
   type GitHubReleasePayload,
 } from "./github-schemas";
@@ -22,6 +23,7 @@ import {
   type ChangelogPullRequest,
   type ChangelogPullRequestsResult,
   type ChangelogRelease,
+  type ChangelogReleaseLookup,
   type ChangelogReleasesResult,
 } from "./types";
 
@@ -188,6 +190,44 @@ export async function loadChangelogReleases(): Promise<ChangelogReleasesResult> 
       .filter((release): release is ChangelogRelease => release !== null)
       .toSorted((left, right) => right.publishedAt.localeCompare(left.publishedAt));
     return { status: "ready", releases };
+  } catch (error) {
+    return { status: "unavailable", error: toLoadError(error) };
+  }
+}
+
+async function fetchReleaseByTag(tag: string): Promise<GitHubReleasePayload | null> {
+  const url = `https://api.github.com/repos/${COMPOZY_REPOSITORY.owner}/${COMPOZY_REPOSITORY.name}/releases/tags/${encodeURIComponent(tag)}`;
+  let payload: unknown;
+  try {
+    payload = await githubJson(url, { method: "GET", cache: "no-store" }, false);
+  } catch (error) {
+    if (error instanceof GitHubClientError && error.status === 404) return null;
+    throw error;
+  }
+  const parsed = githubReleaseSchema.safeParse(payload);
+  if (!parsed.success) {
+    throw new GitHubClientError(
+      "invalid-response",
+      `GitHub release data failed validation: ${parsed.error.message}`
+    );
+  }
+  return parsed.data;
+}
+
+/**
+ * Resolves one release directly by tag so a release published after the last
+ * cached list refresh is still reachable on its own page.
+ */
+export async function loadChangelogReleaseByTag(tag: string): Promise<ChangelogReleaseLookup> {
+  const trimmed = tag.trim();
+  if (!trimmed || !releaseTagIsAtOrAfter(trimmed, CHANGELOG_CUTOFF_TAG)) {
+    return { status: "missing" };
+  }
+  try {
+    const payload = await fetchReleaseByTag(trimmed);
+    if (!payload) return { status: "missing" };
+    const release = buildRelease(payload);
+    return release ? { status: "found", release } : { status: "missing" };
   } catch (error) {
     return { status: "unavailable", error: toLoadError(error) };
   }

--- a/packages/site/lib/changelog/types.ts
+++ b/packages/site/lib/changelog/types.ts
@@ -61,6 +61,11 @@ export type ChangelogReleasesResult =
   | { status: "ready"; releases: ChangelogRelease[] }
   | { status: "unavailable"; error: ChangelogLoadError };
 
+export type ChangelogReleaseLookup =
+  | { status: "found"; release: ChangelogRelease }
+  | { status: "missing" }
+  | { status: "unavailable"; error: ChangelogLoadError };
+
 export interface ChangelogPullRequestAuthor {
   login: string;
   url: string;


### PR DESCRIPTION
## What & why

Two problems, one cycle.

**The v0.3.0-beta.22 changelog page 404s.** `app/changelog/[version]` is fully dynamic — with no `generateStaticParams` it never enters the Full Route Cache, so it never gets the ISR regeneration pass that advances the Data Cache. It read a stale releases list and called `notFound()`, while the ISR index at `/changelog` already listed beta.22. Measured in production: index `x-nextjs-prerender: 1` with beta.22 present; detail `x-vercel-cache: MISS`, `age: 0`, 404 on six consecutive cache-busted requests, with beta.19/20/21 all returning 200. The last production deploy landed 54 minutes *before* the release published, which is why every earlier release worked.

`loadChangelogReleaseByTag` now resolves a cache miss with an uncached lookup of the exact tag before 404ing, guarded by the existing cutoff so it is not an unbounded rate-limit surface. A GitHub outage on that path reports `unavailable` instead of collapsing into a 404.

**No PR in the beta.22 cycle wrote a release note.** Between `v0.3.0-beta.21..v0.3.0-beta.22` zero `.release-notes/*.md` files were added, so both the published beta.22 body and the pending `RELEASE_BODY.md` on `release/v0.3.0` omit the work. This adds the 12 missing notes, which the release PR archives into `.release-notes/archive/v0.3.0/`.

Contributing cause worth a separate decision: the `CompozyOS PR release note` workflow has been disabled (`if: false`) since `e8df3c29c`, 2026-08-19.

## How you verified it

- `make gate` — `all affected local lanes passed`, status 0.
- `bunx turbo run lint typecheck test --filter=./packages/site` — 56 files, 324 tests pass; `github-changelog.test.ts` goes from 3 to 5 cases.
- `scripts/check-product-language.sh` — pass over the full default path set.
- Every fact in the notes was checked against the merge diffs, not the PR titles. Corrections found this way: the removed Kill routes are `/workspaces/{workspace_id}/loop-runs/...`, not `/loops/runs/...`; #509 also removed the `operator_kill` transition cause, the `node_killed` event kind, and the `on_parent_close: cancel` DSL value; #523 means ACP agents no longer receive `session/cancel` on prompt cancel; #517 rewired the composer stop control to cancel the turn; #519 added a worktree usage lease that makes `worktree remove` report an operation in progress.

## Impact

- **Web/Docs:** `packages/site` changelog data layer and detail route only. No `web/` change, no docs page change.
- **CLI / HTTP / UDS / config:** none.
- **Tests:** two cases added to the canonical `packages/site/lib/__tests__/github-changelog.test.ts` boundary suite — a release absent from the cached list is still resolvable by tag with the draft and cutoff filters intact, and a GitHub 500 surfaces as `unavailable` rather than a silent 404.

Compozy Impact Audit:

- Native tools: no impact — no `compozy__*` ID, toolset, descriptor, schema digest, risk flag, or capability gate is touched.
- Extensibility and hooks: no impact — no extension, hook, skill, capability, tool/resource, registry, bridge SDK, MCP sidecar, or `config.toml` key changes. `.release-notes/*.md` is `pr-release` input, archived by the release PR.
- Workspace data isolation: no impact — the changelog reads public GitHub Releases only; no workspace-scoped datum, cache key, SSE path, or event is involved.
- Official Compozy skill: no impact — no public behavior, tool ID, CLI path, hook event, capability, or extension resource changed.

QA tracker impact: no new user-visible runtime behavior. The site fix restores a page that should already have rendered; it introduces no new operator-facing control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Changelog pages can now display releases immediately by their version tag, even when the release list is not yet updated.
  * Improved handling distinguishes unavailable releases from releases that do not exist.

* **Bug Fixes**
  * Missing releases now show the appropriate not-found page.
  * Temporary service errors are surfaced correctly instead of being treated as missing releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->