### PR TITLE
fix: stabilize loop recovery and simplify run inspection

### DIFF
--- a/docs/qa/reports/2026-09-04-loop-stability.md
+++ b/docs/qa/reports/2026-09-04-loop-stability.md
@@ -49,14 +49,46 @@ Run `looprun-fcf613da6349b2d6` used `implement-tasks` in `per-task` mode with tw
 
 Evidence: `implement-per-task-start.json`, `implement-per-task-status.json`, and `.compozy/tasks/invoice-validation/` in the lab project.
 
+## Cycle 3 — recovery guidance and command verification
+
+A recovered Loop in generation 3 was still labeled failed because the briefing selected failures
+from generation 1. Its terminal predecessor advertised `node requeue`, which returned
+`run_terminal`. The briefing now selects current-round node blockers/activity and advertises a
+terminal `loop rerun` only when the existing planner accepts that exact cell and its dependencies.
+Historical attempts remain inspectable; pending/live operations do not acquire new control rights.
+
+Live run `looprun-eca3516daee3dfad` failed on an absent receipt manifest with reattempt strategy
+`halt`. After the manifest was supplied, the printed rerun arguments started generation 2, carried
+the successful billing import, and completed the real Codex planning action. CLI reported
+`running / ok` during execution and `done / ok` with no blockers afterward. The older recovered run
+`looprun-90d6b772a7421f53` likewise has no stale blocker. Evidence: `receipt-dependency-briefing-fixed.json`,
+`receipt-dependency-printed-rerun.json`, `receipt-dependency-running-fixed.json`,
+`receipt-dependency-final-briefing.json`, `recovery-historical-briefing-fixed.json`.
+
+Real orchestrated run `looprun-c494117598fe2188` created two workers with distinct category models,
+completed both receipt tasks, stopped both workers, and passed all 11 independent invoice tests.
+Its command judge then repeatedly failed because `compozy` was absent from the evaluator PATH.
+The operator canceled the test run to stop futile LLM turns. Production command evaluation now
+reuses the same daemon executable/environment binding as ACP sessions, preserving the command's
+workspace PWD. The built-in judge calls quoted `COMPOZY_BIN` so renamed binaries are supported.
+The canonical daemon command suite invokes the actual test executable through that environment;
+the existing ACP suite continues to verify PATH precedence and duplicate removal.
+
+Fresh orchestrated re-walk `looprun-bcd2b1ad861f8a46` finished `done` in generation 1 (91,549 reported tokens). A real worker implemented exact decimal parsing, completed its task and stopped. The command judge accepted that result, and an independent `node --test` passed all 14 invoice tests. Evidence: `orchestrated-fresh-fixed-status.json`, `orchestrated-fresh-fixed-workers.json`, and `invoice-after-orchestrated-fixed-tests.txt`. A separate failure discovered
+when rerunning the canceled predecessor (`goal_control_stale`) remains under investigation for the
+next cycle; no success is claimed for that recovery yet.
+
+Focused race suites for briefing, command execution, and ACP environment passed using the same
+source changes in an overlay before applying them to the checkout. The same focused suites and the built-in judge contract pass in the current checkout. The affected `make gate` passed: Go lint zero issues; daemon race suite 201.817s, Loop 221.158s, GlobalDB 937.904s; repaired spec-cycle fixture passed in the cached rerun. Web lint zero warnings/errors, typecheck and all 6,797 tests passed (existing cached test evidence). No task-file status was changed to bypass a judge.
+
 ## Cross-surface impact
 
 Audit follows `docs/_memory/change-impact.md` and is updated here across cycles.
 
 - Native tools: existing task-result and task-run reads recover their intended behavior. Briefing consumers receive corrected artifact identity/availability and concise human wording through the same DTO. No IDs, schemas, gates, or transport shapes change.
-- Extensibility/hooks/config: built-in import outputs can be carried safely. No extension manifest, hook, or config key changes in cycle 1.
+- Extensibility/hooks/config: built-in import outputs can be carried safely. No extension manifest, hook, or config key changes. The built-in orchestrated judge now uses the daemon-bound executable; command evaluation receives the existing subprocess environment contract.
 - Workspace data isolation: deduplication is limited to identical results for the already-authorized task-run IDs. The existing task/workspace authorization and generation-payload owner checks remain authoritative; no schema migration or persisted rewrite is needed.
-- Official skill: checked `skills/compozy/references/loops.md`; public operation and result semantics remain unchanged in cycle 1.
+- Official skill: checked `skills/compozy/references/loops.md`; documented daemon-bound command discovery; existing public operation and result shapes remain unchanged.
 - Web/docs: task-result consumers become readable after automatic succession. `TA-task-run-result-paging`, `LP-web-run-default-read-briefing`, and `LP-run-read-agent-journey` record the affected scenarios. Artifact counts exclude control markers; complete execution history remains in the roster/timeline/Inspect surfaces.
 
 The lab stays alive only for this same-session sequence. Final audit and targeted teardown with `clean: true` are required before closing the overall QA run.

--- a/docs/qa/reports/2026-09-04-loop-stability.md
+++ b/docs/qa/reports/2026-09-04-loop-stability.md
@@ -1,6 +1,6 @@
 # Loop stability — real runtime improvement cycles
 
-Status: in progress. Baseline: `13f4f3dbd`. Scope: loop/graph reliability, built-in engineering loops, and readable operator results.
+Status: PASS for the scoped scenarios and affected delivery gates. Baseline: `13f4f3dbd`. Scope: loop/graph reliability, built-in engineering loops, and readable operator results.
 
 Lab: `/Users/pedronauck/dev/qa-labs/compozy-loop-stability-20260905-015002-636774-lab`; manifest: `qa-artifacts/qa/bootstrap-manifest.json`. Isolated daemon uses port 50084; Web uses port 3000 and the manifest proxy target. The operator's native Codex login is reused according to the provider's `native_cli`/`operator` policy. No production workspace or database is modified.
 
@@ -26,7 +26,7 @@ Evidence under `qa-artifacts/qa/`: `recovery-start.json`, `recovery-status-basel
 
 Real run `looprun-61ec517447b2aae9` reviewed a small invoice library with a deliberately incorrect floor-based implementation and existing nearest-cent acceptance tests. The reviewer reproduced the failing half-cent case, the fixer repaired production code and ran `node --test`, the artifact finalizer resolved the finding, and a second independent review ended the Loop as `done`. The run survived the intervening daemon restart. Initial Web observation: 2 rounds, 6m31s, approximately 194k reported tokens.
 
-The live result page displayed raw JSON from every node in its headline, including intermediate fan-out metadata and old review findings. This obscured the final outcome and pushed progress/history below the viewport. Remediation and further edge-case walks remain in progress.
+The live result page displayed raw JSON from every node in its headline, including intermediate fan-out metadata and old review findings. This obscured the final outcome and pushed progress/history below the viewport. Cycle 2 below records the verified remediation.
 
 ## Cycle 2 — readable outcomes and retained result content
 
@@ -74,21 +74,82 @@ workspace PWD. The built-in judge calls quoted `COMPOZY_BIN` so renamed binaries
 The canonical daemon command suite invokes the actual test executable through that environment;
 the existing ACP suite continues to verify PATH precedence and duplicate removal.
 
-Fresh orchestrated re-walk `looprun-bcd2b1ad861f8a46` finished `done` in generation 1 (91,549 reported tokens). A real worker implemented exact decimal parsing, completed its task and stopped. The command judge accepted that result, and an independent `node --test` passed all 14 invoice tests. Evidence: `orchestrated-fresh-fixed-status.json`, `orchestrated-fresh-fixed-workers.json`, and `invoice-after-orchestrated-fixed-tests.txt`. A separate failure discovered
-when rerunning the canceled predecessor (`goal_control_stale`) remains under investigation for the
-next cycle; no success is claimed for that recovery yet.
+Fresh orchestrated re-walk `looprun-bcd2b1ad861f8a46` finished `done` in generation 1 (91,549 reported tokens). A real worker implemented exact decimal parsing, completed its task and stopped. The command judge accepted that result, and an independent `node --test` passed all 14 invoice tests. Evidence: `orchestrated-fresh-fixed-status.json`, `orchestrated-fresh-fixed-workers.json`, and `invoice-after-orchestrated-fixed-tests.txt`. A separate failure discovered when rerunning the canceled predecessor (`goal_control_stale`) led to the binding and generation repairs in cycle 4 below.
 
 Focused race suites for briefing, command execution, and ACP environment passed using the same
 source changes in an overlay before applying them to the checkout. The same focused suites and the built-in judge contract pass in the current checkout. The affected `make gate` passed: Go lint zero issues; daemon race suite 201.817s, Loop 221.158s, GlobalDB 937.904s; repaired spec-cycle fixture passed in the cached rerun. Web lint zero warnings/errors, typecheck and all 6,797 tests passed (existing cached test evidence). No task-file status was changed to bypass a judge.
+
+## Cycle 4 — terminal generation recovery and lifecycle events
+
+Real rerun of the canceled orchestrated predecessor exposed two independent owner-state errors.
+An unbound Goal checkpoint defaulted to binding epoch 1 although the run-local handle retained a
+closed attempt. Allocation now chooses the next epoch inside the existing checkpoint-owner
+transaction. Active binding policy checks, creation idempotency and explicit rotation fences remain
+unchanged. The canonical binding lifecycle integration suite reproduces the old failure and passes
+with eight concurrent callers and skipped-target rejection. Real closed-session rerun
+`looprun-bcd2b1ad861f8a46` completed generation 2 with a new real Codex session (154,991 cumulative
+reported tokens).
+
+The canceled predecessor also had run cursor 3 with immutable generation 4 already persisted.
+Rerun tried to insert generation 4 again. The service now plans from the latest lineage entry while
+retaining the original run projection for its atomic compare-and-swap. The existing service history
+suite checks latest carried results, parent generation, replay and the original ownership fence.
+Public rerun accepted generation 5 with parent 4 on the same database. Its quarantined cell stayed
+parked and the run settled failed under the existing policy: this verifies correct generation
+selection, not implicit unquarantine. No database row was manually repaired.
+
+Fable's real UI inspection found duplicate initial-round starts. The coordinator emitted both the
+pre-reservation and post-reservation lifecycle event using a stale in-memory cursor. Updating that
+cursor after the first snapshot prevents the second event. The existing succession observability
+matrix reproduced two starts instead of one, then passed after the production fix. Fresh public
+run `looprun-a2ea94c346678c31` completed with zero model tokens and exactly one `generation_started`
+event among its ten timeline entries. Historical event bytes remain unchanged.
+
+Evidence: `orchestrated-completed-binding-fixed-status.json`,
+`orchestrated-generation-fixed-rerun.json`, `orchestrated-generation-fixed-briefing.json`,
+`timeline-fixed-start.json`, `timeline-fixed-status.json`, `timeline-fixed-events.json` under
+`qa-artifacts/`; focused red/green logs are indexed under `qa-artifacts/qa/`. Current-checkout binding lifecycle integration passed with race detection (13.058s), and the
+succession matrix passed (4.190s). The final affected `make gate` passed: Go lint zero issues; daemon race suite 148.035s, Loop 158.463s and GlobalDB 821.279s. Web lint reported zero warnings/errors; typecheck and all 6,807 tests in 748 files passed. Existing test-environment act/navigation/timer diagnostics remain as recorded in the log; no assertion failed. Evidence: `qa-artifacts/qa/final-gate.log` and `final-gate-*.json`.
+
+
+A final real cancellation re-walk started orchestrated run `looprun-8aadd5927f46987b` and waited
+for actual Codex thought/tool events. Public cancellation revoked the in-flight first-generation
+prompt. Rerun then completed generation 2 with a distinct session, binding epoch 2, and an
+approved command judge (73,056 reported tokens). No orchestrator session remained active.
+Evidence: `cancel-recovery-final-{history,cancel,rerun,status,turns,active-sessions}.json` under
+`qa-artifacts/`. This covers cancellation recovery without a pre-existing quarantined cell.
+
+## Cycle 5 — progressive disclosure and terminal quarantine
+
+Claude Fable 5.1 at High effort worked through a named Herdr TUI. It used `eng-design`, `react`,
+`agent-browser` and the `eng-ui-screenshot` capture helpers. Production changes reuse `Button`,
+`cn`, existing state-chip `Pill`/`PillDot` and `Sheet` composites from `@compozy/ui`; no parallel
+primitive, palette or shared-package change was introduced.
+
+Real review/fix progress shrank from seven rows to one, and orchestrated progress from thirteen
+to seven. Successful control/source rows and declined routes fold behind a counted disclosure;
+expansion restores graph order. Running, pending, failed, parked and fan-out rows remain visible.
+Source rows no longer inflate the progress bar. A terminal quarantine entry keeps its hint and
+attempt chain but withdraws Requeue/Cancel and explains that the run ended. Live recovery remains
+available. Existing model, component and route suites cover those behaviors.
+
+The controller inspected the diff and before/after captures, including the terminal sheet and
+`RegisterRoutedGraph` at 1440×900. Evidence is retained in `qa-artifacts/qa/ui/`, including
+`fable-report.md`, `controller-verification.md`, and `VC-20-register-routed-graph.png`. The scoped
+density change is accepted under this user request; the historical task_05 visual bundle is not
+present in this checkout. This work does not claim to change historical reads whose stored status
+is still live. Fresh controller Turbo execution (with `--force`) passed all 183 tests in the three existing suites; zero tasks were cached. Worker-owned Storybook and browser sessions were stopped, and the accepted Fable TUI was retired.
 
 ## Cross-surface impact
 
 Audit follows `docs/_memory/change-impact.md` and is updated here across cycles.
 
-- Native tools: existing task-result and task-run reads recover their intended behavior. Briefing consumers receive corrected artifact identity/availability and concise human wording through the same DTO. No IDs, schemas, gates, or transport shapes change.
+- Native tools: existing task-result and task-run reads recover their intended behavior. Briefing consumers receive corrected artifact identity/availability and concise human wording through the same DTO. No IDs, schemas, authorization gates, or transport shapes change. Rerun chooses durable lineage and fresh Goal binding epochs; new runs emit one start event per round.
 - Extensibility/hooks/config: built-in import outputs can be carried safely. No extension manifest, hook, or config key changes. The built-in orchestrated judge now uses the daemon-bound executable; command evaluation receives the existing subprocess environment contract.
 - Workspace data isolation: deduplication is limited to identical results for the already-authorized task-run IDs. The existing task/workspace authorization and generation-payload owner checks remain authoritative; no schema migration or persisted rewrite is needed.
 - Official skill: checked `skills/compozy/references/loops.md`; documented daemon-bound command discovery; existing public operation and result shapes remain unchanged.
 - Web/docs: task-result consumers become readable after automatic succession. `TA-task-run-result-paging`, `LP-web-run-default-read-briefing`, and `LP-run-read-agent-journey` record the affected scenarios. Artifact counts exclude control markers; complete execution history remains in the roster/timeline/Inspect surfaces.
 
-The lab stays alive only for this same-session sequence. Final audit and targeted teardown with `clean: true` are required before closing the overall QA run.
+QA scope excludes unrelated network-channel collaboration; the bootstrap contract and its original copy record that explicit adjustment. Provider, role, artifact-reuse, disruption and cross-surface minimums remain enforced.
+
+The targeted lab teardown completed on 2026-09-05 at 03:41 UTC. `qa-artifacts/qa/teardown.json` records `clean: true` and no survivors. Runtime evidence and the project remain available; no QA server is left running. The affected gate and strict evidence audit passed. These results establish the recorded journeys and regression invariants, not a guarantee over every possible Loop definition.

--- a/docs/qa/reports/2026-09-04-loop-stability.md
+++ b/docs/qa/reports/2026-09-04-loop-stability.md
@@ -1,0 +1,41 @@
+# Loop stability — real runtime improvement cycles
+
+Status: in progress. Baseline: `13f4f3dbd`. Scope: loop/graph reliability, built-in engineering loops, and readable operator results.
+
+Lab: `/Users/pedronauck/dev/qa-labs/compozy-loop-stability-20260905-015002-636774-lab`; manifest: `qa-artifacts/qa/bootstrap-manifest.json`. Isolated daemon uses port 50084; Web uses port 3000 and the manifest proxy target. The operator's native Codex login is reused according to the provider's `native_cli`/`operator` policy. No production workspace or database is modified.
+
+## Cycle 1 — carried external results
+
+Related issue: [#541](https://github.com/compozy/compozy/issues/541). Inspection of the latest 100 PRs also covered recent provider failures, node-state projection, review finalization, recovery, and built-in delivery changes.
+
+The public CLI published a billing-planning Loop that imports 60 pending regional rollout tasks through the bundled spec-cycle action, then asks Codex `gpt-5.6-sol` to plan their execution. Its 23,953-byte import result exceeds the inline limit. A second definition introduces a missing receipt-task manifest after that successful import, exercising automatic `failed_only` succession.
+
+- Baseline run `looprun-90d6b772a7421f53` carried the successful import into generation 2 with its original task-run identity. Public task-result reads then failed with `multiple external results`.
+- Stopping and restarting the baseline daemon reproduced the reported startup failure: detached-harness recovery could not list terminal task runs. The process exited before readiness.
+- Starting the corrected binary against the **same database** succeeded. No state or history was rewritten. CLI/UDS and HTTP returned identical bytes, matching the original import from `looprun-249cd3c22209af4e`.
+- Payload SHA-256: `04a086956afa6d4a04df752c6f1fd50196ddb805fd0d110366aa856ce9e81001`.
+- Operator rerun was also exercised; its carried cells intentionally omit task-run identity, so automatic reattempt is the relevant reproduction for #541.
+
+Production change: both external-result queries deduplicate identical descriptors. Different content-addressed references still fail as corruption. Invariant owner: the existing `TestGlobalDBCompleteRunLeaseShouldStoreLargeLoopOutputByRef` GlobalDB suite, extended for three carried generations, reopen, all four readers, and conflicting descriptors.
+
+Validation: `CGO_ENABLED=1 go test -race ./internal/store/globaldb -run '^TestGlobalDBCompleteRunLeaseShouldStoreLargeLoopOutputByRef$' -count=1` fails before the fix and passes afterward. The test-shape checker reports the same eight unrelated baseline findings; none belongs to the changed suite. `make gate` passed: Go lint reported zero issues, and all affected `./internal/store/...` race suites passed (GlobalDB 860.622s; lane 878s).
+
+Evidence under `qa-artifacts/qa/`: `recovery-start.json`, `recovery-status-baseline.json`, `recovery-result-baseline.json`, `daemon-restart-baseline.stderr`, `daemon-restart-fixed.json`, `recovery-result-fixed.json`, and `recovery-result-http-fixed.json`.
+
+## Built-in review/fix and observed UI defect
+
+Real run `looprun-61ec517447b2aae9` reviewed a small invoice library with a deliberately incorrect floor-based implementation and existing nearest-cent acceptance tests. The reviewer reproduced the failing half-cent case, the fixer repaired production code and ran `node --test`, the artifact finalizer resolved the finding, and a second independent review ended the Loop as `done`. The run survived the intervening daemon restart. Initial Web observation: 2 rounds, 6m31s, approximately 194k reported tokens.
+
+The live result page displayed raw JSON from every node in its headline, including intermediate fan-out metadata and old review findings. This obscured the final outcome and pushed progress/history below the viewport. Remediation and further edge-case walks remain in progress.
+
+## Cross-surface impact
+
+Audit follows `docs/_memory/change-impact.md` and is updated here across cycles.
+
+- Native tools: existing task-result and task-run reads recover their intended behavior. No IDs, schemas, gates, or transport shapes change.
+- Extensibility/hooks/config: built-in import outputs can be carried safely. No extension manifest, hook, or config key changes in cycle 1.
+- Workspace data isolation: deduplication is limited to identical results for the already-authorized task-run IDs. The existing task/workspace authorization and generation-payload owner checks remain authoritative; no schema migration or persisted rewrite is needed.
+- Official skill: checked `skills/compozy/references/loops.md`; public operation and result semantics remain unchanged in cycle 1.
+- Web/docs: task-result consumers become readable after automatic succession. Existing `TA-task-run-result-paging` gains this scenario; the raw Loop headline finding is tracked above.
+
+The lab stays alive only for this same-session sequence. Final audit and targeted teardown with `clean: true` are required before closing the overall QA run.

--- a/docs/qa/reports/2026-09-04-loop-stability.md
+++ b/docs/qa/reports/2026-09-04-loop-stability.md
@@ -156,6 +156,10 @@ The targeted lab teardown completed on 2026-09-05 at 03:41 UTC. `qa-artifacts/qa
 
 ## PR delivery follow-up
 
-PR #554 includes fourteen real application screenshots uploaded with the official GitHub CLI attachment support. Its first full frontend CI run found the site's exact-copy Loop example still using bare `compozy`. The published MDX example now mirrors the shipped YAML; the existing `runtime-docs-truth` suite remains unchanged. The preflight language check also caught retired product wording in the new official-skill paragraph; it now uses the canonical CompozyOS name.
+PR #554 includes sixteen real application screenshots uploaded with the official GitHub CLI attachment support. Its first full frontend CI run found the site's exact-copy Loop example still using bare `compozy`. The published MDX example now mirrors the shipped YAML; the existing `runtime-docs-truth` suite remains unchanged. The preflight language check also caught retired product wording in the new official-skill paragraph; it now uses the canonical CompozyOS name.
 
 The capture walk also exposes a remaining generation-inspector projection discrepancy: the completed cancellation/rerun case has a done run and approved Goal turn, but generation rows show no verdict/interrupted and the roster can retain pending branches. This is documented in the PR rather than claimed repaired by the current changes.
+
+The subsequent CI run exposed two operational rows incorrectly folded with static metadata: Last woke and Best result. The About rail now keeps both visible when present, while identity and configuration remain collapsed. Existing watch-events and best-generation E2E assertions are unchanged. E2E-012 now expands About before checking the intentionally folded identity. The pre-existing terminal keyboard test targets the xterm input instead of its non-focusable log wrapper and additionally verifies real command output through the daemon; terminal production code is unchanged.
+
+Controller verification for the CI repair: fresh root Turbo component execution passed 166 tests with no cache; the rebuilt Web app and real daemon passed all four focused Playwright scenarios (default read, durable watch cursor, exhausted best-generation navigation, terminal keyboard activation and command output). Runtime fixtures disposed their owned daemons after each case.

--- a/docs/qa/reports/2026-09-04-loop-stability.md
+++ b/docs/qa/reports/2026-09-04-loop-stability.md
@@ -28,14 +28,35 @@ Real run `looprun-61ec517447b2aae9` reviewed a small invoice library with a deli
 
 The live result page displayed raw JSON from every node in its headline, including intermediate fan-out metadata and old review findings. This obscured the final outcome and pushed progress/history below the viewport. Remediation and further edge-case walks remain in progress.
 
+## Cycle 2 — readable outcomes and retained result content
+
+The real review/fix run returned a 2,644-character headline and 14 artifact rows. Nine rows represented control/source execution markers rather than action results; all inline JSON results were falsely labeled pruned because only external blob availability was checked.
+
+The briefing now keeps payloads out of labels/headlines, identifies unnamed results by their producer/round/item, lists the latest round first, excludes execution markers, and recognizes inline results as available. Explicit logical artifact identities and pruned result records remain intact. Web previews three results, expands older results and raw contents on demand, and keeps aggregate partial/pruned signals visible even when their rows are folded. About metadata is collapsed by default; Usage remains visible.
+
+Real validation against the same persisted run after a normal daemon restart:
+
+- CLI and HTTP agree on the 19-character headline and five available action results. The human CLI keeps its separate `Produced:` lines.
+- Chrome displays the final review first. Expanding its Details shows `{"issues":[]}`; expanding the additional results and first review exposes the original finding. No history bytes were changed.
+- About expands to the original version, inputs, caller, workspace, run ID and copy control.
+- `TestBriefingContract` passes with race detection. The affected `make gate` passed: Loop race suite 156.988s, GlobalDB race suite 954.587s, Web lint with zero warnings/errors, typecheck, and all 6,797 Web tests in 748 files. Untouched session/OS tests emitted React act and NaN timer diagnostics; no assertions failed.
+
+Evidence: `review-briefing-fixed.json`, `review-briefing-http-fixed.json`, `review-briefing-fixed.txt`, `daemon-restart-ui.json`; rendered Chrome observations and screenshot in the working session.
+
+## Built-in task implementation
+
+Run `looprun-fcf613da6349b2d6` used `implement-tasks` in `per-task` mode with two dependent invoice-library tasks and Codex `gpt-5.6-sol`. Separate real worker sessions validated monetary inputs, then added exact item totalization. Both task frontmatter statuses reached `completed`; the Loop settled `done` in generation 1. An independent `node --test` passed all seven tests, preserving the original rounding assertions and covering invalid inputs, full discounts, individually rounded items, and safe-integer overflow. No implementation or tracking commit was requested in the customer project.
+
+Evidence: `implement-per-task-start.json`, `implement-per-task-status.json`, and `.compozy/tasks/invoice-validation/` in the lab project.
+
 ## Cross-surface impact
 
 Audit follows `docs/_memory/change-impact.md` and is updated here across cycles.
 
-- Native tools: existing task-result and task-run reads recover their intended behavior. No IDs, schemas, gates, or transport shapes change.
+- Native tools: existing task-result and task-run reads recover their intended behavior. Briefing consumers receive corrected artifact identity/availability and concise human wording through the same DTO. No IDs, schemas, gates, or transport shapes change.
 - Extensibility/hooks/config: built-in import outputs can be carried safely. No extension manifest, hook, or config key changes in cycle 1.
 - Workspace data isolation: deduplication is limited to identical results for the already-authorized task-run IDs. The existing task/workspace authorization and generation-payload owner checks remain authoritative; no schema migration or persisted rewrite is needed.
 - Official skill: checked `skills/compozy/references/loops.md`; public operation and result semantics remain unchanged in cycle 1.
-- Web/docs: task-result consumers become readable after automatic succession. Existing `TA-task-run-result-paging` gains this scenario; the raw Loop headline finding is tracked above.
+- Web/docs: task-result consumers become readable after automatic succession. `TA-task-run-result-paging`, `LP-web-run-default-read-briefing`, and `LP-run-read-agent-journey` record the affected scenarios. Artifact counts exclude control markers; complete execution history remains in the roster/timeline/Inspect surfaces.
 
 The lab stays alive only for this same-session sequence. Final audit and targeted teardown with `clean: true` are required before closing the overall QA run.

--- a/docs/qa/reports/2026-09-04-loop-stability.md
+++ b/docs/qa/reports/2026-09-04-loop-stability.md
@@ -147,9 +147,15 @@ Audit follows `docs/_memory/change-impact.md` and is updated here across cycles.
 - Native tools: existing task-result and task-run reads recover their intended behavior. Briefing consumers receive corrected artifact identity/availability and concise human wording through the same DTO. No IDs, schemas, authorization gates, or transport shapes change. Rerun chooses durable lineage and fresh Goal binding epochs; new runs emit one start event per round.
 - Extensibility/hooks/config: built-in import outputs can be carried safely. No extension manifest, hook, or config key changes. The built-in orchestrated judge now uses the daemon-bound executable; command evaluation receives the existing subprocess environment contract.
 - Workspace data isolation: deduplication is limited to identical results for the already-authorized task-run IDs. The existing task/workspace authorization and generation-payload owner checks remain authoritative; no schema migration or persisted rewrite is needed.
-- Official skill: checked `skills/compozy/references/loops.md`; documented daemon-bound command discovery; existing public operation and result shapes remain unchanged.
+- Official skill/site: `skills/compozy/references/loops.md` documents daemon-bound command discovery. The complete `implement-tasks` YAML example in `packages/site/content/docs/examples/implement-tasks-loop.mdx` mirrors the quoted `COMPOZY_BIN` invocation; existing public operation and result shapes remain unchanged.
 - Web/docs: task-result consumers become readable after automatic succession. `TA-task-run-result-paging`, `LP-web-run-default-read-briefing`, and `LP-run-read-agent-journey` record the affected scenarios. Artifact counts exclude control markers; complete execution history remains in the roster/timeline/Inspect surfaces.
 
 QA scope excludes unrelated network-channel collaboration; the bootstrap contract and its original copy record that explicit adjustment. Provider, role, artifact-reuse, disruption and cross-surface minimums remain enforced.
 
 The targeted lab teardown completed on 2026-09-05 at 03:41 UTC. `qa-artifacts/qa/teardown.json` records `clean: true` and no survivors. Runtime evidence and the project remain available; no QA server is left running. The affected gate and strict evidence audit passed. These results establish the recorded journeys and regression invariants, not a guarantee over every possible Loop definition.
+
+## PR delivery follow-up
+
+PR #554 includes fourteen real application screenshots uploaded with the official GitHub CLI attachment support. Its first full frontend CI run found the site's exact-copy Loop example still using bare `compozy`. The published MDX example now mirrors the shipped YAML; the existing `runtime-docs-truth` suite remains unchanged. The preflight language check also caught retired product wording in the new official-skill paragraph; it now uses the canonical CompozyOS name.
+
+The capture walk also exposes a remaining generation-inspector projection discrepancy: the completed cancellation/rerun case has a done run and approved Goal turn, but generation rows show no verdict/interrupted and the roster can retain pending branches. This is documented in the PR rather than claimed repaired by the current changes.

--- a/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
+++ b/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
@@ -37,3 +37,11 @@ Speed and typed ACP-option defaults before pinning the immutable creation profil
 the controller expressly prohibits the local E2E needed to repeat the orchestrated-mode public walk.
 The focused race-test evidence is recorded in the worker report and the cited canonical suites; it does
 not substitute for a public-interface walk. No QA lab or runtime process was started, so teardown is not applicable.
+
+QA impact 2026-09-04 (loop-stability): live Codex workers completed both dependent receipt tasks
+and stopped, but the deterministic judge could not find `compozy` in its PATH. The evaluator now
+shares the daemon-bound subprocess environment and the built-in check uses quoted `COMPOZY_BIN`.
+Fresh real-provider re-walk `looprun-bcd2b1ad861f8a46` passed: one actual worker completed exact
+decimal parsing, stopped, and the Loop settled `done` in generation 1; all 14 independent invoice
+tests passed. Canceled-run recovery separately exposed binding-epoch allocation and generation
+selection failures under investigation. Evidence: the loop-stability report, cycle 3.

--- a/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
+++ b/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
@@ -45,3 +45,8 @@ Fresh real-provider re-walk `looprun-bcd2b1ad861f8a46` passed: one actual worker
 decimal parsing, stopped, and the Loop settled `done` in generation 1; all 14 independent invoice
 tests passed. Canceled-run recovery separately exposed binding-epoch allocation and generation
 selection failures under investigation. Evidence: the loop-stability report, cycle 3.
+
+QA 2026-09-05 (loop-stability): rerunning a completed Goal uses a fresh binding epoch after
+terminal cleanup; live run `looprun-bcd2b1ad861f8a46` completed generation 2. The prior canceled
+run's immutable next-round selection also recovers without rewriting history. Quarantined nodes
+remain parked under existing policy. See the loop-stability report, cycle 4.

--- a/docs/qa/scenarios/LP-run-read-agent-journey.md
+++ b/docs/qa/scenarios/LP-run-read-agent-journey.md
@@ -81,3 +81,8 @@ logical names are separate from result bytes and terminal headlines remain conci
 CLI still prints each result on its own `Produced:` line. This walk covers the changed briefing
 projection; the broader node/resume scenarios retain their independently recorded status.
 Evidence: `docs/qa/reports/2026-09-04-loop-stability.md`, cycle 2.
+
+QA result 2026-09-04 (recovery): only current-round node state contributes to blockers/activity.
+The printed terminal rerun was accepted for the failed receipt import after its manifest became
+available. Generation 2 remained `running / ok`, then settled `done / ok` without old failure
+blockers. CLI keeps all original node history. Evidence: the loop-stability report, cycle 3.

--- a/docs/qa/scenarios/LP-run-read-agent-journey.md
+++ b/docs/qa/scenarios/LP-run-read-agent-journey.md
@@ -73,3 +73,11 @@ QA impact 2026-09-04: reset because branch-skipped terminal nodes now require du
 PR owner explicitly prohibited local E2E, so verification requires a human-run isolated lab. Re-run
 `CH-loop-legibility-run-read-resume` and compare `compozy loop nodes --all -o json` over CLI, HTTP,
 and UDS for a completed false branch and a failed run with an unfinished node.
+
+QA result 2026-09-04: the persisted built-in run `looprun-61ec517447b2aae9` was reopened after
+restart. Public CLI/UDS and HTTP briefings agreed on five available action results, including
+inline JSON from both rounds. Control and skipped-route markers no longer appear as artifacts;
+logical names are separate from result bytes and terminal headlines remain concise. The human
+CLI still prints each result on its own `Produced:` line. This walk covers the changed briefing
+projection; the broader node/resume scenarios retain their independently recorded status.
+Evidence: `docs/qa/reports/2026-09-04-loop-stability.md`, cycle 2.

--- a/docs/qa/scenarios/LP-run-read-agent-journey.md
+++ b/docs/qa/scenarios/LP-run-read-agent-journey.md
@@ -86,3 +86,8 @@ QA result 2026-09-04 (recovery): only current-round node state contributes to bl
 The printed terminal rerun was accepted for the failed receipt import after its manifest became
 available. Generation 2 remained `running / ok`, then settled `done / ok` without old failure
 blockers. CLI keeps all original node history. Evidence: the loop-stability report, cycle 3.
+
+QA 2026-09-05 (loop-stability): a canceled run with cursor 3 and persisted round 4 now reruns from
+round 4 into round 5 without a uniqueness conflict; quarantine remains protected. A fresh
+completed run emits one initial-round start despite pre/post-reservation snapshots. Evidence:
+`docs/qa/reports/2026-09-04-loop-stability.md`, cycle 4.

--- a/docs/qa/scenarios/LP-web-run-default-read-briefing.md
+++ b/docs/qa/scenarios/LP-web-run-default-read-briefing.md
@@ -29,3 +29,12 @@ steps:
 4. Confirm the briefing offers no Approve/Reject — only the quiet pointer to the card.
 5. Let the run finish, reload, and confirm the outcome and artifacts lead the page.
 6. Repeat against a failed run and confirm the failure signal is visible with everything collapsed.
+
+QA result 2026-09-04: a real two-round built-in review/fix run exposed a 2,644-character JSON
+headline and false retention warnings. The corrected default read has a 19-character outcome
+headline and three previews of five actual action results, with latest-round results first.
+Content and remaining results expand on demand; partial/pruned counts remain visible while folded.
+About metadata starts collapsed and preserves its links, inputs, identity, and copy control when
+opened. The final empty review and the earlier finding were both opened in Chrome after a daemon
+restart. CLI and HTTP returned matching result identity, availability, and headline.
+Evidence: `docs/qa/reports/2026-09-04-loop-stability.md`, cycle 2.

--- a/docs/qa/scenarios/LP-web-run-default-read-briefing.md
+++ b/docs/qa/scenarios/LP-web-run-default-read-briefing.md
@@ -25,7 +25,7 @@ not walk its rendered briefing, needs-you, progress, story, Usage, or About cont
 steps:
 1. Start a loop run that reaches a human approval gate and open `/loop-runs/<run-id>` with every disclosure collapsed.
 2. Read the briefing strip, the needs-you card, the progress line and the story without expanding anything.
-3. Confirm the run id appears only in the About rail, never in the main column.
+3. Expand About and confirm the run id appears only there, never in the main column. With About closed, confirm a recorded Last woke timestamp and daemon-selected Best result link remain visible when present.
 4. Confirm the briefing offers no Approve/Reject — only the quiet pointer to the card.
 5. Let the run finish, reload, and confirm the outcome and artifacts lead the page.
 6. Repeat against a failed run and confirm the failure signal is visible with everything collapsed.

--- a/docs/qa/scenarios/LP-web-run-default-read-briefing.md
+++ b/docs/qa/scenarios/LP-web-run-default-read-briefing.md
@@ -38,3 +38,19 @@ About metadata starts collapsed and preserves its links, inputs, identity, and c
 opened. The final empty review and the earlier finding were both opened in Chrome after a daemon
 restart. CLI and HTTP returned matching result identity, availability, and headline.
 Evidence: `docs/qa/reports/2026-09-04-loop-stability.md`, cycle 2.
+
+QA result 2026-09-05 (Progress disclosure): the same runs, read in Chrome, showed the Progress
+list contradicting its own heading — "Step 1 of 1" over seven rows (five "not taken"), and
+"Step 7 of 7" over thirteen identical "succeeded" rows with an eight-segment bar, because control
+and source nodes rendered exactly like the counted steps. The default read now lists only the
+counted steps and anything parked, failed, running, or still ahead; control and source rows that
+succeeded and branches the route declined fold behind "N more steps · X succeeded · Y not taken",
+and one click brings them back in graph order. Fan-out bands, quarantined and pending rows never
+fold; nothing folds when fewer than two rows are quiet or when nothing would remain. The bar now
+draws one segment per counted step, matching the heading. On a terminal run, the quarantine row
+in Needs you reads "Set aside after N attempts. This run has ended." and keeps "Open entry"; the
+entry sheet keeps the hint, facts and attempt chain but offers neither Requeue nor Cancel, and its
+foot says the run has ended. Live runs keep the requeue instruction and both verbs. Observed on
+`looprun-61ec517447b2aae9` (done, review-and-fix), `looprun-bcd2b1ad861f8a46` (done,
+orchestrated), and `looprun-c494117598fe2188` (failed, quarantined `orchestrate`). VC-20
+(`RegisterRoutedGraph`) recaptured at 1440×900 through the eng-ui-screenshot helper.

--- a/docs/qa/scenarios/TA-task-run-result-paging.md
+++ b/docs/qa/scenarios/TA-task-run-result-paging.md
@@ -20,4 +20,8 @@ Create one Loop action result that crosses both the 16 KiB inline boundary and 6
 
 QA impact 2026-08-31: new public task-run result resource and agent-manageable readers.
 
+Carry the external result through automatic `failed_only` generations while preserving its task-run identity. Confirm task read/list/status-list and paged result reads still describe one result, then stop and restart the daemon and compare the bytes. Identical references are valid provenance; different references for one task run remain corruption.
+
+QA 2026-09-04: the live 60-task import and missing-dependent-manifest scenario reproduced a failed baseline boot. The corrected binary reopened the same state and CLI/UDS plus HTTP returned the original 23,953 bytes with SHA-256 `04a086956afa6d4a04df752c6f1fd50196ddb805fd0d110366aa856ce9e81001`. The canonical GlobalDB suite verifies all four readers and conflicting descriptors. See `docs/qa/reports/2026-09-04-loop-stability.md` for commands and evidence.
+
 QA 2026-08-31: CLI/UDS, HTTP, and `compozy__task_run_result` returned the same descriptor and ordered 16 KiB byte pages. Five decoded pages reconstructed 71,694 bytes with SHA-256 `97eca41229b21547388b09aa0f26e9a46f7fee61bc2a85daa8cc4169a670da3f` before and after restart. An inline 1,944-byte run returned one JSON page with `eof=true`; invalid range returned 400 and a missing run returned the masked 404 shape. Canonical store/service tests own corruption, multibyte-boundary, and foreign-workspace probes.

--- a/extensions/spec-cycle/embed_test.go
+++ b/extensions/spec-cycle/embed_test.go
@@ -1186,7 +1186,7 @@ printf '{"type":"list_page","page":{"total":0}}\n'
 	command.Dir = workspace
 	command.Env = append(
 		os.Environ(),
-		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"COMPOZY_BIN="+filepath.Join(fakeBin, "compozy"),
 	)
 	if activeWorker {
 		command.Env = append(command.Env, "COMPOZY_TEST_ACTIVE_WORKER=1")

--- a/extensions/spec-cycle/loops/implement-tasks/loop.yaml
+++ b/extensions/spec-cycle/loops/implement-tasks/loop.yaml
@@ -282,7 +282,7 @@ graph:
               ' "$f" || exit 1;
               done;
               for state in starting active stopping; do
-              sessions="$(compozy session list --type spawned --state "$state" --query "orchestrate-${slug}-" --limit 1 -o jsonl)" || exit 1;
+              sessions="$("$COMPOZY_BIN" session list --type spawned --state "$state" --query "orchestrate-${slug}-" --limit 1 -o jsonl)" || exit 1;
               if printf '%s\n' "$sessions" | grep -q '"id"[[:space:]]*:'; then exit 1; fi;
               done
         max_turns: 12

--- a/internal/acp/client_process.go
+++ b/internal/acp/client_process.go
@@ -136,7 +136,8 @@ func normalizeStartOpts(opts StartOpts) (StartOpts, error) {
 	return normalized, nil
 }
 
-func daemonMatchedEnv(base []string) []string {
+// DaemonMatchedEnv binds subprocess CLI discovery to the executable running the daemon.
+func DaemonMatchedEnv(base []string) []string {
 	env := append([]string(nil), base...)
 	if len(env) == 0 {
 		env = os.Environ()

--- a/internal/acp/client_start_contract_test.go
+++ b/internal/acp/client_start_contract_test.go
@@ -216,7 +216,7 @@ func TestDaemonMatchedEnvPinsCurrentBinary(t *testing.T) {
 	}
 	binDir := filepath.Dir(executable)
 
-	env := daemonMatchedEnv([]string{
+	env := DaemonMatchedEnv([]string{
 		"PATH=/should-be-ignored",
 		"FOO=bar",
 		"COMPOZY_BIN=/should-be-replaced",
@@ -226,16 +226,16 @@ func TestDaemonMatchedEnvPinsCurrentBinary(t *testing.T) {
 
 	gotCompozyBin, ok := envValue(env, "COMPOZY_BIN")
 	if !ok || gotCompozyBin != executable {
-		t.Fatalf("daemonMatchedEnv() COMPOZY_BIN = %q, %v, want %q", gotCompozyBin, ok, executable)
+		t.Fatalf("DaemonMatchedEnv() COMPOZY_BIN = %q, %v, want %q", gotCompozyBin, ok, executable)
 	}
 
 	gotPath, ok := envValue(env, "PATH")
 	if !ok {
-		t.Fatal("daemonMatchedEnv() PATH missing")
+		t.Fatal("DaemonMatchedEnv() PATH missing")
 	}
 	wantPath := binDir + string(os.PathListSeparator) + "/usr/local/bin" + string(os.PathListSeparator) + "/usr/bin"
 	if gotPath != wantPath {
-		t.Fatalf("daemonMatchedEnv() PATH = %q, want %q", gotPath, wantPath)
+		t.Fatalf("DaemonMatchedEnv() PATH = %q, want %q", gotPath, wantPath)
 	}
 
 	pathCount := 0
@@ -250,7 +250,7 @@ func TestDaemonMatchedEnvPinsCurrentBinary(t *testing.T) {
 	}
 	if pathCount != 1 || compozyBinCount != 1 {
 		t.Fatalf(
-			"daemonMatchedEnv() duplicate entries remain: PATH=%d COMPOZY_BIN=%d env=%#v",
+			"DaemonMatchedEnv() duplicate entries remain: PATH=%d COMPOZY_BIN=%d env=%#v",
 			pathCount,
 			compozyBinCount,
 			env,

--- a/internal/acp/launch_identity.go
+++ b/internal/acp/launch_identity.go
@@ -154,7 +154,7 @@ func (l *localLauncher) PrepareLaunch(
 	}
 
 	next := spec
-	next.Env = daemonMatchedEnv(spec.Env)
+	next.Env = DaemonMatchedEnv(spec.Env)
 	if next.ResolvedExecutable != "" {
 		next.Args = append([]string(nil), next.Args...)
 		return next, nil

--- a/internal/daemon/loop_runtime_adapters.go
+++ b/internal/daemon/loop_runtime_adapters.go
@@ -223,6 +223,7 @@ func (r loopGateCommandRunner) RunCommand(
 	// this boundary only through command templates whose emitted actions end in shellQuote.
 	cmd := exec.CommandContext(ctx, "sh", "-c", command)
 	cmd.Dir = rootDir
+	cmd.Env = acp.DaemonMatchedEnv(cmd.Environ())
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -645,6 +645,27 @@ func TestLoopGateCommandRunnerShouldExecuteInResolvedWorkspace(t *testing.T) {
 		}
 	})
 
+	t.Run("Should invoke the daemon executable through the command environment", func(t *testing.T) {
+		t.Parallel()
+		rootDir := t.TempDir()
+		runner := loopGateCommandRunner{workspaceResolver: loopActionBinderWorkspaceResolver{
+			byID: map[string]workspacepkg.ResolvedWorkspace{
+				"ws-command": {Workspace: workspacepkg.Workspace{ID: "ws-command", RootDir: rootDir}},
+			},
+		}}
+		result, err := runner.RunCommand(t.Context(), gate.CommandRequest{
+			WorkspaceID: "ws-command",
+			Command:     `"$COMPOZY_BIN" -test.list '^TestLoopGateCommandRunnerShouldExecuteInResolvedWorkspace$'`,
+		})
+		if err != nil {
+			t.Fatalf("RunCommand() error = %v", err)
+		}
+		if result.ExitCode != 0 ||
+			strings.TrimSpace(result.Stdout) != "TestLoopGateCommandRunnerShouldExecuteInResolvedWorkspace" {
+			t.Fatalf("daemon executable command = %#v", result)
+		}
+	})
+
 	t.Run("Should fail before execution when the workspace cannot be resolved", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/loop/briefing.go
+++ b/internal/loop/briefing.go
@@ -266,6 +266,7 @@ func nodeBlocker(kind string, source *BriefingSource, node RosterNode) Blocker {
 
 func failureRerunCommand(source *BriefingSource, node RosterNode) string {
 	run := source.Run
+	run.Generation = currentBriefingGeneration(source)
 	if !run.Status.Terminal() || node.Generation != run.Generation {
 		return ""
 	}

--- a/internal/loop/briefing.go
+++ b/internal/loop/briefing.go
@@ -302,7 +302,7 @@ func terminalBriefing(result Briefing, source *BriefingSource) Briefing {
 		result.Headline = "Run finished without producing outputs."
 		result.Artifacts = []RunArtifact{}
 	} else {
-		result.Headline = terminalHeadline(*result.Outcome, result.Artifacts)
+		result.Headline = terminalHeadline(*result.Outcome)
 	}
 	result.Detail = progressDetail(result.Progress)
 	return result
@@ -315,9 +315,6 @@ func labelTerminalArtifacts(artifacts []RunArtifact) []RunArtifact {
 			label = strings.TrimSpace(artifacts[index].Output)
 		}
 		if label == "" {
-			label = strings.TrimSpace(artifacts[index].Ref)
-		}
-		if label == "" {
 			label = fmt.Sprintf("output %d", index+1)
 		}
 		artifacts[index].Name = label
@@ -325,25 +322,11 @@ func labelTerminalArtifacts(artifacts []RunArtifact) []RunArtifact {
 	return artifacts
 }
 
-func terminalHeadline(outcome RunOutcome, artifacts []RunArtifact) string {
-	base := fmt.Sprintf("Run finished: %s.", outcome.Status)
+func terminalHeadline(outcome RunOutcome) string {
 	if outcome.ActorKind != "" {
-		base = fmt.Sprintf(
-			"Run %s by %s %s at %s.",
-			outcome.Status,
-			outcome.ActorKind,
-			outcome.ActorRef,
-			outcome.At.Format(time.RFC3339),
-		)
+		return fmt.Sprintf("Run %s by %s %s.", outcome.Status, outcome.ActorKind, outcome.ActorRef)
 	}
-	names := []string{}
-	for _, item := range artifacts {
-		names = append(names, item.Name)
-	}
-	if len(names) > 0 {
-		base += " Produced: " + strings.Join(names, ", ") + "."
-	}
-	return base
+	return fmt.Sprintf("Run finished: %s.", outcome.Status)
 }
 
 func usageFromRun(run Run, now time.Time) RunUsage {

--- a/internal/loop/briefing.go
+++ b/internal/loop/briefing.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/kballard/go-shellquote"
 )
 
@@ -90,6 +91,8 @@ type Briefing struct {
 
 // BriefingSource contains the durable facts required to project one briefing.
 type BriefingSource struct {
+	Graph                dsl.Graph
+	Outputs              []GenerationOutput
 	Run                  Run
 	Roster               RosterPage
 	Requests             []Request
@@ -126,7 +129,7 @@ func ProjectBriefing(source *BriefingSource) Briefing {
 		result.Headline = "Waiting for the configured watch source."
 		result.Detail = "No new matching input has arrived."
 	default:
-		result.Headline = runningHeadline(source.Roster, source.Run.Generation)
+		result.Headline = runningHeadline(source.Roster, result.Progress.Round)
 		result.Detail = progressDetail(result.Progress)
 	}
 	return result
@@ -165,6 +168,7 @@ func ProgressFromRosterSource(source *RosterSource) (StepProgress, error) {
 }
 
 func briefingBlockers(source *BriefingSource, now time.Time) []Blocker {
+	generation := currentBriefingGeneration(source)
 	items := []Blocker{}
 	if source.Run.Status == StatusNeedsApproval || source.Run.ActiveGateID != "" {
 		items = append(items, Blocker{
@@ -178,8 +182,11 @@ func briefingBlockers(source *BriefingSource, now time.Time) []Blocker {
 		})
 	}
 	for _, node := range source.Roster.Nodes {
+		if node.Generation != generation {
+			continue
+		}
 		if node.State == NodeStateQuarantined {
-			items = append(items, nodeBlocker(string(NodeControlMutationQuarantine), source.Run, node))
+			items = append(items, nodeBlocker(string(NodeControlMutationQuarantine), source, node))
 		}
 	}
 	for _, request := range source.Requests {
@@ -204,8 +211,11 @@ func briefingBlockers(source *BriefingSource, now time.Time) []Blocker {
 		items = append(items, blocker)
 	}
 	for _, node := range source.Roster.Nodes {
+		if node.Generation != generation {
+			continue
+		}
 		if node.State == NodeStateFailed {
-			items = append(items, nodeBlocker(namespaceFailureKey, source.Run, node))
+			items = append(items, nodeBlocker(namespaceFailureKey, source, node))
 		}
 		if node.State == NodeStateRetrying {
 			items = append(items, Blocker{
@@ -234,21 +244,49 @@ func requestUnblockerDecision(request Request) string {
 	return "<decision>"
 }
 
-func nodeBlocker(kind string, run Run, node RosterNode) Blocker {
+func nodeBlocker(kind string, source *BriefingSource, node RosterNode) Blocker {
+	run := source.Run
 	waitingSince := timeOrZero(node.StartedAt)
 	if kind == namespaceFailureKey {
 		waitingSince = timeOrZero(node.EndedAt)
 	}
-	return Blocker{
-		Kind: kind, NodeID: node.NodeID, ItemIndex: node.ItemIndex,
-		WaitingSince: waitingSince,
-		Unblocker: shellquote.Join(
+	blocker := Blocker{Kind: kind, NodeID: node.NodeID, ItemIndex: node.ItemIndex, WaitingSince: waitingSince}
+	if kind == namespaceFailureKey {
+		blocker.Unblocker = failureRerunCommand(source, node)
+	} else if !run.Status.Terminal() {
+		blocker.Unblocker = shellquote.Join(
 			"compozy", "loop", "node", "requeue",
 			"--workspace", string(run.WorkspaceID),
 			"--run-id", string(run.ID),
 			"--node", string(node.NodeID),
-		),
+		)
 	}
+	return blocker
+}
+
+func failureRerunCommand(source *BriefingSource, node RosterNode) string {
+	run := source.Run
+	if !run.Status.Terminal() || node.Generation != run.Generation {
+		return ""
+	}
+	outputs := make([]GenerationOutput, 0)
+	for _, output := range source.Outputs {
+		if output.Generation == run.Generation {
+			outputs = append(outputs, output)
+		}
+	}
+	// Advertise only a rerun the existing planner accepts, including pending dependents.
+	_, labels, err := planOperatorRerun(source.Graph, outputs, node.NodeID, &node.ItemIndex, run.Generation+1)
+	if err != nil || validateTerminalRerunOutputs(outputs, labels) != nil {
+		return ""
+	}
+	return shellquote.Join(
+		"compozy", "loop", "rerun",
+		"--workspace", string(run.WorkspaceID),
+		"--run-id", string(run.ID),
+		"--from-node", string(node.NodeID),
+		"--item", strconv.Itoa(node.ItemIndex),
+	)
 }
 
 func blockerTone(kind string) BriefingTone {

--- a/internal/loop/briefing_test.go
+++ b/internal/loop/briefing_test.go
@@ -281,7 +281,7 @@ func TestBriefingContract(t *testing.T) {
 		if got.Outcome == nil || len(got.Artifacts) != 3 ||
 			got.Outcome.Cause != "verified" || got.Detail == "" ||
 			got.Artifacts[2].Availability != ArtifactPruned ||
-			!strings.Contains(got.Headline, "Produced: report, summary, archive") {
+			got.Headline != "Run finished: done." {
 			t.Fatalf("briefing = %#v", got)
 		}
 	})
@@ -296,13 +296,13 @@ func TestBriefingContract(t *testing.T) {
 			{},
 		}
 		got := ProjectBriefing(&source)
-		wantNames := []string{"report", "summary-output", "sha256:archive", "output 4"}
+		wantNames := []string{"report", "summary-output", "output 3", "output 4"}
 		gotNames := make([]string, 0, len(got.Artifacts))
 		for _, artifact := range got.Artifacts {
 			gotNames = append(gotNames, artifact.Name)
 		}
 		if !slices.Equal(gotNames, wantNames) ||
-			got.Headline != "Run finished: done. Produced: report, summary-output, sha256:archive, output 4." {
+			got.Headline != "Run finished: done." {
 			t.Fatalf("briefing = %#v, want artifact names %#v", got, wantNames)
 		}
 	})
@@ -313,7 +313,7 @@ func TestBriefingContract(t *testing.T) {
 		source.Artifacts = []RunArtifact{{}, {}}
 		got := ProjectBriefing(&source)
 		if len(got.Artifacts) != 2 ||
-			got.Headline != "Run finished: done. Produced: output 1, output 2." ||
+			got.Headline != "Run finished: done." ||
 			got.Artifacts[0].Name != "output 1" || got.Artifacts[1].Name != "output 2" {
 			t.Fatalf("briefing = %#v", got)
 		}
@@ -332,7 +332,7 @@ func TestBriefingContract(t *testing.T) {
 	})
 	t.Run("Should preserve durable logical artifact identity in UT-051", func(t *testing.T) {
 		t.Parallel()
-		artifacts := artifactsFromOutputs([]GenerationOutput{{
+		artifacts := artifactsFromOutputs(dsl.Graph{}, []GenerationOutput{{
 			NodeID:       "writer-node",
 			ItemIndex:    3,
 			TaskRunID:    "task-run-internal",
@@ -343,6 +343,58 @@ func TestBriefingContract(t *testing.T) {
 		if len(artifacts) != 1 || artifacts[0].Name != "post-final.md" ||
 			artifacts[0].Output != "saida" || artifacts[0].Ref != "sha256:retained" {
 			t.Fatalf("artifacts = %#v", artifacts)
+		}
+	})
+	t.Run("Should keep large result payloads out of the terminal headline", func(t *testing.T) {
+		t.Parallel()
+		source := healthyBriefing(now)
+		source.Run.Status = StatusCanceled
+		source.Outcome = &RunOutcome{Status: StatusCanceled, ActorKind: "human", ActorRef: "pedro", At: now}
+		payload := `{"summary":"` + strings.Repeat("result ", 1000) + `"}`
+		for range 100 {
+			source.Artifacts = append(source.Artifacts, RunArtifact{Ref: payload, Availability: ArtifactAvailable})
+		}
+		got := ProjectBriefing(&source)
+		if got.Headline != "Run canceled by human pedro." || len(got.Artifacts) != 100 ||
+			got.Artifacts[0].Name != "output 1" || got.Artifacts[0].Ref != payload ||
+			got.Outcome.ActorRef != source.Outcome.ActorRef {
+			t.Fatalf("terminal briefing lost detail or promoted it into the headline: %#v", got)
+		}
+	})
+	t.Run("Should expose retained action results without control markers or false pruning", func(t *testing.T) {
+		t.Parallel()
+		graph := dsl.Graph{Nodes: []dsl.Node{
+			{ID: "review", Class: dsl.NodeClassAction},
+			{ID: "branch", Class: dsl.NodeClassControl},
+			{ID: "collect", Class: dsl.NodeClassControl},
+			{ID: "input", Class: dsl.NodeClassSource},
+		}}
+		retained := OutputRefForPayload(json.RawMessage(`{"report":"retained"}`))
+		pruned := OutputRefForPayload(json.RawMessage(`{"report":"pruned"}`))
+		outputs := []GenerationOutput{
+			{NodeID: "input", OutputRef: `"slug"`},
+			{NodeID: "branch", OutputRef: "branch:true"},
+			{NodeID: "collect", OutputRef: `{"count":2}`},
+			{NodeID: "review", OutputRef: branchSkippedOutputRef},
+			{NodeID: "review", Generation: 1, Status: "succeeded", OutputRef: `{"findings":[]}`},
+			{NodeID: "review", Generation: 2, Status: "partial", OutputRef: `{"findings":["incomplete"]}`},
+			{NodeID: "review", Generation: 2, ItemIndex: 1, Status: "succeeded", OutputRef: retained},
+			{NodeID: "review", Generation: 2, ItemIndex: 2, Status: "succeeded", OutputRef: pruned},
+		}
+		got := artifactsFromOutputs(graph, outputs, map[string]bool{retained: true})
+		if len(got) != 4 {
+			t.Fatalf("artifacts = %#v, want four action results", got)
+		}
+		want := []ArtifactAvailability{ArtifactPartial, ArtifactAvailable, ArtifactPruned, ArtifactAvailable}
+		wantRefs := []string{outputs[5].OutputRef, retained, pruned, outputs[4].OutputRef}
+		for index, item := range got {
+			if item.Availability != want[index] || item.Ref != wantRefs[index] ||
+				strings.Contains(item.Name, "{") || !strings.Contains(item.Name, "review") {
+				t.Fatalf("artifact %d = %#v", index, item)
+			}
+		}
+		if got[0].Name == got[1].Name || got[1].Name == got[2].Name {
+			t.Fatalf("round and item identities are ambiguous: %#v", got)
 		}
 	})
 	t.Run("Should derive the terminal outcome from durable status evidence", func(t *testing.T) {

--- a/internal/loop/briefing_test.go
+++ b/internal/loop/briefing_test.go
@@ -60,7 +60,10 @@ func TestBriefingContract(t *testing.T) {
 		t.Parallel()
 		source := healthyBriefing(now)
 		source.Run.ActiveGateID = "gate"
-		source.Roster.Nodes = append(source.Roster.Nodes, RosterNode{NodeID: "q", State: NodeStateQuarantined})
+		source.Roster.Nodes = append(
+			source.Roster.Nodes,
+			RosterNode{Generation: 2, NodeID: "q", State: NodeStateQuarantined},
+		)
 		source.Requests = []Request{
 			{
 				LoopRunID: "run-a",
@@ -259,6 +262,81 @@ func TestBriefingContract(t *testing.T) {
 		got := ProjectBriefing(&source)
 		if got.Tone != BriefingToneOK || !strings.Contains(got.Headline, "live") {
 			t.Fatalf("briefing = %#v", got)
+		}
+	})
+	t.Run("Should ignore historical failures and controls after a new round starts", func(t *testing.T) {
+		t.Parallel()
+		source := healthyBriefing(now)
+		source.Roster.Nodes = append(source.Roster.Nodes,
+			RosterNode{Generation: 1, NodeID: "old-failure", State: NodeStateFailed},
+			RosterNode{Generation: 1, NodeID: "old-quarantine", State: NodeStateQuarantined},
+			RosterNode{Generation: 1, NodeID: "old-retry", State: NodeStateRetrying},
+			RosterNode{Generation: 3, NodeID: "current-worker", State: NodeStateRunning, Action: true},
+		)
+		got := ProjectBriefing(&source)
+		if len(got.Blockers) != 0 || got.Tone != BriefingToneOK || got.Progress.Round != 3 ||
+			!strings.Contains(got.Headline, "current-worker") {
+			t.Fatalf("historical state replaced current work: %#v", got)
+		}
+		source.Run.Status = StatusDone
+		source.Run.Generation = 3
+		source.Roster.Nodes[len(source.Roster.Nodes)-1].State = NodeStateSucceeded
+		got = ProjectBriefing(&source)
+		if len(got.Blockers) != 0 || got.Tone != BriefingToneOK {
+			t.Fatalf("completed recovery retains historical blockers: %#v", got)
+		}
+	})
+	t.Run(
+		"Should offer a terminal rerun that preserves the failed lane and its pending dependents",
+		func(t *testing.T) {
+			t.Parallel()
+			source := healthyBriefing(now)
+			source.Run.Status = StatusFailed
+			source.Run.WorkspaceID = "workspace with spaces"
+			source.Graph = dsl.Graph{
+				Nodes: []dsl.Node{
+					{ID: "failed", Class: dsl.NodeClassAction},
+					{ID: "after", Class: dsl.NodeClassAction},
+				},
+				Edges: []dsl.Edge{{From: "failed", To: "after"}},
+			}
+			source.Roster.Nodes = []RosterNode{{Generation: 2, NodeID: "failed", State: NodeStateFailed}}
+			source.Outputs = []GenerationOutput{
+				{Generation: 2, NodeID: "failed", Status: "failed"},
+				{Generation: 2, NodeID: "after", Status: "pending"},
+			}
+			got := ProjectBriefing(&source)
+			assertBlockerCommand(t, got.Blockers, 0, []string{
+				"compozy", "loop", "rerun", "--workspace", "workspace with spaces",
+				"--run-id", "run-a", "--from-node", "failed", "--item", "0",
+			})
+			// An unrelated in-flight cell makes this same suggestion invalid at the owner.
+			source.Outputs = append(source.Outputs, GenerationOutput{
+				Generation: 2, NodeID: "unrelated", Status: "enqueued",
+			})
+			got = ProjectBriefing(&source)
+			if len(got.Blockers) != 1 || got.Blockers[0].Unblocker != "" {
+				t.Fatalf("advertised a rerun the planner rejects: %#v", got.Blockers)
+			}
+		},
+	)
+	t.Run("Should not recommend terminal-only reruns during live failure settlement", func(t *testing.T) {
+		t.Parallel()
+		source := healthyBriefing(now)
+		source.Roster.Nodes[1].State = NodeStateFailed
+		got := ProjectBriefing(&source)
+		if len(got.Blockers) != 1 || got.Blockers[0].Unblocker != "" {
+			t.Fatalf("live failure command = %#v", got.Blockers)
+		}
+	})
+	t.Run("Should not recommend requeue after terminal quarantine settlement", func(t *testing.T) {
+		t.Parallel()
+		source := healthyBriefing(now)
+		source.Run.Status = StatusFailed
+		source.Roster.Nodes[1].State = NodeStateQuarantined
+		got := ProjectBriefing(&source)
+		if len(got.Blockers) != 1 || got.Blockers[0].Unblocker != "" {
+			t.Fatalf("terminal quarantine command = %#v", got.Blockers)
 		}
 	})
 	t.Run("Should satisfy UT-051 with typed terminal outcome and artifact availability", func(t *testing.T) {

--- a/internal/loop/briefing_test.go
+++ b/internal/loop/briefing_test.go
@@ -310,6 +310,10 @@ func TestBriefingContract(t *testing.T) {
 				"compozy", "loop", "rerun", "--workspace", "workspace with spaces",
 				"--run-id", "run-a", "--from-node", "failed", "--item", "0",
 			})
+			source.Run.Generation = 1
+			if latest := ProjectBriefing(&source); latest.Blockers[0].Unblocker != got.Blockers[0].Unblocker {
+				t.Fatalf("latest persisted round lost recovery guidance: %#v", latest.Blockers)
+			}
 			// An unrelated in-flight cell makes this same suggestion invalid at the owner.
 			source.Outputs = append(source.Outputs, GenerationOutput{
 				Generation: 2, NodeID: "unrelated", Status: "enqueued",

--- a/internal/loop/run_read_briefing.go
+++ b/internal/loop/run_read_briefing.go
@@ -1,9 +1,15 @@
 package loop
 
 import (
+	"cmp"
 	"context"
+	"encoding/json"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
+
+	"github.com/compozy/compozy/internal/loop/dsl"
 )
 
 func (s *computedRunReadService) Briefing(
@@ -24,7 +30,7 @@ func (s *computedRunReadService) Briefing(
 	if err != nil {
 		return Briefing{}, fmt.Errorf("read loop briefing requests: %w", err)
 	}
-	artifacts, err := s.loadArtifacts(ctx, ws, runID, source.Outputs)
+	artifacts, err := s.loadArtifacts(ctx, ws, runID, source.Graph, source.Outputs)
 	if err != nil {
 		return Briefing{}, err
 	}
@@ -112,6 +118,7 @@ func (s *computedRunReadService) loadArtifacts(
 	ctx context.Context,
 	workspaceID WorkspaceID,
 	runID RunID,
+	graph dsl.Graph,
 	outputs []GenerationOutput,
 ) ([]RunArtifact, error) {
 	refs := outputRefs(outputs)
@@ -127,7 +134,7 @@ func (s *computedRunReadService) loadArtifacts(
 			available[ref] = true
 		}
 	}
-	return artifactsFromOutputs(outputs, available), nil
+	return artifactsFromOutputs(graph, outputs, available), nil
 }
 
 func outputRefs(outputs []GenerationOutput) []string {
@@ -143,21 +150,38 @@ func outputRefs(outputs []GenerationOutput) []string {
 	return refs
 }
 
-func artifactsFromOutputs(outputs []GenerationOutput, available map[string]bool) []RunArtifact {
+func artifactsFromOutputs(graph dsl.Graph, outputs []GenerationOutput, available map[string]bool) []RunArtifact {
+	actions := make(map[string]bool, len(graph.Nodes))
+	for _, node := range graph.Nodes {
+		actions[string(node.ID)] = node.Class == dsl.NodeClassAction
+	}
+	outputs = slices.Clone(outputs)
+	slices.SortStableFunc(outputs, func(a, b GenerationOutput) int {
+		return cmp.Compare(b.Generation, a.Generation)
+	})
 	items := make([]RunArtifact, 0)
 	for _, output := range outputs {
-		if output.OutputRef == "" {
+		if output.OutputRef == "" || outputRefRepresentsAbsentValue(output.OutputRef) ||
+			(!actions[output.NodeID] && output.ArtifactName == "" && output.OutputID == "") {
 			continue
 		}
 		availability := ArtifactPruned
-		if available[output.OutputRef] {
+		// Small results live in the generation row itself; blob retention does not own them.
+		if json.Valid([]byte(output.OutputRef)) || available[output.OutputRef] {
 			availability = ArtifactAvailable
+			if output.Status == string(NodeStatePartial) {
+				availability = ArtifactPartial
+			}
 		}
-		if available[output.OutputRef] && output.Status == string(NodeStatePartial) {
-			availability = ArtifactPartial
+		name := strings.TrimSpace(output.ArtifactName)
+		if name == "" {
+			name = strings.TrimSpace(output.OutputID)
+		}
+		if name == "" {
+			name = fmt.Sprintf("%s (round %d, item %d)", output.NodeID, output.Generation, output.ItemIndex+1)
 		}
 		items = append(items, RunArtifact{
-			Name:         output.ArtifactName,
+			Name:         name,
 			Output:       output.OutputID,
 			Ref:          output.OutputRef,
 			Availability: availability,

--- a/internal/loop/run_read_briefing.go
+++ b/internal/loop/run_read_briefing.go
@@ -39,6 +39,8 @@ func (s *computedRunReadService) Briefing(
 		return Briefing{}, err
 	}
 	return ProjectBriefing(&BriefingSource{
+		Graph:                source.Graph,
+		Outputs:              source.Outputs,
 		Run:                  source.Run,
 		Roster:               roster,
 		Requests:             requests,

--- a/internal/loop/service_test.go
+++ b/internal/loop/service_test.go
@@ -2900,6 +2900,58 @@ func TestServiceTimeTravelShouldPreserveHistoryContracts(t *testing.T) {
 		}
 	})
 
+	t.Run("Should rerun the latest persisted generation when cancellation precedes its boundary", func(t *testing.T) {
+		t.Parallel()
+		store := newTimeTravelFakeStore()
+		service := newTestServiceWithOptions(t, store, validDefinition())
+		run, err := service.Start(context.Background(), "ws-1", "valid-loop", loop.Inputs{
+			ProfileID: storepkg.DefaultProfileID, Values: map[string]any{"tasks": "task-ref"},
+		}, humanActor(t))
+		if err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+		run.Status, run.Generation = loop.StatusCanceled, 1
+		store.seed(*run)
+		store.generationOutputs[run.ID] = []loop.GenerationOutput{
+			{Generation: 1, NodeID: "load", Status: "succeeded", OutputRef: "old-load"},
+			{Generation: 1, NodeID: "agent", Status: "failed"},
+			{Generation: 2, NodeID: "load", Status: "succeeded", OutputRef: "latest-load"},
+			{Generation: 2, NodeID: "agent", Status: "canceled"},
+		}
+		svc := service.(loop.TimeTravelService)
+		input := loop.RerunInput{
+			WorkspaceID: run.WorkspaceID,
+			RunID:       run.ID,
+			FromNode:    "agent",
+			RequestID:   "rerun-latest",
+			Actor:       humanActor(t),
+		}
+		result, err := svc.RerunFromNode(context.Background(), input)
+		if err != nil {
+			t.Fatalf("RerunFromNode() error = %v", err)
+		}
+		if result.Generation != 3 || result.ParentGeneration != 2 {
+			t.Fatalf("rerun = %#v, want generation 3 from 2", result)
+		}
+		request := store.rerunRequest
+		if request.Source.Generation != 1 || *request.Operation.SourceGeneration != 2 {
+			t.Fatalf("rerun request = %#v, want original CAS and latest provenance", request)
+		}
+		for _, output := range request.NextOutputs {
+			if output.Generation != 3 {
+				t.Fatalf("output = %#v, want generation 3", output)
+			}
+			if output.NodeID == "load" && output.OutputRef != "latest-load" {
+				t.Fatalf("carried output = %#v, want latest result", output)
+			}
+		}
+		store.rerunReplay, store.replayDigest = &result, request.RequestDigest
+		replay, err := svc.RerunFromNode(context.Background(), input)
+		if err != nil || !replay.Replayed || replay.Generation != 3 {
+			t.Fatalf("replay = %#v, error = %v", replay, err)
+		}
+	})
+
 	t.Run("Should create an immutable seeded linked fork UT-078 through UT-082b", func(t *testing.T) {
 		t.Parallel()
 
@@ -3793,6 +3845,27 @@ func (s *timeTravelFakeStore) ListRouteCauses(
 	generation int64,
 ) ([]loop.RouteCause, error) {
 	return append([]loop.RouteCause(nil), s.routes[timeTravelHistoryKey(runID, generation)]...), nil
+}
+
+func (s *timeTravelFakeStore) ListGenerations(
+	_ context.Context,
+	workspaceID, runID string,
+) ([]loop.LoopGeneration, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	run, ok := s.runs[loop.RunID(runID)]
+	if !ok || string(run.WorkspaceID) != workspaceID {
+		return nil, loop.ErrRunNotFound
+	}
+	seen := map[int]bool{run.Generation: true}
+	for _, output := range s.generationOutputs[run.ID] {
+		seen[output.Generation] = true
+	}
+	var result []loop.LoopGeneration
+	for generation := range seen {
+		result = append(result, loop.LoopGeneration{RunID: runID, Generation: int64(generation)})
+	}
+	return result, nil
 }
 
 func (s *timeTravelFakeStore) CreateRerun(

--- a/internal/loop/service_timetravel.go
+++ b/internal/loop/service_timetravel.go
@@ -26,6 +26,10 @@ func (s *service) RerunFromNode(ctx context.Context, input RerunInput) (RerunRes
 	if err != nil {
 		return RerunResult{}, err
 	}
+	historyRun, err := rerunHistoryRun(ctx, store, run)
+	if err != nil {
+		return RerunResult{}, err
+	}
 	digest, err := rerunRequestDigest(run, input)
 	if err != nil {
 		return RerunResult{}, err
@@ -36,7 +40,7 @@ func (s *service) RerunFromNode(ctx context.Context, input RerunInput) (RerunRes
 		return RerunResult{}, replayErr
 	} else if found {
 		outputs, _, rerunNodes, planErr := s.planRerunGeneration(
-			ctx, run, int(replay.ParentGeneration), input.FromNode, input.ItemIndex, int(replay.Generation),
+			ctx, historyRun, int(replay.ParentGeneration), input.FromNode, input.ItemIndex, int(replay.Generation),
 		)
 		if planErr != nil {
 			return RerunResult{}, planErr
@@ -54,9 +58,9 @@ func (s *service) RerunFromNode(ctx context.Context, input RerunInput) (RerunRes
 			"run_id": string(run.ID), namespaceStatusKey: string(run.Status),
 		})
 	}
-	nextGeneration := run.Generation + 1
+	nextGeneration := historyRun.Generation + 1
 	outputs, next, rerunNodes, err := s.planRerunGeneration(
-		ctx, run, run.Generation, input.FromNode, input.ItemIndex, nextGeneration,
+		ctx, historyRun, historyRun.Generation, input.FromNode, input.ItemIndex, nextGeneration,
 	)
 	if err != nil {
 		return RerunResult{}, err
@@ -65,7 +69,7 @@ func (s *service) RerunFromNode(ctx context.Context, input RerunInput) (RerunRes
 		timeTravelKindRerun,
 		input.RequestID,
 		digest,
-		run,
+		historyRun,
 		input.Actor,
 		input.Reason,
 		input.FromNode,
@@ -79,7 +83,7 @@ func (s *service) RerunFromNode(ctx context.Context, input RerunInput) (RerunRes
 	}
 	result, replayed, err := store.CreateRerun(ctx, RerunStoreRequest{
 		WorkspaceID: input.WorkspaceID, Source: &run, NextOutputs: next,
-		Intent: GenerationIntent{Generation: int64(nextGeneration), ParentGeneration: int64(run.Generation),
+		Intent: GenerationIntent{Generation: int64(nextGeneration), ParentGeneration: int64(historyRun.Generation),
 			Origin: OriginOperatorRerun},
 		Operation: op, RequestDigest: digest, IdempotencyKey: strings.TrimSpace(input.RequestID), At: s.now(),
 	})
@@ -90,6 +94,19 @@ func (s *service) RerunFromNode(ctx context.Context, input RerunInput) (RerunRes
 	result.Carried = len(outputs) - len(rerunNodes)
 	result.Replayed = replayed
 	return result, nil
+}
+
+// Reruns use immutable generation history: a successor can be persisted before
+// its first coordinator boundary updates the run's generation projection.
+func rerunHistoryRun(ctx context.Context, reader GenerationLineageReader, run Run) (Run, error) {
+	generations, err := reader.ListGenerations(ctx, string(run.WorkspaceID), string(run.ID))
+	if err != nil {
+		return Run{}, err
+	}
+	for _, generation := range generations {
+		run.Generation = max(run.Generation, int(generation.Generation))
+	}
+	return run, nil
 }
 
 func rerunRequestDigest(run Run, input RerunInput) (string, error) {

--- a/internal/loop/timetravel_types.go
+++ b/internal/loop/timetravel_types.go
@@ -156,6 +156,7 @@ type ForkStoreRequest struct {
 }
 
 type TimeTravelStore interface {
+	GenerationLineageReader
 	LookupRerunReplay(context.Context, WorkspaceID, string, string) (RerunResult, bool, error)
 	CreateRerun(context.Context, RerunStoreRequest) (RerunResult, bool, error)
 	CreateFork(context.Context, ForkStoreRequest) (Run, bool, error)

--- a/internal/store/globaldb/global_db_goal_binding_allocate.go
+++ b/internal/store/globaldb/global_db_goal_binding_allocate.go
@@ -193,10 +193,16 @@ func allocateNextSessionBindingAttempt(
 	if creatingCount != 0 {
 		return goal.SessionBinding{}, goalControlStaleError("another binding creation attempt is already pending")
 	}
-	if req.TargetBindingEpoch != maximumEpoch+1 {
+	epoch := req.TargetBindingEpoch
+	if req.ExpectedCheckpointBindingEpoch == 0 && epoch == 1 {
+		// A new generation has no binding checkpoint, but the run-local handle
+		// can retain closed attempts from earlier generations. Allocate under
+		// this transaction's owner fence instead of restarting its history.
+		epoch = maximumEpoch + 1
+	}
+	if epoch != maximumEpoch+1 {
 		return goal.SessionBinding{}, goalControlStaleError("binding allocation must target the next epoch")
 	}
-	epoch := req.TargetBindingEpoch
 	attemptID, sessionID := goal.DeriveBindingIdentity(req.CheckpointKey, req.IdentityHandle, epoch)
 	creationOptions := req.CreationOptions
 	creationOptions.SessionID = sessionID

--- a/internal/store/globaldb/global_db_goal_binding_integration_test.go
+++ b/internal/store/globaldb/global_db_goal_binding_integration_test.go
@@ -152,161 +152,198 @@ func TestGoalSessionCreationIdentityIntegration(t *testing.T) {
 func TestGoalSessionBindingLifecycleIntegration(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should atomically rotate an active same-profile binding to the target epoch", func(t *testing.T) {
-		t.Parallel()
+	for _, tc := range []struct {
+		name           string
+		closePrior     bool
+		targetEpoch    int64
+		wantPriorState goal.BindingState
+	}{
+		{name: "Should atomically rotate an active same-profile binding to the target epoch", targetEpoch: 2, wantPriorState: goal.BindingStateReseeded},
+		{name: "Should allocate the next binding for an unbound generation after terminal cleanup", closePrior: true, targetEpoch: 1, wantPriorState: goal.BindingStateClosed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		const (
-			workspaceID = "ws-goal-binding-allocate"
-			loopRunID   = "run-goal-binding-allocate"
-			handle      = "goal:binding-allocate"
-		)
-		globalDB := openLoopTestGlobalDB(t, workspaceID)
-		ctx := testutil.Context(t)
-		now := time.Date(2026, 8, 26, 14, 0, 0, 0, time.UTC)
-		insertGoalSchemaLoopRun(t, globalDB, loopRunID, workspaceID, "catalog", nil)
-		profile := store.SessionCreationProfile{
-			Version: store.SessionCreationProfileVersion, AgentName: "codex", Provider: "native",
-			ProfileID: store.DefaultProfileID, WorkspaceID: workspaceID, CWD: "/tmp",
-			SandboxMode: store.SessionCreationSandboxNone,
-		}
-		profileRef, err := profile.Ref()
-		if err != nil {
-			t.Fatalf("SessionCreationProfile.Ref() error = %v", err)
-		}
-		policyDigest, err := profile.PolicySpecDigest()
-		if err != nil {
-			t.Fatalf("SessionCreationProfile.PolicySpecDigest() error = %v", err)
-		}
-		creationOptions := store.SessionCreationOptions{
-			NetworkOwnerKey:      "loop_run:" + loopRunID,
-			NetworkParticipation: participation.LocalSpec(),
-			SessionType:          "loop-goal",
-		}
-		priorOptions := creationOptions
-		priorOptions.SessionID = "session-binding-allocate-1"
-		priorCreationDigest, err := profile.CreationDigest(priorOptions)
-		if err != nil {
-			t.Fatalf("SessionCreationProfile.CreationDigest() error = %v", err)
-		}
-		seedActiveGoalBindingWithIdentityForTest(
-			t,
-			globalDB,
-			loopRunID,
-			workspaceID,
-			handle,
-			1,
-			priorOptions.SessionID,
-			goal.BindingOwnershipRunOwned,
-			store.SessionCreationIdentity{
-				CreationProfileRef: profileRef,
-				PolicySpecDigest:   policyDigest,
-				CreationDigest:     priorCreationDigest,
-			},
-			now,
-		)
-		if _, err := globalDB.db.ExecContext(
-			ctx,
-			`UPDATE loop_runs SET generation = 2 WHERE id = ? AND workspace_id = ?`,
-			loopRunID,
-			workspaceID,
-		); err != nil {
-			t.Fatalf("advance Goal Run generation error = %v", err)
-		}
-		checkpointKey := goal.TurnKey{
-			WorkspaceID: workspaceID,
-			LoopRunID:   loopRunID,
-			Generation:  2,
-			NodeID:      "goal-binding-allocate",
-		}
-		if _, err := globalDB.CreateCheckpoint(ctx, goal.CreateCheckpointRequest{Checkpoint: goal.Checkpoint{
-			Key: checkpointKey, ControlEpoch: 1, Phase: "idle", Status: "active", TurnLimit: 3,
-			TaskRunID: "task-goal-binding-allocate", ContextState: "unknown", ContextNudgeRatio: 0.8,
-			UpdatedAt: now.Add(2 * time.Second),
-		}}); err != nil {
-			t.Fatalf("CreateCheckpoint() error = %v", err)
-		}
-		request := goal.AllocateBindingAttemptRequest{
-			Key:           goal.BindingKey{WorkspaceID: workspaceID, LoopRunID: loopRunID, Handle: handle},
-			CheckpointKey: checkpointKey, ExpectedControlEpoch: 1, ExpectedCheckpointPhase: "idle",
-			TargetBindingEpoch: 2, ExpectedTaskRunID: "task-goal-binding-allocate", IdentityHandle: handle,
-			CreationProfile: profile,
-			CreationOptions: creationOptions,
-			CreatedAt:       now.Add(3 * time.Second),
-		}
-
-		const contenders = 8
-		results := make(chan goal.SessionBinding, contenders)
-		errorsCh := make(chan error, contenders)
-		var wait sync.WaitGroup
-		wait.Add(contenders)
-		for range contenders {
-			go func() {
-				defer wait.Done()
-				binding, err := globalDB.AllocateSessionBindingAttempt(testutil.Context(t), &request)
-				if err != nil {
-					errorsCh <- err
-					return
-				}
-				results <- binding
-			}()
-		}
-		wait.Wait()
-		close(results)
-		close(errorsCh)
-		for err := range errorsCh {
-			t.Errorf("AllocateSessionBindingAttempt() error = %v", err)
-		}
-		wantAttemptID, wantSessionID := goal.DeriveBindingIdentity(checkpointKey, handle, 2)
-		for binding := range results {
-			if binding.BindingEpoch != 2 || binding.State != goal.BindingStateCreating ||
-				binding.BindingAttemptID != wantAttemptID || binding.SessionID != wantSessionID {
-				t.Errorf("allocated binding = %#v, want deterministic creating epoch 2", binding)
+			const (
+				workspaceID = "ws-goal-binding-allocate"
+				loopRunID   = "run-goal-binding-allocate"
+				handle      = "goal:binding-allocate"
+			)
+			globalDB := openLoopTestGlobalDB(t, workspaceID)
+			ctx := testutil.Context(t)
+			now := time.Date(2026, 8, 26, 14, 0, 0, 0, time.UTC)
+			insertGoalSchemaLoopRun(t, globalDB, loopRunID, workspaceID, "catalog", nil)
+			profile := store.SessionCreationProfile{
+				Version: store.SessionCreationProfileVersion, AgentName: "codex", Provider: "native",
+				ProfileID: store.DefaultProfileID, WorkspaceID: workspaceID, CWD: "/tmp",
+				SandboxMode: store.SessionCreationSandboxNone,
 			}
-		}
-		var bindingCount int
-		if err := globalDB.db.QueryRowContext(
-			ctx,
-			`SELECT COUNT(*) FROM loop_session_bindings WHERE loop_run_id = ? AND handle = ?`,
-			loopRunID,
-			handle,
-		).Scan(&bindingCount); err != nil {
-			t.Fatalf("count Goal bindings error = %v", err)
-		}
-		if bindingCount != 2 {
-			t.Fatalf("binding count = %d, want active epoch 1 and creating epoch 2", bindingCount)
-		}
-		creating, err := globalDB.GetSessionBindingAttempt(ctx, request.Key, request.TargetBindingEpoch)
-		if err != nil {
-			t.Fatalf("GetSessionBindingAttempt(rotation) error = %v", err)
-		}
-		registerGoalSessionIdentityForTest(
-			t,
-			globalDB,
-			goalSessionInfoForTest(creating.SessionID, workspaceID, now.Add(4*time.Second)),
-			store.SessionCreationIdentity{
-				CreationProfileRef: creating.CreationProfileRef,
-				PolicySpecDigest:   creating.PolicySpecDigest,
-				CreationDigest:     creating.CreationDigest,
-			},
-		)
-		activated, stopped, err := globalDB.FinalizeSessionBindingCreation(ctx, goal.ActivateBindingRequest{
-			Key: request.Key, CheckpointKey: &checkpointKey, ExpectedBindingEpoch: request.TargetBindingEpoch,
-			ExpectedControlEpoch: request.ExpectedControlEpoch, ActivatedAt: now.Add(5 * time.Second),
+			profileRef, err := profile.Ref()
+			if err != nil {
+				t.Fatalf("SessionCreationProfile.Ref() error = %v", err)
+			}
+			policyDigest, err := profile.PolicySpecDigest()
+			if err != nil {
+				t.Fatalf("SessionCreationProfile.PolicySpecDigest() error = %v", err)
+			}
+			creationOptions := store.SessionCreationOptions{
+				NetworkOwnerKey:      "loop_run:" + loopRunID,
+				NetworkParticipation: participation.LocalSpec(),
+				SessionType:          "loop-goal",
+			}
+			priorOptions := creationOptions
+			priorOptions.SessionID = "session-binding-allocate-1"
+			priorCreationDigest, err := profile.CreationDigest(priorOptions)
+			if err != nil {
+				t.Fatalf("SessionCreationProfile.CreationDigest() error = %v", err)
+			}
+			seedActiveGoalBindingWithIdentityForTest(
+				t,
+				globalDB,
+				loopRunID,
+				workspaceID,
+				handle,
+				1,
+				priorOptions.SessionID,
+				goal.BindingOwnershipRunOwned,
+				store.SessionCreationIdentity{
+					CreationProfileRef: profileRef,
+					PolicySpecDigest:   policyDigest,
+					CreationDigest:     priorCreationDigest,
+				},
+				now,
+			)
+			if tc.closePrior {
+				if err := globalDB.CloseSessionBinding(ctx, goal.CloseBindingRequest{
+					Key: goal.BindingKey{
+						WorkspaceID: workspaceID,
+						LoopRunID:   loopRunID,
+						Handle:      handle,
+					},
+					ExpectedBindingEpoch: 1,
+					ClosedAt:             now.Add(time.Second),
+				}); err != nil {
+					t.Fatalf("CloseSessionBinding(prior generation) error = %v", err)
+				}
+			}
+			if _, err := globalDB.db.ExecContext(
+				ctx,
+				`UPDATE loop_runs SET generation = 2 WHERE id = ? AND workspace_id = ?`,
+				loopRunID,
+				workspaceID,
+			); err != nil {
+				t.Fatalf("advance Goal Run generation error = %v", err)
+			}
+			checkpointKey := goal.TurnKey{
+				WorkspaceID: workspaceID,
+				LoopRunID:   loopRunID,
+				Generation:  2,
+				NodeID:      "goal-binding-allocate",
+			}
+			if _, err := globalDB.CreateCheckpoint(ctx, goal.CreateCheckpointRequest{Checkpoint: goal.Checkpoint{
+				Key: checkpointKey, ControlEpoch: 1, Phase: "idle", Status: "active", TurnLimit: 3,
+				TaskRunID: "task-goal-binding-allocate", ContextState: "unknown", ContextNudgeRatio: 0.8,
+				UpdatedAt: now.Add(2 * time.Second),
+			}}); err != nil {
+				t.Fatalf("CreateCheckpoint() error = %v", err)
+			}
+			request := goal.AllocateBindingAttemptRequest{
+				Key: goal.BindingKey{
+					WorkspaceID: workspaceID,
+					LoopRunID:   loopRunID,
+					Handle:      handle,
+				},
+				CheckpointKey:           checkpointKey,
+				ExpectedControlEpoch:    1,
+				ExpectedCheckpointPhase: "idle",
+				TargetBindingEpoch:      tc.targetEpoch,
+				ExpectedTaskRunID:       "task-goal-binding-allocate",
+				IdentityHandle:          handle,
+				CreationProfile:         profile,
+				CreationOptions:         creationOptions,
+				CreatedAt:               now.Add(3 * time.Second),
+			}
+
+			invalid := request
+			invalid.TargetBindingEpoch = 3
+			if _, err := globalDB.AllocateSessionBindingAttempt(ctx, &invalid); err == nil {
+				t.Fatal("AllocateSessionBindingAttempt() accepted a skipped target epoch")
+			}
+
+			const contenders = 8
+			results := make(chan goal.SessionBinding, contenders)
+			errorsCh := make(chan error, contenders)
+			var wait sync.WaitGroup
+			wait.Add(contenders)
+			for range contenders {
+				go func() {
+					defer wait.Done()
+					binding, err := globalDB.AllocateSessionBindingAttempt(testutil.Context(t), &request)
+					if err != nil {
+						errorsCh <- err
+						return
+					}
+					results <- binding
+				}()
+			}
+			wait.Wait()
+			close(results)
+			close(errorsCh)
+			for err := range errorsCh {
+				t.Errorf("AllocateSessionBindingAttempt() error = %v", err)
+			}
+			wantAttemptID, wantSessionID := goal.DeriveBindingIdentity(checkpointKey, handle, 2)
+			for binding := range results {
+				if binding.BindingEpoch != 2 || binding.State != goal.BindingStateCreating ||
+					binding.BindingAttemptID != wantAttemptID || binding.SessionID != wantSessionID {
+					t.Errorf("allocated binding = %#v, want deterministic creating epoch 2", binding)
+				}
+			}
+			var bindingCount int
+			if err := globalDB.db.QueryRowContext(
+				ctx,
+				`SELECT COUNT(*) FROM loop_session_bindings WHERE loop_run_id = ? AND handle = ?`,
+				loopRunID,
+				handle,
+			).Scan(&bindingCount); err != nil {
+				t.Fatalf("count Goal bindings error = %v", err)
+			}
+			if bindingCount != 2 {
+				t.Fatalf("binding count = %d, want active epoch 1 and creating epoch 2", bindingCount)
+			}
+			creating, err := globalDB.GetSessionBindingAttempt(ctx, request.Key, 2)
+			if err != nil {
+				t.Fatalf("GetSessionBindingAttempt(rotation) error = %v", err)
+			}
+			registerGoalSessionIdentityForTest(
+				t,
+				globalDB,
+				goalSessionInfoForTest(creating.SessionID, workspaceID, now.Add(4*time.Second)),
+				store.SessionCreationIdentity{
+					CreationProfileRef: creating.CreationProfileRef,
+					PolicySpecDigest:   creating.PolicySpecDigest,
+					CreationDigest:     creating.CreationDigest,
+				},
+			)
+			activated, stopped, err := globalDB.FinalizeSessionBindingCreation(ctx, goal.ActivateBindingRequest{
+				Key: request.Key, CheckpointKey: &checkpointKey, ExpectedBindingEpoch: 2,
+				ExpectedControlEpoch: request.ExpectedControlEpoch, ActivatedAt: now.Add(5 * time.Second),
+			})
+			if err != nil || stopped {
+				t.Fatalf("FinalizeSessionBindingCreation(rotation) = %#v/%t, %v", activated, stopped, err)
+			}
+			if activated.BindingEpoch != 2 || activated.State != goal.BindingStateActive {
+				t.Fatalf("activated rotation = %#v, want active epoch %d", activated, 2)
+			}
+			prior, err := globalDB.GetSessionBindingAttempt(ctx, request.Key, 1)
+			if err != nil {
+				t.Fatalf("GetSessionBindingAttempt(prior) error = %v", err)
+			}
+			if prior.State != tc.wantPriorState {
+				t.Fatalf("prior binding state = %q, want %q", prior.State, tc.wantPriorState)
+			}
 		})
-		if err != nil || stopped {
-			t.Fatalf("FinalizeSessionBindingCreation(rotation) = %#v/%t, %v", activated, stopped, err)
-		}
-		if activated.BindingEpoch != request.TargetBindingEpoch || activated.State != goal.BindingStateActive {
-			t.Fatalf("activated rotation = %#v, want active epoch %d", activated, request.TargetBindingEpoch)
-		}
-		prior, err := globalDB.GetSessionBindingAttempt(ctx, request.Key, 1)
-		if err != nil {
-			t.Fatalf("GetSessionBindingAttempt(prior) error = %v", err)
-		}
-		if prior.State != goal.BindingStateReseeded {
-			t.Fatalf("prior binding state = %q, want %q", prior.State, goal.BindingStateReseeded)
-		}
-	})
+	}
 
 	t.Run("Should replay cleanup metadata while rejecting a changed immutable identity", func(t *testing.T) {
 		t.Parallel()

--- a/internal/store/globaldb/global_db_task_claim_test.go
+++ b/internal/store/globaldb/global_db_task_claim_test.go
@@ -8297,12 +8297,43 @@ func TestGlobalDBCompleteRunLeaseShouldStoreLargeLoopOutputByRef(t *testing.T) {
 		if !outputRef.Valid || outputRef.String != wantRef {
 			t.Fatalf("output_ref = %#v, want %q", outputRef, wantRef)
 		}
+		for generation := 2; generation <= 3; generation++ {
+			if _, err := globalDB.db.ExecContext(ctx, `INSERT INTO loop_generation_outputs (
+				loop_run_id, generation, node_id, item_index, status, output_ref, task_run_id
+			) SELECT loop_run_id, ?, node_id, item_index, status, output_ref, task_run_id
+			  FROM loop_generation_outputs
+			  WHERE loop_run_id = ? AND generation = 1 AND node_id = 'summarize' AND item_index = 0`,
+				generation, string(loopRun.ID)); err != nil {
+				t.Fatalf("carry generation output error = %v", err)
+			}
+		}
 
 		databasePath := globalDB.path
 		if err := globalDB.Close(ctx); err != nil {
 			t.Fatalf("Close() before result reload error = %v", err)
 		}
 		globalDB = openGlobalDBForTest(t, databasePath)
+		carriedRun, err := globalDB.GetTaskRun(ctx, claim.Run.ID)
+		if err != nil {
+			t.Fatalf("GetTaskRun(carried after reopen) error = %v", err)
+		}
+		listedRuns, err := globalDB.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: taskRecord.ID})
+		if err != nil || len(listedRuns) != 1 {
+			t.Fatalf("ListTaskRuns(carried) = %d runs, error = %v", len(listedRuns), err)
+		}
+		terminalRuns, err := globalDB.ListTaskRunsByStatus(ctx, []taskpkg.RunStatus{taskpkg.TaskRunStatusCompleted})
+		if err != nil || len(terminalRuns) != 1 {
+			t.Fatalf("ListTaskRunsByStatus(carried) = %d runs, error = %v", len(terminalRuns), err)
+		}
+		for _, run := range []taskpkg.Run{carriedRun, listedRuns[0], terminalRuns[0]} {
+			if run.ResultReference() != wantRef || run.ResultByteCount() != int64(len(resultPayload)) {
+				t.Fatalf("carried result descriptor = %q/%d", run.ResultReference(), run.ResultByteCount())
+			}
+		}
+		carriedPage, err := globalDB.ReadTaskRunResultPage(ctx, claim.Run.ID, pageOffset, pageLimit)
+		if err != nil || carriedPage != page {
+			t.Fatalf("ReadTaskRunResultPage(carried) = %#v, error = %v, want %#v", carriedPage, err, page)
+		}
 
 		owner := looppkg.GenerationOutputPayloadKey{
 			WorkspaceID: loopRun.WorkspaceID,
@@ -8325,7 +8356,7 @@ func TestGlobalDBCompleteRunLeaseShouldStoreLargeLoopOutputByRef(t *testing.T) {
 		wrongRun := owner
 		wrongRun.RunID = "looprun-other"
 		wrongGeneration := owner
-		wrongGeneration.Generation = 2
+		wrongGeneration.Generation = 4
 		wrongNode := owner
 		wrongNode.NodeID = "other"
 		wrongItem := owner
@@ -8369,6 +8400,48 @@ func TestGlobalDBCompleteRunLeaseShouldStoreLargeLoopOutputByRef(t *testing.T) {
 			taskpkg.ErrTaskRunResultCorrupt,
 		) {
 			t.Fatalf("ReadTaskRunResultPage(corrupt) error = %v, want corrupt result", err)
+		}
+		if _, err := globalDB.db.ExecContext(ctx,
+			`UPDATE loop_output_blobs SET payload_json = ? WHERE output_ref = ?`, string(resultPayload), wantRef,
+		); err != nil {
+			t.Fatalf("restore intact output blob error = %v", err)
+		}
+		conflictingPayload := json.RawMessage(`{"status":"different"}`)
+		conflictingRef := looppkg.OutputRefForPayload(conflictingPayload)
+		if _, err := globalDB.db.ExecContext(ctx,
+			`INSERT INTO loop_output_blobs (output_ref, payload_json, byte_size, created_at, last_used_at)
+			 VALUES (?, ?, ?, ?, ?)`,
+			conflictingRef, string(conflictingPayload), len(conflictingPayload), now, now,
+		); err != nil {
+			t.Fatalf("insert conflicting output blob error = %v", err)
+		}
+		if _, err := globalDB.db.ExecContext(ctx,
+			`UPDATE loop_generation_outputs SET output_ref = ? WHERE loop_run_id = ? AND generation = 3`,
+			conflictingRef, string(loopRun.ID),
+		); err != nil {
+			t.Fatalf("set conflicting carried output error = %v", err)
+		}
+		if _, err := globalDB.GetTaskRun(ctx, claim.Run.ID); !errors.Is(err, taskpkg.ErrTaskRunResultCorrupt) {
+			t.Fatalf("GetTaskRun(conflicting) error = %v, want corrupt result", err)
+		}
+		if _, err := globalDB.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: taskRecord.ID}); !errors.Is(
+			err, taskpkg.ErrTaskRunResultCorrupt,
+		) {
+			t.Fatalf("ListTaskRuns(conflicting) error = %v, want corrupt result", err)
+		}
+		if _, err := globalDB.ListTaskRunsByStatus(
+			ctx,
+			[]taskpkg.RunStatus{taskpkg.TaskRunStatusCompleted},
+		); !errors.Is(
+			err,
+			taskpkg.ErrTaskRunResultCorrupt,
+		) {
+			t.Fatalf("ListTaskRunsByStatus(conflicting) error = %v, want corrupt result", err)
+		}
+		if _, err := globalDB.ReadTaskRunResultPage(ctx, claim.Run.ID, 0, pageLimit); !errors.Is(
+			err, taskpkg.ErrTaskRunResultCorrupt,
+		) {
+			t.Fatalf("ReadTaskRunResultPage(conflicting) error = %v, want corrupt result", err)
 		}
 	})
 }

--- a/internal/store/globaldb/global_db_task_claim_test.go
+++ b/internal/store/globaldb/global_db_task_claim_test.go
@@ -4020,6 +4020,39 @@ func TestGlobalDBCompleteCoordinatorAndEnqueueNextShouldPersistPostReserveGenera
 func TestGlobalDBGenerationSuccessionObservabilityCoverageMatrix(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should emit one start when reservation rewrites the same initial generation", func(t *testing.T) {
+		t.Parallel()
+		globalDB := openLoopTestGlobalDB(t)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 9, 5, 3, 0, 0, 0, time.UTC)
+		run, err := globalDB.CreateLoopRunForStart(
+			ctx,
+			testLoopRun("looprun-same-generation-start", now, looppkg.StatusRunning),
+			dsl.ConcurrencyAllow,
+		)
+		if err != nil {
+			t.Fatalf("CreateLoopRunForStart() error = %v", err)
+		}
+		claim := claimCoordinatorRunForTest(ctx, t, globalDB, run.ID, "run-same-generation-start", now)
+		snapshot := taskpkg.GenerationSnapshot{LoopRunID: string(run.ID), Generation: 1}
+		_, err = globalDB.CompleteCoordinatorAndEnqueueNext(ctx, taskpkg.CoordinatorCompletion{
+			RunID: claim.Run.ID, ClaimToken: claim.ClaimToken, Actor: coordinatorActorContextForTest(),
+			Plan: taskpkg.CoordinatorCompletionPlan{
+				Snapshot: snapshot, PostReserveSnapshot: &snapshot,
+				NextCoordinator: &taskpkg.EnqueueSpec{
+					TaskID: claim.Run.TaskID, RunID: "run-same-generation-followup",
+					RunKind: taskpkg.RunKindCoordinator, LoopRunID: string(run.ID),
+					IdempotencyKey: "same-generation-followup",
+				},
+			},
+			Now: now.Add(time.Second),
+		}, looppkg.NewStoreFinalizer())
+		if err != nil {
+			t.Fatalf("CompleteCoordinatorAndEnqueueNext() error = %v", err)
+		}
+		assertLoopLifecycleEventCounts(ctx, t, globalDB, run.ID, 1, 0)
+	})
+
 	t.Run(
 		"Should persist exactly one provenance row and generation event for every successor origin",
 		func(t *testing.T) {

--- a/internal/store/globaldb/global_db_task_coordinator.go
+++ b/internal/store/globaldb/global_db_task_coordinator.go
@@ -254,14 +254,11 @@ func (g *TaskRepo) finalizeCoordinatorGenerationWithExecutor(
 		}
 	}
 	if err := g.applyCoordinatorGenerationSnapshotIntentsWithExecutor(
-		ctx,
-		exec,
-		loopRun,
-		snapshot,
-		completion.Now,
+		ctx, exec, loopRun, snapshot, completion.Now,
 	); err != nil {
 		return coordinatorBoundaryState{}, err
 	}
+	loopRun.Generation = max(loopRun.Generation, snapshot.Generation)
 	return coordinatorBoundaryState{
 		snapshot:            snapshot,
 		postReserveSnapshot: postReserve,

--- a/internal/store/globaldb/global_db_task_run_results.go
+++ b/internal/store/globaldb/global_db_task_run_results.go
@@ -33,7 +33,7 @@ func attachTaskRunResultDescriptors(
 	}
 	placeholders, args := sqlInPlaceholders(runIDs)
 	// dynamic-sql: the run-id batch changes the IN arity and prevents per-run descriptor queries.
-	query := `SELECT output.task_run_id, output.output_ref, blob.byte_size
+	query := `SELECT DISTINCT output.task_run_id, output.output_ref, blob.byte_size
 		FROM loop_generation_outputs AS output
 		JOIN loop_output_blobs AS blob ON blob.output_ref = output.output_ref
 		WHERE output.task_run_id IN (` + placeholders + `)
@@ -92,7 +92,7 @@ func (g *TaskRunRepo) ReadTaskRunResultPage(
 	}
 	rows, err := g.db.QueryContext(
 		ctx,
-		`SELECT output.output_ref, blob.payload_json, blob.byte_size
+		`SELECT DISTINCT output.output_ref, blob.payload_json, blob.byte_size
 		 FROM loop_generation_outputs AS output
 		 JOIN loop_output_blobs AS blob ON blob.output_ref = output.output_ref
 		 WHERE output.task_run_id = ? AND output.output_ref IS NOT NULL

--- a/packages/site/content/docs/examples/implement-tasks-loop.mdx
+++ b/packages/site/content/docs/examples/implement-tasks-loop.mdx
@@ -302,7 +302,7 @@ graph:
               ' "$f" || exit 1;
               done;
               for state in starting active stopping; do
-              sessions="$(compozy session list --type spawned --state "$state" --query "orchestrate-${slug}-" --limit 1 -o jsonl)" || exit 1;
+              sessions="$("$COMPOZY_BIN" session list --type spawned --state "$state" --query "orchestrate-${slug}-" --limit 1 -o jsonl)" || exit 1;
               if printf '%s\n' "$sessions" | grep -q '"id"[[:space:]]*:'; then exit 1; fi;
               done
         max_turns: 12

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -422,6 +422,11 @@ escapes, comments, and `<<` constructs; compilation rejects unsafe substitutions
 authored pipes, redirects, and chaining while preventing inputs, trigger payloads, or node outputs
 from introducing shell syntax.
 
+Command criteria inherit the run workspace and daemon environment. `COMPOZY_BIN` identifies the
+executable running that daemon; use `"$COMPOZY_BIN"` for Compozy CLI checks, including when the
+executable was renamed or launched outside the shell PATH. Its directory also leads PATH, matching
+agent subprocess discovery.
+
 Namespace roots: `inputs.<name>`, `nodes.<id>.output.<path>`, `nodes.<id>.status`,
 `nodes.<fan-out-id>.progress.<field>`, `item`/`index` and `progress.<field>` (fan-out body only),
 custom `bind_as`/`index_as` names (their fan-out body only), `trigger.<path>` (trigger/webhook starts only), `event.<path>` (`watch-events`

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -423,7 +423,7 @@ authored pipes, redirects, and chaining while preventing inputs, trigger payload
 from introducing shell syntax.
 
 Command criteria inherit the run workspace and daemon environment. `COMPOZY_BIN` identifies the
-executable running that daemon; use `"$COMPOZY_BIN"` for Compozy CLI checks, including when the
+executable running that daemon; use `"$COMPOZY_BIN"` for CompozyOS CLI checks, including when the
 executable was renamed or launched outside the shell PATH. Its directory also leads PATH, matching
 agent subprocess discovery.
 

--- a/web/e2e/__tests__/loop-run.spec.ts
+++ b/web/e2e/__tests__/loop-run.spec.ts
@@ -823,7 +823,7 @@ function rosterRow(
 }
 
 test.describe("Loop run page — two registers", () => {
-  test("E2E-012: the default read answers everything without opening a disclosure", async ({
+  test("E2E-012: the default read shows state and usage with identity in About", async ({
     appPage,
     runtime,
   }) => {
@@ -845,12 +845,12 @@ test.describe("Loop run page — two registers", () => {
     await expect(appPage.getByTestId("loop-run-inspect")).toBeVisible();
     await expect(appPage.getByTestId("loop-run-inspect-panel")).toBeHidden();
 
-    // The id assertion, scoped to the main column. The About rail's labelled
-    // `Run` row is the one place an id belongs in the default read, so grepping
-    // the whole page would fail on the very element the design calls for.
+    // Runtime identity stays out of the main column and remains available
+    // through the About disclosure.
     const mainColumn = appPage.locator("main");
     await expect(mainColumn).not.toContainText("looprun-");
     await expect(mainColumn).not.toContainText("loop.");
+    await appPage.getByRole("button", { name: "About this run", exact: true }).click();
     await expect(appPage.getByTestId("loop-run-detail-rail")).toContainText(runId);
   });
 

--- a/web/e2e/__tests__/loops.spec.ts
+++ b/web/e2e/__tests__/loops.spec.ts
@@ -1214,6 +1214,7 @@ test("Parked watch-events run renders its durable cursor from the real daemon", 
   await appPage.reload({ waitUntil: "domcontentloaded" });
   await expect(appPage.getByTestId("loop-run-detail-content")).toBeVisible();
   await expect(appPage.getByText(/last woke/i)).toBeVisible();
+  await browserArtifacts.captureScreenshot("loop-run-watch-events-default", appPage);
   await appPage.getByTestId("loop-run-open-inspect").click();
   const watch = appPage.getByTestId("loop-run-inspect-watch");
   await watch.scrollIntoViewIfNeeded();

--- a/web/e2e/__tests__/terminal.spec.ts
+++ b/web/e2e/__tests__/terminal.spec.ts
@@ -1181,6 +1181,8 @@ test("E2E-018: keyboard activation opens a working terminal from the dock", asyn
   appPage,
   runtime,
 }) => {
+  assertLaunchRuntime(runtime);
+  const workspace = await runtimeWorkspace(runtime);
   await ensureProjectWorkspace(appPage, runtime);
   const launcher = appPage
     .locator('[data-slot="os-dock"]:visible, [data-slot="os-dock-tabbar"]:visible')
@@ -1194,13 +1196,19 @@ test("E2E-018: keyboard activation opens a working terminal from the dock", asyn
   await expect(terminalWindow).toBeVisible();
   // One activation is the whole flow: the window resolves straight into a
   // terminal, with no launcher step in between.
-  await visibleTerminalPaneID(terminalWindow);
+  const terminalId = await visibleTerminalPaneID(terminalWindow);
 
   const journalToggle = terminalWindow.getByTestId("terminal-journal-toggle");
   await journalToggle.focus();
   await expect(journalToggle).toBeFocused();
 
   const log = await interactiveTerminalLog(terminalWindow);
-  await log.focus();
-  await expect(log).toBeFocused();
+  const input = log.getByRole("textbox", { name: "Terminal input", exact: true });
+  await input.focus();
+  await expect(input).toBeFocused();
+  await appPage.keyboard.type("printf 'keyboard-terminal-%s\\n' ready");
+  await appPage.keyboard.press("Enter");
+  await expect
+    .poll(async () => (await terminalScreen(runtime, workspace.id, terminalId)).content)
+    .toContain("keyboard-terminal-ready");
 });

--- a/web/src/systems/loops/components/__tests__/loop-run-page.test.tsx
+++ b/web/src/systems/loops/components/__tests__/loop-run-page.test.tsx
@@ -1002,7 +1002,7 @@ describe("LoopRunUsageRail", () => {
 });
 
 describe("LoopRunAboutRail", () => {
-  it("Should link the loop, pin the version, and expose the run id", () => {
+  it("Should reveal the loop, pinned version, inputs, and run id from About", async () => {
     render(
       <LoopRunAboutRail
         run={run()}
@@ -1012,6 +1012,8 @@ describe("LoopRunAboutRail", () => {
         workspaceLabel="Home"
       />
     );
+    expect(screen.queryByTestId("loop-run-about-id")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "About this run" }));
     expect(screen.getByTestId("loop-run-about-loop")).toHaveAttribute(
       "data-params",
       JSON.stringify({ name: "implement-tasks" })
@@ -1036,6 +1038,7 @@ describe("LoopRunAboutRail", () => {
       />
     );
 
+    await userEvent.click(screen.getByRole("button", { name: "About this run" }));
     expect(screen.getByTestId("loop-run-about-last-woke")).toHaveTextContent("Last woke");
     const best = screen.getByRole("link", { name: "Best result · Gen 1 · 0.70" });
     expect(best).toHaveAttribute("href", "#loop-generation-1");
@@ -1369,7 +1372,7 @@ describe("staged register scenarios", () => {
 // Truthful UI: the page must not offer a control the runtime cannot honour, and
 // must not paint a deliberate cancellation as a success.
 describe("run-page affordances that have to be real", () => {
-  it("Should print a produced artifact's ref as evidence, never as an Open link", () => {
+  it("Should reveal a produced artifact ref on demand without promising an Open link", async () => {
     render(
       <LoopRunArtifactList
         outcome={{
@@ -1393,8 +1396,69 @@ describe("run-page affordances that have to be real", () => {
     // would promise a destination the product does not have.
     expect(screen.queryByRole("link")).toBeNull();
     expect(screen.queryByText("Open")).toBeNull();
+    expect(screen.queryByTestId("loop-run-artifact-ref-post.md")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Details for post.md" }));
     expect(screen.getByTestId("loop-run-artifact-ref-post.md")).toHaveTextContent(
       "sha256:2f81c4a9"
+    );
+  });
+
+  it("Should bound the default result list while keeping partial and pruned evidence discoverable", async () => {
+    const artifacts = Array.from({ length: 20 }, (_, index) => ({
+      key: `result-${index}`,
+      name: `Result ${index + 1}`,
+      output: null,
+      availability: "available" as const,
+      note: null,
+      ref: `{"summary":"Result ${index + 1}"}`,
+      toneForNote: null,
+    }));
+    render(
+      <LoopRunArtifactList
+        outcome={{
+          outcome: null,
+          producedNothing: false,
+          artifacts: [
+            ...artifacts,
+            {
+              key: "partial",
+              name: "Partial result",
+              output: null,
+              availability: "partial",
+              note: "Partial",
+              ref: "partial contents",
+              toneForNote: "warning",
+            },
+            {
+              key: "pruned",
+              name: "Old report",
+              output: null,
+              availability: "pruned",
+              note: "Content no longer stored",
+              ref: null,
+              toneForNote: "neutral",
+            },
+          ],
+        }}
+      />
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getByText("1 partial")).toBeVisible();
+    expect(screen.getByText("1 no longer stored")).toBeVisible();
+    const more = screen.getByRole("button", { name: "19 more outputs" });
+    expect(more).toHaveAttribute("aria-expanded", "false");
+    await userEvent.click(more);
+    expect(screen.getAllByRole("listitem")).toHaveLength(22);
+    expect(screen.getByTestId("loop-run-artifact-Old report")).toHaveTextContent(
+      "Content no longer stored"
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Details for Result 20" }));
+    expect(screen.getByTestId("loop-run-artifact-ref-Result 20")).toHaveTextContent(
+      artifacts[19]!.ref
+    );
+    await userEvent.click(more);
+    await waitFor(() =>
+      expect(screen.queryByTestId("loop-run-artifact-Result 20")).not.toBeInTheDocument()
     );
   });
 

--- a/web/src/systems/loops/components/__tests__/loop-run-page.test.tsx
+++ b/web/src/systems/loops/components/__tests__/loop-run-page.test.tsx
@@ -65,6 +65,7 @@ const { checkLoopWaitPayload, loopWaitExpectRequiredKeys } =
   await import("../../lib/loop-node-wait-payload");
 type LoopNodeLifecycle = import("../../lib/loop-node-lifecycle").LoopNodeLifecycle;
 const { LoopRunUsageRail } = await import("../run-page/loop-run-usage-rail");
+const { LoopRunStepsProgress } = await import("../run-page/loop-run-steps-progress");
 const { LoopRunAboutRail } = await import("../run-page/loop-run-about-rail");
 const { LoopRunRegisters } = await import("../run-page/loop-run-registers");
 const { projectLoopRunRegisters } = await import("../../lib/loop-run-registers-view");
@@ -307,8 +308,52 @@ describe("LoopRunNeedsYouCard", () => {
     );
     expect(screen.getByTestId("loop-run-needs-quarantine-fix_batch-g2")).toBeInTheDocument();
     expect(screen.queryByTestId("loop-run-needs-approval")).not.toBeInTheDocument();
+    // A live run can still take the verb, so the row points at it.
+    expect(screen.getByTestId("loop-run-needs-quarantine-detail-fix_batch-g2")).toHaveTextContent(
+      "Requeue it from the entry once it is repaired."
+    );
     fireEvent.click(screen.getByTestId("loop-run-needs-open-quarantine-fix_batch-g2"));
     expect(onOpenQuarantine).toHaveBeenCalledWith("fix_batch");
+  });
+
+  it("Should stop instructing a requeue once the run has ended", () => {
+    const onOpenQuarantine = vi.fn();
+    render(
+      <LoopRunNeedsYouCard
+        run={run({ status: "failed" })}
+        request={null}
+        fallbackFacts={[]}
+        showApproval={false}
+        quarantinedNodes={[
+          loopNodeLifecycleFixture({
+            nodeId: "orchestrate",
+            label: "orchestrate",
+            state: "quarantined",
+            parked: true,
+            quarantined: true,
+            quarantineEntry: {
+              nodeId: "orchestrate",
+              inputRef: "loop-run:r-1:node:orchestrate:input",
+              target: "compozy__goal",
+              episodes: [],
+              requeues: [],
+              truncated: false,
+              attemptCount: 2,
+              hint: "",
+            },
+          }),
+        ]}
+        onOpenQuarantine={onOpenQuarantine}
+        onDecision={vi.fn()}
+      />
+    );
+    // The daemon rejects requeue on a terminal run; the row keeps the reason
+    // and the entry, and no longer asks for a verb nobody can take.
+    const detail = screen.getByTestId("loop-run-needs-quarantine-detail-orchestrate-g2");
+    expect(detail).toHaveTextContent("Set aside after 2 attempts. This run has ended.");
+    expect(detail).not.toHaveTextContent(/requeue/i);
+    fireEvent.click(screen.getByTestId("loop-run-needs-open-quarantine-orchestrate-g2"));
+    expect(onOpenQuarantine).toHaveBeenCalledWith("orchestrate");
   });
 
   it("Should keep distinct testids when fan-out quarantines two items of the same node", () => {
@@ -918,6 +963,29 @@ describe("LoopQuarantineSheet", () => {
     );
     expect(screen.queryByTestId("loop-quarantine-requeue")).not.toBeInTheDocument();
     expect(screen.queryByTestId("loop-quarantine-cancel")).not.toBeInTheDocument();
+  });
+
+  it("Should keep the entry readable but withdraw the verbs once the run has ended", () => {
+    const quarantined = loopNodeLifecycleFixture({
+      state: "quarantined",
+      parked: true,
+      quarantined: true,
+      quarantineEntry: entry,
+    });
+    const props = { onOpenChange: vi.fn(), onVerb: vi.fn(), open: true, runId: "r-1" };
+    const { rerender } = render(<LoopQuarantineSheet {...props} node={quarantined} />);
+    // Live: the verbs are on offer and the foot says the run is still going.
+    expect(screen.getByTestId("loop-quarantine-requeue")).toBeInTheDocument();
+    expect(screen.getByTestId("loop-quarantine-foot")).toHaveTextContent("The run keeps working");
+
+    rerender(<LoopQuarantineSheet {...props} node={quarantined} runEnded />);
+    // Ended: the daemon rejects requeue and cancel, so neither is offered, while
+    // the hint, the facts and the attempt chain stay exactly as retained.
+    expect(screen.queryByTestId("loop-quarantine-requeue")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("loop-quarantine-cancel")).not.toBeInTheDocument();
+    expect(screen.getByTestId("loop-quarantine-foot")).toHaveTextContent("This run has ended.");
+    expect(screen.getByTestId("loop-quarantine-hint")).toHaveTextContent(entry.hint);
+    expect(screen.getByTestId("loop-quarantine-chain")).toHaveTextContent("transport failed");
   });
 
   it("Should pair a retained episode with the requeue from the same generation", () => {
@@ -1778,5 +1846,60 @@ describe("LoopRunRegisters roster and generation lanes", () => {
       "event.payload.to_status == 'blocked'"
     );
     expect(screen.getByTestId("loop-run-inspect-cursors")).toHaveTextContent("loop_run_events17");
+  });
+});
+
+// The default read of Progress is the steps the served count is counting. A
+// gate that passed and a branch the route declined carry state but say nothing
+// the reader needs first, so they fold behind their own count — hidden, never
+// dropped, and back in graph order on one click.
+describe("LoopRunStepsProgress fold", () => {
+  function routedProgress() {
+    // VC-20's roster through the production projection: review ran, the gate
+    // passed, write_artifacts was provably declined, collect_fixes is still ahead.
+    return buildScenarioProps(registerFixtures.registerRoutedScenario()).registers.progress!;
+  }
+
+  it("Should hide quiet rows behind a counted summary and keep the way ahead visible", () => {
+    render(<LoopRunStepsProgress progress={routedProgress()} />);
+
+    expect(screen.getByTestId("loop-run-step-review")).toBeInTheDocument();
+    // Reachable-but-unstarted is where the run is going; it never folds.
+    expect(screen.getByTestId("loop-run-step-collect_fixes")).toBeInTheDocument();
+    expect(screen.queryByTestId("loop-run-step-has_issues")).toBeNull();
+    expect(screen.queryByTestId("loop-run-step-write_artifacts")).toBeNull();
+
+    // The fact the hidden rows carried stays on screen while they are hidden.
+    expect(screen.getByTestId("loop-run-step-fold-summary")).toHaveTextContent(
+      "1 succeeded · 1 not taken"
+    );
+    const toggle = screen.getByTestId("loop-run-step-fold-toggle");
+    expect(toggle).toHaveTextContent("2 more steps");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(toggle).toHaveAttribute("aria-controls", screen.getByTestId("loop-run-step-list").id);
+  });
+
+  it("Should bring the folded rows back in graph order, not as an appendix", async () => {
+    render(<LoopRunStepsProgress progress={routedProgress()} />);
+
+    await userEvent.click(screen.getByTestId("loop-run-step-fold-toggle"));
+
+    const rows = within(screen.getByTestId("loop-run-step-list")).getAllByRole("listitem");
+    expect(rows.map(row => row.getAttribute("data-node-id"))).toEqual([
+      "review",
+      "has_issues",
+      "write_artifacts",
+      "collect_fixes",
+    ]);
+    // Pending and not-taken stay distinguishable at a glance (SI-14): the
+    // literal word travels with the chip once the row is back.
+    expect(
+      within(screen.getByTestId("loop-run-step-write_artifacts")).getByTestId(
+        "loop-state-chip-not_taken"
+      )
+    ).toHaveTextContent("not taken");
+    const toggle = screen.getByTestId("loop-run-step-fold-toggle");
+    expect(toggle).toHaveTextContent("Show fewer steps");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
   });
 });

--- a/web/src/systems/loops/components/__tests__/loop-run-page.test.tsx
+++ b/web/src/systems/loops/components/__tests__/loop-run-page.test.tsx
@@ -1106,12 +1106,16 @@ describe("LoopRunAboutRail", () => {
       />
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "About this run" }));
+    // Operational status and navigation read with About still closed.
+    expect(screen.queryByTestId("loop-run-about-id")).not.toBeInTheDocument();
     expect(screen.getByTestId("loop-run-about-last-woke")).toHaveTextContent("Last woke");
     const best = screen.getByRole("link", { name: "Best result · Gen 1 · 0.70" });
     expect(best).toHaveAttribute("href", "#loop-generation-1");
     await userEvent.click(best);
     expect(onOpenGeneration).toHaveBeenCalledWith(1);
+
+    await userEvent.click(screen.getByRole("button", { name: "About this run" }));
+    expect(screen.getByTestId("loop-run-about-id")).toHaveTextContent(run().id);
   });
 });
 

--- a/web/src/systems/loops/components/run-page/loop-quarantine-sheet.tsx
+++ b/web/src/systems/loops/components/run-page/loop-quarantine-sheet.tsx
@@ -29,6 +29,8 @@ interface LoopQuarantineSheetProps {
   runId: string;
   open: boolean;
   isRequeuePending?: boolean;
+  /** The run reached a terminal status, so the daemon rejects requeue and cancel. */
+  runEnded?: boolean;
   onOpenChange: (open: boolean) => void;
   onVerb: (verb: LoopNodeVerb, node: LoopNodeLifecycle) => void;
   /** Slot for the requeue confirm dialog, nested inside the sheet. */
@@ -52,14 +54,16 @@ function countGist(attempts: number, episodes: number): string {
  *
  * Nothing is synthesized. If the entry carries no hint, no hint section renders;
  * if an attempt recorded no cause, its line is just the class and disposition.
- * Requeue disappears the moment refreshed truth says the node left quarantine,
- * so the sheet can never offer a verb the daemon would now reject.
+ * Requeue disappears the moment refreshed truth says the node left quarantine
+ * or the run ended, so the sheet can never offer a verb the daemon would now
+ * reject. The entry itself stays readable either way.
  */
 export function LoopQuarantineSheet({
   node,
   runId,
   open,
   isRequeuePending,
+  runEnded = false,
   onOpenChange,
   onVerb,
   children,
@@ -171,11 +175,13 @@ export function LoopQuarantineSheet({
               </div>
             </ScrollArea>
             <SheetFooter className="flex-row items-center justify-between gap-3 border-t border-line px-5 py-3">
-              <span className="text-small-body text-muted">
-                The run keeps working — quarantine never stops it by itself.
+              <span className="text-small-body text-muted" data-testid="loop-quarantine-foot">
+                {runEnded
+                  ? "This run has ended. The entry is kept as a record."
+                  : "The run keeps working — quarantine never stops it by itself."}
               </span>
               <span className="flex shrink-0 items-center gap-2">
-                {node.quarantined ? (
+                {node.quarantined && !runEnded ? (
                   <>
                     <Button
                       data-testid="loop-quarantine-cancel"

--- a/web/src/systems/loops/components/run-page/loop-run-about-rail.tsx
+++ b/web/src/systems/loops/components/run-page/loop-run-about-rail.tsx
@@ -49,13 +49,37 @@ export function LoopRunAboutRail({
   ...props
 }: LoopRunAboutRailProps) {
   const best = loopRunBestLabel(run);
+  const showBest = best && run.best_generation !== null && run.best_generation !== undefined;
+  const hasStatusRows = Boolean(showBest || lastWakeAt);
   return (
     <div
       className={cn("border-t border-line-soft px-4.5 py-4", className)}
       data-testid="loop-run-about"
       {...props}
     >
-      <Collapsible>
+      {/* Operational status stays readable with About closed; metadata folds. */}
+      {showBest ? (
+        <PropertyRow label="Best result" data-testid="loop-run-about-best">
+          <a
+            aria-label={`Best result · ${best}`}
+            className="inline-flex min-h-6 items-center rounded-xs font-mono text-mono-id text-info hover:text-fg-strong focus-visible:outline-none focus-visible:shadow-focus-ring"
+            href={`#loop-generation-${run.best_generation}`}
+            onClick={event => {
+              if (!onOpenGeneration) return;
+              event.preventDefault();
+              onOpenGeneration(run.best_generation as number);
+            }}
+          >
+            {best}
+          </a>
+        </PropertyRow>
+      ) : null}
+      {lastWakeAt ? (
+        <PropertyRow label="Last woke" data-testid="loop-run-about-last-woke">
+          <Time iso={lastWakeAt} />
+        </PropertyRow>
+      ) : null}
+      <Collapsible className={hasStatusRows ? "mt-2" : undefined}>
         <CollapsibleTrigger className="group/about flex w-full items-center gap-1.5 text-left">
           <Info aria-hidden="true" className="size-3 text-muted" />
           <Eyebrow className="text-subtle">About this run</Eyebrow>
@@ -78,27 +102,6 @@ export function LoopRunAboutRail({
           {versionLabel !== undefined ? (
             <PropertyRow label="Version" mono data-testid="loop-run-about-version">
               {versionLabel}
-            </PropertyRow>
-          ) : null}
-          {best && run.best_generation !== null && run.best_generation !== undefined ? (
-            <PropertyRow label="Best result" data-testid="loop-run-about-best">
-              <a
-                aria-label={`Best result · ${best}`}
-                className="inline-flex min-h-6 items-center rounded-xs font-mono text-mono-id text-info hover:text-fg-strong focus-visible:outline-none focus-visible:shadow-focus-ring"
-                href={`#loop-generation-${run.best_generation}`}
-                onClick={event => {
-                  if (!onOpenGeneration) return;
-                  event.preventDefault();
-                  onOpenGeneration(run.best_generation as number);
-                }}
-              >
-                {best}
-              </a>
-            </PropertyRow>
-          ) : null}
-          {lastWakeAt ? (
-            <PropertyRow label="Last woke" data-testid="loop-run-about-last-woke">
-              <Time iso={lastWakeAt} />
             </PropertyRow>
           ) : null}
           {inputRows.map(row =>

--- a/web/src/systems/loops/components/run-page/loop-run-about-rail.tsx
+++ b/web/src/systems/loops/components/run-page/loop-run-about-rail.tsx
@@ -1,8 +1,17 @@
 import type { ComponentProps } from "react";
 import { Link } from "@tanstack/react-router";
-import { Info } from "lucide-react";
+import { ChevronDown, Info } from "lucide-react";
 
-import { cn, Eyebrow, MonoId, PropertyRow, Time } from "@compozy/ui";
+import {
+  cn,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Eyebrow,
+  MonoId,
+  PropertyRow,
+  Time,
+} from "@compozy/ui";
 
 import type { LoopRunInputRow } from "../../lib/loop-run-about";
 import { loopRunBestLabel } from "../../lib/loop-generation-presentation";
@@ -46,83 +55,95 @@ export function LoopRunAboutRail({
       data-testid="loop-run-about"
       {...props}
     >
-      <div className="mb-2 flex items-center gap-1.5">
-        <Info aria-hidden="true" className="size-3 text-muted" />
-        <Eyebrow className="text-subtle">About this run</Eyebrow>
-      </div>
-      <PropertyRow label="Loop">
-        <Link
-          className="inline-flex min-h-6 items-center truncate rounded-xs text-small-body font-medium text-fg hover:text-fg-strong focus-visible:outline-none focus-visible:shadow-focus-ring"
-          data-testid="loop-run-about-loop"
-          params={{ name: run.loop_name }}
-          to="/loops/$name"
-        >
-          {run.loop_name}
-        </Link>
-      </PropertyRow>
-      {versionLabel !== undefined ? (
-        <PropertyRow label="Version" mono data-testid="loop-run-about-version">
-          {versionLabel}
-        </PropertyRow>
-      ) : null}
-      {best && run.best_generation !== null && run.best_generation !== undefined ? (
-        <PropertyRow label="Best result" data-testid="loop-run-about-best">
-          <a
-            aria-label={`Best result · ${best}`}
-            className="inline-flex min-h-6 items-center rounded-xs font-mono text-mono-id text-info hover:text-fg-strong focus-visible:outline-none focus-visible:shadow-focus-ring"
-            href={`#loop-generation-${run.best_generation}`}
-            onClick={event => {
-              if (!onOpenGeneration) return;
-              event.preventDefault();
-              onOpenGeneration(run.best_generation as number);
-            }}
-          >
-            {best}
-          </a>
-        </PropertyRow>
-      ) : null}
-      {lastWakeAt ? (
-        <PropertyRow label="Last woke" data-testid="loop-run-about-last-woke">
-          <Time iso={lastWakeAt} />
-        </PropertyRow>
-      ) : null}
-      {inputRows.map(row =>
-        row.isAgent ? (
-          <PropertyRow key={row.key} label={row.label} data-testid={`loop-run-input-${row.key}`}>
-            <span
-              aria-hidden="true"
-              className="grid size-4 shrink-0 place-items-center rounded-xs bg-badge-fill font-mono text-pill-group-badge font-semibold text-muted"
+      <Collapsible>
+        <CollapsibleTrigger className="group/about flex w-full items-center gap-1.5 text-left">
+          <Info aria-hidden="true" className="size-3 text-muted" />
+          <Eyebrow className="text-subtle">About this run</Eyebrow>
+          <ChevronDown
+            aria-hidden="true"
+            className="ml-auto size-3.5 text-faint group-data-panel-open/about:rotate-180"
+          />
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-2">
+          <PropertyRow label="Loop">
+            <Link
+              className="inline-flex min-h-6 items-center truncate rounded-xs text-small-body font-medium text-fg hover:text-fg-strong focus-visible:outline-none focus-visible:shadow-focus-ring"
+              data-testid="loop-run-about-loop"
+              params={{ name: run.loop_name }}
+              to="/loops/$name"
             >
-              {avatarSeed(row.value)}
-            </span>
-            <span className="truncate">{row.value}</span>
+              {run.loop_name}
+            </Link>
           </PropertyRow>
-        ) : (
-          <PropertyRow
-            key={row.key}
-            label={row.label}
-            mono
-            data-testid={`loop-run-input-${row.key}`}
-          >
-            {row.value}
+          {versionLabel !== undefined ? (
+            <PropertyRow label="Version" mono data-testid="loop-run-about-version">
+              {versionLabel}
+            </PropertyRow>
+          ) : null}
+          {best && run.best_generation !== null && run.best_generation !== undefined ? (
+            <PropertyRow label="Best result" data-testid="loop-run-about-best">
+              <a
+                aria-label={`Best result · ${best}`}
+                className="inline-flex min-h-6 items-center rounded-xs font-mono text-mono-id text-info hover:text-fg-strong focus-visible:outline-none focus-visible:shadow-focus-ring"
+                href={`#loop-generation-${run.best_generation}`}
+                onClick={event => {
+                  if (!onOpenGeneration) return;
+                  event.preventDefault();
+                  onOpenGeneration(run.best_generation as number);
+                }}
+              >
+                {best}
+              </a>
+            </PropertyRow>
+          ) : null}
+          {lastWakeAt ? (
+            <PropertyRow label="Last woke" data-testid="loop-run-about-last-woke">
+              <Time iso={lastWakeAt} />
+            </PropertyRow>
+          ) : null}
+          {inputRows.map(row =>
+            row.isAgent ? (
+              <PropertyRow
+                key={row.key}
+                label={row.label}
+                data-testid={`loop-run-input-${row.key}`}
+              >
+                <span
+                  aria-hidden="true"
+                  className="grid size-4 shrink-0 place-items-center rounded-xs bg-badge-fill font-mono text-pill-group-badge font-semibold text-muted"
+                >
+                  {avatarSeed(row.value)}
+                </span>
+                <span className="truncate">{row.value}</span>
+              </PropertyRow>
+            ) : (
+              <PropertyRow
+                key={row.key}
+                label={row.label}
+                mono
+                data-testid={`loop-run-input-${row.key}`}
+              >
+                {row.value}
+              </PropertyRow>
+            )
+          )}
+          <PropertyRow label="Started by" data-testid="loop-run-about-started-by">
+            {startedBy}
           </PropertyRow>
-        )
-      )}
-      <PropertyRow label="Started by" data-testid="loop-run-about-started-by">
-        {startedBy}
-      </PropertyRow>
-      <PropertyRow label="Workspace" data-testid="loop-run-about-workspace">
-        {workspaceLabel}
-      </PropertyRow>
-      <PropertyRow label="Run id" mono>
-        <MonoId
-          className="text-muted"
-          copy
-          copyLabel="Copy run id"
-          data-testid="loop-run-about-id"
-          value={run.id}
-        />
-      </PropertyRow>
+          <PropertyRow label="Workspace" data-testid="loop-run-about-workspace">
+            {workspaceLabel}
+          </PropertyRow>
+          <PropertyRow label="Run id" mono>
+            <MonoId
+              className="text-muted"
+              copy
+              copyLabel="Copy run id"
+              data-testid="loop-run-about-id"
+              value={run.id}
+            />
+          </PropertyRow>
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 }

--- a/web/src/systems/loops/components/run-page/loop-run-artifact-list.tsx
+++ b/web/src/systems/loops/components/run-page/loop-run-artifact-list.tsx
@@ -1,21 +1,15 @@
-import { FileText } from "lucide-react";
+import { ChevronDown, FileText } from "lucide-react";
 
-import { Pill } from "@compozy/ui";
+import { Button, Collapsible, CollapsibleContent, CollapsibleTrigger, Pill } from "@compozy/ui";
 
-import type { LoopRunOutcomeModel } from "../../lib/loop-run-artifacts";
+import type { LoopArtifactRow, LoopRunOutcomeModel } from "../../lib/loop-run-artifacts";
 
 interface LoopRunArtifactListProps {
   outcome: LoopRunOutcomeModel;
 }
 
-/**
- * What the run produced, listed under its outcome.
- *
- * Every entry the run wrote stays listed, including the ones whose content
- * retention has since removed: the name is evidence that the work happened, and
- * dropping the row would quietly revise the run's history. A pruned entry simply
- * offers nothing to open and says why.
- */
+const PREVIEW_COUNT = 3;
+
 export function LoopRunArtifactList({ outcome }: LoopRunArtifactListProps) {
   if (outcome.producedNothing) {
     return (
@@ -25,44 +19,105 @@ export function LoopRunArtifactList({ outcome }: LoopRunArtifactListProps) {
     );
   }
   if (outcome.artifacts.length === 0) return null;
+  const preview = outcome.artifacts.slice(0, PREVIEW_COUNT);
+  const remaining = outcome.artifacts.slice(PREVIEW_COUNT);
+  const partialCount = outcome.artifacts.filter(
+    artifact => artifact.availability === "partial"
+  ).length;
+  const prunedCount = outcome.artifacts.filter(
+    artifact => artifact.availability === "pruned"
+  ).length;
   return (
-    <ul className="mt-3 flex flex-col gap-1.5" data-testid="loop-run-artifacts">
-      {outcome.artifacts.map(artifact => (
+    <div className="mt-3 space-y-2" data-testid="loop-run-artifacts">
+      <div className="flex flex-wrap items-center gap-2 text-small-body text-muted">
+        <span>
+          {outcome.artifacts.length} {outcome.artifacts.length === 1 ? "output" : "outputs"}
+        </span>
+        {partialCount > 0 ? <Pill tone="warning">{partialCount} partial</Pill> : null}
+        {prunedCount > 0 ? <span>{prunedCount} no longer stored</span> : null}
+      </div>
+      <ArtifactRows artifacts={preview} />
+      {remaining.length > 0 ? (
+        <Collapsible>
+          <CollapsibleTrigger
+            className="group/artifacts"
+            render={
+              <Button size="sm" type="button" variant="ghost">
+                {remaining.length} more outputs
+                <ChevronDown
+                  aria-hidden="true"
+                  className="group-data-panel-open/artifacts:rotate-180"
+                />
+              </Button>
+            }
+          />
+          <CollapsibleContent className="pt-2">
+            <ArtifactRows artifacts={remaining} />
+          </CollapsibleContent>
+        </Collapsible>
+      ) : null}
+    </div>
+  );
+}
+
+function ArtifactRows({ artifacts }: { artifacts: LoopArtifactRow[] }) {
+  return (
+    <ul className="flex flex-col gap-1.5">
+      {artifacts.map(artifact => (
         <li
-          className="flex flex-wrap items-center gap-2 rounded-md border border-line-soft bg-canvas-tint px-3 py-2"
+          className="rounded-md border border-line-soft px-3 py-2"
           data-availability={artifact.availability}
           data-testid={`loop-run-artifact-${artifact.name}`}
           key={artifact.key}
         >
-          <FileText aria-hidden="true" className="size-3.5 shrink-0 text-muted" />
-          <span className="min-w-0 truncate text-small-body font-medium text-fg-strong">
-            {artifact.name}
-          </span>
-          {artifact.output ? (
-            <span className="font-mono text-mono-id text-faint">via {artifact.output}</span>
-          ) : null}
-          {artifact.note ? (
-            <Pill
-              data-testid={`loop-run-artifact-note-${artifact.availability}`}
-              tone={artifact.toneForNote ?? "neutral"}
-            >
-              {artifact.note}
-            </Pill>
-          ) : null}
-          {/* The ref is a content digest, and nothing in the product resolves
-              one — there is no read operation that takes it. It is evidence the
-              bytes existed under that name, so it is printed as evidence. An
-              arrowed "Open" here promised a destination the runtime does not
-              have, which is exactly the control this page must not render. */}
-          {artifact.ref ? (
-            <span
-              className="ml-auto truncate font-mono text-mono-id text-faint"
-              data-testid={`loop-run-artifact-ref-${artifact.name}`}
-              title={artifact.ref}
-            >
-              {artifact.ref}
-            </span>
-          ) : null}
+          <Collapsible>
+            <div className="flex flex-wrap items-center gap-2">
+              <FileText aria-hidden="true" className="size-3.5 shrink-0 text-muted" />
+              <span className="min-w-0 break-words text-small-body font-medium text-fg-strong">
+                {artifact.name}
+              </span>
+              {artifact.note ? (
+                <Pill
+                  data-testid={`loop-run-artifact-note-${artifact.availability}`}
+                  tone={artifact.toneForNote ?? "neutral"}
+                >
+                  {artifact.note}
+                </Pill>
+              ) : null}
+              {artifact.ref || artifact.output ? (
+                <CollapsibleTrigger
+                  className="group/artifact ml-auto"
+                  render={
+                    <Button
+                      aria-label={`Details for ${artifact.name}`}
+                      size="sm"
+                      type="button"
+                      variant="ghost"
+                    >
+                      Details
+                      <ChevronDown
+                        aria-hidden="true"
+                        className="group-data-panel-open/artifact:rotate-180"
+                      />
+                    </Button>
+                  }
+                />
+              ) : null}
+            </div>
+            <CollapsibleContent>
+              {artifact.output ? (
+                <p className="mt-2 text-small-body text-muted">Output: {artifact.output}</p>
+              ) : null}
+              {artifact.ref ? (
+                <pre
+                  className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md bg-canvas-tint p-3 font-mono text-mono-id text-muted"
+                  data-testid={`loop-run-artifact-ref-${artifact.name}`}
+                >
+                  {artifact.ref}
+                </pre>
+              ) : null}
+            </CollapsibleContent>
+          </Collapsible>
         </li>
       ))}
     </ul>

--- a/web/src/systems/loops/components/run-page/loop-run-needs-you-card.tsx
+++ b/web/src/systems/loops/components/run-page/loop-run-needs-you-card.tsx
@@ -7,6 +7,7 @@ import type {
   LoopApprovalRequest,
   LoopGateDecision,
 } from "../../lib/loop-events";
+import { isTerminalLoopStatus } from "../../lib/loop-formatters";
 import type { LoopNodeLifecycle } from "../../lib/loop-node-lifecycle";
 import { humanizeLoopNodeId } from "../../lib/loop-node-labels";
 import type { LoopRequestView } from "../../lib/loop-request-model";
@@ -78,6 +79,17 @@ const NO_QUARANTINED_NODES: readonly LoopNodeLifecycle[] = [];
 const NO_REQUEST_VIEWS: readonly LoopRequestView[] = [];
 
 /**
+ * Requeue is a live verb: the daemon rejects it once the run has ended, so a
+ * terminal row keeps the reason and the entry but stops asking for one.
+ */
+function quarantineDetail(attempts: number, runEnded: boolean): string {
+  const setAside = attempts > 0 ? `Set aside after ${attempts} attempts.` : "Set aside.";
+  return runEnded
+    ? `${setAside} This run has ended.`
+    : `${setAside} Requeue it from the entry once it is repaired.`;
+}
+
+/**
  * The "Needs you" region: a neutral panelbox whose only colour is the warning
  * glyph. Requests present as a one-at-a-time questionnaire; approval decisions
  * and quarantine entries share the same shell.
@@ -113,6 +125,7 @@ export function LoopRunNeedsYouCard({
     .filter((part): part is string => part !== null)
     .join(" · ");
   const gistCount = (showApproval ? 1 : 0) + quarantinedNodes.length + requests.length;
+  const runEnded = isTerminalLoopStatus(run.status);
   return (
     <LoopSection
       className="mb-0"
@@ -210,10 +223,11 @@ export function LoopRunNeedsYouCard({
                 <div className="text-ws-name font-medium text-fg-strong">
                   {node.label} was quarantined
                 </div>
-                <p className="mt-0.75 max-w-[62ch] text-small-body leading-relaxed text-muted">
-                  {attempts > 0
-                    ? `Set aside after ${attempts} attempts. Requeue it from the entry once it is repaired.`
-                    : "Set aside. Requeue it from the entry once it is repaired."}
+                <p
+                  className="mt-0.75 max-w-[62ch] text-small-body leading-relaxed text-muted"
+                  data-testid={`loop-run-needs-quarantine-detail-${rowKey}`}
+                >
+                  {quarantineDetail(attempts, runEnded)}
                 </p>
                 <div className="mt-1.5 font-mono text-pill-group-badge text-faint">
                   {`node_controls.quarantined true · ${nodeIdentity(node)}`}

--- a/web/src/systems/loops/components/run-page/loop-run-step-row.tsx
+++ b/web/src/systems/loops/components/run-page/loop-run-step-row.tsx
@@ -86,8 +86,9 @@ export function LoopRunStepRow({ step, className, ...props }: LoopRunStepRowProp
         "flex items-start gap-2.5 border-t border-line-soft py-2.25 first:border-t-0",
         className
       )}
-      data-control={step.isControl ? "true" : undefined}
+      data-node-class={step.nodeClass ?? undefined}
       data-node-id={step.nodeId}
+      data-quiet={step.quiet ? "true" : undefined}
       data-testid={`loop-run-step-${step.nodeId}`}
       {...props}
     >

--- a/web/src/systems/loops/components/run-page/loop-run-steps-progress.tsx
+++ b/web/src/systems/loops/components/run-page/loop-run-steps-progress.tsx
@@ -1,4 +1,7 @@
-import { Gauge } from "lucide-react";
+import { useId, useState } from "react";
+import { ChevronDown, Gauge } from "lucide-react";
+
+import { Button, cn } from "@compozy/ui";
 
 import { withOccurrenceKeys } from "@/lib/occurrence-keys";
 
@@ -36,6 +39,12 @@ export function LoopRunStepsProgress({
   // list below is built from the roster itself, so a partial read makes it short —
   // and it has to say so rather than read as the whole round.
   const reachNote = reach ? loopRosterReachNote(reach) : null;
+  // In-page state like the register's lane; opens in place so hidden rows
+  // return in graph order.
+  const [showAll, setShowAll] = useState(false);
+  const listId = useId();
+  const fold = progress.fold;
+  const rows = fold && !showAll ? progress.steps.filter(step => !step.quiet) : progress.steps;
   return (
     <LoopSection
       className="mb-0"
@@ -86,12 +95,41 @@ export function LoopRunStepsProgress({
               </span>
             ) : null}
           </div>
-          {progress.steps.length > 0 ? (
-            <ul className="mt-3.5 flex flex-col" data-testid="loop-run-step-list">
-              {progress.steps.map(step => (
+          {rows.length > 0 ? (
+            <ul className="mt-3.5 flex flex-col" data-testid="loop-run-step-list" id={listId}>
+              {rows.map(step => (
                 <LoopRunStepRow key={step.key} step={step} />
               ))}
             </ul>
+          ) : null}
+          {fold ? (
+            // The summary keeps the folded rows' fates on screen while hidden.
+            <div
+              className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-line-soft pt-2"
+              data-testid="loop-run-step-fold"
+            >
+              <Button
+                aria-controls={listId}
+                aria-expanded={showAll}
+                data-testid="loop-run-step-fold-toggle"
+                onClick={() => setShowAll(open => !open)}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                {showAll ? "Show fewer steps" : `${fold.hiddenCount} more steps`}
+                <ChevronDown
+                  aria-hidden="true"
+                  className={cn(
+                    "transition-transform motion-reduce:transition-none",
+                    showAll && "rotate-180"
+                  )}
+                />
+              </Button>
+              <span className="text-form-hint text-subtle" data-testid="loop-run-step-fold-summary">
+                {fold.summary}
+              </span>
+            </div>
           ) : null}
           {reachNote ? (
             <p className="mt-3 text-form-hint text-subtle" data-testid="loop-run-progress-reach">

--- a/web/src/systems/loops/lib/__tests__/loop-run-progress.test.ts
+++ b/web/src/systems/loops/lib/__tests__/loop-run-progress.test.ts
@@ -227,6 +227,152 @@ describe("buildStepsProgress", () => {
     expect(model.segments).toHaveLength(4);
   });
 
+  // A finished review round: one action step ran, the gate passed, and the whole
+  // fix branch was provably declined. Seven rows, of which the reader needs one.
+  function reviewRoundWithoutIssues() {
+    return buildStepsProgress({
+      progress: progress({ round: 2, steps_done: 1, steps_total: 1 }),
+      nodes: [
+        node("review", "succeeded", { generation: 2 }),
+        node("has_issues", "succeeded", { generation: 2 }),
+        node("write_artifacts", "not_taken", { generation: 2 }),
+        node("fix_batches", "not_taken", { generation: 2 }),
+        node("fix_batch", "not_taken", { generation: 2 }),
+        node("collect_fixes", "not_taken", { generation: 2 }),
+        node("finalize_round", "not_taken", { generation: 2 }),
+      ],
+      rollups: [],
+      rosterIsComplete: true,
+      graph: graph([
+        ["review", "action"],
+        ["has_issues", "control"],
+        ["write_artifacts", "action"],
+        ["fix_batches", "control"],
+        ["fix_batch", "action"],
+        ["collect_fixes", "control"],
+        ["finalize_round", "action"],
+      ]),
+    });
+  }
+
+  it("Should fold settled control steps and declined branches behind one summary", () => {
+    const model = reviewRoundWithoutIssues();
+
+    // Every row is still there, in graph order — the fold hides, it never drops.
+    expect(model.steps.map(step => step.nodeId)).toEqual([
+      "review",
+      "has_issues",
+      "write_artifacts",
+      "fix_batches",
+      "fix_batch",
+      "collect_fixes",
+      "finalize_round",
+    ]);
+    expect(model.steps.filter(step => !step.quiet).map(step => step.nodeId)).toEqual(["review"]);
+    // The summary keeps the hidden rows' fates in the chips' own words.
+    expect(model.fold).toEqual({
+      hiddenCount: 6,
+      summary: "1 succeeded · 5 not taken",
+    });
+  });
+
+  it("Should keep parked, failed and pending control steps in the default read", () => {
+    const model = buildStepsProgress({
+      progress: progress({ round: 1, steps_done: 2, steps_total: 3 }),
+      nodes: [
+        node("review", "succeeded"),
+        node("has_issues", "succeeded"),
+        node("approve", "control_pending"),
+        node("route", "failed"),
+        node("collect_fixes", "pending"),
+        node("write_artifacts", "not_taken"),
+      ],
+      rollups: [],
+      rosterIsComplete: true,
+      graph: graph([
+        ["review", "action"],
+        ["has_issues", "control"],
+        ["approve", "control"],
+        ["route", "control"],
+        ["collect_fixes", "control"],
+        ["write_artifacts", "action"],
+      ]),
+    });
+
+    // A gate waiting on a person, a control step that broke, and a control step
+    // still ahead of the run are where the run is going; only the clean gate and
+    // the declined branch fold.
+    expect(model.steps.filter(step => step.quiet).map(step => step.nodeId)).toEqual([
+      "has_issues",
+      "write_artifacts",
+    ]);
+    expect(model.fold).toEqual({
+      hiddenCount: 2,
+      summary: "1 succeeded · 1 not taken",
+    });
+  });
+
+  it("Should not fold a single quiet row or a round that would fold away entirely", () => {
+    const oneQuiet = buildStepsProgress({
+      progress: progress({ round: 1, steps_done: 1, steps_total: 2 }),
+      nodes: [
+        node("review", "succeeded"),
+        node("has_issues", "succeeded"),
+        node("fix_batch", "running"),
+      ],
+      rollups: [],
+      rosterIsComplete: true,
+      graph: graph([
+        ["review", "action"],
+        ["has_issues", "control"],
+        ["fix_batch", "action"],
+      ]),
+    });
+    // Folding one row behind a line of the same height would save nothing.
+    expect(oneQuiet.fold).toBeNull();
+
+    const onlyQuiet = buildStepsProgress({
+      progress: progress({ round: 1, steps_done: 0, steps_total: 0 }),
+      nodes: [node("has_issues", "succeeded"), node("collect_fixes", "succeeded")],
+      rollups: [],
+      rosterIsComplete: true,
+      graph: graph([
+        ["has_issues", "control"],
+        ["collect_fixes", "control"],
+      ]),
+    });
+    // A list that is all summary and no rows would hide the very thing it was
+    // asked to show; nothing folds when nothing would remain.
+    expect(onlyQuiet.fold).toBeNull();
+    expect(onlyQuiet.steps.every(step => step.quiet)).toBe(true);
+  });
+
+  it("Should give a source node no segment, so the bar matches the served count", () => {
+    const model = buildStepsProgress({
+      progress: progress({ round: 2, steps_done: 2, steps_total: 2 }),
+      nodes: [
+        node("slug_input", "succeeded", { generation: 2 }),
+        node("select_mode", "succeeded", { generation: 2 }),
+        node("load_tasks", "succeeded", { generation: 2 }),
+        node("orchestrate", "succeeded", { generation: 2 }),
+      ],
+      rollups: [],
+      rosterIsComplete: true,
+      graph: graph([
+        ["slug_input", "source"],
+        ["select_mode", "control"],
+        ["load_tasks", "action"],
+        ["orchestrate", "action"],
+      ]),
+    });
+
+    // The daemon counts two steps; the bar draws two, not four. The source and
+    // the route fold together, and the summary names neither class.
+    expect(model.segments).toEqual(["clean", "clean"]);
+    expect(model.ariaLabel).toBe("Step 2 of 2 · round 2: 2 settled");
+    expect(model.fold).toEqual({ hiddenCount: 2, summary: "2 succeeded" });
+  });
+
   it("Should say so plainly when a round has no steps rather than count to zero", () => {
     const model = buildStepsProgress({
       progress: progress({ round: 1, steps_done: 0, steps_total: 0 }),

--- a/web/src/systems/loops/lib/loop-run-progress.ts
+++ b/web/src/systems/loops/lib/loop-run-progress.ts
@@ -1,5 +1,5 @@
 import type { LoopFanoutRollup, LoopRosterNode, LoopStepProgress } from "../types";
-import { type LoopGraph, topoOrder } from "./loop-graph";
+import { type LoopGraph, type LoopNodeClass, topoOrder } from "./loop-graph";
 import {
   type LoopFanOutBand,
   type LoopProgressSegment,
@@ -42,8 +42,21 @@ export interface LoopStepRow {
   attemptLabel: string | null;
   /** Present only on a fan-out container; the branches live inside it. */
   fanOut: LoopFanOutBand | null;
-  /** True for control segments — they carry state but contribute no step. */
-  isControl: boolean;
+  /** The authored class; null for a roster row the definition does not name. */
+  nodeClass: LoopNodeClass | null;
+  /**
+   * Foldable out of the default read: a control or source row that succeeded,
+   * or a branch the route declined. Parked, failed, running and pending rows
+   * are where the run is going and never fold.
+   */
+  quiet: boolean;
+}
+
+/** The folded rows' fates, counted, so hiding them never hides the fact. */
+export interface LoopStepsFold {
+  hiddenCount: number;
+  /** "1 succeeded · 5 not taken" — the chips' own words, no class taxonomy. */
+  summary: string;
 }
 
 export interface LoopStepsProgressModel {
@@ -62,7 +75,10 @@ export interface LoopStepsProgressModel {
    * dominant reason instead of a percentage that has stopped meaning anything.
    */
   parkedReason: string | null;
+  /** Every row of the round in graph order; `quiet` marks the foldable ones. */
   steps: LoopStepRow[];
+  /** Null when fewer than two rows are quiet, or every row is. */
+  fold: LoopStepsFold | null;
   ariaLabel: string;
 }
 
@@ -102,11 +118,22 @@ function indexRoster(
   return { byNode, rollups: roundRollups, rollupByNode, claimed };
 }
 
-function isControlNode(graph: LoopGraph | null, nodeId: string): boolean {
-  const authored = graph?.nodes.find(node => node.id === nodeId);
-  // An unauthored roster row is treated as an action step: it executed, so it
-  // counts. Only a node the definition calls `control` contributes zero.
-  return authored?.nodeClass === "control";
+function authoredClass(graph: LoopGraph | null, nodeId: string): LoopNodeClass | null {
+  return graph?.nodes.find(node => node.id === nodeId)?.nodeClass ?? null;
+}
+
+/**
+ * Whether a row is one of the steps the served count counts. An unauthored row
+ * executed, so it counts; `control` and `source` rows contribute no segment,
+ * matching the daemon's `steps_total`.
+ */
+function contributesStep(nodeClass: LoopNodeClass | null): boolean {
+  return nodeClass !== "control" && nodeClass !== "source";
+}
+
+function isQuietStep(nodeClass: LoopNodeClass | null, state: string): boolean {
+  if (state === "not_taken") return true;
+  return !contributesStep(nodeClass) && state === "succeeded";
 }
 
 /** Graph order when the definition is readable, roster order otherwise. */
@@ -155,10 +182,13 @@ function buildSteps(
         ),
         attemptLabel: null,
         fanOut: band,
-        isControl: false,
+        nodeClass: authoredClass(graph, nodeId),
+        // A fan-out never folds: the band is the only place its width is drawn.
+        quiet: false,
       });
       continue;
     }
+    const nodeClass = authoredClass(graph, nodeId);
     for (const node of index.byNode.get(nodeId) ?? []) {
       // A branch already drawn inside its fan-out never reappears as a sibling.
       if (index.claimed.has(rowKey(node))) continue;
@@ -168,11 +198,27 @@ function buildSteps(
         chip: loopRosterStateChip(node.state),
         attemptLabel: loopAttemptLabel(node.attempt),
         fanOut: null,
-        isControl: isControlNode(graph, nodeId),
+        nodeClass,
+        quiet: isQuietStep(nodeClass, node.state),
       });
     }
   }
   return steps;
+}
+
+/** Folding one row behind a line of the same height would save nothing. */
+const STEP_FOLD_MIN = 2;
+
+/** Nothing folds when nothing would remain: an all-quiet round reads whole. */
+function buildFold(steps: readonly LoopStepRow[]): LoopStepsFold | null {
+  const quiet = steps.filter(step => step.quiet);
+  if (quiet.length < STEP_FOLD_MIN || quiet.length === steps.length) return null;
+  const notTaken = quiet.filter(step => step.chip.state === "not_taken").length;
+  const succeeded = quiet.length - notTaken;
+  const parts: string[] = [];
+  if (succeeded > 0) parts.push(`${succeeded} succeeded`);
+  if (notTaken > 0) parts.push(`${notTaken} not taken`);
+  return { hiddenCount: quiet.length, summary: parts.join(" · ") };
 }
 
 /**
@@ -186,11 +232,12 @@ function buildSteps(
 function buildSegments(steps: readonly LoopStepRow[]): LoopProgressSegment[] {
   const segments: LoopProgressSegment[] = [];
   for (const step of steps) {
-    if (step.isControl) continue;
+    // A fan-out container is authored `control`; its lanes are the counted steps.
     if (step.fanOut) {
       segments.push(...step.fanOut.segments.filter(segment => segment !== "never"));
       continue;
     }
+    if (!contributesStep(step.nodeClass)) continue;
     if (step.chip.state === "not_taken") continue;
     segments.push(progressSegmentForState(step.chip.state));
   }
@@ -203,7 +250,7 @@ function dominantParkReason(
   graph: LoopGraph | null
 ): string | null {
   const actionable = nodesInRound.filter(
-    node => !isControlNode(graph, node.node_id) && node.state !== "not_taken"
+    node => contributesStep(authoredClass(graph, node.node_id)) && node.state !== "not_taken"
   );
   if (actionable.length === 0) return null;
   if (!actionable.every(node => isParkedRosterState(node.state))) return null;
@@ -276,6 +323,7 @@ export function buildStepsProgress({
     rightMeta: remaining > 0 ? `${remaining} to go` : "",
     parkedReason,
     steps,
+    fold: buildFold(steps),
     ariaLabel: ariaLabel(progress, segments, rosterIsComplete),
   };
 }

--- a/web/src/systems/os/apps/loops/__tests__/loop-run-detail-location.test.tsx
+++ b/web/src/systems/os/apps/loops/__tests__/loop-run-detail-location.test.tsx
@@ -15,6 +15,7 @@ const workspace = vi.hoisted(() => ({
   ],
 }));
 const loopRunPageBodySpy = vi.hoisted(() => vi.fn((_props: Record<string, unknown>) => null));
+const quarantineSheetSpy = vi.hoisted(() => vi.fn((_props: Record<string, unknown>) => null));
 const loopRunPageSpy = vi.hoisted(() => vi.fn());
 const pageRun = vi.hoisted(() => ({
   current: null as {
@@ -51,7 +52,7 @@ vi.mock("../use-loop-run-page", () => ({
       effectiveRun: {
         generation: 1,
         historical: pageRun.current?.historical ?? false,
-        status: "running",
+        status: pageRun.current?.status ?? "running",
         workspace_id: "ws_home",
       },
       goalTurnsQuery: {
@@ -111,13 +112,18 @@ vi.mock("../use-loop-run-timetravel", () => ({
   }),
 }));
 
-vi.mock("@/systems/loops", () => ({
+vi.mock("@/systems/loops", async () => ({
+  // The real status vocabulary: the route decides "ended" with it, and a stub
+  // that answered from a hand-written list would only test the list.
+  ...(await vi.importActual<typeof import("@/systems/loops/lib/loop-formatters")>(
+    "@/systems/loops/lib/loop-formatters"
+  )),
   LoopForkDialog: () => null,
   LoopNodeAmendDialog: () => null,
   LoopNodeControlDialog: () => null,
   LoopNodeRerunDialog: () => null,
   LoopNodeRowActions: () => null,
-  LoopQuarantineSheet: () => null,
+  LoopQuarantineSheet: (props: Record<string, unknown>) => quarantineSheetSpy(props),
   LoopRunControlDialog: () => null,
   LoopRunControls: () => null,
   LoopRunOverflowMenu: () => null,
@@ -143,6 +149,7 @@ describe("LoopRunDetailLocation", () => {
     workspace.activeWorkspace = { id: "ws_project", name: "Project workspace" };
     workspace.runtimeWorkspaceId = "ws_home";
     loopRunPageBodySpy.mockClear();
+    quarantineSheetSpy.mockClear();
     loopRunPageSpy.mockClear();
     pageRun.current = null;
     vi.mocked(useTopbarSlot).mockClear();
@@ -215,6 +222,28 @@ describe("LoopRunDetailLocation", () => {
     expect(slot?.actions).toBeUndefined();
     expect(loopRunPageBodySpy).toHaveBeenLastCalledWith(
       expect.objectContaining({ renderNodeActions: undefined })
+    );
+  });
+
+  // The quarantine sheet offers requeue only while the daemon would accept it.
+  // The route owns that scoping, from the run's own status: live stays live.
+  it("Should keep the quarantine sheet live while the run is still running", () => {
+    pageRun.current = { loop_name: "implement-tasks", status: "running" };
+
+    render(<LoopRunDetailLocation runId="run-1" />);
+
+    expect(quarantineSheetSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ runEnded: false })
+    );
+  });
+
+  it("Should mark the quarantine sheet ended once the run reaches a terminal status", () => {
+    pageRun.current = { loop_name: "implement-tasks", status: "failed" };
+
+    render(<LoopRunDetailLocation runId="run-1" />);
+
+    expect(quarantineSheetSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ runEnded: true })
     );
   });
 });

--- a/web/src/systems/os/apps/loops/loop-run-detail-location.tsx
+++ b/web/src/systems/os/apps/loops/loop-run-detail-location.tsx
@@ -8,6 +8,7 @@ import { useLoopRunDetail } from "./use-loop-run-detail";
 
 import { useCurrentWindowLiveDataEnabled } from "../../hooks/use-window-live-data-enabled";
 import {
+  isTerminalLoopStatus,
   LoopForkDialog,
   LoopNodeAmendDialog,
   LoopNodeControlDialog,
@@ -324,6 +325,7 @@ function LoopRunDetail({
       <LoopQuarantineSheet
         isRequeuePending={nodeControls.isPending}
         node={quarantineNode}
+        runEnded={isTerminalLoopStatus(page.effectiveRun.status)}
         onOpenChange={open => {
           if (!open) nodeControls.closeQuarantine();
         }}


### PR DESCRIPTION
## What & why

Loop runs could complete useful work but become unreadable, fail to restart, or fail when an operator tried to recover them. The run page also mixed action results with execution markers and displayed quiet control/skipped steps with the same weight as the work that mattered.

This PR repairs those failures and makes the default run view easier to read while keeping results, attempts, metadata, and history available on demand. It contains five implementation commits, a documentation co-ship correction, and a verified CI repair, driven by public CLI/API/Web walks with real Codex sessions rather than simulated provider success.

Fixes #541.

### Reliability changes

| Trigger | Previous behavior | Result with this change |
| --- | --- | --- |
| Automatic `failed_only` succession carries a large result with its original task-run identity | Identical external result references were treated as conflicting results; task-result reads and detached-harness recovery could fail, preventing daemon startup | Both result queries deduplicate identical descriptors. Different content-addressed references still trigger the corruption guard |
| A later generation recovers from an earlier failure | Briefing could keep reporting a previous generation's failure/backoff/quarantine as the current blocker | Blockers and current activity use the current generation; prior attempts remain in history |
| A terminal run needs an operator retry | Guidance suggested `node requeue`, which the daemon rejected with `run_terminal` | A terminal `loop rerun` command is offered only when the existing planner accepts the exact node/item and dependencies |
| The built-in orchestrated command judge runs with a different executable name or PATH | `compozy` could be missing even after the real worker completed; the judge repeatedly failed and spent more model turns | Command evaluation uses the daemon-matched environment, preserves workspace PWD, and the built-in judge invokes quoted `COMPOZY_BIN` |
| A completed/canceled Goal is rerun with a fresh checkpoint | The checkpoint requested epoch 1 although its run-local handle already retained a closed binding, producing `goal_control_stale` | The existing owner transaction allocates the next run-local epoch; idempotency, active-binding policy and explicit rotation fences remain enforced |
| Cancellation happens after a successor is persisted but before the run cursor advances | Rerun could select an already-existing generation number | Rerun plans against immutable lineage while keeping the original run projection for the atomic compare-and-swap |
| Initial coordinator completion applies pre- and post-reservation snapshots | A stale in-memory generation cursor could emit two `generation_started` events | The cursor advances after the first snapshot, so new rounds emit one start event; historical events are not rewritten |

### Run-page changes

- **Outcome first:** raw payloads no longer become headlines or result names. Results have producer/round/item identities, latest-round results come first, and control/source execution markers are excluded from the artifact list.
- **Readable results:** show three output previews, expand the remaining outputs, then open individual Details. Inline JSON is correctly treated as available; real partial/pruned signals remain visible while their rows are folded.
- **Progressive disclosure:** successful control/source rows and `not_taken` branches fold behind a counted “N more steps” control. Expansion restores graph order. Running, pending, failed, quarantined, parked, and fan-out rows remain visible. An all-quiet round and a single quiet row stay expanded.
- **Consistent bar population:** source nodes no longer add progress segments; fan-out lanes retain their existing contribution.
- **Metadata on demand:** About starts closed while Usage stays visible. Identity, inputs, caller, workspace, version and copy controls remain available when expanded.
- **Terminal quarantine truth:** the card says the run ended; the entry sheet keeps its hint, input and attempt chain but withdraws Requeue/Cancel. Live-run recovery controls remain available.

Measured on the same real runs:

| Read | Before | After |
| --- | ---: | ---: |
| Review/fix outcome headline | 2,644 characters | 19 characters |
| Review/fix artifact rows | 14, including execution markers | 5 action results, 3 previewed |
| Review/fix primary progress rows | 7 | 1 + expandable summary |
| Orchestrated primary progress rows | 13 | 7 + expandable summary |
| Orchestrated progress segments | 8 | 7, matching the served count |

## How you verified it

### Real runtime scenarios

The isolated QA workspace used the actual daemon, public CLI/UDS and HTTP surfaces, the Web app, and native Codex sessions. The full reproduction and evidence index is in [the committed QA report](https://github.com/compozy/compozy/blob/596a83208/docs/qa/reports/2026-09-04-loop-stability.md).

| Scenario | Observed evidence |
| --- | --- |
| Carried external result and daemon restart | A real spec-cycle import produced a 23,953-byte result for 60 tasks. Automatic carry reproduced the baseline startup failure. The fixed daemon started against the same database; CLI and HTTP returned identical payload bytes with SHA-256 `04a086956afa6d4a04df752c6f1fd50196ddb805fd0d110366aa856ce9e81001` |
| Built-in review/fix | A reviewer reproduced incorrect invoice rounding, a fixer repaired production code, artifact finalization resolved the finding, and a second review returned an empty issue list. The run completed two rounds and survived a daemon restart |
| Per-task implementation | Two dependent invoice tasks ran in separate real worker sessions and completed. Independent `node --test` passed all seven tests at that stage |
| Orchestrated implementation | Real category workers completed tasks and stopped. After the command-environment repair, a fresh receipt-parser run finished with an approved judge; independent invoice tests passed all 14 cases |
| Missing dependency recovery | A missing receipt manifest caused a halt. After the manifest was supplied, the printed rerun arguments started generation 2, carried the successful import, and completed the real planning action without stale blockers |
| Completed Goal rerun | The orchestrated run completed generation 2 using a new Codex session and binding epoch 2 |
| In-flight cancellation and rerun | Actual thought/tool events preceded cancellation. The old prompt was revoked; public rerun completed generation 2 with a distinct session, epoch 2, an approved command judge and 73,056 reported tokens. No orchestrator session remained active |
| Lagging generation projection | A canceled run with cursor 3 and immutable generation 4 accepted generation 5 with parent 4, retaining the original ownership fence and existing quarantine policy |
| Lifecycle event uniqueness | A fresh public run had exactly one `generation_started` among ten raw timeline entries |

### Automated checks

```sh
make gate
make gate-status

bunx turbo run test --force --filter=./web -- \
  src/systems/loops/lib/__tests__/loop-run-progress.test.ts \
  src/systems/loops/components/__tests__/loop-run-page.test.tsx \
  src/systems/os/apps/loops/__tests__/loop-run-detail-location.test.tsx
```

- Final local gate: **PASS**. Go lint reported zero issues. Affected race suites passed, including daemon (148.035s), Loop (158.463s), and GlobalDB (821.279s).
- Web lint: **zero warnings/errors**; typecheck passed; **6,807 tests in 748 files passed**.
- Independent controller rerun of the three existing UI suites: **183 tests passed**, with **zero cached tasks**.
- Gate records were refreshed for the final content; all three lanes report `CURRENT-PASS` for fingerprint `2a0ef8c34c6601607f4fe24d701c59824ff33710`, including the documentation and CI follow-ups.
- Existing regression owners were extended: `TestGlobalDBCompleteRunLeaseShouldStoreLargeLoopOutputByRef`, `TestGoalSessionBindingLifecycleIntegration`, `TestServiceTimeTravelShouldPreserveHistoryContracts`, `TestGlobalDBGenerationSuccessionObservabilityCoverageMatrix`, `TestBriefingContract`, and the existing daemon/ACP/Web suites. Reproduced production failures were fixed without weakening assertions.
- Strict QA evidence audit: **PASS**, zero blockers/warnings. The runtime QA teardown completed with `clean: true` and no survivors. Screenshot capture reopened only the retained isolated lab.
- Existing test-environment React act/navigation/timer diagnostics are retained in the logs; no assertion failed. They are not presented as newly repaired behavior.

### CI documentation follow-up

The initial CI run caught two documentation omissions: the complete `implement-tasks` example still invoked bare `compozy`, and the new official-skill paragraph used the retired product name. Commit `208801f3b` synchronizes the example with the shipped `"$COMPOZY_BIN"` check and uses CompozyOS terminology. The existing tests remain unchanged.

```sh
make product-language-check
bunx turbo run test --filter=./packages/site -- lib/__tests__/runtime-docs-truth.test.ts
make gate
```

All three passed locally: the exact-copy documentation suite passed **15 tests with no cached tasks**, the language check passed, and the affected gate was refreshed. Current-head CI is still in progress; the first checklist item remains unchecked until it passes.

### Screenshots

These are real application captures from the retained QA runs. The two “before” images were taken before the final progress-disclosure pass, **after** the earlier outcome/result repair; they are not a claim of a full pre-PR baseline. Current captures use the final implementation. Window size and capture height vary to keep the relevant content readable.

**Default final read:** concise outcome, three result previews, folded progress, visible Usage and collapsed About.

![Completed review with concise outcome, three result previews and folded progress](https://github.com/user-attachments/assets/cad8c7e5-8a75-4b94-b04e-34d910b4ef6a)

<details>
<summary>1. Result content and prior findings remain inspectable</summary>

The latest review is first and its Details shows `{"issues":[]}`. Expanding the older outputs exposes the original rounding finding. This verifies that simplifying the default read did not remove the earlier result.

![Latest review Details with an empty issue list](https://github.com/user-attachments/assets/b1281e2e-83c3-4649-8946-e407ce7b9751)

![Earlier review finding retained behind the additional outputs disclosure](https://github.com/user-attachments/assets/8e5c078c-96ae-4627-9c3e-867c48cc572b)

</details>

<details>
<summary>2. Usage stays visible; About expands to the original metadata</summary>

Inputs, pinned version, agent references, caller, workspace and run identity remain available. The closed state is visible in the default screenshot above.

![Expanded About metadata beside the unchanged Usage panel](https://github.com/user-attachments/assets/24037c21-6724-4878-bfb1-75f8b7f80a0a)

</details>

<details>
<summary>3. Review progress: seven rows become one, with all rows recoverable</summary>

Before the final disclosure pass, the one-step round showed seven rows. The final default view above keeps the executed review prominent and counts the six quiet rows. Expanding restores the original graph order and each state label.

![Review progress before the final disclosure change](https://github.com/user-attachments/assets/d340325f-7e90-4126-9606-e4b034c97a6d)

![All seven review steps restored in graph order after expansion](https://github.com/user-attachments/assets/1f16baa7-7c45-4cc7-9897-9b8f4f1c2995)

</details>

<details>
<summary>4. Orchestrated progress: thirteen rows become seven; eight segments become seven</summary>

The successful source/control rows move behind the counted disclosure, and the bar matches the served seven-step count. These images are the same completed orchestrated run.

![Orchestrated progress before the final disclosure and source-count correction](https://github.com/user-attachments/assets/36b82acc-5a9f-4657-af40-0d5067d54ab7)

![Final orchestrated progress with seven rows and seven bar segments](https://github.com/user-attachments/assets/75f19abb-fe1c-4a7f-93c2-ae8f431b2f31)

</details>

<details>
<summary>5. Recovered dependency failure has a current successful briefing</summary>

The receipt dependency was supplied and the public rerun completed round 2. The old failure no longer dominates the current briefing; original results and story remain inspectable.

![Dependency recovery completed in round two without a stale failure card](https://github.com/user-attachments/assets/27963b19-eb3d-4a5f-978b-d10cf4a4ee53)

</details>

<details>
<summary>6. Terminal quarantine preserves evidence and withdraws invalid actions</summary>

The terminal card explains that the run ended and retains Open entry. The sheet keeps the hint, input, counters and ordered attempt chain, without Requeue or Cancel. This historical quarantined run is intentionally still failed; it is not claimed to have been automatically unquarantined.

![Terminal quarantine card with ended-run guidance and Open entry](https://github.com/user-attachments/assets/06f78cff-d383-43da-aa7a-b01e4160fe97)

![Terminal quarantine sheet retaining attempt history without Requeue or Cancel](https://github.com/user-attachments/assets/895eee09-e927-47a9-8fe8-a6886dfa1574)

</details>

<details>
<summary>7. Real cancellation recovery and its retained generation history</summary>

The run status is `done` in generation 2 after a real in-flight cancellation and public rerun. CLI turn evidence records the new session/binding epoch and approved command judge. The generation inspector still exposes the existing “no verdict recorded” / “interrupted before it finished” projection discussed under limitations below; the screenshot is included rather than hiding that discrepancy.

![Completed run after in-flight cancellation and rerun](https://github.com/user-attachments/assets/80899130-3215-4950-87c6-73dbc0e68417)

![Preserved generation history, including the remaining verdict-projection limitation](https://github.com/user-attachments/assets/33c3abab-ef45-49bc-8f1c-c87c948706a5)

</details>

<details>
<summary>8. Fresh timeline has one initial-round start</summary>

The narrated story contains one “Round 1 started”. The public raw timeline separately confirmed exactly one `generation_started`; the UI does not deduplicate persisted events to conceal the bug.

![Fresh completed run with one initial-round start in its story](https://github.com/user-attachments/assets/68fe1db5-a908-472f-be2b-fdbbf35f68b0)

</details>

<details>
<summary>9. Operational wake status and best-result navigation remain visible</summary>

The CI follow-up keeps Last woke and the daemon-selected Best result outside the closed About disclosure. Static identity and configuration remain folded. These captures come from the rebuilt application and real daemon using the existing deterministic E2E fixtures; they are separate from the live-provider QA walks above.

![Watch run with Last woke visible while About is closed](https://github.com/user-attachments/assets/8382a982-cb73-4de7-a916-1e2920054d63)

![Exhausted run with the daemon-selected best result accessible while About is closed](https://github.com/user-attachments/assets/8c26f6cd-281d-454f-a1f1-7f4061ed07c4)

The unchanged watch cursor and best-generation navigation assertions pass. The default-read E2E expands About before asserting run identity. The terminal keyboard E2E now focuses the actual xterm input and additionally proves executed command output, with no terminal production change. All four focused browser scenarios and 166 component tests passed.

</details>

The follow-up is committed as `596a83208`. Fresh focused browser validation passed all four scenarios; the final affected gate passed with 6,807 Web tests, typecheck, lint, and Go race/integration coverage. [CI for the current head](https://github.com/compozy/compozy/actions/runs/33973181368) passed 24 jobs on its first attempt, including the corrected Loop and terminal cases. One unchanged session-provider override case timed out waiting for a prompt request; its trace shows the runtime picker regained focus with the message still in the composer. Two fresh local repetitions passed unchanged. Only the failed Web shard and aggregate check are being rerun; the delivery checkbox remains open until they pass.

### Agent contribution and verification

Codex implemented and verified the core changes and assembled the delivery. **Claude Fable 5.1, High effort**, was orchestrated through a named **Herdr** TUI for the frontend. It used `eng-design`, `react`, `agent-browser` and the `eng-ui-screenshot` helpers. The UI reuses `Button`, `cn`, existing `Pill`/`PillDot` state chips and `Sheet` composites from `@compozy/ui`; no parallel primitive, palette or shared-package change was introduced.

The controller inspected the production diff and screenshots, reran the focused UI suites without cache, verified the real runtime outcomes and final gate, and retired the worker. Human review is still required before merge; no human verification is implied by agent execution.

## Impact

| Surface | Impact / compatibility |
| --- | --- |
| CLI and native tools | Existing task-result reads recover their intended behavior; briefing guidance uses the existing accepted rerun operation. No new verb, flag, output schema or `compozy__*` ID |
| HTTP / UDS / Web reads | Corrected result identity/availability, current-generation blockers and lifecycle events through existing DTOs/routes; Web progressively discloses content and scopes terminal quarantine controls |
| Built-in extensions | `implement-tasks` command judging uses the daemon-bound executable. No extension manifest, hook or config-key change |
| Persistence | No schema migration or persisted rewrite. Identical carried references deduplicate at the read boundary; conflicting references still fail. Rerun uses immutable lineage and the original atomic ownership check |
| Workspace isolation | Existing task/workspace authorization, generation owner checks, binding owner fences and run-local identities remain authoritative |
| `packages/ui` | Existing exports consumed; no source/token changes |
| Official skill / docs | `skills/compozy/references/loops.md` documents daemon-bound command discovery. Five affected QA scenario files and the runtime report are updated. The complete `packages/site/content/docs/examples/implement-tasks-loop.mdx` example is synchronized with the shipped YAML; no route/config reference change is needed |

### Limits and review focus

- Existing quarantined cells remain parked according to the current policy; this PR does not implicitly unquarantine them. Old duplicate timeline events remain immutable.
- Screenshot follow-up exposed a remaining generation-inspector discrepancy on the completed cancellation/rerun case: run status and Goal turn evidence say completed/approved, while generation rows still render “no verdict recorded” / “interrupted before it finished”. The current progress roster can also retain pending branches. This PR does not claim to fix those independent projections.
- Historical UI reads whose stored status is live retain their previous behavior; only terminal-status quarantine scoping changed here.
- The QA contract explicitly excludes unrelated network-channel collaboration. The original generic contract was retained; actual provider, role, artifact-reuse, disruption and cross-surface checks were preserved.
- Review the binding allocation guard, original rerun compare-and-swap, conflicting-result corruption guard, and preservation of live quarantine actions. Validation covers the recorded scenarios and regression invariants, not arbitrary Loop definitions.

---

- [ ] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Run steps can now be folded to reduce visual clutter, with summaries showing hidden steps.
  - Artifact lists preview the first three results, with expandable details and summaries for partial or pruned outputs.
  - “About this run” details are now collapsible.
  - Artifact names and output availability are displayed more clearly across generations.

- **Bug Fixes**
  - Quarantine actions are no longer offered after a run has ended.
  - Run summaries and rerun suggestions now reflect the latest generation and current run state.
  - Large outputs remain accessible without overwhelming the run headline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
