### PR TITLE
fix: tolerate unmatched terms in memory recall

### DIFF
--- a/docs/qa/scenarios/MS-006.md
+++ b/docs/qa/scenarios/MS-006.md
@@ -5,7 +5,7 @@ title: Search durable memory
 persona: Rafa
 journey: J-25
 expected: `POST /api/memory/search` runs recall; if empty, falls back to explicit `Search`; returns results + recall trace.
-entry_points: Web Knowledge search bar; `POST /api/memory/search`
+entry_points: Web Knowledge search bar; `POST /api/memory/search`; `compozy memory search`; `compozy__memory_search`
 qa_status: blocked-verify
 bug_ids:
 fix_status:
@@ -29,3 +29,31 @@ src: docs/qa/_seeds/feature-stories/05_analysis_memory-settings.md
 inventory: Implemented
 
 QA impact 2026-07-11: Memory listing is now exact beyond 200 entries with identity-scoped type/sort/cursor filters; catalog readiness and dirty recovery changed; FTS is rebuilt by an append-only repair migration; decision filename filtering occurs before the limit. Stale verdict reset to untested. Planning update only; historical evidence and bug/fix/retest fields preserved; no QA session ran.
+
+## Tolerant lexical recall regression
+
+Enable memory explicitly in the isolated runtime. Write a workspace note containing the unique
+term `zx00841` and a partition count. Search for `zx00841`, `zx00841 banana`, and
+`zx00841 banana laranja` through CLI and HTTP/UDS; each must recover the note. Exercise explicit
+single-term and unknown-word queries through an agent-hosted `compozy__memory_search` call as well.
+A query with no matching term must stay empty. More relevant matches must rank ahead of partial
+matches, including when the candidate and result limits are one. Other workspaces must remain
+excluded. FTS operators and punctuation must be handled as literal normalized terms, and automatic
+turn recall must continue skipping trivial queries.
+
+Owning suites: `TestStoreRecall`, `TestDaemonNativeTools`,
+`TestDaemonE2EMemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation`, and
+`TestDaemonE2EAgentMemoryBatchIsRecalledByNextSession`.
+
+Scoped regression evidence (2026-09-09): the real daemon CLI/HTTP/UDS and agent-hosted MCP run
+retains artifacts under `/private/tmp/compozy-iso-562-2wn59a/artifacts`, with targeted cleanup
+recorded in `artifacts/qa/teardown.json`. The command output is
+`/tmp/issue-562-integration-short.log`; the catalog/ranking race run is
+`/tmp/issue-562-recall-test.log`, and the native registry race run is
+`/tmp/issue-562-native-test.log`. This scope does not replace the historical Web walkthrough
+status above.
+
+Result: CLI/HTTP/UDS recall, native MCP search, catalog ranking/isolation, and unchanged background
+trivial-query filtering passed. The final targeted teardown reports `clean: true` with no
+survivors. The initial macOS socket-length setup failure was resolved by using the short owned
+root as `TMPDIR`; no product checks or runtime paths were changed for that environment issue.

--- a/docs/qa/scenarios/MS-006.md
+++ b/docs/qa/scenarios/MS-006.md
@@ -39,11 +39,12 @@ single-term and unknown-word queries through an agent-hosted `compozy__memory_se
 A query with no matching term must stay empty. More relevant matches must rank ahead of partial
 matches, including when the candidate and result limits are one. Other workspaces must remain
 excluded. FTS operators and punctuation must be handled as literal normalized terms, and automatic
-turn recall must continue skipping trivial queries.
+turn recall must continue skipping trivial queries and incidental partial matches. Continuing a
+compacted parent through a child must not inject the archived parent fact on a generic prompt.
 
-Owning suites: `TestStoreRecall`, `TestDaemonNativeTools`,
+Owning suites: `TestStoreRecall`, `TestNewRecallAugmenter`, `TestDaemonNativeTools`,
 `TestDaemonE2EMemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation`, and
-`TestDaemonE2EAgentMemoryBatchIsRecalledByNextSession`.
+`TestDaemonE2EAgentMemoryBatchIsRecalledByNextSession`, and `TestDaemonE2ECompactionResumeSafety`.
 
 Scoped regression evidence (2026-09-09): the real daemon CLI/HTTP/UDS and agent-hosted MCP run
 retains artifacts under `/private/tmp/compozy-iso-562-2wn59a/artifacts`, with targeted cleanup
@@ -53,7 +54,12 @@ recorded in `artifacts/qa/teardown.json`. The command output is
 `/tmp/issue-562-native-test.log`. This scope does not replace the historical Web walkthrough
 status above.
 
-Result: CLI/HTTP/UDS recall, native MCP search, catalog ranking/isolation, and unchanged background
-trivial-query filtering passed. The final targeted teardown reports `clean: true` with no
+Review follow-up: `/tmp/issue-562-integration-review.log` records the combined CLI/HTTP, native MCP,
+and unchanged compaction-resume safety suites passing with race detection (57.859s). The
+compaction suite passed in 18.19s after automatic prompt injection retained all-term matching.
+The catalog and augmenter race suites passed in `/tmp/issue-562-recall-review-test.log`.
+
+Result: CLI/HTTP/UDS recall, native MCP search, catalog ranking/isolation, automatic partial-match
+filtering, trivial-query filtering, and child-session compaction isolation passed. The final targeted teardown reports `clean: true` with no
 survivors. The initial macOS socket-length setup failure was resolved by using the short owned
 root as `TMPDIR`; no product checks or runtime paths were changed for that environment issue.

--- a/internal/daemon/daemon_memory_e2e_integration_test.go
+++ b/internal/daemon/daemon_memory_e2e_integration_test.go
@@ -130,7 +130,11 @@ func TestDaemonE2ERolesLiveApplyChangesNextMemoryExtractorModel(t *testing.T) {
 func TestDaemonE2EMemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation(t *testing.T) {
 	t.Parallel()
 
-	harness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{})
+	harness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+		ConfigSeed: e2etest.ConfigSeedOptions{Mutate: func(cfg *compozyconfig.Config) {
+			cfg.Memory.Enabled = true
+		}},
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
@@ -187,6 +191,60 @@ func TestDaemonE2EMemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation(t *test
 		"Release plan covers durable release checklist and observability ownership.",
 		memcontract.ScopeWorkspace,
 	)
+
+	t.Run("Should recover a unique term with unknown words through CLI and HTTP", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		writeMemoryViaCLI(t, ctx, harness, harness.WorkspaceRoot, "sonda-zx00841.md",
+			memcontract.TypeProject, "Partition count", "A contagem distinta de kind na particao zx00841 e 29.",
+			memcontract.ScopeWorkspace)
+		for _, query := range []string{"zx00841", "zx00841 banana", "zx00841 banana laranja"} {
+			var cliResult, httpResult compozycontract.MemorySearchResponse
+			if err := harness.CLI.RunJSONInDir(
+				ctx,
+				harness.WorkspaceRoot,
+				&cliResult,
+				"memory",
+				"search",
+				query,
+				"--scope",
+				"workspace",
+				"--workspace",
+				harness.WorkspaceRoot,
+				"-o",
+				"json",
+			); err != nil {
+				t.Fatalf("CLI search(%q): %v", query, err)
+			}
+			if err := harness.HTTPJSON(
+				ctx,
+				http.MethodPost,
+				"/api/memory/search",
+				memorySearchRequest(
+					query,
+					memcontract.ScopeWorkspace,
+					harness.WorkspaceRoot,
+				),
+				&httpResult,
+			); err != nil {
+				t.Fatalf("HTTP search(%q): %v", query, err)
+			}
+			for _, result := range []compozycontract.MemorySearchResponse{cliResult, httpResult} {
+				if len(result.Results) != 1 ||
+					!containsSearchResult(result, "project_sonda_zx00841.md", memcontract.ScopeWorkspace) {
+					t.Fatalf("search(%q) = %#v, want unique partition fact", query, result)
+				}
+				if len(result.Recall.Blocks) != 1 || len(result.Recall.Blocks[0].Entries) != 1 ||
+					result.Recall.Blocks[0].Entries[0].Filename != "project_sonda_zx00841.md" {
+					t.Fatalf(
+						"search(%q) recall = %#v, want catalog recall rather than an explicit-search fallback",
+						query,
+						result.Recall,
+					)
+				}
+			}
+		}
+	})
 
 	t.Run("Should return matching CLI and HTTP search results while ignoring noncanonical paths", func(t *testing.T) {
 		var cliSearch compozycontract.MemorySearchResponse
@@ -369,6 +427,9 @@ func TestDaemonE2EAgentMemoryBatchIsRecalledByNextSession(t *testing.T) {
 	t.Parallel()
 
 	harness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+		ConfigSeed: e2etest.ConfigSeedOptions{Mutate: func(cfg *compozyconfig.Config) {
+			cfg.Memory.Enabled = true
+		}},
 		MockAgents: []e2etest.MockAgentSpec{
 			{
 				FixturePath:  mockFixturePath(t, "hosted_native_tools_fixture.json"),
@@ -442,6 +503,35 @@ func TestDaemonE2EAgentMemoryBatchIsRecalledByNextSession(t *testing.T) {
 		!strings.Contains(string(structured), `"operations"`) {
 		t.Fatalf("memory batch structuredContent = %s, want applied operations", structured)
 	}
+
+	t.Run("Should recover explicit native queries with unknown terms", func(t *testing.T) {
+		for _, query := range []string{"cobalt", "cobalt quuxnonexistent"} {
+			search, err := client.CallTool(ctx, &sdkmcp.CallToolParams{
+				Name:      toolspkg.ToolIDMemorySearch.String(),
+				Arguments: map[string]any{"query": query, "scope": "workspace", "limit": 1},
+			})
+			if err != nil {
+				t.Fatalf("native memory search(%q): %v", query, err)
+			}
+			if search == nil || search.IsError {
+				t.Fatalf("native memory search(%q) = %#v", query, search)
+			}
+			payload, err := json.Marshal(search.StructuredContent)
+			if err != nil {
+				t.Fatalf("Marshal(native search): %v", err)
+			}
+			var result struct {
+				Recall memcontract.Packaged `json:"recall"`
+			}
+			if err := json.Unmarshal(payload, &result); err != nil {
+				t.Fatalf("Unmarshal(native search): %v", err)
+			}
+			if len(result.Recall.Blocks) != 1 || len(result.Recall.Blocks[0].Entries) != 1 ||
+				result.Recall.Blocks[0].Entries[0].Filename != "project_atomic_batch.md" {
+				t.Fatalf("native search(%q) = %s, want committed batch fact", query, payload)
+			}
+		}
+	})
 
 	readerSession := createFixtureBackedSession(
 		t,

--- a/internal/daemon/daemon_memory_e2e_integration_test.go
+++ b/internal/daemon/daemon_memory_e2e_integration_test.go
@@ -199,50 +199,52 @@ func TestDaemonE2EMemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation(t *test
 			memcontract.TypeProject, "Partition count", "A contagem distinta de kind na particao zx00841 e 29.",
 			memcontract.ScopeWorkspace)
 		for _, query := range []string{"zx00841", "zx00841 banana", "zx00841 banana laranja"} {
-			var cliResult, httpResult compozycontract.MemorySearchResponse
-			if err := harness.CLI.RunJSONInDir(
-				ctx,
-				harness.WorkspaceRoot,
-				&cliResult,
-				"memory",
-				"search",
-				query,
-				"--scope",
-				"workspace",
-				"--workspace",
-				harness.WorkspaceRoot,
-				"-o",
-				"json",
-			); err != nil {
-				t.Fatalf("CLI search(%q): %v", query, err)
-			}
-			if err := harness.HTTPJSON(
-				ctx,
-				http.MethodPost,
-				"/api/memory/search",
-				memorySearchRequest(
-					query,
-					memcontract.ScopeWorkspace,
+			t.Run("Should recall query "+query, func(t *testing.T) {
+				var cliResult, httpResult compozycontract.MemorySearchResponse
+				if err := harness.CLI.RunJSONInDir(
+					ctx,
 					harness.WorkspaceRoot,
-				),
-				&httpResult,
-			); err != nil {
-				t.Fatalf("HTTP search(%q): %v", query, err)
-			}
-			for _, result := range []compozycontract.MemorySearchResponse{cliResult, httpResult} {
-				if len(result.Results) != 1 ||
-					!containsSearchResult(result, "project_sonda_zx00841.md", memcontract.ScopeWorkspace) {
-					t.Fatalf("search(%q) = %#v, want unique partition fact", query, result)
+					&cliResult,
+					"memory",
+					"search",
+					query,
+					"--scope",
+					"workspace",
+					"--workspace",
+					harness.WorkspaceRoot,
+					"-o",
+					"json",
+				); err != nil {
+					t.Fatalf("CLI search(%q): %v", query, err)
 				}
-				if len(result.Recall.Blocks) != 1 || len(result.Recall.Blocks[0].Entries) != 1 ||
-					result.Recall.Blocks[0].Entries[0].Filename != "project_sonda_zx00841.md" {
-					t.Fatalf(
-						"search(%q) recall = %#v, want catalog recall rather than an explicit-search fallback",
+				if err := harness.HTTPJSON(
+					ctx,
+					http.MethodPost,
+					"/api/memory/search",
+					memorySearchRequest(
 						query,
-						result.Recall,
-					)
+						memcontract.ScopeWorkspace,
+						harness.WorkspaceRoot,
+					),
+					&httpResult,
+				); err != nil {
+					t.Fatalf("HTTP search(%q): %v", query, err)
 				}
-			}
+				for _, result := range []compozycontract.MemorySearchResponse{cliResult, httpResult} {
+					if len(result.Results) != 1 ||
+						!containsSearchResult(result, "project_sonda_zx00841.md", memcontract.ScopeWorkspace) {
+						t.Fatalf("search(%q) = %#v, want unique partition fact", query, result)
+					}
+					if len(result.Recall.Blocks) != 1 || len(result.Recall.Blocks[0].Entries) != 1 ||
+						result.Recall.Blocks[0].Entries[0].Filename != "project_sonda_zx00841.md" {
+						t.Fatalf(
+							"search(%q) recall = %#v, want catalog recall rather than an explicit-search fallback",
+							query,
+							result.Recall,
+						)
+					}
+				}
+			})
 		}
 	})
 
@@ -506,30 +508,32 @@ func TestDaemonE2EAgentMemoryBatchIsRecalledByNextSession(t *testing.T) {
 
 	t.Run("Should recover explicit native queries with unknown terms", func(t *testing.T) {
 		for _, query := range []string{"cobalt", "cobalt quuxnonexistent"} {
-			search, err := client.CallTool(ctx, &sdkmcp.CallToolParams{
-				Name:      toolspkg.ToolIDMemorySearch.String(),
-				Arguments: map[string]any{"query": query, "scope": "workspace", "limit": 1},
+			t.Run("Should recall query "+query, func(t *testing.T) {
+				search, err := client.CallTool(ctx, &sdkmcp.CallToolParams{
+					Name:      toolspkg.ToolIDMemorySearch.String(),
+					Arguments: map[string]any{"query": query, "scope": "workspace", "limit": 1},
+				})
+				if err != nil {
+					t.Fatalf("native memory search(%q): %v", query, err)
+				}
+				if search == nil || search.IsError {
+					t.Fatalf("native memory search(%q) = %#v", query, search)
+				}
+				payload, err := json.Marshal(search.StructuredContent)
+				if err != nil {
+					t.Fatalf("Marshal(native search): %v", err)
+				}
+				var result struct {
+					Recall memcontract.Packaged `json:"recall"`
+				}
+				if err := json.Unmarshal(payload, &result); err != nil {
+					t.Fatalf("Unmarshal(native search): %v", err)
+				}
+				if len(result.Recall.Blocks) != 1 || len(result.Recall.Blocks[0].Entries) != 1 ||
+					result.Recall.Blocks[0].Entries[0].Filename != "project_atomic_batch.md" {
+					t.Fatalf("native search(%q) = %s, want committed batch fact", query, payload)
+				}
 			})
-			if err != nil {
-				t.Fatalf("native memory search(%q): %v", query, err)
-			}
-			if search == nil || search.IsError {
-				t.Fatalf("native memory search(%q) = %#v", query, search)
-			}
-			payload, err := json.Marshal(search.StructuredContent)
-			if err != nil {
-				t.Fatalf("Marshal(native search): %v", err)
-			}
-			var result struct {
-				Recall memcontract.Packaged `json:"recall"`
-			}
-			if err := json.Unmarshal(payload, &result); err != nil {
-				t.Fatalf("Unmarshal(native search): %v", err)
-			}
-			if len(result.Recall.Blocks) != 1 || len(result.Recall.Blocks[0].Entries) != 1 ||
-				result.Recall.Blocks[0].Entries[0].Filename != "project_atomic_batch.md" {
-				t.Fatalf("native search(%q) = %s, want committed batch fact", query, payload)
-			}
 		}
 	})
 

--- a/internal/daemon/native_tool_workspace_memory_calls.go
+++ b/internal/daemon/native_tool_workspace_memory_calls.go
@@ -165,7 +165,8 @@ func (n *daemonNativeTools) memorySearch(
 		AgentName:   location.AgentName,
 		QueryText:   queryText,
 	}, memcontract.RecallOptions{
-		TopK: input.Limit,
+		TopK:              input.Limit,
+		AllowTrivialQuery: true,
 	})
 	if err != nil {
 		return toolspkg.ToolResult{}, nativeMemoryToolError(req.ToolID, err)

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -10332,24 +10332,26 @@ func TestDaemonNativeTools(t *testing.T) {
 		requireNativeStructuredExcludes(t, workspaceReadResult, []byte(rawClaim))
 
 		for _, query := range []string{"workspace memory body", "workspace", "workspace zx00841unknown"} {
-			searchResult, err := registry.Call(
-				t.Context(),
-				toolspkg.Scope{Operator: true, ProfileID: store.DefaultProfileID},
-				toolspkg.CallRequest{
-					ToolID: toolspkg.ToolIDMemorySearch,
-					Input:  json.RawMessage(`{"query":"` + query + `","workspace":"` + stableWorkspaceID + `"}`),
-				},
-			)
-			if err != nil {
-				t.Fatalf("Registry.Call(memory_search) error = %v", err)
-			}
-			requireNativeStructuredContains(t, searchResult, []byte(`workspace memory body`))
-			requireNativeStructuredContains(
-				t,
-				searchResult,
-				[]byte(`workspace::`+stableWorkspaceID+`::workspace.md::chunk:0001`),
-			)
-			requireNativeStructuredExcludes(t, searchResult, []byte(rawClaim))
+			t.Run("Should recall query "+query, func(t *testing.T) {
+				searchResult, err := registry.Call(
+					t.Context(),
+					toolspkg.Scope{Operator: true, ProfileID: store.DefaultProfileID},
+					toolspkg.CallRequest{
+						ToolID: toolspkg.ToolIDMemorySearch,
+						Input:  json.RawMessage(`{"query":"` + query + `","workspace":"` + stableWorkspaceID + `"}`),
+					},
+				)
+				if err != nil {
+					t.Fatalf("Registry.Call(memory_search) error = %v", err)
+				}
+				requireNativeStructuredContains(t, searchResult, []byte(`workspace memory body`))
+				requireNativeStructuredContains(
+					t,
+					searchResult,
+					[]byte(`workspace::`+stableWorkspaceID+`::workspace.md::chunk:0001`),
+				)
+				requireNativeStructuredExcludes(t, searchResult, []byte(rawClaim))
+			})
 		}
 		if err := memoryStore.ForWorkspace(workspaceRoot).Write(t.Context(),
 			memcontract.ScopeWorkspace,

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -10331,24 +10331,26 @@ func TestDaemonNativeTools(t *testing.T) {
 		requireNativeStructuredContains(t, workspaceReadResult, []byte(`"workspace.md"`))
 		requireNativeStructuredExcludes(t, workspaceReadResult, []byte(rawClaim))
 
-		searchResult, err := registry.Call(
-			t.Context(),
-			toolspkg.Scope{Operator: true, ProfileID: store.DefaultProfileID},
-			toolspkg.CallRequest{
-				ToolID: toolspkg.ToolIDMemorySearch,
-				Input:  json.RawMessage(`{"query":"workspace memory body","workspace":"` + stableWorkspaceID + `"}`),
-			},
-		)
-		if err != nil {
-			t.Fatalf("Registry.Call(memory_search) error = %v", err)
+		for _, query := range []string{"workspace memory body", "workspace", "workspace zx00841unknown"} {
+			searchResult, err := registry.Call(
+				t.Context(),
+				toolspkg.Scope{Operator: true, ProfileID: store.DefaultProfileID},
+				toolspkg.CallRequest{
+					ToolID: toolspkg.ToolIDMemorySearch,
+					Input:  json.RawMessage(`{"query":"` + query + `","workspace":"` + stableWorkspaceID + `"}`),
+				},
+			)
+			if err != nil {
+				t.Fatalf("Registry.Call(memory_search) error = %v", err)
+			}
+			requireNativeStructuredContains(t, searchResult, []byte(`workspace memory body`))
+			requireNativeStructuredContains(
+				t,
+				searchResult,
+				[]byte(`workspace::`+stableWorkspaceID+`::workspace.md::chunk:0001`),
+			)
+			requireNativeStructuredExcludes(t, searchResult, []byte(rawClaim))
 		}
-		requireNativeStructuredContains(t, searchResult, []byte(`workspace memory body`))
-		requireNativeStructuredContains(
-			t,
-			searchResult,
-			[]byte(`workspace::`+stableWorkspaceID+`::workspace.md::chunk:0001`),
-		)
-		requireNativeStructuredExcludes(t, searchResult, []byte(rawClaim))
 		if err := memoryStore.ForWorkspace(workspaceRoot).Write(t.Context(),
 			memcontract.ScopeWorkspace,
 			"batch.md",

--- a/internal/memory/catalog_document.go
+++ b/internal/memory/catalog_document.go
@@ -46,7 +46,8 @@ func buildCatalogMatchQuery(query string) (string, error) {
 	for _, term := range terms {
 		quoted = append(quoted, quoteCatalogMatchTerm(term))
 	}
-	return strings.Join(quoted, " AND "), nil
+	// BM25 ranks partial matches without letting an absent term discard useful candidates.
+	return strings.Join(quoted, " OR "), nil
 }
 
 func quoteCatalogMatchTerm(term string) string {

--- a/internal/memory/catalog_document.go
+++ b/internal/memory/catalog_document.go
@@ -37,7 +37,7 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func buildCatalogMatchQuery(query string) (string, error) {
+func buildCatalogMatchQuery(query string, matchAllTerms bool) (string, error) {
 	terms, err := searchQueryTerms(query)
 	if err != nil {
 		return "", err
@@ -45,6 +45,9 @@ func buildCatalogMatchQuery(query string) (string, error) {
 	quoted := make([]string, 0, len(terms))
 	for _, term := range terms {
 		quoted = append(quoted, quoteCatalogMatchTerm(term))
+	}
+	if matchAllTerms {
+		return strings.Join(quoted, " AND "), nil
 	}
 	// BM25 ranks partial matches without letting an absent term discard useful candidates.
 	return strings.Join(quoted, " OR "), nil

--- a/internal/memory/catalog_query.go
+++ b/internal/memory/catalog_query.go
@@ -159,7 +159,7 @@ func (c *catalog) search(
 		return nil, nil
 	}
 
-	match, err := buildCatalogMatchQuery(query)
+	match, err := buildCatalogMatchQuery(query, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/memory/recall.go
+++ b/internal/memory/recall.go
@@ -69,13 +69,14 @@ func NewProfileRecallAugmenter(
 			target = target.ForWorkspace(workspaceRoot)
 		}
 
-		packaged, err := target.Recall(ctx, memcontract.Query{
+		// Automatic prompt injection requires all terms to avoid surfacing incidental matches.
+		packaged, err := target.recall(ctx, memcontract.Query{
 			AgentName: sAgentName(target),
 			QueryText: query,
 		}, memcontract.RecallOptions{
 			TopK:          maxRecallResults,
 			RawCandidates: 20,
-		})
+		}, true)
 		if err != nil {
 			return message, err
 		}

--- a/internal/memory/recall/recall_packaging.go
+++ b/internal/memory/recall/recall_packaging.go
@@ -131,15 +131,11 @@ func groupBlocks(ranked []rankedCandidate, now time.Time) []memcontract.Block {
 
 	blocks := make([]memcontract.Block, 0, len(order))
 	for _, key := range order {
-		entries := groups[key]
-		sort.SliceStable(entries, func(i, j int) bool {
-			return entries[i].ID < entries[j].ID
-		})
 		meta := blockMeta[key]
 		blocks = append(blocks, memcontract.Block{
 			Scope:     meta.scope,
 			AgentTier: meta.tier,
-			Entries:   entries,
+			Entries:   groups[key],
 		})
 	}
 	return blocks

--- a/internal/memory/recall_source.go
+++ b/internal/memory/recall_source.go
@@ -27,6 +27,15 @@ func (s *Store) Recall(
 	query memcontract.Query,
 	opts memcontract.RecallOptions,
 ) (memcontract.Packaged, error) {
+	return s.recall(ctx, query, opts, false)
+}
+
+func (s *Store) recall(
+	ctx context.Context,
+	query memcontract.Query,
+	opts memcontract.RecallOptions,
+	matchAllTerms bool,
+) (memcontract.Packaged, error) {
 	if ctx == nil {
 		return memcontract.Packaged{}, errors.New("memory: recall context is required")
 	}
@@ -56,7 +65,7 @@ func (s *Store) Recall(
 		defer lease.Release()
 		options = append(options, memoryrecall.WithSignalRecorder(lease))
 	}
-	recaller := memoryrecall.New(s, options...)
+	recaller := memoryrecall.New(catalogRecallSource{Store: s, matchAllTerms: matchAllTerms}, options...)
 	return recaller.Recall(ctx, query, opts)
 }
 
@@ -145,11 +154,33 @@ func (s *Store) ensureRecallCatalogReady(ctx context.Context, query memcontract.
 	return nil
 }
 
+type catalogRecallSource struct {
+	*Store
+	matchAllTerms bool
+}
+
+func (s catalogRecallSource) Candidates(
+	ctx context.Context,
+	query memcontract.Query,
+	opts memcontract.RecallOptions,
+) ([]memoryrecall.Candidate, error) {
+	return s.Store.recallCandidates(ctx, query, opts, s.matchAllTerms)
+}
+
 // Candidates implements recall.Source on top of the derived chunk catalog.
 func (s *Store) Candidates(
 	ctx context.Context,
 	query memcontract.Query,
 	opts memcontract.RecallOptions,
+) ([]memoryrecall.Candidate, error) {
+	return s.recallCandidates(ctx, query, opts, false)
+}
+
+func (s *Store) recallCandidates(
+	ctx context.Context,
+	query memcontract.Query,
+	opts memcontract.RecallOptions,
+	matchAllTerms bool,
 ) ([]memoryrecall.Candidate, error) {
 	if s.catalog == nil {
 		return nil, nil
@@ -161,7 +192,7 @@ func (s *Store) Candidates(
 	if db == nil {
 		return nil, nil
 	}
-	match, err := buildCatalogMatchQuery(query.QueryText)
+	match, err := buildCatalogMatchQuery(query.QueryText, matchAllTerms)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/memory/recall_source.go
+++ b/internal/memory/recall_source.go
@@ -164,7 +164,7 @@ func (s catalogRecallSource) Candidates(
 	query memcontract.Query,
 	opts memcontract.RecallOptions,
 ) ([]memoryrecall.Candidate, error) {
-	return s.Store.recallCandidates(ctx, query, opts, s.matchAllTerms)
+	return s.recallCandidates(ctx, query, opts, s.matchAllTerms)
 }
 
 // Candidates implements recall.Source on top of the derived chunk catalog.

--- a/internal/memory/recall_test.go
+++ b/internal/memory/recall_test.go
@@ -89,6 +89,18 @@ func TestNewRecallAugmenter(t *testing.T) {
 		if strings.Contains(got, "User message:") {
 			t.Fatalf("Augment() = %q, want no legacy user message marker", got)
 		}
+
+		t.Run("Should leave partial matches out of automatic recall", func(t *testing.T) {
+			query := "auth sessions quuxnonexistent"
+			got, err := augmenter(t.Context(),
+				&session.Session{Type: session.SessionTypeUser, Workspace: workspaceRoot}, query)
+			if err != nil {
+				t.Fatalf("Augment(partial query) error = %v", err)
+			}
+			if got != query {
+				t.Fatalf("Augment(partial query) = %q, want unchanged user message", got)
+			}
+		})
 	})
 
 	t.Run("Should resolve durable recall from the session profile", func(t *testing.T) {

--- a/internal/memory/recall_test.go
+++ b/internal/memory/recall_test.go
@@ -189,6 +189,93 @@ func TestBuildPackagedRecallBlock(t *testing.T) {
 func TestStoreRecall(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should retrieve partial lexical matches with ranked bounded and isolated results", func(t *testing.T) {
+		t.Parallel()
+		baseDir := t.TempDir()
+		store := newOpenTestStore(t, filepath.Join(baseDir, "global"),
+			WithCatalogDatabasePath(filepath.Join(baseDir, "compozy.db")),
+		).ForWorkspace(filepath.Join(baseDir, "workspace"))
+		if err := store.EnsureDirs(); err != nil {
+			t.Fatalf("EnsureDirs() error = %v", err)
+		}
+		for _, fixture := range []struct{ filename, body string }{
+			{"strong.md", "A contagem distinta de kind na particao zx00841 e 29."},
+			{"partial.md", "A contagem de kind e 10."},
+			{"unrelated.md", "Orchids bloom in spring."},
+		} {
+			if err := store.Write(
+				t.Context(),
+				memcontract.ScopeWorkspace,
+				fixture.filename,
+				mustMemoryContent(
+					t,
+					testMemoryMeta{Name: fixture.filename, Type: memcontract.TypeProject},
+					fixture.body,
+				),
+			); err != nil {
+				t.Fatalf("Write(%s) error = %v", fixture.filename, err)
+			}
+		}
+		other := store.ForWorkspace(filepath.Join(baseDir, "other"))
+		if err := other.EnsureDirs(); err != nil {
+			t.Fatalf("other.EnsureDirs() error = %v", err)
+		}
+		if err := other.Write(
+			t.Context(),
+			memcontract.ScopeWorkspace,
+			"hidden.md",
+			mustMemoryContent(
+				t,
+				testMemoryMeta{Name: "Hidden", Type: memcontract.TypeProject},
+				"zx00841 banana kind",
+			),
+		); err != nil {
+			t.Fatalf("other.Write() error = %v", err)
+		}
+		closeRecallRecorders(t, store)
+		for _, test := range []struct {
+			name, query string
+			wantCount   int
+		}{
+			{"Should match a unique term", "zx00841", 1},
+			{"Should tolerate an unknown term", "zx00841 banana", 1},
+			{"Should tolerate multiple unknown terms", "zx00841 banana laranja", 1},
+			{"Should rank more relevant matches first", "kind zx00841", 2},
+			{"Should tolerate natural language", "kind distinct count zx00841", 2},
+			{"Should tokenize FTS syntax as literal words", `"zx00841" OR (banana*) -NEAR:unknown`, 1},
+			{"Should normalize repeated mixed case terms", "ZX00841 zx00841 banana", 1},
+			{"Should return nothing without a lexical match", "quuxnonexistent banana", 0},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+				for range 2 {
+					packaged, err := store.Recall(t.Context(), memcontract.Query{QueryText: test.query},
+						memcontract.RecallOptions{TopK: 5, AllowTrivialQuery: true})
+					if err != nil {
+						t.Fatalf("Recall(%q) error = %v", test.query, err)
+					}
+					entries := packagedRecallEntries(packaged)
+					if len(entries) != test.wantCount {
+						t.Fatalf("Recall(%q) = %#v, want %d entries", test.query, entries, test.wantCount)
+					}
+					if len(entries) > 0 && entries[0].Filename != "strong.md" {
+						t.Fatalf("Recall(%q) = %#v, want strong.md first", test.query, entries)
+					}
+					limited, err := store.Recall(t.Context(), memcontract.Query{QueryText: test.query},
+						memcontract.RecallOptions{TopK: 1, RawCandidates: 1, AllowTrivialQuery: true})
+					if err != nil {
+						t.Fatalf("bounded Recall(%q) error = %v", test.query, err)
+					}
+					bounded := packagedRecallEntries(limited)
+					if len(bounded) != min(1, test.wantCount) ||
+						(len(bounded) > 0 && bounded[0].Filename != "strong.md") {
+						t.Fatalf("bounded Recall(%q) = %#v", test.query, bounded)
+					}
+				}
+			})
+		}
+	})
+
 	t.Run("Should isolate profile recall while sharing workspace memory IT-058 IT-074", func(t *testing.T) {
 		t.Parallel()
 

--- a/packages/site/content/docs/memory/system.mdx
+++ b/packages/site/content/docs/memory/system.mdx
@@ -247,7 +247,8 @@ Search matches any normalized term and ranks candidates with BM25 before recall 
 Unicode, trigram, recency, and signal scores. Results remain bounded by the requested limit and
 the caller's visible memory scopes. Queries with no lexical match return no results. Punctuation
 separates terms; query text is not an FTS expression. Automatic turn recall retains its trivial-query
-filter to avoid injecting memory for short conversational messages.
+filter and requires all normalized terms to match. This keeps short conversational messages and
+incidental partial matches from injecting memory into prompts.
 
 ## Frozen snapshot and recall
 

--- a/packages/site/content/docs/memory/system.mdx
+++ b/packages/site/content/docs/memory/system.mdx
@@ -237,6 +237,18 @@ land by itself. Retrying the same payload returns the existing decision and mark
 `content` fields. Batch support is currently agent-manageable through `compozy__memory_propose`; the
 CLI and HTTP/UDS entry-write shapes remain single-document replacements.
 
+## Searching memory
+
+CLI, HTTP/UDS, and `compozy__memory_search` accept explicit single-term queries. Adding an unknown
+word does not remove a useful lexical match: a query such as `zx00841 banana` can return a note
+containing the unique term `zx00841`, even when `banana` is absent.
+
+Search matches any normalized term and ranks candidates with BM25 before recall combines the
+Unicode, trigram, recency, and signal scores. Results remain bounded by the requested limit and
+the caller's visible memory scopes. Queries with no lexical match return no results. Punctuation
+separates terms; query text is not an FTS expression. Automatic turn recall retains its trivial-query
+filter to avoid injecting memory for short conversational messages.
+
 ## Frozen snapshot and recall
 
 At session start, CompozyOS captures a **frozen snapshot** of the resolved memory context (profile,

--- a/skills/compozy/references/memory.md
+++ b/skills/compozy/references/memory.md
@@ -87,7 +87,8 @@ matches any normalized query term, so adding an unknown word does not discard an
 (for example, `zx00841 banana` can recover a note containing `zx00841`). BM25 orders the bounded
 candidate sets before recall combines Unicode, trigram, recency, and signal scores. Queries
 without a lexical match return no results. Punctuation separates terms; FTS operators are not
-accepted as query syntax. Automatic turn recall still skips trivial queries.
+accepted as query syntax. Automatic turn recall still skips trivial queries and requires all
+normalized terms before injecting a memory, so incidental partial matches do not enter prompts.
 
 The search path prefers the derived catalog and falls back to deterministic lexical search when needed. Rebuild derived indexes after large memory edits or suspected catalog drift:
 

--- a/skills/compozy/references/memory.md
+++ b/skills/compozy/references/memory.md
@@ -82,6 +82,13 @@ Search deterministic Memory v2 recall before opening individual files:
     compozy memory search "auth sessions" --scope workspace -o json
     compozy memory search "review tone" --scope agent --agent reviewer --agent-tier global --include-system -o json
 
+Explicit CLI/API and `compozy__memory_search` queries accept a single term. Lexical retrieval
+matches any normalized query term, so adding an unknown word does not discard an exact match
+(for example, `zx00841 banana` can recover a note containing `zx00841`). BM25 orders the bounded
+candidate sets before recall combines Unicode, trigram, recency, and signal scores. Queries
+without a lexical match return no results. Punctuation separates terms; FTS operators are not
+accepted as query syntax. Automatic turn recall still skips trivial queries.
+
 The search path prefers the derived catalog and falls back to deterministic lexical search when needed. Rebuild derived indexes after large memory edits or suspected catalog drift:
 
     compozy memory reindex --scope workspace -o json


### PR DESCRIPTION
## What & why

Fixes #562.

A note containing the unique term `zx00841` could be found with `zx00841`, but adding an unknown word (`zx00841 banana`) removed every recall candidate. Explicit native-tool single-word searches also returned an empty package even though CLI/API searches accepted them.

The shared FTS expression required every normalized term with `AND` in both Unicode and trigram retrieval. The native search handler also omitted `AllowTrivialQuery`. In addition, a precision regression exposed that packaging sorted already-ranked entries by ID, placing a weaker lexical match before a stronger one in the same scope.

This change:

- Explicit searches retrieve candidates matching any normalized, quoted term. Existing BM25 ordering, per-index candidate bounds, score fusion, shadow precedence, and deterministic tie-breakers remain the ranking architecture; no new search backend or query syntax is introduced.
- Preserves relevance order within each packaged scope block instead of sorting entries alphabetically by ID. Scope-block order and global top-K selection remain unchanged.
- Enables `AllowTrivialQuery` for explicit `compozy__memory_search` calls, matching the existing API/CLI behavior. Automatic turn recall retains its intentional trivial-query filter and all-term candidate retrieval. A private adapter over the existing recall source interface selects strict matching only for prompt augmentation, without changing public options or coupling retrieval semantics to `AllowTrivialQuery`.
- Documents the supported behavior and extends the existing catalog, native-tool, and daemon integration suites.

## How you verified it

Implemented and verified by OpenAI Codex (GPT-6-Astra, high reasoning).

The regression was reproduced before the production fix with real SQLite catalog fixtures: unique-term plus unknown-word queries returned zero entries. The native regression independently returned an empty package for a single-term explicit query. The ranking test then exposed the packaging-order defect and passed after correcting production packaging.

Current head: `0982f9c6519b6fdeb3070aa8d5b6dbe062ff4f6c`. The original implementation gate below checked `8e7707cabecf5dd493a76c8f4d42326108bd36c0`; follow-up behavior was verified with the additional commands below.

- `GOMAXPROCS=4 COMPOZY_GO_TEST_P=1 COMPOZY_GO_LINT_CONCURRENCY=2 mise exec -- make gate`: passed all affected lanes. Pinned golangci-lint 2.13.1 reported zero issues; Go race tests for `./internal/daemon/... ./internal/memory/... ./skills/...` passed (daemon 223.849s; gate test lane 237s). Both gate records use fingerprint `c356737053893cb17ec50c8039c5eccafa9f40af`.
- Focused `TestStoreRecall|TestRecaller` race suites and the existing native-tool suite passed, including the new regression cases.
- Existing test-convention checks passed for all three modified test files. Pre-commit formatting and commitlint passed with fully staged files and a temporary no-stash hook configuration; repository hooks remain unchanged.

An earlier gate hit the existing five-second boot-reconciliation test deadline under shared-machine load. The unchanged test passed in isolation (14.924s), and the complete affected gate then passed with repository-supported resource caps. No timeout or assertion was relaxed.

Follow-up validation and review remediation:

- `GOMAXPROCS=4 CGO_ENABLED=1 mise exec -- go test -race -p=1 -parallel=4 ./internal/memory -run 'TestNewRecallAugmenter|TestStoreRecall' -count=1`: passed (2.201s), covering tolerant explicit retrieval and conservative automatic prompt augmentation.
- `GOMAXPROCS=4 CGO_ENABLED=1 mise exec -- go test -race -p=1 -tags=integration ./internal/daemon -run '^TestDaemonE2E(MemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation|AgentMemoryBatchIsRecalledByNextSession|CompactionResumeSafety)$' -count=1 -parallel=4 -v -artifacts -outputdir <owned-root>/artifacts`: all three existing integration suites passed (57.859s total; compaction 18.19s). Log: `/tmp/issue-562-integration-review.log`. Artifacts: `artifacts/_artifacts/3191788729/e2e-145583170` and `artifacts/_artifacts/162758681/e2e-2116209254`; targeted teardown at 17:05:23Z reports `clean: true` with no survivors or forced kills.
- The first CI runtime run exposed an automatic-recall precision regression: a generic child-session prompt retrieved a parent checkpoint through an incidental term. Production prompt augmentation now retains its original all-term retrieval. The existing compaction safety assertions were left unchanged and passed after this correction.
- CodeRabbit's consolidated minor finding was addressed with sequential named `Should ...` subtests for all three query loops, preserving all assertions. Its generic docstring-coverage warning conflicts with the repository's explicit comment convention; the investigated disposition is recorded in the PR discussion. Greptile's initial review reported confidence 5/5 and no actionable findings; both bots must review the final head.
- At the user's direction, publication of the follow-up does not wait for another local gate; current-head required CI owns final delivery validation. The already-running affected local gate finished with one staticcheck QF1008 finding (redundant embedded-field selector), corrected in the final one-line commit without changing behavior. The final head is validated by CI.

The catalog matrix covers a unique term, one/multiple unknown terms, natural language, strong-versus-partial precision, duplicate/case normalization, FTS punctuation/operators, no-match behavior, workspace isolation, repeated deterministic output, and top-K/raw-candidate limits of one. Existing suites retain profile/agent shadowing, CJK trigram lookup, reserved-word handling, and background trivial-query coverage.

Real runtime evidence uses the built daemon, real SQLite, CLI over UDS, HTTP, and an agent-hosted MCP tool call (the existing ACP fixture supplies the agent transport, not memory results):

- `CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2E(MemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation|AgentMemoryBatchIsRecalledByNextSession)$' -count=1 -parallel=1 -v -artifacts -outputdir <owned-root>/artifacts`: the native MCP/batch/next-session suite passed, including `cobalt` and `cobalt quuxnonexistent`. The CLI test exposed an incorrect fixture filename expectation; it was corrected to the existing controller's underscore normalization.
- `GOMAXPROCS=4 CGO_ENABLED=1 mise exec -- go test -race -p=1 -tags=integration ./internal/daemon -run '^TestDaemonE2EMemoryCatalogCLIHTTPParityAndNoncanonicalPathIsolation$' -count=1 -parallel=4 -v -artifacts -outputdir <owned-root>/artifacts`: passed (38.870s). CLI/HTTP results and their recall blocks recovered `zx00841`, `zx00841 banana`, and `zx00841 banana laranja`; the unchanged reindex, health, log, no-match, and noncanonical-path checks also passed.

Owned runtime root: `/private/tmp/compozy-iso-562-2wn59a`. Native artifacts: `artifacts/_artifacts/3287995610/e2e-2140222561`; final CLI/HTTP artifacts: `artifacts/_artifacts/1519789123/e2e-1000379763`. `artifacts/qa/teardown.json` records `clean: true`, no survivors, and no forced kills. Scenario `docs/qa/scenarios/MS-006.md` records the evidence. The first environment attempt exceeded macOS's UDS path limit; a short isolated `TMPDIR` fixed setup without changing runtime code or test thresholds.

## Impact

Cross-surface audit using `docs/_memory/change-impact.md`:

- **Native tools:** `compozy__memory_search` now accepts explicit single-term queries and tolerates unknown terms. Tool IDs, schemas, capability gates, redaction, and authorization are unchanged.
- **CLI/HTTP/UDS:** `compozy memory search` and `POST /api/memory/search` share tolerant catalog retrieval and relevance-preserving packaging. Request/response shapes and flags are unchanged. No SDK or OpenAPI regeneration is needed.
- **Extensibility/hooks/config:** no extension, hook, bridge, provider, or config contract changes. Memory defaults, extractor parsing, and dreaming settings are untouched. Runtime fixtures enable memory explicitly.
- **Workspace data isolation:** existing profile/workspace/agent SQL visibility predicates still run before ordering and limiting. The new regression includes a stronger matching entry in another workspace and verifies it cannot enter the result set.
- **User-state compatibility (SD-013):** no schema changes, migrations, file rewrites, or config changes. Existing derived indexes remain usable immediately; no reindex is required. Public data shapes remain compatible; result membership becomes tolerant and entries within each scope block retain relevance order.
- **Official skill:** updated `skills/compozy/references/memory.md` with explicit-query behavior and the automatic-recall distinction.
- **Web/Docs:** Knowledge search consumes the same API behavior; no frontend implementation changed. Updated `packages/site/content/docs/memory/system.mdx` and scenario `MS-006`. Backend/public transport evidence is recorded above; this change does not claim a new browser walkthrough or a live model/provider evaluation. Recall itself is deterministic and model-independent. Automatic prompt augmentation keeps all-term precision to preserve child-session compaction isolation.

---

- [x] Original implementation passed `make gate`; follow-up delivery requires current-head CI green (publication with CI validation explicitly authorized)
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved memory search to find relevant results when queries contain uncommon or previously unknown terms.
  * Improved automatic memory recall so partial or weak matches do not trigger unrelated results.
  * Preserved workspace boundaries and redaction while supporting broader search scenarios.
  * Improved recall consistency and result ordering across CLI, HTTP, and native memory searches.
* **Tests**
  * Expanded coverage for cross-session memory recall, query variations, and CLI/HTTP search consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->