### PR TITLE
test: preserve zoom precondition in grouping e2e

### DIFF
--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -351,8 +351,10 @@ test("E2E-137: grouping into a zoomed window keeps the frame zoomed and unzoom r
   const workspace = await prepareShell(appPage, runtime);
   const tasks = await openDockApp(appPage, "Tasks", "tasks");
   const settings = await openDockApp(appPage, "Settings", "settings");
+  const agents = await openDockApp(appPage, "Agents", "agents");
   const tasksID = await windowID(tasks);
   const settingsID = await windowID(settings);
+  const agentsID = await windowID(agents);
   await arrangeWindows(
     runtime,
     workspace.id,
@@ -373,8 +375,6 @@ test("E2E-137: grouping into a zoomed window keeps the frame zoomed and unzoom r
   const zoomed = await windowManagerSnapshot(runtime, workspace.id);
   const liftedID = zoomed.windows[tasksID]?.desktop_id;
 
-  const agents = await openDockApp(appPage, "Agents", "agents");
-  const agentsID = await windowID(agents);
   await groupWindowsInAuthority(runtime, workspace.id, tasksID, [agentsID]);
 
   const grouped = await windowManagerSnapshot(runtime, workspace.id);


### PR DESCRIPTION
## What & why

E2E-137 opened a visible peer after zooming the Tasks window. The current shell contract intentionally exits zoom when that peer is revealed, so the test cleared its own precondition before asking the grouping reducer to cross desktops. Open and identify the peer first, then arrange and zoom Tasks before the explicit grouping action.

This preserves every zoom, grouping, and unzoom assertion while aligning setup with the shell behavior introduced by #525.

An AI coding agent co-wrote this change. I independently verified the result.

## How you verified it

- E2E-137: 3 consecutive runs passed.
- `make gate` with Node 22: 722 web test files and 6,423 tests passed.
- `make web-build`: passed.
- Independent exact-delta review: no findings.

## Impact

Test-only change. No CLI command, HTTP/UDS route, configuration key, web product surface, or documentation behavior changes. The Compozy Impact Audit found no native tool, extension, hook, workspace-isolation, or official-skill impact.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself
