### PR TITLE
feat: add You.com hosted MCP server to the curated catalog

### DIFF
--- a/catalog/mcp.json
+++ b/catalog/mcp.json
@@ -229,7 +229,7 @@
         {
             "entry_id": "you-search",
             "name": "You.com",
-            "description": "Search the web with freshness, domain, and country filters, and pull page content from results, through You.com's hosted keyless MCP profile.",
+            "description": "Search the web with freshness, domain, and country filters through You.com's hosted keyless MCP profile.",
             "launch": { "type": "remote", "url": "https://api.you.com/mcp?profile=free" },
             "default_scope": "workspace"
         }

--- a/catalog/mcp.json
+++ b/catalog/mcp.json
@@ -225,6 +225,13 @@
             "launch": { "type": "remote", "url": "https://mcp.cloudflare.com/mcp" },
             "auth": { "method": "oauth", "registration": "auto" },
             "default_scope": "workspace"
+        },
+        {
+            "entry_id": "you-search",
+            "name": "You.com",
+            "description": "Search the web with freshness, domain, and country filters, and pull page content from results, through You.com's hosted keyless MCP profile.",
+            "launch": { "type": "remote", "url": "https://api.you.com/mcp?profile=free" },
+            "default_scope": "workspace"
         }
     ]
 }

--- a/packages/site/content/docs/marketplace/mcp-catalog.mdx
+++ b/packages/site/content/docs/marketplace/mcp-catalog.mdx
@@ -68,8 +68,9 @@ credentials in the host callback rather than generated code. [Cloudflare Code
 Mode](https://developers.cloudflare.com/agents/model-context-protocol/codemode/)
 
 You.com publishes a hosted Streamable HTTP endpoint and a keyless `profile=free` variant that
-serves web search and page content tools without credentials. The catalog uses the keyless
-profile so the entry installs with no secret input. [You.com MCP
+serves basic web search without credentials. The catalog uses the keyless profile so the entry
+installs with no secret input; the full toolset, including page-content extraction, is available
+on the authenticated endpoint. [You.com MCP
 docs](https://you.com/docs/_mcp/server)
 
 ## Deliberate omissions

--- a/packages/site/content/docs/marketplace/mcp-catalog.mdx
+++ b/packages/site/content/docs/marketplace/mcp-catalog.mdx
@@ -28,6 +28,7 @@ make a server ready. Install through the daemon, then inspect its authorization 
 | Grafana               | Pinned uvx package `mcp-grafana==1.0.0`                   | Workspace scope; requires a Grafana URL and service-account token, and launches with `--disable-write`.                                  |
 | Cal.com               | Hosted Streamable HTTP                                    | Workspace scope; OAuth discovery and registration are automatic.                                                                         |
 | Cloudflare Code Mode  | Hosted Streamable HTTP                                    | Workspace scope; OAuth discovery and registration are automatic.                                                                         |
+| You.com               | Hosted Streamable HTTP                                    | Workspace scope; keyless `profile=free` endpoint for web search with domain/freshness filters, no credentials required.                   |
 
 Pinned local distributions are exact so a catalog refresh cannot silently select a different
 package. A Docker distribution is additionally pinned to a verified image digest. Hosted entries
@@ -65,6 +66,11 @@ default. [Yaw Labs PostgreSQL MCP](https://www.npmjs.com/package/@yawlabs/postgr
 Cloudflare's Code Mode design exposes a small progressive-discovery interface and keeps
 credentials in the host callback rather than generated code. [Cloudflare Code
 Mode](https://developers.cloudflare.com/agents/model-context-protocol/codemode/)
+
+You.com publishes a hosted Streamable HTTP endpoint and a keyless `profile=free` variant that
+serves web search and page content tools without credentials. The catalog uses the keyless
+profile so the entry installs with no secret input. [You.com MCP
+docs](https://you.com/docs/_mcp/server)
 
 ## Deliberate omissions
 


### PR DESCRIPTION
## What & why

Adds You.com as a hosted remote entry in the curated MCP catalog (`catalog/mcp.json`) and the matching row plus curation note in the marketplace docs.

CompozyOS agents currently get one curated web-search option (Brave Search, which requires an API key). You.com publishes a hosted Streamable HTTP endpoint with a keyless `profile=free` variant, so the entry installs with zero credentials — useful as a no-setup search tool for a fresh workspace. The keyless profile currently serves `you-search` (web search with domain, country, language, and freshness filters) and `you-discover`.

I followed the shape of the existing hosted remote entries (Linear, Notion, Sentry, Cloudflare): a `remote` launch URL, no catalog version (the provider owns the running service version), no auth block (the keyless profile needs none), and the default `workspace` scope.

Users who want the full authenticated toolset (search, contents extraction, research) can still point a workspace MCP config at `https://api.you.com/mcp` with a `YDC_API_KEY` bearer — that stays outside the catalog, same as any custom remote server.

## How you verified it

- `go run ./cmd/compozy-catalog validate ./catalog` — passes (same command the `catalog.yml` CI workflow runs).
- `go test ./internal/marketplace/ ./cmd/compozy-catalog/` — passes.
- Live MCP handshake against `https://api.you.com/mcp?profile=free`: `initialize` returns server info (You.com, Streamable HTTP), and `tools/list` returns `you-search` and `you-discover`.

## Impact

Additive catalog entry only — no existing entry or daemon behavior changes. Docs table in `packages/site/content/docs/marketplace/mcp-catalog.mdx` updated to list the new entry.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green — ran the affected checks directly (`compozy-catalog validate` + marketplace/compozy-catalog tests) since the change touches only `catalog/**` and docs
- [x] New or changed behavior is covered by tests, or I explained above why not — the catalog validator and its CI workflow are the existing coverage for feed documents; no new behavior is added
- [ ] If an agent wrote or co-wrote this, I named it above and verified the result myself — an AI coding agent (Claude) helped prepare this change; I reviewed the diff, ran the validator, tests, and live handshake against the endpoint myself

Tracking: youdotcom-oss/integration-tracking#254