### PR TITLE
test: wait for shell command readiness

### DIFF
--- a/desktop/e2e/_electron/__tests__/shell.spec.ts
+++ b/desktop/e2e/_electron/__tests__/shell.spec.ts
@@ -1489,6 +1489,10 @@ test("E2E-030: a plain browser explains global hotkeys while keeping the in-app 
       globalSection.getByRole("button", { name: /Record global hotkey/u }).first()
     ).toBeDisabled();
 
+    await expect(page.locator('[data-slot="os-menubar-command"]')).toHaveAttribute(
+      "title",
+      /^Command palette · /u
+    );
     if (process.platform === "darwin") {
       // Chromium reserves Command-based browser shortcuts before Playwright can
       // deliver them; dispatch the same renderer event the registry consumes.

--- a/web/e2e/fixtures/os-navigation.ts
+++ b/web/e2e/fixtures/os-navigation.ts
@@ -30,6 +30,12 @@ export async function openAppWindow(page: Page, title: string, app: string): Pro
       : page
           .locator('[data-slot="os-dock"]:visible, [data-slot="os-dock-tabbar"]:visible')
           .getByRole("button", { exact: true, name: title });
+  if (app === "settings") {
+    await expect(page.locator('[data-slot="os-menubar-command"]')).toHaveAttribute(
+      "title",
+      /^Command palette · /u
+    );
+  }
   await launcher.click();
   const win = appWindow(page, app);
   await expect(win).toBeVisible();
@@ -121,11 +127,12 @@ export function commandPalette(page: Page): Locator {
 /** Opens ⌘K and waits for the overlay; the palette must not block on the daemon. */
 export async function openCommandPalette(page: Page): Promise<Locator> {
   const palette = commandPalette(page);
-  await expect(async () => {
-    if (await palette.isVisible().catch(() => false)) return;
-    await page.keyboard.press("ControlOrMeta+KeyK");
-    await expect(palette).toBeVisible({ timeout: 500 });
-  }).toPass({ timeout: 20_000 });
+  await expect(page.locator('[data-slot="os-menubar-command"]')).toHaveAttribute(
+    "title",
+    /^Command palette · /u
+  );
+  await page.keyboard.press("ControlOrMeta+KeyK");
+  await expect(palette).toBeVisible();
   return palette;
 }
 


### PR DESCRIPTION
## What & why

The launcher and desktop chrome can become visible before the atomic command catalog has registered `palette.open`. A single Settings click or palette shortcut can therefore arrive during a short readiness gap and be refused.

Gate those one-shot E2E actions on the menubar command button's registered shortcut title, a neutral catalog-readiness signal. The product assertions and single user actions remain unchanged; the shared web palette helper receives the same contract.

An AI coding agent co-wrote this change. I independently verified the result.

## How you verified it

- Profiles E2E-014: 5 consecutive runs passed.
- Web palette E2E-027: 3 consecutive runs passed.
- `make gate` with Node 22: desktop lane passed; 722 web test files and 6,423 tests passed.
- The local macOS desktop scenario reached the existing live-layout readiness check but not this changed command-readiness step; the required Linux desktop CI remains the end-to-end platform proof.
- Independent exact-delta review after one remediation batch: no findings.

## Impact

Test-harness-only change. No CLI command, HTTP/UDS route, configuration key, web product surface, or documentation behavior changes. The Compozy Impact Audit found no native tool, extension, hook, workspace-isolation, or official-skill impact.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded hotkey coverage to verify that the command palette action displays the expected title in the operating system menu bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->