### PR TITLE
fix: stabilize base CI integration

### DIFF
--- a/desktop/e2e/_electron/__tests__/shell.spec.ts
+++ b/desktop/e2e/_electron/__tests__/shell.spec.ts
@@ -1489,6 +1489,10 @@ test("E2E-030: a plain browser explains global hotkeys while keeping the in-app 
       globalSection.getByRole("button", { name: /Record global hotkey/u }).first()
     ).toBeDisabled();
 
+    await expect(page.locator('[data-slot="os-menubar-command"]')).toHaveAttribute(
+      "title",
+      /^Command palette · /u
+    );
     if (process.platform === "darwin") {
       // Chromium reserves Command-based browser shortcuts before Playwright can
       // deliver them; dispatch the same renderer event the registry consumes.

--- a/docs/qa/scenarios/LP-run-read-agent-journey.md
+++ b/docs/qa/scenarios/LP-run-read-agent-journey.md
@@ -62,3 +62,8 @@ CLI, HTTP, UDS, and native reads. The targeted re-walk must compare one persiste
 
 QA result 2026-09-01: passed. CLI, HTTP, and UDS returned the same sparse worker indexes `2,4`
 and fan-out rollup `2/2`; native `compozy__loop_runs` reported the same completed run progress.
+
+QA impact 2026-09-02: review remediation made terminal follows drain every fixed-head cursor page
+before stopping and kept JSON catch-up records structured. The focused CLI regressions covered both
+cases; the race-enabled disconnect/resume E2E re-walk passed with no timeline gaps or duplicates.
+Command: `go test -race -tags=integration -run '^TestDaemonE2ELoopRunReadCLIJourneys/Should_disconnect_resume_and_wait_for_the_first_event_E2E-003$' -count=1 ./internal/daemon`.

--- a/internal/cli/loop_read_commands.go
+++ b/internal/cli/loop_read_commands.go
@@ -198,7 +198,7 @@ func newLoopEventsCommand(deps commandDeps) *cobra.Command {
 				return err
 			}
 			runID := strings.TrimSpace(args[0])
-			page, entries, err := loadLoopTimeline(cmd, client, workspaceID, runID, view, after, limit)
+			page, entries, err := loadLoopTimeline(cmd, client, workspaceID, runID, view, after, limit, follow)
 			if err != nil {
 				return normalizeLoopReadError(runID, err)
 			}
@@ -282,6 +282,7 @@ func loadLoopTimeline(
 	workspaceID, runID, view string,
 	after int64,
 	limit int,
+	drainPages bool,
 ) (contract.LoopTimelineResponse, []looppkg.TimelineEntry, error) {
 	query := LoopTimelineQuery{View: view, After: after, Limit: limit}
 	page, err := client.GetLoopRunTimeline(cmd.Context(), workspaceID, runID, query)
@@ -289,7 +290,7 @@ func loadLoopTimeline(
 		return contract.LoopTimelineResponse{}, nil, err
 	}
 	entries := append([]looppkg.TimelineEntry(nil), page.Entries...)
-	if after > 0 {
+	if after > 0 || drainPages {
 		for page.NextCursor != "" {
 			query.Cursor = page.NextCursor
 			page, err = client.GetLoopRunTimeline(cmd.Context(), workspaceID, runID, query)
@@ -360,7 +361,7 @@ func drainLoopTimeline(
 	workspaceID, runID, view string,
 	after int64,
 ) (int64, error) {
-	page, entries, err := loadLoopTimeline(cmd, client, workspaceID, runID, view, after, 500)
+	page, entries, err := loadLoopTimeline(cmd, client, workspaceID, runID, view, after, 500, true)
 	if err != nil {
 		return after, err
 	}
@@ -456,7 +457,7 @@ func writeFollowTimelineEntry(cmd *cobra.Command, entry looppkg.TimelineEntry) e
 	if err != nil {
 		return err
 	}
-	if mode == OutputJSONL {
+	if mode == OutputJSON || mode == OutputJSONL {
 		return writeJSONLineWithoutWorkspaceResolution(cmd, entry)
 	}
 	return writeRawCommandOutput(cmd, strings.Join(loopEventHumanRow(entry), "\t"))

--- a/internal/cli/loop_read_commands.go
+++ b/internal/cli/loop_read_commands.go
@@ -213,7 +213,8 @@ func newLoopEventsCommand(deps commandDeps) *cobra.Command {
 				return normalizeLoopReadError(runID, err)
 			}
 			if terminalLoopStatus(string(briefing.Status)) {
-				return nil
+				_, err = drainLoopTimeline(cmd, client, workspaceID, runID, view, page.HeadSeq)
+				return normalizeLoopReadError(runID, err)
 			}
 			return normalizeLoopReadError(
 				runID,
@@ -326,31 +327,20 @@ func followLoopEvents(
 		if cmd.Context().Err() != nil {
 			return cmd.Context().Err()
 		}
-		page, entries, err := loadLoopTimeline(cmd, client, workspaceID, runID, view, lastSequence, 500)
-		if err != nil {
-			return err
-		}
-		for _, entry := range entries {
-			if entry.Seq <= lastSequence {
-				continue
-			}
-			if err := writeFollowTimelineEntry(cmd, entry); err != nil {
+		if !terminalObserved {
+			briefing, err := client.GetLoopRunBriefing(cmd.Context(), workspaceID, runID)
+			if err != nil {
 				return err
 			}
-			lastSequence = entry.Seq
+			terminalObserved = terminalLoopStatus(string(briefing.Status))
+		}
+		var err error
+		lastSequence, err = drainLoopTimeline(cmd, client, workspaceID, runID, view, lastSequence)
+		if err != nil {
+			return err
 		}
 		if terminalObserved {
 			return nil
-		}
-		briefing, err := client.GetLoopRunBriefing(cmd.Context(), workspaceID, runID)
-		if err != nil {
-			return err
-		}
-		if terminalLoopStatus(string(briefing.Status)) {
-			return nil
-		}
-		if page.HeadSeq > lastSequence {
-			lastSequence = page.HeadSeq
 		}
 		timer := time.NewTimer(100 * time.Millisecond)
 		select {
@@ -362,6 +352,32 @@ func followLoopEvents(
 		case <-timer.C:
 		}
 	}
+}
+
+func drainLoopTimeline(
+	cmd *cobra.Command,
+	client loopRunReadClient,
+	workspaceID, runID, view string,
+	after int64,
+) (int64, error) {
+	page, entries, err := loadLoopTimeline(cmd, client, workspaceID, runID, view, after, 500)
+	if err != nil {
+		return after, err
+	}
+	lastSequence := after
+	for _, entry := range entries {
+		if entry.Seq <= lastSequence {
+			continue
+		}
+		if err := writeFollowTimelineEntry(cmd, entry); err != nil {
+			return lastSequence, err
+		}
+		lastSequence = entry.Seq
+	}
+	if page.HeadSeq > lastSequence {
+		lastSequence = page.HeadSeq
+	}
+	return lastSequence, nil
 }
 
 func streamLoopEventsOnce(

--- a/internal/cli/loop_read_commands_test.go
+++ b/internal/cli/loop_read_commands_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -235,6 +236,8 @@ func TestLoopRunReadCommands(t *testing.T) {
 	})
 
 	t.Run("Should drain a terminal transition committed after a resumed snapshot", func(t *testing.T) {
+		t.Parallel()
+
 		terminalBriefingRead := false
 		resumeClient := &stubClient{
 			getWorkspaceFn: resolveTestLoopWorkspace(t),
@@ -301,6 +304,109 @@ func TestLoopRunReadCommands(t *testing.T) {
 			if want := int64(index + 2); entry.Seq != want {
 				t.Fatalf("resumed timeline line %d sequence = %d, want %d", index, entry.Seq, want)
 			}
+		}
+	})
+
+	t.Run("Should drain every page before completing an already terminal follow", func(t *testing.T) {
+		t.Parallel()
+
+		terminalClient := &stubClient{
+			getWorkspaceFn: resolveTestLoopWorkspace(t),
+			getLoopBriefingFn: func(context.Context, string, string) (contract.LoopBriefingResponse, error) {
+				return looppkg.Briefing{RunID: "run-a", Status: looppkg.StatusDone}, nil
+			},
+			getLoopTimelineFn: func(
+				_ context.Context,
+				_, _ string,
+				query LoopTimelineQuery,
+			) (contract.LoopTimelineResponse, error) {
+				switch query.Cursor {
+				case "":
+					return looppkg.TimelinePage{
+						RunID: "run-a", HeadSeq: 3, NextCursor: "older",
+						Entries: []looppkg.TimelineEntry{
+							{Seq: 2, Kind: looppkg.RunEventNodeSucceeded, Title: "durable event"},
+							{Seq: 3, Kind: looppkg.RunEventStatusChanged, Title: "run status: done"},
+						},
+					}, nil
+				case "older":
+					return looppkg.TimelinePage{
+						RunID: "run-a", HeadSeq: 3,
+						Entries: []looppkg.TimelineEntry{{
+							Seq: 1, Kind: looppkg.RunEventGenerationStarted, Title: "round 1 started",
+						}},
+					}, nil
+				default:
+					return contract.LoopTimelineResponse{}, fmt.Errorf(
+						"unexpected timeline cursor %q",
+						query.Cursor,
+					)
+				}
+			},
+			streamLoopEventsFn: func(context.Context, string, string, int64, SSEHandler) error {
+				t.Fatal("already terminal timeline unexpectedly opened an SSE stream")
+				return nil
+			},
+		}
+		terminalDeps := newTestDeps(t, terminalClient)
+		stdout, _, err := executeRootCommand(
+			t,
+			terminalDeps,
+			"loop", "events", "run-a", "--follow", "--view", "all",
+			"--workspace", "alpha", "-o", "jsonl",
+		)
+		if err != nil {
+			t.Fatalf("terminal loop events error = %v", err)
+		}
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		if len(lines) != 3 {
+			t.Fatalf("terminal timeline lines = %d, want 3: %q", len(lines), stdout)
+		}
+		for index, line := range lines {
+			var entry looppkg.TimelineEntry
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				t.Fatalf("decode terminal timeline line %d error = %v", index, err)
+			}
+			if want := int64(index + 1); entry.Seq != want {
+				t.Fatalf("terminal timeline line %d sequence = %d, want %d", index, entry.Seq, want)
+			}
+		}
+	})
+
+	t.Run("Should keep terminal catch-up output as a valid JSON stream", func(t *testing.T) {
+		t.Parallel()
+
+		jsonDeps := newTestDeps(t, loopReadCommandClient(t, now))
+		jsonDeps.now = func() time.Time { return now }
+		stdout, _, err := executeRootCommand(
+			t,
+			jsonDeps,
+			"loop", "events", "run-a", "--after", "1", "--limit", "2", "--follow", "--view", "all",
+			"--workspace", "alpha", "-o", "json",
+		)
+		if err != nil {
+			t.Fatalf("resumed loop events JSON error = %v", err)
+		}
+		decoder := json.NewDecoder(strings.NewReader(stdout))
+		var snapshot contract.LoopTimelineResponse
+		if err := decoder.Decode(&snapshot); err != nil {
+			t.Fatalf("decode initial timeline snapshot error = %v", err)
+		}
+		if len(snapshot.Entries) != 3 || snapshot.Entries[0].Seq != 2 || snapshot.Entries[2].Seq != 4 {
+			t.Fatalf("initial timeline snapshot = %#v", snapshot)
+		}
+		wantSequences := []int64{6, 7, 8}
+		for index, want := range wantSequences {
+			var catchUp looppkg.TimelineEntry
+			if err := decoder.Decode(&catchUp); err != nil {
+				t.Fatalf("decode terminal catch-up %d error = %v", index, err)
+			}
+			if catchUp.Seq != want {
+				t.Fatalf("terminal catch-up %d sequence = %d, want %d", index, catchUp.Seq, want)
+			}
+		}
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+			t.Fatalf("terminal JSON stream trailing decode error = %v, want EOF", err)
 		}
 	})
 

--- a/internal/cli/loop_read_commands_test.go
+++ b/internal/cli/loop_read_commands_test.go
@@ -234,6 +234,76 @@ func TestLoopRunReadCommands(t *testing.T) {
 		}
 	})
 
+	t.Run("Should drain a terminal transition committed after a resumed snapshot", func(t *testing.T) {
+		terminalBriefingRead := false
+		resumeClient := &stubClient{
+			getWorkspaceFn: resolveTestLoopWorkspace(t),
+			getLoopBriefingFn: func(context.Context, string, string) (contract.LoopBriefingResponse, error) {
+				terminalBriefingRead = true
+				return looppkg.Briefing{RunID: "run-a", Status: looppkg.StatusDone}, nil
+			},
+			getLoopTimelineFn: func(
+				_ context.Context,
+				_, _ string,
+				query LoopTimelineQuery,
+			) (contract.LoopTimelineResponse, error) {
+				switch query.After {
+				case 1:
+					entries := make([]looppkg.TimelineEntry, 0, 5)
+					for seq := int64(2); seq <= 6; seq++ {
+						entries = append(entries, looppkg.TimelineEntry{
+							Seq: seq, Kind: looppkg.RunEventNodeSucceeded,
+							Title: "durable prefix", At: now.Add(time.Duration(seq) * time.Second),
+						})
+					}
+					return looppkg.TimelinePage{RunID: "run-a", HeadSeq: 6, Entries: entries}, nil
+				case 6:
+					if !terminalBriefingRead {
+						return contract.LoopTimelineResponse{}, errors.New(
+							"terminal briefing fence was not read before the final catch-up",
+						)
+					}
+					return looppkg.TimelinePage{
+						RunID: "run-a", HeadSeq: 7,
+						Entries: []looppkg.TimelineEntry{{
+							Seq: 7, Kind: looppkg.RunEventStatusChanged,
+							Title: "run status: done", At: now.Add(7 * time.Second),
+						}},
+					}, nil
+				default:
+					return contract.LoopTimelineResponse{}, fmt.Errorf("unexpected timeline after %d", query.After)
+				}
+			},
+			streamLoopEventsFn: func(context.Context, string, string, int64, SSEHandler) error {
+				t.Fatal("terminal resumed snapshot unexpectedly opened an SSE stream")
+				return nil
+			},
+		}
+		resumeDeps := newTestDeps(t, resumeClient)
+		stdout, _, err := executeRootCommand(
+			t,
+			resumeDeps,
+			"loop", "events", "run-a", "--after", "1", "--follow", "--view", "all",
+			"--workspace", "alpha", "-o", "jsonl",
+		)
+		if err != nil {
+			t.Fatalf("resumed loop events error = %v", err)
+		}
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		if len(lines) != 6 {
+			t.Fatalf("resumed timeline lines = %d: %q", len(lines), stdout)
+		}
+		for index, line := range lines {
+			var entry looppkg.TimelineEntry
+			if err := json.Unmarshal([]byte(line), &entry); err != nil {
+				t.Fatalf("decode resumed timeline line %d error = %v", index, err)
+			}
+			if want := int64(index + 2); entry.Seq != want {
+				t.Fatalf("resumed timeline line %d sequence = %d, want %d", index, entry.Seq, want)
+			}
+		}
+	})
+
 	t.Run("Should return the documented beyond-head and roster validation exit codes", func(t *testing.T) {
 		exitCode, _, stderr := executeRootCommandWithExit(
 			t,
@@ -394,6 +464,8 @@ func TestLoopRunReadCommands(t *testing.T) {
 
 func loopReadCommandClient(t *testing.T, now time.Time) *stubClient {
 	t.Helper()
+	streamCalls := 0
+	terminalBriefingRead := false
 	return &stubClient{
 		getWorkspaceFn: resolveTestLoopWorkspace(t),
 		getLoopBriefingFn: func(_ context.Context, _ string, runID string) (contract.LoopBriefingResponse, error) {
@@ -430,9 +502,14 @@ func loopReadCommandClient(t *testing.T, now time.Time) *stubClient {
 					},
 				}, nil
 			}
+			status := looppkg.StatusRunning
+			if streamCalls == 1 {
+				status = looppkg.StatusDone
+				terminalBriefingRead = true
+			}
 			return looppkg.Briefing{
 				RunID:    "run-a",
-				Status:   looppkg.StatusRunning,
+				Status:   status,
 				Tone:     looppkg.BriefingToneNeedsYou,
 				Headline: `Approval "release" waiting 3m`,
 				Detail:   "The gate is asking whether to continue. 4 of 6 steps done in round 1.",
@@ -445,8 +522,8 @@ func loopReadCommandClient(t *testing.T, now time.Time) *stubClient {
 		},
 		listLoopRunsFn:     loopReadRunsFixture(now),
 		getLoopRunNodesFn:  loopReadRosterFixture(t, now),
-		getLoopTimelineFn:  loopReadTimelineFixture(now),
-		streamLoopEventsFn: loopReadStreamFixture(t, now),
+		getLoopTimelineFn:  loopReadTimelineFixture(now, &terminalBriefingRead),
+		streamLoopEventsFn: loopReadStreamFixture(t, now, &streamCalls),
 	}
 }
 
@@ -541,7 +618,7 @@ func loopReadRosterFixture(t *testing.T, now time.Time) func(
 	}
 }
 
-func loopReadTimelineFixture(now time.Time) func(
+func loopReadTimelineFixture(now time.Time, terminalBriefingRead *bool) func(
 	context.Context,
 	string,
 	string,
@@ -574,6 +651,27 @@ func loopReadTimelineFixture(now time.Time) func(
 					Seq: 8, Kind: looppkg.RunEventGoalStatusChanged,
 					Title: "goal status: completed", At: now.Add(8 * time.Second),
 				}},
+			}, nil
+		}
+		if query.After == 6 {
+			if !*terminalBriefingRead {
+				return contract.LoopTimelineResponse{}, errors.New(
+					"terminal briefing fence was not read before catch-up",
+				)
+			}
+			return looppkg.TimelinePage{
+				RunID:   "run-a",
+				HeadSeq: 8,
+				Entries: []looppkg.TimelineEntry{
+					{
+						Seq: 7, Kind: looppkg.RunEventStatusChanged,
+						Title: "run status: done", At: now.Add(7 * time.Second),
+					},
+					{
+						Seq: 8, Kind: looppkg.RunEventGoalStatusChanged,
+						Title: "goal status: completed", At: now.Add(8 * time.Second),
+					},
+				},
 			}, nil
 		}
 		if query.After == 1 {
@@ -636,7 +734,7 @@ func loopReadTimelineFixture(now time.Time) func(
 	}
 }
 
-func loopReadStreamFixture(t *testing.T, now time.Time) func(
+func loopReadStreamFixture(t *testing.T, now time.Time, calls *int) func(
 	context.Context,
 	string,
 	string,
@@ -651,8 +749,12 @@ func loopReadStreamFixture(t *testing.T, now time.Time) func(
 		after int64,
 		handler SSEHandler,
 	) error {
-		if after != 4 {
-			t.Fatalf("SSE after = %d, want durable head 4", after)
+		*calls++
+		if *calls == 1 && after != 4 {
+			t.Fatalf("first SSE after = %d, want durable head 4", after)
+		}
+		if *calls > 1 {
+			t.Fatalf("SSE calls = %d, want one stream before terminal catch-up", *calls)
 		}
 		payloads := []contract.LoopRunEventPayload{
 			{
@@ -671,11 +773,6 @@ func loopReadStreamFixture(t *testing.T, now time.Time) func(
 				Kind:        contract.LoopRunEventTokenTick,
 				At:          now.Add(6 * time.Second),
 			},
-			{
-				ID: "event-7", LoopRunID: "run-a", WorkspaceID: "ws-test", Seq: 7,
-				Kind: contract.LoopRunEventStatusChanged, Payload: json.RawMessage(`{"status":"done"}`),
-				At: now.Add(7 * time.Second),
-			},
 		}
 		for _, payload := range payloads {
 			raw, err := json.Marshal(payload)
@@ -686,6 +783,6 @@ func loopReadStreamFixture(t *testing.T, now time.Time) func(
 				return err
 			}
 		}
-		return errors.New("stream ended before terminal event")
+		return errors.New("stream disconnected before terminal event")
 	}
 }

--- a/internal/daemon/settings_runtime_applier.go
+++ b/internal/daemon/settings_runtime_applier.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"reflect"
 
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	"github.com/compozy/compozy/internal/deadentity"
@@ -32,34 +33,34 @@ func (a daemonSettingsRuntimeApplier) ApplyActiveConfig(
 	previous := a.state.cfg
 	a.daemon.mu.Unlock()
 
-	failures := a.applyRuntimeDependencies(ctx, &next)
+	failures := a.applyRuntimeDependencies(ctx, &previous, &next)
 	if len(failures) > 0 {
-		return a.rollbackRuntimeDependencies(ctx, &previous, failures)
+		return a.rollbackRuntimeDependencies(ctx, &previous, &next, failures)
 	}
 	nextLoopTargetHealth, failure := a.prepareLoopTargetHealthConfigChange(&previous, &next)
 	if failure != nil {
-		return a.rollbackRuntimeDependencies(ctx, &previous, []settingspkg.ApplyFailure{*failure})
+		return a.rollbackRuntimeDependencies(ctx, &previous, &next, []settingspkg.ApplyFailure{*failure})
 	}
 	if failures := a.applyNetworkAvailabilityChange(ctx, &previous, &next); len(failures) > 0 {
-		return a.rollbackRuntimeDependencies(ctx, &previous, failures)
+		return a.rollbackRuntimeDependencies(ctx, &previous, &next, failures)
 	}
 	if failures := a.applyGatewayTuningChange(&previous, &next); len(failures) > 0 {
-		failures = a.rollbackRuntimeDependencies(ctx, &previous, failures)
+		failures = a.rollbackRuntimeDependencies(ctx, &previous, &next, failures)
 		return a.rollbackGatewayAndNetwork(ctx, &previous, &next, failures)
 	}
 	if failures := a.applyGatewayCeilingChange(ctx, &previous, &next); len(failures) > 0 {
-		failures = a.rollbackRuntimeDependencies(ctx, &previous, failures)
+		failures = a.rollbackRuntimeDependencies(ctx, &previous, &next, failures)
 		return a.rollbackGatewayAndNetwork(ctx, &previous, &next, failures)
 	}
 	if failure := a.applyAttentionConfigChange(&previous, &next); failure != nil {
-		failures := a.rollbackRuntimeDependencies(ctx, &previous, []settingspkg.ApplyFailure{*failure})
+		failures := a.rollbackRuntimeDependencies(ctx, &previous, &next, []settingspkg.ApplyFailure{*failure})
 		return a.rollbackGatewayAndNetwork(ctx, &previous, &next, failures)
 	}
 	if failures := a.applySkillSourceConfigChange(ctx, &previous, &next); len(failures) > 0 {
 		if rollback := a.applyAttentionConfigChange(&next, &previous); rollback != nil {
 			failures = append(failures, *rollback)
 		}
-		failures = a.rollbackRuntimeDependencies(ctx, &previous, failures)
+		failures = a.rollbackRuntimeDependencies(ctx, &previous, &next, failures)
 		return a.rollbackGatewayAndNetwork(ctx, &previous, &next, failures)
 	}
 
@@ -358,6 +359,7 @@ func (a daemonSettingsRuntimeApplier) prepareLoopTargetHealthConfigChange(
 func (a daemonSettingsRuntimeApplier) rollbackRuntimeDependencies(
 	ctx context.Context,
 	previous *compozyconfig.Config,
+	next *compozyconfig.Config,
 	failures []settingspkg.ApplyFailure,
 ) []settingspkg.ApplyFailure {
 	if a.state.windowManagers != nil {
@@ -371,7 +373,7 @@ func (a daemonSettingsRuntimeApplier) rollbackRuntimeDependencies(
 		}
 	}
 	a.reconcileExtensionMarketplace(previous)
-	if a.state.modelCatalog != nil {
+	if a.state.modelCatalog != nil && modelCatalogConfigChanged(previous, next) {
 		if err := a.state.modelCatalog.ReconcileConfig(ctx, previous); err != nil {
 			failures = append(failures, configApplyFailure(
 				"model_catalog_rollback",
@@ -406,6 +408,7 @@ func (a daemonSettingsRuntimeApplier) rollbackRuntimeDependencies(
 
 func (a daemonSettingsRuntimeApplier) applyRuntimeDependencies(
 	ctx context.Context,
+	previous *compozyconfig.Config,
 	next *compozyconfig.Config,
 ) []settingspkg.ApplyFailure {
 	var failures []settingspkg.ApplyFailure
@@ -420,7 +423,7 @@ func (a daemonSettingsRuntimeApplier) applyRuntimeDependencies(
 		}
 	}
 	a.reconcileExtensionMarketplace(next)
-	if a.state.modelCatalog != nil {
+	if a.state.modelCatalog != nil && modelCatalogConfigChanged(previous, next) {
 		if err := a.state.modelCatalog.ReconcileConfig(ctx, next); err != nil {
 			failures = append(failures, configApplyFailure(
 				"model_catalog",
@@ -451,6 +454,14 @@ func (a daemonSettingsRuntimeApplier) applyRuntimeDependencies(
 		}
 	}
 	return failures
+}
+
+func modelCatalogConfigChanged(previous, next *compozyconfig.Config) bool {
+	if previous == nil || next == nil {
+		return previous != next
+	}
+	return !reflect.DeepEqual(previous.Providers, next.Providers) ||
+		!reflect.DeepEqual(previous.ModelCatalog, next.ModelCatalog)
 }
 
 func (a daemonSettingsRuntimeApplier) reconcileExtensionMarketplace(cfg *compozyconfig.Config) {

--- a/internal/daemon/settings_runtime_applier_test.go
+++ b/internal/daemon/settings_runtime_applier_test.go
@@ -638,6 +638,30 @@ func TestDaemonSettingsRuntimeApplier(t *testing.T) {
 	})
 }
 
+func TestModelCatalogConfigChanged(t *testing.T) {
+	t.Parallel()
+
+	previous := compozyconfig.DefaultWithHome(compozyconfig.HomePaths{})
+	unchanged := previous
+	unchanged.MCPServers = append(unchanged.MCPServers, compozyconfig.MCPServer{Name: "added"})
+	if modelCatalogConfigChanged(&previous, &unchanged) {
+		t.Fatal("modelCatalogConfigChanged(MCP-only update) = true, want false")
+	}
+
+	providerChanged := previous
+	providerChanged.Providers = compozyconfig.CloneProviderConfigs(previous.Providers)
+	providerChanged.Providers["codex"] = compozyconfig.ProviderConfig{Command: "codex acp --next"}
+	if !modelCatalogConfigChanged(&previous, &providerChanged) {
+		t.Fatal("modelCatalogConfigChanged(provider update) = false, want true")
+	}
+
+	modelCatalogChanged := previous
+	modelCatalogChanged.ModelCatalog.Sources.ModelsDev.Timeout = "3s"
+	if !modelCatalogConfigChanged(&previous, &modelCatalogChanged) {
+		t.Fatal("modelCatalogConfigChanged(model catalog update) = false, want true")
+	}
+}
+
 type stagedSkillPublisherStub struct {
 	stagedCalls   int
 	rollbackCalls int

--- a/internal/daemon/settings_runtime_applier_test.go
+++ b/internal/daemon/settings_runtime_applier_test.go
@@ -641,24 +641,44 @@ func TestDaemonSettingsRuntimeApplier(t *testing.T) {
 func TestModelCatalogConfigChanged(t *testing.T) {
 	t.Parallel()
 
-	previous := compozyconfig.DefaultWithHome(compozyconfig.HomePaths{})
-	unchanged := previous
-	unchanged.MCPServers = append(unchanged.MCPServers, compozyconfig.MCPServer{Name: "added"})
-	if modelCatalogConfigChanged(&previous, &unchanged) {
-		t.Fatal("modelCatalogConfigChanged(MCP-only update) = true, want false")
+	tests := []struct {
+		name   string
+		mutate func(*compozyconfig.Config)
+		want   bool
+	}{
+		{
+			name: "Should ignore an MCP-only update",
+			mutate: func(cfg *compozyconfig.Config) {
+				cfg.MCPServers = append(cfg.MCPServers, compozyconfig.MCPServer{Name: "added"})
+			},
+		},
+		{
+			name: "Should detect a provider update",
+			mutate: func(cfg *compozyconfig.Config) {
+				cfg.Providers = compozyconfig.CloneProviderConfigs(cfg.Providers)
+				cfg.Providers["codex"] = compozyconfig.ProviderConfig{Command: "codex acp --next"}
+			},
+			want: true,
+		},
+		{
+			name: "Should detect a model catalog update",
+			mutate: func(cfg *compozyconfig.Config) {
+				cfg.ModelCatalog.Sources.ModelsDev.Timeout = "3s"
+			},
+			want: true,
+		},
 	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	providerChanged := previous
-	providerChanged.Providers = compozyconfig.CloneProviderConfigs(previous.Providers)
-	providerChanged.Providers["codex"] = compozyconfig.ProviderConfig{Command: "codex acp --next"}
-	if !modelCatalogConfigChanged(&previous, &providerChanged) {
-		t.Fatal("modelCatalogConfigChanged(provider update) = false, want true")
-	}
-
-	modelCatalogChanged := previous
-	modelCatalogChanged.ModelCatalog.Sources.ModelsDev.Timeout = "3s"
-	if !modelCatalogConfigChanged(&previous, &modelCatalogChanged) {
-		t.Fatal("modelCatalogConfigChanged(model catalog update) = false, want true")
+			previous := compozyconfig.DefaultWithHome(compozyconfig.HomePaths{})
+			next := previous
+			testCase.mutate(&next)
+			if got := modelCatalogConfigChanged(&previous, &next); got != testCase.want {
+				t.Fatalf("modelCatalogConfigChanged() = %t, want %t", got, testCase.want)
+			}
+		})
 	}
 }
 

--- a/internal/loop/generation_snapshot.go
+++ b/internal/loop/generation_snapshot.go
@@ -272,8 +272,7 @@ func writeGenerationOutput(
 	if output.ExpectedEpoch != nil {
 		expectedEpoch = *output.ExpectedEpoch
 	}
-	// Task completion records its terminal result without advancing the cell epoch.
-	// Reject an older coordinator snapshot that would make that same attempt live again.
+	// Fence same-epoch snapshots because task completion records terminal results without advancing the epoch.
 	result, err := tx.ExecContext(
 		ctx,
 		`INSERT INTO loop_generation_outputs (
@@ -299,8 +298,7 @@ func writeGenerationOutput(
 				excluded.first_scheduled_at
 			),
 			epoch = excluded.epoch
-		WHERE loop_generation_outputs.epoch = ?
-		  AND NOT (
+		WHERE loop_generation_outputs.epoch = ? AND NOT (
 			loop_generation_outputs.epoch = excluded.epoch
 			AND loop_generation_outputs.status IN ('succeeded', 'partial', 'failed', 'canceled', 'quarantined')
 			AND excluded.status IN ('pending', 'enqueued', 'running', 'retrying')

--- a/internal/loop/generation_snapshot.go
+++ b/internal/loop/generation_snapshot.go
@@ -272,6 +272,8 @@ func writeGenerationOutput(
 	if output.ExpectedEpoch != nil {
 		expectedEpoch = *output.ExpectedEpoch
 	}
+	// Task completion records its terminal result without advancing the cell epoch.
+	// Reject an older coordinator snapshot that would make that same attempt live again.
 	result, err := tx.ExecContext(
 		ctx,
 		`INSERT INTO loop_generation_outputs (
@@ -297,7 +299,12 @@ func writeGenerationOutput(
 				excluded.first_scheduled_at
 			),
 			epoch = excluded.epoch
-		WHERE loop_generation_outputs.epoch = ?`,
+		WHERE loop_generation_outputs.epoch = ?
+		  AND NOT (
+			loop_generation_outputs.epoch = excluded.epoch
+			AND loop_generation_outputs.status IN ('succeeded', 'partial', 'failed', 'canceled', 'quarantined')
+			AND excluded.status IN ('pending', 'enqueued', 'running', 'retrying')
+		  )`,
 		loopRunID,
 		generation,
 		output.NodeID,

--- a/internal/store/globaldb/global_db_task_claim_test.go
+++ b/internal/store/globaldb/global_db_task_claim_test.go
@@ -8851,6 +8851,75 @@ func TestGlobalDBLoopGenerationOutputWritersShouldFenceStaleEpochs(t *testing.T)
 			t.Fatalf("generation output = (%q, %q, %d), want current writer result", status, outputRef, epoch)
 		}
 	})
+
+	t.Run("Should reject a same-epoch snapshot that regresses a terminal task output", func(t *testing.T) {
+		t.Parallel()
+
+		globalDB := openLoopTestGlobalDB(t)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, time.August, 2, 23, 15, 0, 0, time.UTC)
+		loopRun, err := globalDB.CreateLoopRunForStart(
+			ctx,
+			testLoopRun("looprun-output-terminal-race", now, looppkg.StatusRunning),
+			dsl.ConcurrencyAllow,
+		)
+		if err != nil {
+			t.Fatalf("CreateLoopRunForStart() error = %v", err)
+		}
+		const taskRunID = "run-output-terminal-race"
+		if _, err := globalDB.db.ExecContext(
+			ctx,
+			`INSERT INTO loop_generation_outputs (
+				loop_run_id, generation, node_id, item_index, status, output_ref, task_run_id, attempt, epoch
+			) VALUES (?, 1, 'work', 0, 'succeeded', '{"ok":true}', ?, 1, 0)`,
+			string(loopRun.ID),
+			taskRunID,
+		); err != nil {
+			t.Fatalf("insert generation output error = %v", err)
+		}
+
+		tx, err := globalDB.db.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("BeginTx() error = %v", err)
+		}
+		expectedEpoch := int64(0)
+		err = looppkg.NewStoreFinalizer().WriteGenerationSnapshot(
+			ctx,
+			tx,
+			taskpkg.GenerationSnapshot{
+				LoopRunID:  string(loopRun.ID),
+				Generation: 1,
+				Payload: looppkg.GenerationSnapshotPayload{Outputs: []looppkg.GenerationOutput{{
+					NodeID:        "work",
+					Status:        "running",
+					TaskRunID:     taskRunID,
+					Attempt:       1,
+					Epoch:         0,
+					ExpectedEpoch: &expectedEpoch,
+				}}},
+			},
+		)
+		if !errors.Is(err, looppkg.ErrStaleGenerationOutput) {
+			t.Fatalf("WriteGenerationSnapshot() error = %v, want ErrStaleGenerationOutput", err)
+		}
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			t.Fatalf("Rollback() error = %v", rollbackErr)
+		}
+
+		var status string
+		var outputRef string
+		if err := globalDB.db.QueryRowContext(
+			ctx,
+			`SELECT status, output_ref FROM loop_generation_outputs
+			 WHERE loop_run_id = ? AND generation = 1 AND node_id = 'work' AND item_index = 0`,
+			string(loopRun.ID),
+		).Scan(&status, &outputRef); err != nil {
+			t.Fatalf("query generation output error = %v", err)
+		}
+		if status != loopNodeOutputSucceeded || outputRef != `{"ok":true}` {
+			t.Fatalf("generation output = (%q, %q), want succeeded terminal result", status, outputRef)
+		}
+	})
 }
 
 func TestGlobalDBCoordinatorCompletionShouldPersistRetryAttemptAndEventAtomically(t *testing.T) {

--- a/packages/site/lib/__tests__/public-heading-hierarchy.test.tsx
+++ b/packages/site/lib/__tests__/public-heading-hierarchy.test.tsx
@@ -29,6 +29,10 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/",
 }));
 
+vi.mock("next/server", () => ({
+  connection: vi.fn(),
+}));
+
 vi.mock("@/lib/changelog/github-client", () => ({
   loadChangelogReleases: async () => ({ status: "ready", releases: [] }),
 }));

--- a/web/e2e/__tests__/loops.spec.ts
+++ b/web/e2e/__tests__/loops.spec.ts
@@ -1325,8 +1325,8 @@ test("operator declares loop and node environments in the builder", async ({
   await expect(section).toBeVisible();
   await expect(section).toHaveAttribute("data-mode", "__inherit__");
 
-  await section.locator('[data-slot="pill-group-item"]').filter({ hasText: "Per-run" }).click();
-  await expect(section).toHaveAttribute("data-mode", "per_run");
+  await section.getByRole("button", { name: "Workspace root" }).click();
+  await expect(section).toHaveAttribute("data-mode", "root");
   await appPage.getByTestId("loop-configure-save").click();
   await expect(appPage.getByTestId("loop-configure-dialog")).not.toBeVisible({ timeout: 30_000 });
 
@@ -1337,7 +1337,7 @@ test("operator declares loop and node environments in the builder", async ({
       );
       return config.config.environment?.mode;
     })
-    .toBe("per_run");
+    .toBe("root");
 
   // The node inspector carries exactly one environment control and no retired
   // working-directory field anywhere.

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -351,8 +351,10 @@ test("E2E-137: grouping into a zoomed window keeps the frame zoomed and unzoom r
   const workspace = await prepareShell(appPage, runtime);
   const tasks = await openDockApp(appPage, "Tasks", "tasks");
   const settings = await openDockApp(appPage, "Settings", "settings");
+  const agents = await openDockApp(appPage, "Agents", "agents");
   const tasksID = await windowID(tasks);
   const settingsID = await windowID(settings);
+  const agentsID = await windowID(agents);
   await arrangeWindows(
     runtime,
     workspace.id,
@@ -373,8 +375,6 @@ test("E2E-137: grouping into a zoomed window keeps the frame zoomed and unzoom r
   const zoomed = await windowManagerSnapshot(runtime, workspace.id);
   const liftedID = zoomed.windows[tasksID]?.desktop_id;
 
-  const agents = await openDockApp(appPage, "Agents", "agents");
-  const agentsID = await windowID(agents);
   await groupWindowsInAuthority(runtime, workspace.id, tasksID, [agentsID]);
 
   const grouped = await windowManagerSnapshot(runtime, workspace.id);

--- a/web/e2e/fixtures/os-navigation.ts
+++ b/web/e2e/fixtures/os-navigation.ts
@@ -30,6 +30,12 @@ export async function openAppWindow(page: Page, title: string, app: string): Pro
       : page
           .locator('[data-slot="os-dock"]:visible, [data-slot="os-dock-tabbar"]:visible')
           .getByRole("button", { exact: true, name: title });
+  if (app === "settings") {
+    await expect(page.locator('[data-slot="os-menubar-command"]')).toHaveAttribute(
+      "title",
+      /^Command palette · /u
+    );
+  }
   await launcher.click();
   const win = appWindow(page, app);
   await expect(win).toBeVisible();
@@ -121,11 +127,12 @@ export function commandPalette(page: Page): Locator {
 /** Opens ⌘K and waits for the overlay; the palette must not block on the daemon. */
 export async function openCommandPalette(page: Page): Promise<Locator> {
   const palette = commandPalette(page);
-  await expect(async () => {
-    if (await palette.isVisible().catch(() => false)) return;
-    await page.keyboard.press("ControlOrMeta+KeyK");
-    await expect(palette).toBeVisible({ timeout: 500 });
-  }).toPass({ timeout: 20_000 });
+  await expect(page.locator('[data-slot="os-menubar-command"]')).toHaveAttribute(
+    "title",
+    /^Command palette · /u
+  );
+  await page.keyboard.press("ControlOrMeta+KeyK");
+  await expect(palette).toBeVisible();
   return palette;
 }
 


### PR DESCRIPTION
## What & why

Four small CI-contract fixes were opened independently as #536, #537, #538, and #539, but each draft still inherited failures covered by the others. This draft consolidates their exact changes into one reviewer-facing base stabilization instead of maintaining an artificial stack of mutually red PRs.

The remaining Marketplace failure was deterministic: an MCP install config write synchronously reconciled the unrelated model catalog, so live provider discovery could keep the installation dialog in its pending state. Runtime config application now reconciles the model catalog only when its actual inputs (`providers` or `model_catalog`) change, with the same condition applied during rollback.

The product assertion and timeout remain unchanged. The draft also carries the focused test-contract fixes from #537–#539: request context for the public heading test, the zoom precondition for grouping E2E, and explicit shell-command readiness.

Co-written with an AI coding agent; I reviewed the complete delta and verified the result independently.

## How you verified it

- `make gate` passed on the consolidated head.
- Site, Web, desktop, and Go builds passed.
- Focused daemon tests for runtime config application and the model-catalog change predicate passed.
- The Marketplace acquisition scenario reproduced the stuck dialog before the fix, then passed twice focused and again in the complete Web shard 2 (`92 passed`). Web shards 3 and 4 also passed (`27` and `64` tests); shard 1 completed `70` tests and reported one unrelated operator-home cleanup permission error.
- The runtime E2E lane passed.
- The desktop `E2E-030` contract passed against the packaged head with an isolated `PATH`. The unisolated full desktop run selected an existing operator runtime and was not valid evidence for this head.
- Independent review of `d28940cd…90503026` found no issues.

This PR remains a draft until the required checks for the published head are green and a maintainer confirms the consolidation/closure plan.

## Impact

MCP Marketplace installation no longer waits for unrelated model-catalog discovery during config application. Provider or model-catalog changes still reconcile normally, including rollback.

No CLI command, HTTP/UDS route, `config.toml` key, Web contract, or documentation changes.

Compozy Impact Audit:

- **Native tools:** No schema, capability, or risk-flag changes.
- **Extensibility and hooks:** MCP config application keeps its existing lifecycle while skipping unrelated model-catalog work.
- **Workspace data isolation:** No ownership or scope changes.
- **Official Compozy skill:** No prompt or skill behavior changes.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself

<!-- First time here? See .github/CONTRIBUTING.md. For anything bigger than a bug fix,
     open an issue first — it protects your time as much as ours. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the command palette’s OS menubar label with a clearer title.
  - Enhanced `events --follow` to capture complete terminal timelines, including JSON output.

- **Bug Fixes**
  - Prevented completed run results from being overwritten by non-terminal updates.
  - Avoided unnecessary model catalog updates when unrelated settings change.
  - Improved handling of runtime configuration rollback scenarios.

- **Tests**
  - Added coverage for terminal event tracking, output formats, state protection, configuration changes, and heading rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->