### PR TITLE
fix: allow creating and listing global agents from catalog

### DIFF
--- a/web/src/systems/os/apps/agents/agents-catalog-location.tsx
+++ b/web/src/systems/os/apps/agents/agents-catalog-location.tsx
@@ -10,58 +10,39 @@ export function AgentsCatalogLocation({ search }: { search: AgentsFleetSearch })
 
   const agentsErrorEmpty = Boolean(page.agentsError) && page.agents.length === 0 && !page.isLoading;
   const headCount =
-    page.isLoading || agentsErrorEmpty || page.isFirstRunEmpty || page.workspaceId === ""
-      ? undefined
-      : page.fleetTotal;
+    page.isLoading || agentsErrorEmpty || page.isFirstRunEmpty ? undefined : page.fleetTotal;
 
   useTopbarSlot({
     glyph: <Users2 />,
     count: headCount,
-    actions:
-      page.isFirstRunEmpty || page.workspaceId === "" ? undefined : (
-        <div className="flex items-center gap-2" data-testid="agents-topbar-actions">
-          <Button
-            data-testid="agents-topbar-create"
-            onClick={page.openCreate}
-            size="sm"
-            type="button"
-          >
-            <Plus aria-hidden="true" className="size-3" />
-            New agent
-          </Button>
-        </div>
-      ),
-    toolbar:
-      page.workspaceId === "" ? undefined : (
-        <AgentFleetToolbar
-          categoryOptions={page.categoryOptions}
-          draftQuery={page.draftQuery}
-          onDraftQueryChange={page.setDraftQuery}
-          onFiltersChange={page.setFilters}
-          onViewChange={page.setView}
-          search={page.search}
-          searchInputRef={page.searchInputRef}
-          showFacets={page.showFacets}
-          showViewToggle={page.showViewToggle}
-          view={page.view}
-        />
-      ),
-  });
-
-  if (page.workspaceId === "") {
-    return (
-      <div
-        className="flex min-h-0 flex-1 items-center justify-center py-10"
-        data-testid="agents-no-workspace"
-      >
-        <Empty
-          description="Select a workspace to browse its agents."
-          icon={Users2}
-          title="No workspace selected"
-        />
+    actions: page.isFirstRunEmpty ? undefined : (
+      <div className="flex items-center gap-2" data-testid="agents-topbar-actions">
+        <Button
+          data-testid="agents-topbar-create"
+          onClick={page.openCreate}
+          size="sm"
+          type="button"
+        >
+          <Plus aria-hidden="true" className="size-3" />
+          New agent
+        </Button>
       </div>
-    );
-  }
+    ),
+    toolbar: (
+      <AgentFleetToolbar
+        categoryOptions={page.categoryOptions}
+        draftQuery={page.draftQuery}
+        onDraftQueryChange={page.setDraftQuery}
+        onFiltersChange={page.setFilters}
+        onViewChange={page.setView}
+        search={page.search}
+        searchInputRef={page.searchInputRef}
+        showFacets={page.showFacets}
+        showViewToggle={page.showViewToggle}
+        view={page.view}
+      />
+    ),
+  });
 
   return (
     <ListingPage data-testid="agent-fleet-page">

--- a/web/src/systems/os/apps/agents/use-agents-catalog.ts
+++ b/web/src/systems/os/apps/agents/use-agents-catalog.ts
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 
+import type { AgentPayload } from "@/systems/agent";
 import type { ListingViewMode } from "@compozy/ui";
 
 import { normalizeListingSearchValue } from "@/lib/listing-search";
@@ -11,17 +12,60 @@ import {
   hasActiveAgentFleetFilters,
   projectAgentFleetRows,
   useAgentCatalog,
+  useAgents,
   useAgentCreateHost,
 } from "@/systems/agent";
+import {
+  agentShadowLayers,
+  formatAgentFleetAriaLabel,
+  formatAgentFleetCardCategory,
+  formatAgentFleetMeta,
+  formatAgentLayer,
+  formatAgentOriginLabel,
+} from "@/systems/agent/lib/agent-fleet-projection";
+import type { AgentFleetRowModel } from "@/systems/agent/lib/agent-fleet-projection";
 import { useSessionCreateActions, useSessionCreateHasActiveWorkspace } from "@/systems/session";
 import { useActiveWorkspace } from "@/systems/workspace";
 
 const SEARCH_DEBOUNCE_MS = 200;
 
+function projectGlobalRows(agents: readonly AgentPayload[]): AgentFleetRowModel[] {
+  return agents.map(agent => ({
+    agent,
+    signals: null,
+    meta: formatAgentFleetMeta(agent),
+    cardCategory: formatAgentFleetCardCategory(agent),
+    cardOrigin: formatAgentOriginLabel(agent.origin),
+    layer: formatAgentLayer(agent),
+    shadowLayers: agentShadowLayers(agent),
+    ariaLabel: formatAgentFleetAriaLabel(agent, null, false),
+    hasDiagnostics: Array.isArray(agent.diagnostics) && agent.diagnostics.length > 0,
+    sessionsAvailable: false,
+  }));
+}
+
+function matchesGlobalAgent(agent: AgentPayload, search: AgentsFleetSearch): boolean {
+  if (search.q) {
+    const q = search.q.trim().toLowerCase();
+    if (q && !agent.name.toLowerCase().includes(q)) return false;
+  }
+  if (search.category) {
+    const category = search.category.trim();
+    if (category) {
+      const paths = agent.category_path ?? [];
+      const formatted = paths.join(" / ");
+      const raw = paths.join("/");
+      if (!paths.includes(category) && formatted !== category && raw !== category) return false;
+    }
+  }
+  return true;
+}
+
 function useAgentsFleetPage(search: AgentsFleetSearch = {}) {
   const { runtimeWorkspaceId } = useActiveWorkspace();
   const liveDataEnabled = useCurrentWindowLiveDataEnabled();
   const workspaceId = runtimeWorkspaceId ?? "";
+  const isGlobal = workspaceId === "";
   const navigate = useNavigate({ from: "/agents" });
   const { openDialog } = useAgentCreateHost();
   const { openForAgent } = useSessionCreateActions();
@@ -38,7 +82,7 @@ function useAgentsFleetPage(search: AgentsFleetSearch = {}) {
       updateSearch(current => ({ ...current, q: normalizeListingSearchValue(nextQuery) })),
   });
 
-  const agentsEnabled = liveDataEnabled && workspaceId !== "";
+  const agentsEnabled = liveDataEnabled && !isGlobal;
   const catalogQuery = useAgentCatalog(
     workspaceId,
     {
@@ -49,9 +93,8 @@ function useAgentsFleetPage(search: AgentsFleetSearch = {}) {
     },
     { enabled: agentsEnabled }
   );
-  const agents = catalogQuery.agents.map(item => item.agent);
-  const sessionsPartial = catalogQuery.isSuccess && !catalogQuery.sessionsAvailable;
-  const view: ListingViewMode = search.view ?? "rows";
+
+  const globalQuery = useAgents(null, { enabled: liveDataEnabled && isGlobal });
 
   const setFilters = (next: Pick<AgentsFleetSearch, "category" | "status">) => {
     updateSearch(current => ({ ...current, category: next.category, status: next.status }));
@@ -74,6 +117,69 @@ function useAgentsFleetPage(search: AgentsFleetSearch = {}) {
   const openNewSession = (agentName: string) => {
     openForAgent(agentName);
   };
+
+  if (isGlobal) {
+    const allGlobalAgents = globalQuery.data ?? [];
+    const filteredAgents = allGlobalAgents.filter(agent => matchesGlobalAgent(agent, search));
+    const filtersActive = Boolean(search.q?.trim() || search.category?.trim());
+    const isLoading = globalQuery.isLoading;
+    const isError = Boolean(globalQuery.isError);
+    const overallTotal = allGlobalAgents.length;
+    const isFirstRunEmpty =
+      !isLoading && !globalQuery.isError && overallTotal === 0 && !filtersActive;
+    const isFilteredEmpty =
+      !isLoading && !globalQuery.isError && filteredAgents.length === 0 && filtersActive;
+    const rows = projectGlobalRows(filteredAgents);
+    const categoryOptions = [
+      ...new Set(
+        allGlobalAgents.flatMap(agent =>
+          (agent.category_path ?? []).flatMap(value => {
+            const trimmed = value.trim();
+            return trimmed ? [trimmed] : [];
+          })
+        )
+      ),
+    ];
+    const showFacets = !isLoading && !isFirstRunEmpty && !(isError && filteredAgents.length === 0);
+    const showViewToggle = !isFirstRunEmpty && !(isError && filteredAgents.length === 0);
+
+    return {
+      workspaceId,
+      catalogQuery: globalQuery as unknown as typeof catalogQuery,
+      agents: filteredAgents,
+      fleetTotal: filteredAgents.length,
+      rows,
+      categoryOptions,
+      search,
+      draftQuery: queryInput.draftValue,
+      searchInputRef,
+      view: (search.view ?? "rows") as ListingViewMode,
+      setDraftQuery: queryInput.setDraftValue,
+      setFilters,
+      setView,
+      clearFilters,
+      openCreate: openDialog,
+      openNewSession,
+      newSessionDisabled: true,
+      isLoading,
+      isFirstRunEmpty,
+      isFilteredEmpty,
+      sessionsPartial: false,
+      hasMore: false,
+      isLoadingMore: false,
+      loadMore: () => {},
+      showFacets,
+      showViewToggle,
+      agentsError: globalQuery.error as unknown as typeof catalogQuery.error,
+      retryAgents: () => {
+        void globalQuery.refetch();
+      },
+    };
+  }
+
+  const agents = catalogQuery.agents.map(item => item.agent);
+  const sessionsPartial = catalogQuery.isSuccess && !catalogQuery.sessionsAvailable;
+  const view: ListingViewMode = search.view ?? "rows";
 
   const rows = projectAgentFleetRows({
     items: catalogQuery.agents,


### PR DESCRIPTION
## What & why

Global scope was a mode in the menubar but the Agents catalog hid its list and New agent button when no workspace was selected, so Global agents were visible only inside a workspace and never creatable via UI. This change makes Global listing and creation work via the same catalog, using `GET /api/agents` for Global and keeping the existing catalog for workspaces.

Fixes deadlock where workspace view could only create workspace agents and Global view had no affordance.

## How you verified it

- `bash scripts/gate.sh auto` scoped to `web` with `bunx turbo run lint typecheck test --filter=./web` (lint 0 warnings, typecheck passes)
- `bunx tsc --noEmit --project web/tsconfig.json` passes
- Manual: switched menubar to Global, verified `GET /api/agents` lists globals and New agent creates with `scope: global`, switched to workspace, verified catalog still shows mixed Global and Workspace agents

## Impact

- Web: `web/src/systems/os/apps/agents/use-agents-catalog.ts`, `agents-catalog-location.tsx` now support Global via `/api/agents`
- CLI, HTTP/UDS, config, docs: no impact, backend already supported `scope: global`

---

- [x] `make gate` passes locally, this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global agents catalog view when no workspace is selected.
  * Global view displays matching agents across all workspaces without pagination or session details.
  * Agent count, creation controls, and toolbar remain available in the global view.

* **Bug Fixes**
  * Removed the empty-workspace state that previously prevented access to the agents listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->