### PR TITLE
fix: scope startup tool guidance to session roles

### DIFF
--- a/docs/qa/reports/2026-09-09-scoped-tool-prompts.md
+++ b/docs/qa/reports/2026-09-09-scoped-tool-prompts.md
@@ -1,0 +1,75 @@
+# Scoped startup tool guidance
+
+Issue: [#563](https://github.com/compozy/compozy/issues/563). Scenario: [ET-049](../scenarios/ET-049.md).
+
+## Verified behavior
+
+The composed startup prompt includes the bundled `compozy` router once for tools-enabled
+interactive sessions, system task workers, dream curators, coordinators, and ordinary spawned
+workers. It does not inline either tool reference manual. The native skill-view suite verifies
+that both complete manuals remain readable on demand through the existing registry, including
+workspace-scoped artifact continuations when the configured result budget offloads the envelope.
+Structured resource content remains complete; display text preserves intentional secret redaction.
+
+Memory extraction is tested through its actual `spawnExtractorSession` caller, using a custom
+agent and the real session manager. Checkpoint summarization is tested through `Summarize`, also
+with a custom agent. Both omit the router because their durable role identifies a routine that
+only transforms supplied input. A stopped and resumed extractor preserves that selection.
+Automatic title generation has the same supplied-input-only contract and is covered in the same
+assembly matrix using its existing `SpawnRoleAutoTitle`. Unknown roles and older unmarked
+checkpoint sessions conservatively retain the router.
+
+## Reproduction and measurement
+
+Before the fix, the existing composed-assembler suite failed the router contract: a minimal
+startup was 53,850 bytes, with 53,836 bytes of bundled tool reference source. The test output
+reported the missing router before production code changed.
+
+The integration pass measured complete prompts at the session driver's startup boundary:
+
+| Session | Assembled bytes | Tool router |
+| --- | ---: | --- |
+| Interactive | 13,987 | once |
+| System worker | 13,991 | once |
+| Dream curator | 13,989 | once |
+| Spawned worker | 13,993 | once |
+| Memory extractor via Spawn | 3,600 | omitted |
+| Resumed extractor | 3,409 | omitted |
+| Checkpoint summary | 3,402 | omitted |
+
+These are fixture measurements, not workload token or billing estimates. The recorded router
+body was 10,648 bytes; formatting and editorial changes can alter byte counts without altering
+selection. The follow-up composed-assembler pass measured an 11,585-byte router and 11,599-byte
+minimal capable startup after the continuation guidance was added; the input-only cases contained
+only the 12-byte base fixture. The table does not imply that every session in one class needs no tools. Coordinator
+selection, disabled tools, role normalization, and unknown roles are covered by the owning
+composed-assembler matrix.
+
+## Verification
+
+- `CGO_ENABLED=1 go test -race ./internal/daemon -run 'TestComposedAssembler|TestHarnessContextResolver|TestDaemonCheckpointSummarizer|TestForkedMemoryExtractor' -count=1` passed.
+- `CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestHarnessContextIntegration' -count=1 -v` passed all four scenarios, including real SQLite creation and resume. The first pass exposed an old task fixture missing its required profile identity and an invalid function-value `reflect.DeepEqual`; the fixture now supplies the profile and resume compares filter behavior as well as all other policy fields.
+- `TestDaemonE2EAutomationPromptTriggerCreatesCompletedSystemSession` passed with the real daemon and ACP mock driver in subprocesses (65.48 seconds for the scenario), using the shared verification lock.
+- The capped follow-up checks passed for boot flag combinations, the complete role matrix
+  (including auto-title), and native full-resource recovery. The latter passed in 40.600 seconds
+  with `go test -race -p=1 -parallel=4 ./internal/daemon -run
+  '^TestDaemonNativeTools/Should_dispatch_skill_catalog_tools_through_the_real_skill_registry$'
+  -count=1 -v`; both direct and retained-envelope paths returned all 19,804 and 34,032 structured
+  manual bytes. The display path retained the two redaction records for the tools-and-skills manual.
+- Native resource coverage extends the existing `TestDaemonNativeTools/Should_dispatch_skill_catalog_tools_through_the_real_skill_registry` case to both manuals, preserving full structured-content checks and intentional display redaction. A 32 KiB fixture
+  budget exercises the existing artifact offload and native paged-read continuation without
+  raising any production limit.
+- Integration homes are allocated by `integrationHomePaths` under `t.TempDir`; the suite isolates `HOME`, `COMPOZY_HOME`, and sockets and joins its owned runtime during cleanup. No operator provider credentials are used. The targeted teardown reported `TEARDOWN_ALL_CLEAN=true`; its captured evidence is retained locally at `.cache/issue-563/teardown.json`.
+
+The integration suite uses the existing driver fixture with real session storage. It does not
+measure real-model compliance with reference reading or provider billing. The PR records the
+additional subprocess runtime check, pinned local gate, current-head CI, and review dispositions.
+
+## Compatibility and scope
+
+No schema, config key, tool ID, descriptor, permission rule, hosted MCP behavior, or workspace
+boundary changes. The existing lineage `spawn_role` field carries the checkpoint-summary role;
+older data remains readable without migration. Startup and turn resolution receive the same
+role. This is prompt selection, not an authorization boundary. Memory/dreaming defaults and the
+extractor parser/lifecycle remain owned by #561 and are unchanged here. Memory-dependent harness
+fixtures explicitly opt in.

--- a/docs/qa/reports/2026-09-09-scoped-tool-prompts.md
+++ b/docs/qa/reports/2026-09-09-scoped-tool-prompts.md
@@ -6,9 +6,13 @@ Issue: [#563](https://github.com/compozy/compozy/issues/563). Scenario: [ET-049]
 
 The composed startup prompt includes the bundled `compozy` router once for tools-enabled
 interactive sessions, system task workers, dream curators, coordinators, and ordinary spawned
-workers. It does not inline either tool reference manual. The native skill-view suite verifies
+workers when skills are enabled. In that configuration it does not inline either tool reference
+manual. When skills are disabled, capable sessions retain both complete manuals inline because the
+reference-reading tool is unavailable. The same role gate still omits all tool guidance for
+input-only routines. The native skill-view suite verifies
 that both complete manuals remain readable on demand through the existing registry, including
 workspace-scoped artifact continuations when the configured result budget offloads the envelope.
+The managed-session continuation is tested under the existing workspace authorization policy.
 Structured resource content remains complete; display text preserves intentional secret redaction.
 
 Memory extraction is tested through its actual `spawnExtractorSession` caller, using a custom
@@ -64,6 +68,18 @@ composed-assembler matrix.
 The integration suite uses the existing driver fixture with real session storage. It does not
 measure real-model compliance with reference reading or provider billing. The PR records the
 additional subprocess runtime check, pinned local gate, current-head CI, and review dispositions.
+
+## Review follow-up
+
+The review follow-up passed `go test -race -p=1 -parallel=4 -tags=integration ./internal/daemon
+-run '^TestHarnessContextIntegration|^TestDaemonNativeTools/Should_dispatch_skill_catalog_tools_through_the_real_skill_registry$'
+-count=1 -v` in 66.863 seconds. The existing creation/resume scenario now runs with skills enabled
+and disabled: capable sessions receive the router or both complete inline manuals respectively;
+extractors and checkpoint summaries omit either form. The same native resource suite verifies
+named cases and the expected truncation state for all three resources, including both tool
+manuals being offloaded under the 32 KiB fixture budget. Complete content and redaction assertions
+remain intact. The original local gate passed; final remediation gates run in CI at the author's
+request.
 
 ## Compatibility and scope
 

--- a/docs/qa/scenarios/ET-049.md
+++ b/docs/qa/scenarios/ET-049.md
@@ -58,8 +58,9 @@ deleted activation toolset. Reset for the next QA cycle.
 ## Startup guidance scope
 
 The startup contract now loads the complete bundled `compozy` router once in tools-enabled capable
-sessions. `references/tools-and-skills.md` and `references/native-tools.md` remain complete and
-readable through `compozy__skill_view`; neither manual is inlined at startup. This supersedes the
+sessions when skills are enabled. `references/tools-and-skills.md` and `references/native-tools.md` remain complete and
+readable through `compozy__skill_view`. When skills are disabled, capable sessions retain both
+manuals inline because native skill reads are unavailable; input-only roles still omit them. This supersedes the
 historical full-manual startup expectation above. Verify complete structured resource content and
 redacted display text under the default result budget, then lower the fixture budget and recover
 the full retained envelope through workspace-scoped `compozy__tool_artifact_read` pages. No
@@ -68,7 +69,7 @@ CLI/filesystem fallback or larger production result limit is needed.
 Verify interactive sessions, system task workers, dream curators, coordinators, and ordinary
 spawned workers retain discovery guidance. Verify the actual memory extractor `Spawn` caller and
 checkpoint summary caller and automatic title generator omit the tool router based on their persisted roles, including custom
-agent routing and resumed extractor sessions. Unknown or historical unmarked roles retain guidance.
+agent routing and resumed extractor sessions, with skills enabled and disabled. Unknown or historical unmarked roles retain guidance.
 Turning tools off still omits the section. Missing guidance must not change tool authorization,
 workspace scope, hosted MCP, or the gateway.
 

--- a/docs/qa/scenarios/ET-049.md
+++ b/docs/qa/scenarios/ET-049.md
@@ -53,3 +53,26 @@ registered, callable, and returned a structured result. Evidence assertions: 32/
 
 QA impact 2026-08-02: native extensibility now includes extension inventory/preview and excludes the
 deleted activation toolset. Reset for the next QA cycle.
+
+
+## Startup guidance scope
+
+The startup contract now loads the complete bundled `compozy` router once in tools-enabled capable
+sessions. `references/tools-and-skills.md` and `references/native-tools.md` remain complete and
+readable through `compozy__skill_view`; neither manual is inlined at startup. This supersedes the
+historical full-manual startup expectation above. Verify complete structured resource content and
+redacted display text under the default result budget, then lower the fixture budget and recover
+the full retained envelope through workspace-scoped `compozy__tool_artifact_read` pages. No
+CLI/filesystem fallback or larger production result limit is needed.
+
+Verify interactive sessions, system task workers, dream curators, coordinators, and ordinary
+spawned workers retain discovery guidance. Verify the actual memory extractor `Spawn` caller and
+checkpoint summary caller and automatic title generator omit the tool router based on their persisted roles, including custom
+agent routing and resumed extractor sessions. Unknown or historical unmarked roles retain guidance.
+Turning tools off still omits the section. Missing guidance must not change tool authorization,
+workspace scope, hosted MCP, or the gateway.
+
+Owning automated checks: `TestComposedAssemblerAssembleStartupLoadsBundledToolsSectionDescriptor`,
+`TestHarnessContextIntegrationScopesToolGuidanceForInternalCallers`, and the existing native skill
+catalog dispatch case in `TestDaemonNativeTools`. Record assembled prompt byte counts and the
+integration/E2E result in [the scoped startup guidance report](../reports/2026-09-09-scoped-tool-prompts.md).

--- a/internal/daemon/checkpoint_summary_summarizer.go
+++ b/internal/daemon/checkpoint_summary_summarizer.go
@@ -11,6 +11,7 @@ import (
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	"github.com/compozy/compozy/internal/memory"
 	"github.com/compozy/compozy/internal/session"
+	"github.com/compozy/compozy/internal/store"
 )
 
 const checkpointSummaryStopTimeout = 10 * time.Second
@@ -82,6 +83,7 @@ func (s *daemonCheckpointSummarizer) Summarize(
 			Name:                checkpointSummarySessionName,
 			Workspace:           strings.TrimSpace(request.WorkspaceRoot),
 			Type:                session.SessionTypeDream,
+			Lineage:             &store.SessionLineage{SpawnRole: session.SpawnRoleCheckpointSummary},
 			DiscardStartFailure: true,
 		})
 		return created, created != nil, createErr

--- a/internal/daemon/checkpoint_summary_summarizer_test.go
+++ b/internal/daemon/checkpoint_summary_summarizer_test.go
@@ -58,6 +58,10 @@ func TestDaemonCheckpointSummarizer(t *testing.T) {
 		if !strings.Contains(got, "cobalt") || !strings.Contains(got, "preserve context") {
 			t.Fatalf("Summarize() = %q, want collected agent chunks", got)
 		}
+		if manager.createOpts.Lineage == nil ||
+			manager.createOpts.Lineage.SpawnRole != session.SpawnRoleCheckpointSummary {
+			t.Fatalf("checkpoint role = %#v, want explicit input-only role", manager.createOpts.Lineage)
+		}
 		if manager.createOpts.Name != checkpointSummarySessionName ||
 			manager.createOpts.Type != session.SessionTypeDream ||
 			manager.createOpts.Workspace != request.WorkspaceRoot ||

--- a/internal/daemon/composed_assembler_test.go
+++ b/internal/daemon/composed_assembler_test.go
@@ -643,11 +643,13 @@ func TestComposedAssemblerAssembleStartupLoadsNetworkResponseRegisterSection(t *
 func TestComposedAssemblerAssembleStartupLoadsBundledToolsSectionDescriptor(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name        string
-		sessionType session.Type
-		role        string
-		disabled    bool
-		wantRouter  bool
+		name           string
+		sessionType    session.Type
+		role           string
+		disabled       bool
+		wantRouter     bool
+		skillsDisabled bool
+		wantManuals    bool
 	}{
 		{name: "Should retain discovery for interactive sessions", sessionType: session.SessionTypeUser, wantRouter: true},
 		{name: "Should retain discovery for system task workers", sessionType: session.SessionTypeSystem, wantRouter: true},
@@ -660,10 +662,19 @@ func TestComposedAssemblerAssembleStartupLoadsBundledToolsSectionDescriptor(t *t
 		{name: "Should normalize internal role metadata", sessionType: session.SessionTypeSpawned, role: " MEMORY-EXTRACTOR "},
 		{name: "Should preserve guidance for unknown roles", sessionType: session.SessionTypeSystem, role: "custom-role", wantRouter: true},
 		{name: "Should respect disabled tools", sessionType: session.SessionTypeUser, disabled: true},
+		{name: "Should preserve complete manuals when skills are disabled", sessionType: session.SessionTypeUser, skillsDisabled: true, wantManuals: true},
+		{name: "Should omit extractor guidance when skills are disabled", sessionType: session.SessionTypeSpawned, role: session.SpawnRoleMemoryExtractor, skillsDisabled: true},
+		{name: "Should omit title guidance when skills are disabled", sessionType: session.SessionTypeSpawned, role: session.SpawnRoleAutoTitle, skillsDisabled: true},
+		{name: "Should omit summary guidance when skills are disabled", sessionType: session.SessionTypeDream, role: session.SpawnRoleCheckpointSummary, skillsDisabled: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			resolver := NewHarnessContextResolver(HarnessRuntimeSignals{ToolsPromptSectionEnabled: !tc.disabled})
+			resolver := NewHarnessContextResolver(
+				HarnessRuntimeSignals{
+					ToolsPromptSectionEnabled:  !tc.disabled,
+					SkillsPromptSectionEnabled: !tc.skillsDisabled,
+				},
+			)
 			assembler := NewComposedAssembler(
 				WithSectionSelector(NewSectionSelector(resolver, nil)),
 				WithPromptSectionDescriptors(defaultStartupPromptSectionDescriptors(nil, nil, nil)...),
@@ -683,7 +694,7 @@ func TestComposedAssemblerAssembleStartupLoadsBundledToolsSectionDescriptor(t *t
 			if count := strings.Count(got, strings.TrimSpace(router)); count != wantCount {
 				t.Fatalf("router occurrences=%d want router=%t", count, tc.wantRouter)
 			}
-			if !tc.wantRouter && got != "Base prompt." {
+			if !tc.wantRouter && !tc.wantManuals && got != "Base prompt." {
 				t.Fatal("input-only startup contains unexpected guidance")
 			}
 			for _, path := range []string{bundledToolsReference, bundledNativeToolsReference} {
@@ -691,8 +702,8 @@ func TestComposedAssemblerAssembleStartupLoadsBundledToolsSectionDescriptor(t *t
 				if err != nil {
 					t.Fatal(err)
 				}
-				if strings.Contains(got, strings.TrimSpace(manual)) {
-					t.Fatalf("startup inlines reference %s", path)
+				if strings.Contains(got, strings.TrimSpace(manual)) != tc.wantManuals {
+					t.Fatalf("startup reference %s presence differs from expected %t", path, tc.wantManuals)
 				}
 			}
 		})

--- a/internal/daemon/composed_assembler_test.go
+++ b/internal/daemon/composed_assembler_test.go
@@ -642,53 +642,61 @@ func TestComposedAssemblerAssembleStartupLoadsNetworkResponseRegisterSection(t *
 
 func TestComposedAssemblerAssembleStartupLoadsBundledToolsSectionDescriptor(t *testing.T) {
 	t.Parallel()
-
-	t.Run("Should render tools guide only when tools section is selected", func(t *testing.T) {
-		t.Parallel()
-
-		resolver := NewHarnessContextResolver(HarnessRuntimeSignals{
-			ToolsPromptSectionEnabled: true,
+	for _, tc := range []struct {
+		name        string
+		sessionType session.Type
+		role        string
+		disabled    bool
+		wantRouter  bool
+	}{
+		{name: "Should retain discovery for interactive sessions", sessionType: session.SessionTypeUser, wantRouter: true},
+		{name: "Should retain discovery for system task workers", sessionType: session.SessionTypeSystem, wantRouter: true},
+		{name: "Should retain discovery for dream curators", sessionType: session.SessionTypeDream, wantRouter: true},
+		{name: "Should retain discovery for coordinators", sessionType: session.SessionTypeCoordinator, wantRouter: true},
+		{name: "Should retain discovery for spawned workers", sessionType: session.SessionTypeSpawned, role: session.DefaultSpawnRole, wantRouter: true},
+		{name: "Should omit discovery for extractor children", sessionType: session.SessionTypeSpawned, role: session.SpawnRoleMemoryExtractor},
+		{name: "Should omit discovery for checkpoint summaries", sessionType: session.SessionTypeDream, role: session.SpawnRoleCheckpointSummary},
+		{name: "Should omit discovery for title generator children", sessionType: session.SessionTypeSpawned, role: session.SpawnRoleAutoTitle},
+		{name: "Should normalize internal role metadata", sessionType: session.SessionTypeSpawned, role: " MEMORY-EXTRACTOR "},
+		{name: "Should preserve guidance for unknown roles", sessionType: session.SessionTypeSystem, role: "custom-role", wantRouter: true},
+		{name: "Should respect disabled tools", sessionType: session.SessionTypeUser, disabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			resolver := NewHarnessContextResolver(HarnessRuntimeSignals{ToolsPromptSectionEnabled: !tc.disabled})
+			assembler := NewComposedAssembler(
+				WithSectionSelector(NewSectionSelector(resolver, nil)),
+				WithPromptSectionDescriptors(defaultStartupPromptSectionDescriptors(nil, nil, nil)...),
+			)
+			got := assembleStartupPrompt(t, assembler, session.StartupPromptContext{
+				SessionType: tc.sessionType, SpawnRole: tc.role,
+			}, testPromptAgent("Base prompt."), t.TempDir())
+			router, err := skillbundled.LoadContent(bundledCompozySkillName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("assembled startup bytes=%d router bytes=%d", len(got), len(router))
+			wantCount := 0
+			if tc.wantRouter {
+				wantCount = 1
+			}
+			if count := strings.Count(got, strings.TrimSpace(router)); count != wantCount {
+				t.Fatalf("router occurrences=%d want router=%t", count, tc.wantRouter)
+			}
+			if !tc.wantRouter && got != "Base prompt." {
+				t.Fatal("input-only startup contains unexpected guidance")
+			}
+			for _, path := range []string{bundledToolsReference, bundledNativeToolsReference} {
+				manual, err := skillbundled.LoadResource(bundledCompozySkillName, path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if strings.Contains(got, strings.TrimSpace(manual)) {
+					t.Fatalf("startup inlines reference %s", path)
+				}
+			}
 		})
-		assembler := NewComposedAssembler(
-			WithSectionSelector(NewSectionSelector(resolver, nil)),
-			WithPromptSectionDescriptors(defaultStartupPromptSectionDescriptors(nil, nil, nil)...),
-		)
-
-		got := assembleStartupPrompt(
-			t,
-			assembler,
-			session.StartupPromptContext{
-				SessionType: session.SessionTypeUser,
-			},
-			testPromptAgent("Base prompt."),
-			t.TempDir(),
-		)
-
-		toolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledToolsReference)
-		if err != nil {
-			t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledToolsReference, err)
-		}
-		toolsGuide = strings.TrimSpace(toolsGuide)
-		nativeToolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledNativeToolsReference)
-		if err != nil {
-			t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledNativeToolsReference, err)
-		}
-		nativeToolsGuide = strings.TrimSpace(nativeToolsGuide)
-		networkSkill, err := skillbundled.LoadResource(bundledCompozySkillName, bundledNetworkReference)
-		if err != nil {
-			t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledNetworkReference, err)
-		}
-		networkSkill = strings.TrimSpace(networkSkill)
-		if !strings.Contains(got, toolsGuide) {
-			t.Fatalf("AssembleStartup() = %q, want bundled tools guide content", got)
-		}
-		if !strings.Contains(got, nativeToolsGuide) {
-			t.Fatalf("AssembleStartup() = %q, want bundled native tools guide content", got)
-		}
-		if strings.Contains(got, networkSkill) {
-			t.Fatalf("AssembleStartup() = %q, want no bundled network content without channel", got)
-		}
-	})
+	}
 }
 
 type recordingPromptProvider struct {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -6351,12 +6351,19 @@ func orderedFragments(wantMemory bool, wantSkills bool) []string {
 	if wantSkills {
 		fragments = append(fragments, "<available-skills>", "compozy")
 	}
-	fragments = append(fragments, "# CompozyOS")
+	if wantSkills {
+		fragments = append(fragments, "# CompozyOS")
+	} else {
+		fragments = append(fragments, "# Tools And Skills", "# Native Tools")
+	}
 	return fragments
 }
 
 func excludedFragments(wantMemory bool, wantSkills bool) []string {
-	fragments := []string{"# Tools And Skills", "# Native Tools"}
+	fragments := []string{"# CompozyOS"}
+	if wantSkills {
+		fragments = []string{"# Tools And Skills", "# Native Tools"}
+	}
 	if !wantMemory {
 		fragments = append(fragments, "# Persistent Memory")
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5348,28 +5348,28 @@ func TestBootInjectsComposedAssemblerForFeatureFlagCombinations(t *testing.T) {
 		wantSkills    bool
 	}{
 		{
-			name:          "memory on and skills on",
+			name:          "Should compose startup with memory on and skills on",
 			memoryEnabled: true,
 			skillsEnabled: true,
 			wantMemory:    true,
 			wantSkills:    true,
 		},
 		{
-			name:          "memory on and skills off",
+			name:          "Should compose startup with memory on and skills off",
 			memoryEnabled: true,
 			skillsEnabled: false,
 			wantMemory:    true,
 			wantSkills:    false,
 		},
 		{
-			name:          "memory off and skills on",
+			name:          "Should compose startup with memory off and skills on",
 			memoryEnabled: false,
 			skillsEnabled: true,
 			wantMemory:    false,
 			wantSkills:    true,
 		},
 		{
-			name:          "memory off and skills off",
+			name:          "Should compose startup with memory off and skills off",
 			memoryEnabled: false,
 			skillsEnabled: false,
 			wantMemory:    false,
@@ -6351,12 +6351,12 @@ func orderedFragments(wantMemory bool, wantSkills bool) []string {
 	if wantSkills {
 		fragments = append(fragments, "<available-skills>", "compozy")
 	}
-	fragments = append(fragments, "# Tools And Skills", "# Native Tools")
+	fragments = append(fragments, "# CompozyOS")
 	return fragments
 }
 
 func excludedFragments(wantMemory bool, wantSkills bool) []string {
-	fragments := make([]string, 0, 2)
+	fragments := []string{"# Tools And Skills", "# Native Tools"}
 	if !wantMemory {
 		fragments = append(fragments, "# Persistent Memory")
 	}

--- a/internal/daemon/harness_context.go
+++ b/internal/daemon/harness_context.go
@@ -8,6 +8,7 @@ import (
 	"github.com/compozy/compozy/internal/acp"
 	"github.com/compozy/compozy/internal/network/participation"
 	"github.com/compozy/compozy/internal/session"
+	"github.com/compozy/compozy/internal/store"
 )
 
 const (
@@ -216,6 +217,7 @@ func (r *HarnessContextResolver) ResolveStartup(startup session.StartupPromptCon
 		Session: HarnessSessionInput{
 			SessionID:            startup.SessionID,
 			Type:                 startup.SessionType,
+			SpawnRole:            startup.SpawnRole,
 			NetworkParticipation: startup.NetworkParticipation,
 			WorkspaceID:          startup.WorkspaceID,
 			Workspace:            startup.Workspace,
@@ -243,6 +245,7 @@ func (r *HarnessContextResolver) ResolvePrompt(
 		Session: HarnessSessionInput{
 			SessionID:            info.ID,
 			Type:                 info.Type,
+			SpawnRole:            store.NormalizeSessionLineage(info.ID, info.Lineage).SpawnRole,
 			NetworkParticipation: info.NetworkParticipation,
 			WorkspaceID:          info.WorkspaceID,
 			Workspace:            info.Workspace,
@@ -327,6 +330,7 @@ func normalizeHarnessSessionContext(input HarnessSessionInput) (HarnessSessionCo
 	return HarnessSessionContext{
 		SessionID:            strings.TrimSpace(input.SessionID),
 		Type:                 sessionType,
+		SpawnRole:            strings.ToLower(strings.TrimSpace(input.SpawnRole)),
 		SessionClass:         sessionClass,
 		NetworkParticipation: networkParticipation,
 		NetworkLive:          networkParticipation.Mode == participation.ModeLive,

--- a/internal/daemon/harness_context_integration_test.go
+++ b/internal/daemon/harness_context_integration_test.go
@@ -42,6 +42,7 @@ func TestHarnessContextIntegrationStartupAndPromptShareResolverPolicy(t *testing
 func testHarnessContextIntegrationStartupAndPromptShareResolverPolicy(t *testing.T) {
 	homePaths := integrationHomePaths(t)
 	cfg := testConfig(t, homePaths)
+	cfg.Memory.Enabled = true
 	workspaceRoot := homePaths.HomeDir + "/workspace"
 	resolvedWorkspace := newHarnessIntegrationWorkspace(t, homePaths, cfg, workspaceRoot)
 	writeDaemonMemoryIndex(t, cfg.Memory.GlobalDir, workspaceRoot)
@@ -163,44 +164,31 @@ func testHarnessContextIntegrationStartupAndPromptShareResolverPolicy(t *testing
 		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledNetworkReference, err)
 	}
 	networkSkill = strings.TrimSpace(networkSkill)
-	toolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledToolsReference)
+	toolRouter, err := skillbundled.LoadContent(bundledCompozySkillName)
 	if err != nil {
-		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledToolsReference, err)
+		t.Fatalf("LoadContent(%q) error = %v", bundledCompozySkillName, err)
 	}
-	toolsGuide = strings.TrimSpace(toolsGuide)
-	nativeToolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledNativeToolsReference)
-	if err != nil {
-		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledNativeToolsReference, err)
-	}
-	nativeToolsGuide = strings.TrimSpace(nativeToolsGuide)
+	toolRouter = strings.TrimSpace(toolRouter)
 	if got := driver.startCalls[0].SystemPrompt; !strings.Contains(got, "# Compozy Network Response Register") {
 		t.Fatalf("start system prompt = %q, want compact network response register section", got)
 	}
 	if got := driver.startCalls[0].SystemPrompt; strings.Contains(got, networkSkill) {
 		t.Fatalf("start system prompt = %q, want compact register, not full network skill", got)
 	}
-	if got := driver.startCalls[0].SystemPrompt; !strings.Contains(got, toolsGuide) {
-		t.Fatalf("start system prompt = %q, want bundled tools guide content", got)
-	}
-	if got := driver.startCalls[0].SystemPrompt; !strings.Contains(got, nativeToolsGuide) {
-		t.Fatalf("start system prompt = %q, want bundled native tools guide content", got)
+	if got := driver.startCalls[0].SystemPrompt; !strings.Contains(got, toolRouter) {
+		t.Fatalf("start system prompt = %q, want bundled tool router content", got)
 	}
 	if got := strings.Count(driver.startCalls[0].SystemPrompt, "# Compozy Network Response Register"); got != 1 {
 		t.Fatalf("network response register occurrences = %d, want 1", got)
 	}
-	if got := strings.Count(driver.startCalls[0].SystemPrompt, toolsGuide); got != 1 {
-		t.Fatalf("tools guide occurrences = %d, want 1", got)
-	}
-	if got := strings.Count(driver.startCalls[0].SystemPrompt, nativeToolsGuide); got != 1 {
-		t.Fatalf("native tools guide occurrences = %d, want 1", got)
+	if got := strings.Count(driver.startCalls[0].SystemPrompt, toolRouter); got != 1 {
+		t.Fatalf("tool router occurrences = %d, want 1", got)
 	}
 	gatedCatalogEntry := `name="` + gatedSkillName + `"`
 	if got := driver.startCalls[0].SystemPrompt; strings.Contains(got, gatedCatalogEntry) {
 		t.Fatalf("start system prompt advertised gated skill %q", gatedSkillName)
 	}
-	// The startup prompt embeds the bundled tools guide, which documents the
-	// "<compozy-situation-context>" open tag in prose; count the closing tag so the
-	// assertion measures rendered sections, not documentation mentions.
+	// Count rendered sections, not documentation mentions.
 	if got := strings.Count(driver.startCalls[0].SystemPrompt, "</compozy-situation-context>"); got != 1 {
 		t.Fatalf("situation context section occurrences = %d, want 1", got)
 	}
@@ -228,8 +216,7 @@ func testHarnessContextIntegrationStartupAndPromptShareResolverPolicy(t *testing
 		"The prior session selected cobalt.",
 		"You are a coding assistant.",
 		"<available-skills>",
-		toolsGuide,
-		nativeToolsGuide,
+		toolRouter,
 		"# Compozy Network Response Register",
 	)
 
@@ -367,6 +354,7 @@ func TestHarnessContextIntegrationResolverStableAcrossResume(t *testing.T) {
 func testHarnessContextIntegrationResolverStableAcrossResume(t *testing.T) {
 	homePaths := integrationHomePaths(t)
 	cfg := testConfig(t, homePaths)
+	cfg.Memory.Enabled = true
 	workspaceRoot := homePaths.HomeDir + "/workspace"
 	resolvedWorkspace := newHarnessIntegrationWorkspace(t, homePaths, cfg, workspaceRoot)
 
@@ -422,7 +410,18 @@ func testHarnessContextIntegrationResolverStableAcrossResume(t *testing.T) {
 		t.Fatalf("ResolvePrompt(after resume) error = %v", err)
 	}
 
-	if !reflect.DeepEqual(beforeResume.Policy, afterResume.Policy) {
+	beforeFilter, afterFilter := beforeResume.Policy.SkillInjectionFilter, afterResume.Policy.SkillInjectionFilter
+	if beforeFilter == nil || afterFilter == nil {
+		t.Fatal("resume policy must retain skill filtering")
+	}
+	for _, skill := range daemonInstance.skillsRegistry.List() {
+		if beforeFilter(skill) != afterFilter(skill) {
+			t.Fatalf("resume changed filtering for skill %q", skill.Meta.Name)
+		}
+	}
+	beforePolicy, afterPolicy := beforeResume.Policy, afterResume.Policy
+	beforePolicy.SkillInjectionFilter, afterPolicy.SkillInjectionFilter = nil, nil
+	if !reflect.DeepEqual(beforePolicy, afterPolicy) {
 		t.Fatalf(
 			"resolved policy changed across resume\nbefore=%#v\nafter=%#v",
 			beforeResume.Policy,
@@ -435,27 +434,19 @@ func testHarnessContextIntegrationResolverStableAcrossResume(t *testing.T) {
 		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledNetworkReference, err)
 	}
 	networkSkill = strings.TrimSpace(networkSkill)
-	toolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledToolsReference)
+	toolRouter, err := skillbundled.LoadContent(bundledCompozySkillName)
 	if err != nil {
-		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledToolsReference, err)
+		t.Fatalf("LoadContent(%q) error = %v", bundledCompozySkillName, err)
 	}
-	toolsGuide = strings.TrimSpace(toolsGuide)
-	nativeToolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledNativeToolsReference)
-	if err != nil {
-		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledNativeToolsReference, err)
-	}
-	nativeToolsGuide = strings.TrimSpace(nativeToolsGuide)
+	toolRouter = strings.TrimSpace(toolRouter)
 	if got := strings.Count(driver.startCalls[1].SystemPrompt, "# Compozy Network Response Register"); got != 1 {
 		t.Fatalf("resume prompt network response register occurrences = %d, want 1", got)
 	}
 	if got := driver.startCalls[1].SystemPrompt; strings.Contains(got, networkSkill) {
 		t.Fatalf("resume prompt = %q, want compact register, not full network skill", got)
 	}
-	if got := strings.Count(driver.startCalls[1].SystemPrompt, toolsGuide); got != 1 {
-		t.Fatalf("resume prompt tools guide occurrences = %d, want 1", got)
-	}
-	if got := strings.Count(driver.startCalls[1].SystemPrompt, nativeToolsGuide); got != 1 {
-		t.Fatalf("resume prompt native tools guide occurrences = %d, want 1", got)
+	if got := strings.Count(driver.startCalls[1].SystemPrompt, toolRouter); got != 1 {
+		t.Fatalf("resume prompt tool router occurrences = %d, want 1", got)
 	}
 	if got := strings.Count(driver.startCalls[1].SystemPrompt, compozyRuntimeEnvelopeStart); got != 1 {
 		t.Fatalf("resume prompt Compozy runtime envelope occurrences = %d, want 1", got)
@@ -472,6 +463,7 @@ func TestHarnessContextIntegrationStartupOmitsNetworkSectionForNonChannelSession
 func testHarnessContextIntegrationStartupOmitsNetworkSectionForNonChannelSession(t *testing.T) {
 	homePaths := integrationHomePaths(t)
 	cfg := testConfig(t, homePaths)
+	cfg.Memory.Enabled = true
 	workspaceRoot := homePaths.HomeDir + "/workspace"
 	resolvedWorkspace := newHarnessIntegrationWorkspace(t, homePaths, cfg, workspaceRoot)
 	writeDaemonMemoryIndex(t, cfg.Memory.GlobalDir, workspaceRoot)
@@ -508,21 +500,13 @@ func testHarnessContextIntegrationStartupOmitsNetworkSectionForNonChannelSession
 	if strings.Contains(driver.startCalls[0].SystemPrompt, networkSkill) {
 		t.Fatalf("start system prompt unexpectedly contains bundled network skill")
 	}
-	toolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledToolsReference)
+	toolRouter, err := skillbundled.LoadContent(bundledCompozySkillName)
 	if err != nil {
-		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledToolsReference, err)
+		t.Fatalf("LoadContent(%q) error = %v", bundledCompozySkillName, err)
 	}
-	toolsGuide = strings.TrimSpace(toolsGuide)
-	nativeToolsGuide, err := skillbundled.LoadResource(bundledCompozySkillName, bundledNativeToolsReference)
-	if err != nil {
-		t.Fatalf("LoadResource(%q, %q) error = %v", bundledCompozySkillName, bundledNativeToolsReference, err)
-	}
-	nativeToolsGuide = strings.TrimSpace(nativeToolsGuide)
-	if !strings.Contains(driver.startCalls[0].SystemPrompt, toolsGuide) {
-		t.Fatalf("start system prompt missing bundled tools guide")
-	}
-	if !strings.Contains(driver.startCalls[0].SystemPrompt, nativeToolsGuide) {
-		t.Fatalf("start system prompt missing bundled native tools guide")
+	toolRouter = strings.TrimSpace(toolRouter)
+	if !strings.Contains(driver.startCalls[0].SystemPrompt, toolRouter) {
+		t.Fatalf("start system prompt missing bundled tool router")
 	}
 	assertPromptContainsInOrder(
 		t,
@@ -534,8 +518,141 @@ func testHarnessContextIntegrationStartupOmitsNetworkSectionForNonChannelSession
 		"# Persistent Memory",
 		"You are a coding assistant.",
 		"<available-skills>",
-		toolsGuide,
-		nativeToolsGuide,
+		toolRouter,
+	)
+}
+
+func TestHarnessContextIntegrationScopesToolGuidanceForInternalCallers(t *testing.T) {
+	t.Run(
+		"Should preserve capable sessions and omit input-only role guidance through creation and resume",
+		func(t *testing.T) {
+			homePaths := integrationHomePaths(t)
+			cfg := testConfig(t, homePaths)
+			cfg.Memory.Enabled = true
+			workspace := newHarnessIntegrationWorkspace(
+				t,
+				homePaths,
+				cfg,
+				filepath.Join(homePaths.HomeDir, "workspace"),
+			)
+			daemonInstance, deps := bootHarnessPolicyDaemon(t, homePaths, &cfg)
+			t.Cleanup(func() {
+				if err := daemonInstance.Shutdown(testutil.Context(t)); err != nil {
+					t.Errorf("Shutdown: %v", err)
+				}
+			})
+			driver := newHarnessIntegrationDriver()
+			manager := newHarnessIntegrationManager(t, homePaths, deps, workspace, driver)
+			router, err := skillbundled.LoadContent(bundledCompozySkillName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertLatestPrompt := func(label string, wantRouter bool) {
+				t.Helper()
+				driver.mu.Lock()
+				prompt := driver.startCalls[len(driver.startCalls)-1].SystemPrompt
+				driver.mu.Unlock()
+				t.Logf("%s assembled startup bytes=%d router bytes=%d", label, len(prompt), len(router))
+				wantCount := 0
+				if wantRouter {
+					wantCount = 1
+				}
+				if count := strings.Count(prompt, router); count != wantCount {
+					t.Fatalf("%s router occurrences=%d want router=%t", label, count, wantRouter)
+				}
+				for _, path := range []string{bundledToolsReference, bundledNativeToolsReference} {
+					manual, loadErr := skillbundled.LoadResource(bundledCompozySkillName, path)
+					if loadErr != nil {
+						t.Fatal(loadErr)
+					}
+					if strings.Contains(prompt, strings.TrimSpace(manual)) {
+						t.Fatalf("%s inlines %s", label, path)
+					}
+				}
+			}
+			stop := func(sess *session.Session) {
+				t.Helper()
+				t.Cleanup(func() {
+					if err := manager.Stop(testutil.Context(t), sess.ID); err != nil {
+						t.Errorf("Stop(%s): %v", sess.ID, err)
+					}
+				})
+			}
+			agentName := workspace.Agents[0].Name
+			parent, err := manager.Create(
+				t.Context(),
+				session.CreateOpts{AgentName: agentName, Workspace: workspace.ID},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stop(parent)
+			assertLatestPrompt("interactive", true)
+			for _, sessionType := range []session.Type{session.SessionTypeSystem, session.SessionTypeDream} {
+				created, createErr := manager.Create(
+					t.Context(),
+					session.CreateOpts{AgentName: agentName, Workspace: workspace.ID, Type: sessionType},
+				)
+				if createErr != nil {
+					t.Fatal(createErr)
+				}
+				stop(created)
+				assertLatestPrompt(string(sessionType), true)
+			}
+			worker, err := manager.Spawn(
+				t.Context(),
+				session.SpawnOpts{ParentSessionID: parent.ID, AgentName: agentName, TTL: time.Minute},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stop(worker)
+			assertLatestPrompt("spawned worker", true)
+			extractor := &forkedMemoryExtractor{sessions: manager, deadline: time.Minute}
+			child, err := extractor.spawnExtractorSession(
+				t.Context(),
+				ResolvedRole{Enabled: true, AgentName: agentName},
+				roleInvocationCorrelation{},
+				memcontract.TurnRecord{SessionID: parent.ID},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if child.Info().Type != session.SessionTypeSpawned {
+				t.Fatal("extractor must exercise Spawn")
+			}
+			assertLatestPrompt("spawned extractor", false)
+			if err := manager.Stop(t.Context(), child.ID); err != nil {
+				t.Fatal(err)
+			}
+			resumed, err := manager.Resume(t.Context(), child.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stop(resumed)
+			assertLatestPrompt("resumed extractor", false)
+			resolved, err := daemonInstance.harnessResolver.ResolvePrompt(
+				resumed.Info(),
+				session.TurnSourceUser,
+				acp.PromptMeta{},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if containsHarnessSection(resolved.Policy.IncludeSections, HarnessPromptSectionTools) {
+				t.Fatal("resume lost extractor role")
+			}
+			summarizer := newDaemonCheckpointSummarizer(
+				manager,
+				resolvedRoleResolver(ResolvedRole{Enabled: true, AgentName: agentName}),
+			)
+			request := checkpointSummaryRequestFixture()
+			request.WorkspaceID, request.WorkspaceRoot, request.SessionID = workspace.ID, workspace.RootDir, parent.ID
+			if _, err := summarizer.Summarize(t.Context(), request); err != nil {
+				t.Fatal(err)
+			}
+			assertLatestPrompt("checkpoint summary", false)
+		},
 	)
 }
 
@@ -563,6 +680,7 @@ func seedHarnessSituationTaskRun(
 	}
 	taskRecord := taskpkg.Task{
 		ID:          "task-run-context",
+		ProfileID:   store.DefaultProfileID,
 		Identifier:  "AUTO-CTX",
 		Scope:       taskpkg.ScopeWorkspace,
 		WorkspaceID: workspaceID,

--- a/internal/daemon/harness_context_integration_test.go
+++ b/internal/daemon/harness_context_integration_test.go
@@ -523,137 +523,145 @@ func testHarnessContextIntegrationStartupOmitsNetworkSectionForNonChannelSession
 }
 
 func TestHarnessContextIntegrationScopesToolGuidanceForInternalCallers(t *testing.T) {
-	t.Run(
-		"Should preserve capable sessions and omit input-only role guidance through creation and resume",
-		func(t *testing.T) {
-			homePaths := integrationHomePaths(t)
-			cfg := testConfig(t, homePaths)
-			cfg.Memory.Enabled = true
-			workspace := newHarnessIntegrationWorkspace(
-				t,
-				homePaths,
-				cfg,
-				filepath.Join(homePaths.HomeDir, "workspace"),
-			)
-			daemonInstance, deps := bootHarnessPolicyDaemon(t, homePaths, &cfg)
-			t.Cleanup(func() {
-				if err := daemonInstance.Shutdown(testutil.Context(t)); err != nil {
-					t.Errorf("Shutdown: %v", err)
-				}
-			})
-			driver := newHarnessIntegrationDriver()
-			manager := newHarnessIntegrationManager(t, homePaths, deps, workspace, driver)
-			router, err := skillbundled.LoadContent(bundledCompozySkillName)
-			if err != nil {
-				t.Fatal(err)
-			}
-			assertLatestPrompt := func(label string, wantRouter bool) {
-				t.Helper()
-				driver.mu.Lock()
-				prompt := driver.startCalls[len(driver.startCalls)-1].SystemPrompt
-				driver.mu.Unlock()
-				t.Logf("%s assembled startup bytes=%d router bytes=%d", label, len(prompt), len(router))
-				wantCount := 0
-				if wantRouter {
-					wantCount = 1
-				}
-				if count := strings.Count(prompt, router); count != wantCount {
-					t.Fatalf("%s router occurrences=%d want router=%t", label, count, wantRouter)
-				}
-				for _, path := range []string{bundledToolsReference, bundledNativeToolsReference} {
-					manual, loadErr := skillbundled.LoadResource(bundledCompozySkillName, path)
-					if loadErr != nil {
-						t.Fatal(loadErr)
-					}
-					if strings.Contains(prompt, strings.TrimSpace(manual)) {
-						t.Fatalf("%s inlines %s", label, path)
-					}
-				}
-			}
-			stop := func(sess *session.Session) {
-				t.Helper()
+	for _, skillsEnabled := range []bool{true, false} {
+		t.Run(
+			fmt.Sprintf(
+				"Should preserve role guidance through creation and resume with skills enabled %t",
+				skillsEnabled,
+			),
+			func(t *testing.T) {
+				homePaths := integrationHomePaths(t)
+				cfg := testConfig(t, homePaths)
+				cfg.Memory.Enabled = true
+				cfg.Skills.Enabled = skillsEnabled
+				workspace := newHarnessIntegrationWorkspace(
+					t,
+					homePaths,
+					cfg,
+					filepath.Join(homePaths.HomeDir, "workspace"),
+				)
+				daemonInstance, deps := bootHarnessPolicyDaemon(t, homePaths, &cfg)
 				t.Cleanup(func() {
-					if err := manager.Stop(testutil.Context(t), sess.ID); err != nil {
-						t.Errorf("Stop(%s): %v", sess.ID, err)
+					if err := daemonInstance.Shutdown(testutil.Context(t)); err != nil {
+						t.Errorf("Shutdown: %v", err)
 					}
 				})
-			}
-			agentName := workspace.Agents[0].Name
-			parent, err := manager.Create(
-				t.Context(),
-				session.CreateOpts{AgentName: agentName, Workspace: workspace.ID},
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			stop(parent)
-			assertLatestPrompt("interactive", true)
-			for _, sessionType := range []session.Type{session.SessionTypeSystem, session.SessionTypeDream} {
-				created, createErr := manager.Create(
-					t.Context(),
-					session.CreateOpts{AgentName: agentName, Workspace: workspace.ID, Type: sessionType},
-				)
-				if createErr != nil {
-					t.Fatal(createErr)
+				driver := newHarnessIntegrationDriver()
+				manager := newHarnessIntegrationManager(t, homePaths, deps, workspace, driver)
+				router, err := skillbundled.LoadContent(bundledCompozySkillName)
+				if err != nil {
+					t.Fatal(err)
 				}
-				stop(created)
-				assertLatestPrompt(string(sessionType), true)
-			}
-			worker, err := manager.Spawn(
-				t.Context(),
-				session.SpawnOpts{ParentSessionID: parent.ID, AgentName: agentName, TTL: time.Minute},
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			stop(worker)
-			assertLatestPrompt("spawned worker", true)
-			extractor := &forkedMemoryExtractor{sessions: manager, deadline: time.Minute}
-			child, err := extractor.spawnExtractorSession(
-				t.Context(),
-				ResolvedRole{Enabled: true, AgentName: agentName},
-				roleInvocationCorrelation{},
-				memcontract.TurnRecord{SessionID: parent.ID},
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if child.Info().Type != session.SessionTypeSpawned {
-				t.Fatal("extractor must exercise Spawn")
-			}
-			assertLatestPrompt("spawned extractor", false)
-			if err := manager.Stop(t.Context(), child.ID); err != nil {
-				t.Fatal(err)
-			}
-			resumed, err := manager.Resume(t.Context(), child.ID)
-			if err != nil {
-				t.Fatal(err)
-			}
-			stop(resumed)
-			assertLatestPrompt("resumed extractor", false)
-			resolved, err := daemonInstance.harnessResolver.ResolvePrompt(
-				resumed.Info(),
-				session.TurnSourceUser,
-				acp.PromptMeta{},
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if containsHarnessSection(resolved.Policy.IncludeSections, HarnessPromptSectionTools) {
-				t.Fatal("resume lost extractor role")
-			}
-			summarizer := newDaemonCheckpointSummarizer(
-				manager,
-				resolvedRoleResolver(ResolvedRole{Enabled: true, AgentName: agentName}),
-			)
-			request := checkpointSummaryRequestFixture()
-			request.WorkspaceID, request.WorkspaceRoot, request.SessionID = workspace.ID, workspace.RootDir, parent.ID
-			if _, err := summarizer.Summarize(t.Context(), request); err != nil {
-				t.Fatal(err)
-			}
-			assertLatestPrompt("checkpoint summary", false)
-		},
-	)
+				router = strings.TrimSpace(router)
+				assertLatestPrompt := func(label string, wantRouter bool) {
+					t.Helper()
+					driver.mu.Lock()
+					prompt := driver.startCalls[len(driver.startCalls)-1].SystemPrompt
+					driver.mu.Unlock()
+					t.Logf("%s assembled startup bytes=%d router bytes=%d", label, len(prompt), len(router))
+					wantCount := 0
+					if wantRouter && skillsEnabled {
+						wantCount = 1
+					}
+					if count := strings.Count(prompt, router); count != wantCount {
+						t.Fatalf("%s router occurrences=%d want router=%t", label, count, wantRouter)
+					}
+					for _, path := range []string{bundledToolsReference, bundledNativeToolsReference} {
+						manual, loadErr := skillbundled.LoadResource(bundledCompozySkillName, path)
+						if loadErr != nil {
+							t.Fatal(loadErr)
+						}
+						wantManual := wantRouter && !skillsEnabled
+						if strings.Contains(prompt, strings.TrimSpace(manual)) != wantManual {
+							t.Fatalf("%s inline %s presence differs from expected %t", label, path, wantManual)
+						}
+					}
+				}
+				stop := func(sess *session.Session) {
+					t.Helper()
+					t.Cleanup(func() {
+						if err := manager.Stop(testutil.Context(t), sess.ID); err != nil {
+							t.Errorf("Stop(%s): %v", sess.ID, err)
+						}
+					})
+				}
+				agentName := workspace.Agents[0].Name
+				parent, err := manager.Create(
+					t.Context(),
+					session.CreateOpts{AgentName: agentName, Workspace: workspace.ID},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				stop(parent)
+				assertLatestPrompt("interactive", true)
+				for _, sessionType := range []session.Type{session.SessionTypeSystem, session.SessionTypeDream} {
+					created, createErr := manager.Create(
+						t.Context(),
+						session.CreateOpts{AgentName: agentName, Workspace: workspace.ID, Type: sessionType},
+					)
+					if createErr != nil {
+						t.Fatal(createErr)
+					}
+					stop(created)
+					assertLatestPrompt(string(sessionType), true)
+				}
+				worker, err := manager.Spawn(
+					t.Context(),
+					session.SpawnOpts{ParentSessionID: parent.ID, AgentName: agentName, TTL: time.Minute},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				stop(worker)
+				assertLatestPrompt("spawned worker", true)
+				extractor := &forkedMemoryExtractor{sessions: manager, deadline: time.Minute}
+				child, err := extractor.spawnExtractorSession(
+					t.Context(),
+					ResolvedRole{Enabled: true, AgentName: agentName},
+					roleInvocationCorrelation{},
+					memcontract.TurnRecord{SessionID: parent.ID},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if child.Info().Type != session.SessionTypeSpawned {
+					t.Fatal("extractor must exercise Spawn")
+				}
+				assertLatestPrompt("spawned extractor", false)
+				if err := manager.Stop(t.Context(), child.ID); err != nil {
+					t.Fatal(err)
+				}
+				resumed, err := manager.Resume(t.Context(), child.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				stop(resumed)
+				assertLatestPrompt("resumed extractor", false)
+				resolved, err := daemonInstance.harnessResolver.ResolvePrompt(
+					resumed.Info(),
+					session.TurnSourceUser,
+					acp.PromptMeta{},
+				)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if containsHarnessSection(resolved.Policy.IncludeSections, HarnessPromptSectionTools) {
+					t.Fatal("resume lost extractor role")
+				}
+				summarizer := newDaemonCheckpointSummarizer(
+					manager,
+					resolvedRoleResolver(ResolvedRole{Enabled: true, AgentName: agentName}),
+				)
+				request := checkpointSummaryRequestFixture()
+				request.WorkspaceID, request.WorkspaceRoot, request.SessionID = workspace.ID, workspace.RootDir, parent.ID
+				if _, err := summarizer.Summarize(t.Context(), request); err != nil {
+					t.Fatal(err)
+				}
+				assertLatestPrompt("checkpoint summary", false)
+			},
+		)
+	}
 }
 
 func seedHarnessSituationTaskRun(

--- a/internal/daemon/harness_context_policy.go
+++ b/internal/daemon/harness_context_policy.go
@@ -1,5 +1,7 @@
 package daemon
 
+import "github.com/compozy/compozy/internal/session"
+
 func (r *HarnessContextResolver) resolveSections(sessionCtx HarnessSessionContext) []HarnessPromptSection {
 	sections := make([]HarnessPromptSection, 0, 6)
 	if r.runtime.RuntimeIdentityPromptSectionEnabled {
@@ -14,7 +16,7 @@ func (r *HarnessContextResolver) resolveSections(sessionCtx HarnessSessionContex
 	if r.runtime.SkillsPromptSectionEnabled {
 		sections = append(sections, HarnessPromptSectionSkills)
 	}
-	if r.runtime.ToolsPromptSectionEnabled {
+	if r.runtime.ToolsPromptSectionEnabled && !inputOnlyHarnessRole(sessionCtx.SpawnRole) {
 		sections = append(sections, HarnessPromptSectionTools)
 	}
 	if sessionCtx.NetworkLive {
@@ -73,4 +75,13 @@ func (r *HarnessContextResolver) resolveDetachedRunMode(
 		return DetachedRunModeTaskRuntime
 	}
 	return DetachedRunModeNone
+}
+
+func inputOnlyHarnessRole(role string) bool {
+	switch role {
+	case session.SpawnRoleMemoryExtractor, session.SpawnRoleCheckpointSummary, session.SpawnRoleAutoTitle:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/daemon/harness_context_session.go
+++ b/internal/daemon/harness_context_session.go
@@ -10,6 +10,7 @@ import (
 type HarnessSessionInput struct {
 	SessionID            string
 	Type                 session.Type
+	SpawnRole            string
 	NetworkParticipation participation.Spec
 	WorkspaceID          string
 	Workspace            string
@@ -22,6 +23,7 @@ type HarnessSessionInput struct {
 type HarnessSessionContext struct {
 	SessionID            string
 	Type                 session.Type
+	SpawnRole            string
 	SessionClass         SessionClass
 	NetworkParticipation participation.Spec
 	NetworkLive          bool

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -2663,71 +2663,82 @@ func TestDaemonNativeTools(t *testing.T) {
 			{name: "Should recover references through workspace-scoped result pages", registry: boundedRegistry, scope: toolspkg.Scope{WorkspaceID: "ws-skills", SessionID: "sess-skills", AgentName: "coder"}, wantOffload: true},
 		} {
 			t.Run(target.name, func(t *testing.T) {
-				for _, resource := range []string{"references/memory.md", "references/tools-and-skills.md", "references/native-tools.md"} {
-					input, err := json.Marshal(map[string]string{"name": "compozy", "file": resource})
-					if err != nil {
-						t.Fatal(err)
-					}
-					viewResult, err := target.registry.Call(
-						t.Context(),
-						target.scope,
-						toolspkg.CallRequest{
-							ToolID: toolspkg.ToolIDSkillView,
-							Input:  input,
-						},
-					)
-					if err != nil {
-						t.Fatalf("Registry.Call(skill_view) error = %v", err)
-					}
-					if resource == "references/native-tools.md" && viewResult.Truncated != target.wantOffload {
-						t.Fatalf(
-							"skill_view(%s) truncated = %t, want %t",
-							resource,
-							viewResult.Truncated,
-							target.wantOffload,
+				for _, reference := range []struct {
+					path        string
+					wantOffload bool
+				}{
+					{path: "references/memory.md"},
+					{path: "references/tools-and-skills.md", wantOffload: true},
+					{path: "references/native-tools.md", wantOffload: true},
+				} {
+					t.Run("Should read the complete "+reference.path+" resource", func(t *testing.T) {
+						resource := reference.path
+						input, err := json.Marshal(map[string]string{"name": "compozy", "file": resource})
+						if err != nil {
+							t.Fatal(err)
+						}
+						viewResult, err := target.registry.Call(
+							t.Context(),
+							target.scope,
+							toolspkg.CallRequest{
+								ToolID: toolspkg.ToolIDSkillView,
+								Input:  input,
+							},
 						)
-					}
-					if viewResult.Truncated {
-						viewResult = readNativeRetainedResult(t, target.registry, target.scope, viewResult)
-					}
-					skill, ok := skillRegistry.Get("compozy")
-					if !ok {
-						t.Fatal("Registry.Get(compozy) found = false, want true")
-					}
-					expectedContent, err := skillRegistry.LoadResource(t.Context(), skill, resource)
-					if err != nil {
-						t.Fatalf("Registry.LoadResource(%s) error = %v", resource, err)
-					}
-					var viewPayload struct {
-						Content string `json:"content"`
-					}
-					if err := json.Unmarshal(viewResult.Structured, &viewPayload); err != nil {
-						t.Fatalf("json.Unmarshal(skill_view) error = %v", err)
-					}
-					if viewPayload.Content != expectedContent || len(viewResult.Content) != 1 ||
-						viewResult.Content[0].Text != diagnostics.Redact(expectedContent) {
-						t.Fatalf(
-							"skill_view(%s) resource mismatch: expected=%d structured=%d text_blocks=%d truncated=%t artifacts=%d redactions=%v",
+						if err != nil {
+							t.Fatalf("Registry.Call(skill_view) error = %v", err)
+						}
+						wantTruncated := reference.wantOffload && target.wantOffload
+						if viewResult.Truncated != wantTruncated {
+							t.Fatalf(
+								"skill_view(%s) truncated = %t, want %t",
+								resource,
+								viewResult.Truncated,
+								wantTruncated,
+							)
+						}
+						if viewResult.Truncated {
+							viewResult = readNativeRetainedResult(t, target.registry, target.scope, viewResult)
+						}
+						skill, ok := skillRegistry.Get("compozy")
+						if !ok {
+							t.Fatal("Registry.Get(compozy) found = false, want true")
+						}
+						expectedContent, err := skillRegistry.LoadResource(t.Context(), skill, resource)
+						if err != nil {
+							t.Fatalf("Registry.LoadResource(%s) error = %v", resource, err)
+						}
+						var viewPayload struct {
+							Content string `json:"content"`
+						}
+						if err := json.Unmarshal(viewResult.Structured, &viewPayload); err != nil {
+							t.Fatalf("json.Unmarshal(skill_view) error = %v", err)
+						}
+						if viewPayload.Content != expectedContent || len(viewResult.Content) != 1 ||
+							viewResult.Content[0].Text != diagnostics.Redact(expectedContent) {
+							t.Fatalf(
+								"skill_view(%s) resource mismatch: expected=%d structured=%d text_blocks=%d truncated=%t artifacts=%d redactions=%v",
+								resource,
+								len(expectedContent),
+								len(viewPayload.Content),
+								len(viewResult.Content),
+								viewResult.Truncated,
+								len(viewResult.Artifacts),
+								viewResult.Redactions,
+							)
+						}
+						if diagnostics.Redact(expectedContent) != expectedContent && len(viewResult.Redactions) == 0 {
+							t.Fatalf("skill_view(%s) omitted display redaction metadata", resource)
+						}
+						t.Logf(
+							"%s: full structured bytes=%d, display redactions=%d",
 							resource,
-							len(expectedContent),
 							len(viewPayload.Content),
-							len(viewResult.Content),
-							viewResult.Truncated,
-							len(viewResult.Artifacts),
-							viewResult.Redactions,
+							len(viewResult.Redactions),
 						)
-					}
-					if diagnostics.Redact(expectedContent) != expectedContent && len(viewResult.Redactions) == 0 {
-						t.Fatalf("skill_view(%s) omitted display redaction metadata", resource)
-					}
-					t.Logf(
-						"%s: full structured bytes=%d, display redactions=%d",
-						resource,
-						len(viewPayload.Content),
-						len(viewResult.Redactions),
-					)
-					requireNativeStructuredContains(t, viewResult, []byte(`"origin":""`))
-					requireNativeStructuredContains(t, viewResult, []byte(`"exposures":[]`))
+						requireNativeStructuredContains(t, viewResult, []byte(`"origin":""`))
+						requireNativeStructuredContains(t, viewResult, []byte(`"exposures":[]`))
+					})
 				}
 			})
 		}

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -2639,37 +2639,98 @@ func TestDaemonNativeTools(t *testing.T) {
 		requireNativeStructuredContains(t, searchResult, []byte(`"compozy"`))
 		requireNativeStructuredContains(t, searchResult, []byte(`"origin":""`))
 
-		viewResult, err := registry.Call(
-			t.Context(),
-			toolspkg.Scope{Operator: true},
-			toolspkg.CallRequest{
-				ToolID: toolspkg.ToolIDSkillView,
-				Input:  json.RawMessage(`{"name":"compozy","file":"references/memory.md"}`),
-			},
+		artifactStore := openDaemonTestToolArtifactStore(t)
+		workspaceResolver := nativeNetworkTestWorkspaceService(t)
+		const reducedBudget = 32 << 10
+		sessions := &nativeSessionAgentManager{
+			StubSessionManager: nativeNetworkTestSessionManager("ws-skills"),
+			agent:              testPromptAgent("Read the requested skill resource."),
+		}
+		boundedRegistry := newDaemonNativeRegistryWithPolicyResolverAndWorkspaceAccess(t, &daemonNativeToolsDeps{
+			Skills: skillRegistry, HomePaths: homePaths, ToolArtifacts: artifactStore, Sessions: sessions,
+			Workspaces: workspaceResolver, WorkspaceResolver: workspaceResolver,
+		}, toolspkg.NewStaticPolicyInputResolver(nativeApproveAllPolicyInputs()), nil,
+			toolspkg.WithDefaultMaxResultBytes(reducedBudget),
+			toolspkg.WithResultProcessor(toolspkg.NewResultProcessor(reducedBudget, artifactStore)),
 		)
-		if err != nil {
-			t.Fatalf("Registry.Call(skill_view) error = %v", err)
+		for _, target := range []struct {
+			name        string
+			registry    *toolspkg.RuntimeRegistry
+			scope       toolspkg.Scope
+			wantOffload bool
+		}{
+			{name: "Should read references with the default result budget", registry: registry, scope: toolspkg.Scope{Operator: true}},
+			{name: "Should recover references through workspace-scoped result pages", registry: boundedRegistry, scope: toolspkg.Scope{WorkspaceID: "ws-skills", SessionID: "sess-skills", AgentName: "coder"}, wantOffload: true},
+		} {
+			t.Run(target.name, func(t *testing.T) {
+				for _, resource := range []string{"references/memory.md", "references/tools-and-skills.md", "references/native-tools.md"} {
+					input, err := json.Marshal(map[string]string{"name": "compozy", "file": resource})
+					if err != nil {
+						t.Fatal(err)
+					}
+					viewResult, err := target.registry.Call(
+						t.Context(),
+						target.scope,
+						toolspkg.CallRequest{
+							ToolID: toolspkg.ToolIDSkillView,
+							Input:  input,
+						},
+					)
+					if err != nil {
+						t.Fatalf("Registry.Call(skill_view) error = %v", err)
+					}
+					if resource == "references/native-tools.md" && viewResult.Truncated != target.wantOffload {
+						t.Fatalf(
+							"skill_view(%s) truncated = %t, want %t",
+							resource,
+							viewResult.Truncated,
+							target.wantOffload,
+						)
+					}
+					if viewResult.Truncated {
+						viewResult = readNativeRetainedResult(t, target.registry, target.scope, viewResult)
+					}
+					skill, ok := skillRegistry.Get("compozy")
+					if !ok {
+						t.Fatal("Registry.Get(compozy) found = false, want true")
+					}
+					expectedContent, err := skillRegistry.LoadResource(t.Context(), skill, resource)
+					if err != nil {
+						t.Fatalf("Registry.LoadResource(%s) error = %v", resource, err)
+					}
+					var viewPayload struct {
+						Content string `json:"content"`
+					}
+					if err := json.Unmarshal(viewResult.Structured, &viewPayload); err != nil {
+						t.Fatalf("json.Unmarshal(skill_view) error = %v", err)
+					}
+					if viewPayload.Content != expectedContent || len(viewResult.Content) != 1 ||
+						viewResult.Content[0].Text != diagnostics.Redact(expectedContent) {
+						t.Fatalf(
+							"skill_view(%s) resource mismatch: expected=%d structured=%d text_blocks=%d truncated=%t artifacts=%d redactions=%v",
+							resource,
+							len(expectedContent),
+							len(viewPayload.Content),
+							len(viewResult.Content),
+							viewResult.Truncated,
+							len(viewResult.Artifacts),
+							viewResult.Redactions,
+						)
+					}
+					if diagnostics.Redact(expectedContent) != expectedContent && len(viewResult.Redactions) == 0 {
+						t.Fatalf("skill_view(%s) omitted display redaction metadata", resource)
+					}
+					t.Logf(
+						"%s: full structured bytes=%d, display redactions=%d",
+						resource,
+						len(viewPayload.Content),
+						len(viewResult.Redactions),
+					)
+					requireNativeStructuredContains(t, viewResult, []byte(`"origin":""`))
+					requireNativeStructuredContains(t, viewResult, []byte(`"exposures":[]`))
+				}
+			})
 		}
-		skill, ok := skillRegistry.Get("compozy")
-		if !ok {
-			t.Fatal("Registry.Get(compozy) found = false, want true")
-		}
-		expectedContent, err := skillRegistry.LoadResource(t.Context(), skill, "references/memory.md")
-		if err != nil {
-			t.Fatalf("Registry.LoadResource(memory) error = %v", err)
-		}
-		var viewPayload struct {
-			Content string `json:"content"`
-		}
-		if err := json.Unmarshal(viewResult.Structured, &viewPayload); err != nil {
-			t.Fatalf("json.Unmarshal(skill_view) error = %v", err)
-		}
-		if viewPayload.Content != expectedContent || len(viewResult.Content) != 1 ||
-			viewResult.Content[0].Text != expectedContent {
-			t.Fatalf("skill_view did not return the resolved bundled resource")
-		}
-		requireNativeStructuredContains(t, viewResult, []byte(`"origin":""`))
-		requireNativeStructuredContains(t, viewResult, []byte(`"exposures":[]`))
 	})
 
 	t.Run("Should classify skill resource lookup failures", func(t *testing.T) {
@@ -11956,6 +12017,60 @@ func (p *recordingNativeWorkspaceAccessPolicy) Authorize(
 	return p.decision, p.err
 }
 
+func readNativeRetainedResult(
+	t *testing.T,
+	registry *toolspkg.RuntimeRegistry,
+	scope toolspkg.Scope,
+	result toolspkg.ToolResult,
+) toolspkg.ToolResult {
+	t.Helper()
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("truncated result has %d artifacts, want one retained envelope", len(result.Artifacts))
+	}
+	var retained []byte
+	for offset := int64(0); ; {
+		input, err := json.Marshal(nativeToolArtifactReadInput{
+			ArtifactURI: result.Artifacts[0].URI, Offset: offset, Limit: 4096,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		pageResult, err := registry.Call(t.Context(), scope, toolspkg.CallRequest{
+			ToolID: toolspkg.ToolIDToolArtifactRead, Input: input,
+		})
+		if err != nil {
+			t.Fatalf("Registry.Call(tool_artifact_read) error = %v", err)
+		}
+		if pageResult.Truncated {
+			t.Fatal("bounded artifact page was truncated")
+		}
+		var page toolspkg.ToolArtifactPage
+		if err := json.Unmarshal(pageResult.Structured, &page); err != nil {
+			t.Fatal(err)
+		}
+		decoded, err := base64.StdEncoding.DecodeString(page.DataBase64)
+		if err != nil {
+			t.Fatal(err)
+		}
+		retained = append(retained, decoded...)
+		if page.EOF {
+			if int64(len(retained)) != page.TotalBytes {
+				t.Fatalf("retained bytes = %d, want complete envelope of %d bytes", len(retained), page.TotalBytes)
+			}
+			break
+		}
+		if page.NextOffset <= offset {
+			t.Fatal("artifact continuation made no progress")
+		}
+		offset = page.NextOffset
+	}
+	var full toolspkg.ToolResult
+	if err := json.Unmarshal(retained, &full); err != nil {
+		t.Fatalf("decode retained result: %v", err)
+	}
+	return full
+}
+
 func openDaemonTestToolArtifactStore(t *testing.T) *toolspkg.FilesystemToolArtifactStore {
 	t.Helper()
 	store, err := toolspkg.OpenFilesystemToolArtifactStore(
@@ -12869,6 +12984,7 @@ func newDaemonNativeRegistryWithPolicyResolverAndWorkspaceAccess(
 	deps *daemonNativeToolsDeps,
 	resolver toolspkg.PolicyInputResolver,
 	workspaceAccess workspaceaccess.Policy,
+	options ...toolspkg.RegistryOption,
 ) *toolspkg.RuntimeRegistry {
 	t.Helper()
 
@@ -12888,7 +13004,7 @@ func newDaemonNativeRegistryWithPolicyResolverAndWorkspaceAccess(
 		t.Fatalf("builtin.ToolsetCatalog() error = %v", err)
 	}
 	workspaceBinder := newNativeWorkspaceInputBinder(deps.Workspaces, deps.Sessions, workspaceAccess, nil)
-	registry, err = toolspkg.NewRegistry(
+	registryOptions := []toolspkg.RegistryOption{
 		toolspkg.WithProviders(provider),
 		toolspkg.WithPolicyInputResolver(resolver, toolsets),
 		toolspkg.WithCallInputBinder(workspaceBinder),
@@ -12898,7 +13014,8 @@ func newDaemonNativeRegistryWithPolicyResolverAndWorkspaceAccess(
 			compozyconfig.DefaultToolsMaxResultBytes,
 			openDaemonTestToolArtifactStore(t),
 		)),
-	)
+	}
+	registry, err = toolspkg.NewRegistry(append(registryOptions, options...)...)
 	if err != nil {
 		t.Fatalf("NewRegistry() error = %v", err)
 	}

--- a/internal/daemon/prompt_sections.go
+++ b/internal/daemon/prompt_sections.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/compozy/compozy/internal/session"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
@@ -33,8 +35,10 @@ const (
 	startupSoulSectionBudget      = 16_000
 	startupSkillsSectionBudget    = 16_000
 	// Keep the router intact; reference manuals are loaded on demand.
-	startupToolsSectionBudget   = 16_000
-	startupNetworkSectionBudget = 512
+	startupToolsSectionBudget = 16_000
+	// Preserve complete operational guidance when the skill registry is disabled.
+	startupToolsReferenceSectionBudget = 64_000
+	startupNetworkSectionBudget        = 512
 )
 
 // PromptSectionPosition identifies whether a startup section renders before or
@@ -160,7 +164,22 @@ func defaultBundledStartupPromptSectionDescriptors(networkResponseGuidanceBudget
 			Provider: promptSectionProviderFunc(func(context.Context, *workspacepkg.ResolvedWorkspace) (string, error) {
 				return skillbundled.LoadContent(bundledCompozySkillName)
 			}),
-			Predicate: policyIncludesSection(HarnessPromptSectionTools),
+			Predicate: func(policy ResolvedHarnessPolicy) bool {
+				return containsHarnessSection(policy.IncludeSections, HarnessPromptSectionTools) &&
+					containsHarnessSection(policy.IncludeSections, HarnessPromptSectionSkills)
+			},
+		},
+		{
+			Name:           string(HarnessPromptSectionTools),
+			Position:       PromptSectionPositionAppend,
+			Order:          startupToolsSectionOrder,
+			Budget:         startupToolsReferenceSectionBudget,
+			BudgetBehavior: PromptSectionBudgetBehaviorTrim,
+			Provider:       promptSectionProviderFunc(bundledToolReferencesPromptSection),
+			Predicate: func(policy ResolvedHarnessPolicy) bool {
+				return containsHarnessSection(policy.IncludeSections, HarnessPromptSectionTools) &&
+					!containsHarnessSection(policy.IncludeSections, HarnessPromptSectionSkills)
+			},
 		},
 		{
 			Name:           string(HarnessPromptSectionNetwork),
@@ -230,4 +249,16 @@ func (fn promptSectionProviderFunc) PromptSection(
 	workspace *workspacepkg.ResolvedWorkspace,
 ) (string, error) {
 	return fn(ctx, workspace)
+}
+
+func bundledToolReferencesPromptSection(context.Context, *workspacepkg.ResolvedWorkspace) (string, error) {
+	contents := make([]string, 0, 2)
+	for _, path := range []string{bundledToolsReference, bundledNativeToolsReference} {
+		content, err := skillbundled.LoadResource(bundledCompozySkillName, path)
+		if err != nil {
+			return "", fmt.Errorf("daemon: load bundled tool guidance %q: %w", path, err)
+		}
+		contents = append(contents, strings.TrimSpace(content))
+	}
+	return strings.Join(contents, "\n\n"), nil
 }

--- a/internal/daemon/prompt_sections.go
+++ b/internal/daemon/prompt_sections.go
@@ -2,9 +2,7 @@ package daemon
 
 import (
 	"context"
-	"fmt"
 	"slices"
-	"strings"
 
 	"github.com/compozy/compozy/internal/session"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
@@ -34,8 +32,8 @@ const (
 	startupMemorySectionBudget    = 24_000
 	startupSoulSectionBudget      = 16_000
 	startupSkillsSectionBudget    = 16_000
-	// Keep enough headroom to avoid truncating canonical tool guidance.
-	startupToolsSectionBudget   = 64_000
+	// Keep the router intact; reference manuals are loaded on demand.
+	startupToolsSectionBudget   = 16_000
 	startupNetworkSectionBudget = 512
 )
 
@@ -159,11 +157,9 @@ func defaultBundledStartupPromptSectionDescriptors(networkResponseGuidanceBudget
 			Order:          startupToolsSectionOrder,
 			Budget:         startupToolsSectionBudget,
 			BudgetBehavior: PromptSectionBudgetBehaviorTrim,
-			Provider: bundledReferencesPromptSectionProvider(
-				bundledCompozySkillName,
-				bundledToolsReference,
-				bundledNativeToolsReference,
-			),
+			Provider: promptSectionProviderFunc(func(context.Context, *workspacepkg.ResolvedWorkspace) (string, error) {
+				return skillbundled.LoadContent(bundledCompozySkillName)
+			}),
 			Predicate: policyIncludesSection(HarnessPromptSectionTools),
 		},
 		{
@@ -234,23 +230,4 @@ func (fn promptSectionProviderFunc) PromptSection(
 	workspace *workspacepkg.ResolvedWorkspace,
 ) (string, error) {
 	return fn(ctx, workspace)
-}
-
-func bundledReferencesPromptSectionProvider(name string, referencePaths ...string) session.PromptProvider {
-	return promptSectionProviderFunc(func(context.Context, *workspacepkg.ResolvedWorkspace) (string, error) {
-		contents := make([]string, 0, len(referencePaths))
-		for _, referencePath := range referencePaths {
-			content, err := skillbundled.LoadResource(strings.TrimSpace(name), strings.TrimSpace(referencePath))
-			if err != nil {
-				return "", fmt.Errorf(
-					"daemon: load bundled startup section %q file %q: %w",
-					name,
-					referencePath,
-					err,
-				)
-			}
-			contents = append(contents, strings.TrimSpace(content))
-		}
-		return strings.Join(contents, "\n\n"), nil
-	})
 }

--- a/internal/session/manager_start.go
+++ b/internal/session/manager_start.go
@@ -168,6 +168,7 @@ func (s *sessionStartSpec) startupPromptContext(updatedAt time.Time) StartupProm
 		WorktreeID:           strings.TrimSpace(s.worktreeID),
 		NetworkParticipation: s.networkParticipation,
 		SessionType:          normalizeSessionType(s.sessionType),
+		SpawnRole:            store.NormalizeSessionLineage(s.sessionID, s.lineage).SpawnRole,
 		SoulSnapshot:         cloneSoulSnapshotPointer(s.soulSnapshot),
 		CreatedAt:            s.createdAt,
 		UpdatedAt:            updatedAt,

--- a/internal/session/prompt_overlay.go
+++ b/internal/session/prompt_overlay.go
@@ -24,6 +24,7 @@ type StartupPromptContext struct {
 	WorktreeID           string
 	NetworkParticipation participation.Spec
 	SessionType          Type
+	SpawnRole            string
 	SoulSnapshot         *soul.Snapshot
 	CreatedAt            time.Time
 	UpdatedAt            time.Time

--- a/internal/session/resume_replay.go
+++ b/internal/session/resume_replay.go
@@ -70,6 +70,7 @@ func (m *Manager) buildResumeReplay(
 			Workspace:            info.Workspace,
 			NetworkParticipation: info.NetworkParticipation,
 			SessionType:          info.Type,
+			SpawnRole:            store.NormalizeSessionLineage(info.ID, info.Lineage).SpawnRole,
 			CreatedAt:            info.CreatedAt,
 			UpdatedAt:            info.UpdatedAt,
 		})

--- a/internal/session/spawn.go
+++ b/internal/session/spawn.go
@@ -23,6 +23,8 @@ const (
 	DefaultSpawnRole = "worker"
 	// SpawnRoleMemoryExtractor marks daemon-owned extractor children.
 	SpawnRoleMemoryExtractor = "memory-extractor"
+	// SpawnRoleCheckpointSummary marks reference-only checkpoint summarization.
+	SpawnRoleCheckpointSummary = "checkpoint-summary"
 	// SpawnRoleAutoTitle marks daemon-owned title generator children.
 	SpawnRoleAutoTitle = "auto-title"
 )

--- a/packages/site/content/docs/skills/bundled.mdx
+++ b/packages/site/content/docs/skills/bundled.mdx
@@ -82,16 +82,29 @@ one:
 compozy skill view compozy --file references/network.md
 ```
 
-The daemon also injects selected `compozy` reference files when a session context requires them:
+With tools enabled, startup includes the `compozy` router. The complete
+`references/tools-and-skills.md` and `references/native-tools.md` manuals stay available through
+`compozy__skill_view`; they are loaded on demand before the matching operation. If a result is
+truncated, the router explains how to use `compozy__tool_artifact_read` in the same workspace and
+follow `next_offset` through `eof` to recover the complete retained result. Display redaction
+remains in effect; agents do not bypass a denied read through CLI or filesystem access.
 
-| Context                      | Injected reference                                                |
-| ---------------------------- | ----------------------------------------------------------------- |
-| Tool prompt section          | `references/tools-and-skills.md` and `references/native-tools.md` |
-| Network channel session      | `references/network.md`                                           |
-| Task reviewer routing prompt | `references/tasks-and-orchestration.md`                           |
+The daemon omits the tool router for memory extractor children, automatic title generation, and checkpoint summarization,
+whose roles transform supplied input into output. This uses the persisted role, including an
+extractor created through `Spawn`, rather than excluding every `system`, `dream`, or `spawned`
+session. Task workers, coordinators, dream curators, interactive sessions, and unknown roles retain
+the router when tools are enabled. Older checkpoint sessions without an explicit role also retain
+it. The role is preserved across resume and custom background-agent routing.
 
-These injections are contextual prompt help. Runtime authority still lives in the daemon services,
-not in the skill text.
+| Context                      | Injected guidance                                    |
+| ---------------------------- | ---------------------------------------------------- |
+| Tool prompt section          | `compozy` router; matching references load on demand |
+| Network channel session      | Compact network response-register guidance           |
+| Task reviewer routing prompt | `references/tasks-and-orchestration.md`              |
+
+These selections change prompt guidance only. Tool registration, discovery, authorization, MCP,
+and the `tools.enabled` gateway switch keep their existing behavior. No additional configuration
+key or user-state migration is required.
 
 ## Native tools and authority
 

--- a/packages/site/content/docs/skills/bundled.mdx
+++ b/packages/site/content/docs/skills/bundled.mdx
@@ -82,27 +82,30 @@ one:
 compozy skill view compozy --file references/network.md
 ```
 
-With tools enabled, startup includes the `compozy` router. The complete
+With tools and skills enabled, startup includes the `compozy` router. The complete
 `references/tools-and-skills.md` and `references/native-tools.md` manuals stay available through
 `compozy__skill_view`; they are loaded on demand before the matching operation. If a result is
 truncated, the router explains how to use `compozy__tool_artifact_read` in the same workspace and
 follow `next_offset` through `eof` to recover the complete retained result. Display redaction
 remains in effect; agents do not bypass a denied read through CLI or filesystem access.
 
-The daemon omits the tool router for memory extractor children, automatic title generation, and checkpoint summarization,
+When tools are enabled but skills are disabled, capable sessions keep both complete tool manuals
+inline. This preserves operational guidance without enabling the skill registry or changing tool
+authorization. The daemon omits all tool guidance for memory extractor children, automatic title generation, and checkpoint summarization,
 whose roles transform supplied input into output. This uses the persisted role, including an
 extractor created through `Spawn`, rather than excluding every `system`, `dream`, or `spawned`
 session. Task workers, coordinators, dream curators, interactive sessions, and unknown roles retain
-the router when tools are enabled. Older checkpoint sessions without an explicit role also retain
+the appropriate guidance when tools are enabled. Older checkpoint sessions without an explicit role also retain
 it. The role is preserved across resume and custom background-agent routing.
 
-| Context                      | Injected guidance                                    |
-| ---------------------------- | ---------------------------------------------------- |
-| Tool prompt section          | `compozy` router; matching references load on demand |
-| Network channel session      | Compact network response-register guidance           |
-| Task reviewer routing prompt | `references/tasks-and-orchestration.md`              |
+| Context                        | Injected guidance                                    |
+| ------------------------------ | ---------------------------------------------------- |
+| Tools and skills enabled       | `compozy` router; matching references load on demand |
+| Tools enabled, skills disabled | Both complete tool manuals inline                    |
+| Network channel session        | Compact network response-register guidance           |
+| Task reviewer routing prompt   | `references/tasks-and-orchestration.md`              |
 
-These selections change prompt guidance only. Tool registration, discovery, authorization, MCP,
+These selections provide contextual prompt help only. Tool registration, discovery, authorization, MCP,
 and the `tools.enabled` gateway switch keep their existing behavior. No additional configuration
 key or user-state migration is required.
 

--- a/skills/compozy/SKILL.md
+++ b/skills/compozy/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # CompozyOS
 
-This body routes to the matching reference. Startup includes this router, not the full reference manuals. Daemon-owned memory extraction, title generation, and checkpoint summarization omit the tool router because their role consumes supplied input and returns output; other tools-enabled sessions retain it.
+This body routes to the matching reference. When tools and skills are enabled, startup includes this router, not the full reference manuals. With tools enabled and skills disabled, capable sessions retain the two complete tool manuals inline because native skill reads are unavailable. Daemon-owned memory extraction, title generation, and checkpoint summarization omit the tool router because their role consumes supplied input and returns output; other tools-enabled sessions retain the appropriate guidance.
 
 To read a reference in a managed session, resolve `compozy__skill_view` through the active harness and call the returned tool reference with `{"name":"compozy","file":"references/<file>.md"}` using the exact path below. Tool discovery, descriptor reads, skill reads, and retained-result reads needed to load these references are the bootstrap exception to the reading prerequisite. Inspect the live descriptor before calling other tools; discover capabilities with `compozy__tool_search`. Keep existing tool authorization: missing guidance does not grant or revoke access, and a denied skill read is not permission to bypass policy through CLI or filesystem access.
 

--- a/skills/compozy/SKILL.md
+++ b/skills/compozy/SKILL.md
@@ -11,7 +11,11 @@ metadata:
 
 # CompozyOS
 
-This body routes to the matching reference. Load it before acting.
+This body routes to the matching reference. Startup includes this router, not the full reference manuals. Daemon-owned memory extraction, title generation, and checkpoint summarization omit the tool router because their role consumes supplied input and returns output; other tools-enabled sessions retain it.
+
+To read a reference in a managed session, resolve `compozy__skill_view` through the active harness and call the returned tool reference with `{"name":"compozy","file":"references/<file>.md"}` using the exact path below. Tool discovery, descriptor reads, skill reads, and retained-result reads needed to load these references are the bootstrap exception to the reading prerequisite. Inspect the live descriptor before calling other tools; discover capabilities with `compozy__tool_search`. Keep existing tool authorization: missing guidance does not grant or revoke access, and a denied skill read is not permission to bypass policy through CLI or filesystem access.
+
+If a reference result is truncated and includes an artifact, resolve `compozy__tool_artifact_read` through the active harness. Pass the returned artifact URI unchanged as `artifact_uri`, start at `offset: 0`, and continue with each `next_offset` until `eof`. Decode and concatenate `data_base64` pages to read the retained result envelope, including its full structured `content`; preserve any redactions in display text. Use the current workspace scope. A preview alone is not a complete reference. If the result has no usable artifact or a continuation is denied, report the reference as unavailable; do not use CLI or filesystem access to bypass it.
 
 ## Required Reading Router
 
@@ -80,6 +84,6 @@ for a one-command terminal demonstration; multi-step terminal interaction still 
 the affected operation and report the exact path. Preserve structured runtime errors, follow the
 diagnostic order in `references/runtime-operations.md`, and keep daemon-owned state authoritative.
 
-**STOP. Read references/tools-and-skills.md and references/native-tools.md in full before discovering, invoking, creating, or modifying any CompozyOS tool or skill.** The catalog in this file is only a router.
+**Read references/tools-and-skills.md and references/native-tools.md in full before operational tool calls or tool/skill mutations.** Discovery, descriptor inspection, reference reads, and their retained-result continuations may run first to load that guidance. The catalog in this file is only a router.
 
 **STOP. Read references/tasks-and-orchestration.md in full before acting as a coordinator, worker, or reviewer.** Task authority and review verdicts are runtime contracts, not prompt conventions.


### PR DESCRIPTION
## What & why

Fixes #563.

Every tools-enabled startup selected two complete bundled manuals regardless of the session's role. A minimal assembled prompt reproduced at **53,850 bytes**, with **53,836 bytes** of source reference material. Memory extractor children take the ordinary `Spawn` path and are classified `spawned`; checkpoint summaries use `dream`. Excluding every `system` or `dream` session would also remove useful guidance from tool-capable task workers and curators.

With tools and skills enabled, startup now includes the existing bundled **`compozy` router**, with the complete manuals available through `compozy__skill_view` on demand. The router explicitly explains reference loading through the active harness and permits the discovery/descriptor/skill reads needed to bootstrap that loading. It also explains the existing workspace-scoped `compozy__tool_artifact_read` continuation when a reference result is offloaded. Operational calls still require the matching reference guidance.

The daemon carries the existing persisted `spawn_role` into startup, live harness resolution, and resume continuity. It omits the tools section only for the explicit memory-extractor, auto-title, and checkpoint-summary roles. The extractor and title generator reuse their existing roles; the actual checkpoint caller now stamps its role in the existing lineage record. Interactive sessions, system workers, dream curators, coordinators, ordinary spawned workers, and unknown roles retain the router when tools are enabled. This works independently of the configured background agent name and survives resume.

When tools are enabled but skills are disabled, capable sessions retain both complete manuals inline: their native reference-reading tool is unavailable. Two mutually exclusive section predicates select the router (16,000-character budget) or this existing-configuration fallback (64,000 characters), while the role gate omits either form for input-only routines. Tests require the complete router without truncation or duplication. Neither manual's contents changed.

## How you verified it

Implemented and reviewed by Codex (GPT-6-Astra). The owning suites exercise observable prompt selection, real session storage and resume, and complete native resource retrieval.

- **Reproduction:** the existing composed-assembler suite failed before the production change, reporting a 53,850-byte startup and a missing router.
- **Focused race suite:** `CGO_ENABLED=1 go test -race ./internal/daemon -run 'TestComposedAssembler|TestHarnessContextResolver|TestDaemonCheckpointSummarizer|TestForkedMemoryExtractor' -count=1` passed.
- **Existing integration suite:** `CGO_ENABLED=1 go test -race -tags=integration ./internal/daemon -run '^TestHarnessContextIntegration' -count=1 -v` passed all four scenarios. It uses real SQLite and the real session manager, including the actual extractor spawn caller, the checkpoint summarizer, and a stopped/resumed extractor.
- **Native resource contract:** extended the existing skill catalog dispatch case to read both manuals through the real native registry and verify complete structured content and intentionally redacted display text. A smaller 32 KiB fixture budget verifies full recovery through native artifact pages, with production result limits unchanged. The capped follow-up passed in 40.600 seconds; boot feature-flag combinations and the complete role matrix also passed after the gate findings were corrected.
- **Runtime subprocess check:** `go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EAutomationPromptTriggerCreatesCompletedSystemSession$' -count=1 -timeout=10m -v` passed (65.48 seconds for the scenario), with the real daemon and ACP fixture in separate processes under the shared verification lock. Isolated runtime teardown reported clean.
- **Pinned local gate before initial publication (`977d28f42`):** `GOMAXPROCS=4 COMPOZY_GO_TEST_P=1 COMPOZY_GO_LINT_CONCURRENCY=2 mise exec -- make gate` passed with zero lint issues (54 seconds) and all affected race-test packages green (438 seconds). Go 1.26.6 and golangci-lint 2.13.1. Pre-commit lint-staged tasks and commitlint also passed with stash disabled; the initial resulting tree exactly matched the checked tree. The author subsequently requested that final remediation gates run in CI.
- **Checked implementation head:** `8beb507bdb6649ab7446a8c9bb8f24432f48b835`. Current-head CI and both bot review dispositions are recorded below before final delivery.

[QA scenario](docs/qa/scenarios/ET-049.md) and [measurement/verification report](docs/qa/reports/2026-09-09-scoped-tool-prompts.md) are co-shipped. The measured integration prompts were approximately 14 KB for capable sessions, 3.6 KB for extractor startup, and 3.4 KB for checkpoint summary; exact fixture counts and their measurement scope are in the report. These are prompt-byte observations, not a claim about provider billing or real-model reference-reading compliance.

The integration run also exposed two stale test assumptions: a task fixture missing the required profile identity, and `reflect.DeepEqual` applied to a policy containing function values. The fixture now supplies the owner profile. Resume compares filter behavior for the loaded catalog and compares every remaining policy field. No production validation was relaxed. Memory-dependent harness fixtures explicitly opt in to avoid relying on the defaults owned by #561.

The review follow-up adds the skills-disabled fallback, normalizes router matching, names every
resource subtest, and checks truncation state for each resource. The existing integration suite,
now exercising creation/resume with skills both enabled and disabled, and the native full-resource
suite passed together with `go test -race -p=1 -parallel=4 -tags=integration ./internal/daemon
-run '^TestHarnessContextIntegration|^TestDaemonNativeTools/Should_dispatch_skill_catalog_tools_through_the_real_skill_registry$'
-count=1 -v` in 66.863 seconds. The boot/assembly fallback checks passed separately in 9.947 seconds.
The frontend failure was a removed documentation contract phrase; its instructional-authority
meaning is restored without modifying the owning test.

## Impact

Cross-surface audit following `docs/_memory/change-impact.md`:

| Surface | Impact and compatibility |
| --- | --- |
| Native tools | Startup guidance and discovery instructions change. Tool IDs, schemas, descriptors, registration, policy evaluation, approval requirements, and CLI/API fallbacks are unchanged. Suppressing guidance is not an authorization boundary. |
| Extensibility, hooks, config | The official router teaches on-demand reads. Hosted MCP, skill resolution, hooks, provider routing, and `tools.enabled` keep their behavior. No new global switch. |
| Workspace data isolation | Session-local context reads the existing lineage record. No new read/write routes or workspace lookups, and no authority is inferred from the advisory role. Integration fixtures use isolated homes and SQLite. |
| User state / SD-013 | No database or JSON shape change. The existing free-form lineage role carries an additional internal value for newly created summaries. Older unmarked summaries keep guidance. No migration, configuration edits, or data loss. |
| Official skill | `skills/compozy/SKILL.md` now documents bootstrap discovery and on-demand references. Both reference manuals remain unchanged and readable in full. |
| Web / Docs | No Web routes, components, caches, or SDK contracts change. Updated the bundled-skill page, ET-049 startup contract, and QA report. No generated artifacts changed. |

Memory/dreaming defaults and the extractor JSONL parser/lifecycle remain outside this PR and are owned by #561. No PR is merged by this delivery.

---

- [x] Initial `make gate` passed locally; final remediation gates run in CI at the author's request, and delivery requires green current-head checks
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself
