### PR TITLE
test: mock request context in heading hierarchy

### DIFF
--- a/packages/site/lib/__tests__/public-heading-hierarchy.test.tsx
+++ b/packages/site/lib/__tests__/public-heading-hierarchy.test.tsx
@@ -29,6 +29,10 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/",
 }));
 
+vi.mock("next/server", () => ({
+  connection: vi.fn(),
+}));
+
 vi.mock("@/lib/changelog/github-client", () => ({
   loadChangelogReleases: async () => ({ status: "ready", releases: [] }),
 }));


### PR DESCRIPTION
## What & why

The public heading-hierarchy test renders the changelog route directly, but that route now enters Next's request scope through `connection()`. Mock the request-context boundary in the unit harness so the test can keep checking the real heading structure without failing before render.

An AI coding agent co-wrote this change. I independently verified the result.

## How you verified it

- Heading-hierarchy test: 3 consecutive runs, 4/4 assertions passed each run.
- `make gate` with Node 22: 56 site test files and 329 tests passed.
- `make site-build`: passed.
- Independent exact-delta review: no findings.

## Impact

Test-only change. No CLI command, HTTP/UDS route, configuration key, web product surface, or documentation behavior changes. The Compozy Impact Audit found no native tool, extension, hook, workspace-isolation, or official-skill impact.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by replacing a server-dependent API with a safe test stub.
  - Prevented public heading hierarchy tests from relying on live server functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->