### PR TITLE
fix: preserve migrated state during update recovery

### DIFF
--- a/desktop/e2e/_electron/__tests__/shell.spec.ts
+++ b/desktop/e2e/_electron/__tests__/shell.spec.ts
@@ -580,6 +580,30 @@ test("E2E-004: launch bursts reuse one window and deliver the last deep link", a
   ).toBe(true);
 });
 
+test("E2E-007: quitting during bootstrap completes cleanup and preserves the daemon", async ({
+  launchDesktop,
+}) => {
+  const desktop = await launchDesktop({
+    prepare: async ({ home, environment }) => {
+      environment.COMPOZY_DESKTOP_E2E_READY_FILE = join(home, "withheld-product-ready");
+    },
+  });
+  await expect(async () => {
+    expect((await bootstrapEvents(desktop.home)).at(-1)?.phase).toBe("ready");
+  }).toPass({ timeout: 30_000 });
+  const initial = await jsonCommand(desktop, ["status", "-o", "json"]);
+  const initialDaemon = initial.daemon as Record<string, unknown>;
+  await desktop.closeShell();
+  expect(desktop.shellProcess.signalCode).toBeNull();
+  const alive = await jsonCommand(desktop, ["status", "-o", "json"]);
+  expect(alive).toMatchObject({ daemon: { status: "running", pid: initialDaemon.pid } });
+  const record = JSON.parse(await readFile(join(desktop.home, "app.json"), "utf8")) as Record<
+    string,
+    unknown
+  >;
+  expect(record.state).not.toBe("product");
+});
+
 test("E2E-005 E2E-007: relaunch attaches, stopped runtime starts once, and shell quit leaves it alive", async ({
   launchDesktop,
 }) => {

--- a/desktop/e2e/_electron/__tests__/updates.spec.ts
+++ b/desktop/e2e/_electron/__tests__/updates.spec.ts
@@ -399,3 +399,46 @@ test("E2E-017: expired installer handoff records old-version truth and a fresh r
     await closeFixture(feed, restoreEnvironment);
   }
 });
+
+test("A staged app update starts while runtime bootstrap is failing", async ({
+  copyPackagedExecutable,
+  launchDesktop,
+}) => {
+  const fixture = await updateFixture();
+  const packaged = await copyPackagedExecutable(fixture.baseline_executable);
+  const feed = await startMockFeed(fixture, { holdAsset: true });
+  let desktop: DesktopInstance | undefined;
+  try {
+    await configureFeed(packaged, feed.url);
+    const digest = await artifactDigest(fixture);
+    desktop = await launchDesktop({
+      executablePath: packaged.executablePath,
+      environment: await updaterEnvironment(fixture, packaged),
+      prepare: async ({ home }) => {
+        await mkdir(join(home, "compozy.db"));
+        await seedOperation(home, operation(fixture, digest));
+      },
+    });
+    const home = desktop.home;
+    await expect(async () => {
+      expect((await readAppRecord(home)).state).toBe("error");
+    }).toPass({ timeout: 30_000 });
+    await expect
+      .poll(async () => {
+        const active = JSON.parse(await readFile(join(home, "update-operation.json"), "utf8")) as {
+          app: { phase: string };
+        };
+        return active.app.phase;
+      })
+      .toBe("applying");
+    await desktop.boot.screenshot({
+      path: test.info().outputPath("update-during-bootstrap-failure.png"),
+    });
+  } finally {
+    try {
+      await desktop?.closeShell();
+    } finally {
+      await feed.close();
+    }
+  }
+});

--- a/desktop/e2e/_electron/__tests__/updates.spec.ts
+++ b/desktop/e2e/_electron/__tests__/updates.spec.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { createServer, type Server } from "node:http";
-import { copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { access, copyFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -441,4 +441,35 @@ test("A staged app update starts while runtime bootstrap is failing", async ({
       await feed.close();
     }
   }
+});
+
+test("A staged app update never executes an unverified runtime bundle", async ({
+  copyPackagedExecutable,
+  launchDesktop,
+}) => {
+  const fixture = await updateFixture();
+  const packaged = await copyPackagedExecutable(fixture.baseline_executable);
+  const digest = await artifactDigest(fixture);
+  const desktop = await launchDesktop({
+    executablePath: packaged.executablePath,
+    prepare: async ({ home, bundleRuntimePath }) => {
+      await writeFile(
+        bundleRuntimePath,
+        '#!/bin/sh\nprintf executed > "$COMPOZY_HOME/unverified-runtime-executed"\nexit 1\n',
+        { mode: 0o700 }
+      );
+      await seedOperation(home, operation(fixture, digest));
+    },
+  });
+  await expect(async () => {
+    const record = await readAppRecord(desktop.home);
+    expect(record.state).toBe("error");
+    expect(record.error).toMatchObject({
+      safe_message: expect.stringContaining("integrity check"),
+    });
+  }).toPass({ timeout: 30_000 });
+  await desktop.closeShell();
+  await expect(access(join(desktop.home, "unverified-runtime-executed"))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
 });

--- a/desktop/e2e/_electron/__tests__/updates.spec.ts
+++ b/desktop/e2e/_electron/__tests__/updates.spec.ts
@@ -424,12 +424,17 @@ test("A staged app update starts while runtime bootstrap is failing", async ({
       expect((await readAppRecord(home)).state).toBe("error");
     }).toPass({ timeout: 30_000 });
     await expect
-      .poll(async () => {
-        const active = JSON.parse(await readFile(join(home, "update-operation.json"), "utf8")) as {
-          app: { phase: string };
-        };
-        return active.app.phase;
-      })
+      .poll(
+        async () => {
+          const active = JSON.parse(
+            await readFile(join(home, "update-operation.json"), "utf8")
+          ) as {
+            app: { phase: string };
+          };
+          return active.app.phase;
+        },
+        { timeout: 30_000 }
+      )
       .toBe("applying");
     await desktop.boot.screenshot({
       path: test.info().outputPath("update-during-bootstrap-failure.png"),

--- a/desktop/e2e/_electron/fixtures.ts
+++ b/desktop/e2e/_electron/fixtures.ts
@@ -192,11 +192,18 @@ async function terminateRuntime(home: string, environment: NodeJS.ProcessEnv): P
     if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
   }
   if (pid === null) {
-    // A failed boot may exit before publishing daemon.json. Still verify its lock PID exited.
+    // A booting daemon has no discovery record yet; tear down only this lab's lock PID.
     const lockName = process.platform === "win32" ? "daemon.lock.pid" : "daemon.lock";
     try {
       const lockPID = Number((await readFile(join(home, lockName), "utf8")).trim());
-      if (Number.isSafeInteger(lockPID) && lockPID > 0) await waitForProcessExit(lockPID);
+      if (Number.isSafeInteger(lockPID) && lockPID > 0) {
+        try {
+          process.kill(lockPID, "SIGTERM");
+        } catch (error) {
+          if (!(error instanceof Error && "code" in error && error.code === "ESRCH")) throw error;
+        }
+        await waitForProcessExit(lockPID);
+      }
     } catch (error) {
       if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
     }

--- a/desktop/e2e/_electron/fixtures.ts
+++ b/desktop/e2e/_electron/fixtures.ts
@@ -191,8 +191,19 @@ async function terminateRuntime(home: string, environment: NodeJS.ProcessEnv): P
   } catch (error) {
     if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
   }
-  await command(runtime, ["daemon", "stop"], environment);
-  if (pid !== null) await waitForProcessExit(pid);
+  if (pid === null) {
+    // A failed boot may exit before publishing daemon.json. Still verify its lock PID exited.
+    const lockName = process.platform === "win32" ? "daemon.lock.pid" : "daemon.lock";
+    try {
+      const lockPID = Number((await readFile(join(home, lockName), "utf8")).trim());
+      if (Number.isSafeInteger(lockPID) && lockPID > 0) await waitForProcessExit(lockPID);
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
+    }
+  } else {
+    await command(runtime, ["daemon", "stop"], environment);
+    await waitForProcessExit(pid);
+  }
   await waitForPathRemoval(join(home, "daemon.sock"));
 }
 

--- a/desktop/src/bootstrap/bootstrap-runner.ts
+++ b/desktop/src/bootstrap/bootstrap-runner.ts
@@ -48,9 +48,13 @@ export class BootstrapRunner {
     this.#environment = options.environment ?? process.env;
   }
 
-  async run(onEvent: (event: BootstrapEvent) => Promise<void>): Promise<BootstrapResult> {
+  /** Observes one bootstrap attempt; aborting stops the observer without stopping its detached daemon. */
+  async run(
+    onEvent: (event: BootstrapEvent) => Promise<void>,
+    signal?: AbortSignal
+  ): Promise<BootstrapResult> {
     if (this.#running) return await this.#running;
-    const attempt = this.#execute(onEvent);
+    const attempt = this.#execute(onEvent, signal);
     this.#running = attempt;
     try {
       return await attempt;
@@ -59,7 +63,10 @@ export class BootstrapRunner {
     }
   }
 
-  async #execute(onEvent: (event: BootstrapEvent) => Promise<void>): Promise<BootstrapResult> {
+  async #execute(
+    onEvent: (event: BootstrapEvent) => Promise<void>,
+    signal?: AbortSignal
+  ): Promise<BootstrapResult> {
     await verifyRuntimeBundle(this.#bundlePath, this.#manifestPath);
     await ensurePrivateDirectory(dirname(this.#logPath));
     const child = spawn(
@@ -82,6 +89,8 @@ export class BootstrapRunner {
         env: this.#environment,
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
+        // This child observes bootstrap; the runtime daemon is detached and remains alive.
+        signal,
       }
     );
     if (!child.stdout || !child.stderr)
@@ -90,6 +99,8 @@ export class BootstrapRunner {
       child.once("error", reject);
       child.once("close", resolve);
     });
+    // Observe spawn/abort rejection immediately while stdout is still being drained.
+    void exit.catch(() => undefined);
     let ready: BootstrapResult | null = null;
     let stderr = "";
     child.stderr.setEncoding("utf8");

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -6,6 +6,7 @@ import { join, resolve } from "node:path";
 import { app, globalShortcut, ipcMain, session, shell, systemPreferences } from "electron";
 
 import { BootstrapRunner } from "./bootstrap/bootstrap-runner";
+import { verifyRuntimeBundle } from "./bootstrap/bundle-integrity";
 import { RuntimeHealthMonitor } from "./bootstrap/runtime-health-monitor";
 import { bootstrapSnapshot } from "./boot/bootstrap-state";
 import { isForwardedBootMethod } from "./boot/boot-contract";
@@ -261,6 +262,8 @@ async function start(): Promise<void> {
 
   async function runBootstrapAttempt(): Promise<void> {
     try {
+      await verifyRuntimeBundle(resources.bundle, resources.manifest);
+      startUpdateConsumer(statePublisher);
       const runtime = await runner.run(async event => {
         await statePublisher.publish(bootstrapSnapshot(event, paths.bootstrapLog));
       });
@@ -351,7 +354,6 @@ async function start(): Promise<void> {
     operationWatcher.start();
   }
 
-  startUpdateConsumer(statePublisher);
   await runBootstrap();
 }
 

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { access, mkdir } from "node:fs/promises";
 import { performance } from "node:perf_hooks";
+import { setTimeout as delay } from "node:timers/promises";
 import { join, resolve } from "node:path";
 
 import { app, globalShortcut, ipcMain, session, shell, systemPreferences } from "electron";
@@ -63,19 +64,22 @@ let publisher: AppStatePublisher | null = null;
 let productBridge: ProductBridgeController | null = null;
 let cleanupPromise: Promise<void> | null = null;
 let cleanupComplete = false;
+const bootstrapAbort = new AbortController();
+let bootstrapFlow: Promise<void> | null = null;
 
 async function waitForE2EProductReady(): Promise<void> {
   const readyPath = process.env.COMPOZY_DESKTOP_E2E_READY_FILE?.trim();
   if (process.env.COMPOZY_DESKTOP_E2E !== "1" || !readyPath) return;
   const deadline = Date.now() + 10_000;
   while (Date.now() < deadline) {
+    bootstrapAbort.signal.throwIfAborted();
     try {
       await access(readyPath);
       return;
     } catch (error) {
       if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) throw error;
     }
-    await new Promise(resolveDelay => setTimeout(resolveDelay, 25));
+    await delay(25, undefined, { signal: bootstrapAbort.signal });
   }
   throw new Error("The desktop E2E product-ready gate timed out.");
 }
@@ -115,9 +119,11 @@ function resourcePaths(): {
   };
 }
 
+/** Cancels and drains bootstrap before releasing shell resources for quit or installer handoff. */
 async function cleanup(): Promise<void> {
   if (cleanupPromise) return await cleanupPromise;
   cleanupPromise = (async () => {
+    bootstrapAbort.abort();
     const errors: Error[] = [];
     const attempt = async (step: () => void | Promise<void>): Promise<void> => {
       try {
@@ -127,6 +133,7 @@ async function cleanup(): Promise<void> {
       }
     };
     try {
+      await attempt(async () => await bootstrapFlow);
       await attempt(async () => await product?.flushState());
       await attempt(() => productBridge?.unregister());
       await attempt(() => operationWatcher?.stop());
@@ -156,6 +163,7 @@ async function quitCleanly(): Promise<void> {
   app.quit();
 }
 
+/** Initializes the shell and permits verified staged updates before runtime readiness. */
 async function start(): Promise<void> {
   await mkdir(paths.home, { recursive: true, mode: 0o700 });
   const resources = resourcePaths();
@@ -249,8 +257,9 @@ async function start(): Promise<void> {
     channel: __COMPOZY_RELEASE_CHANNEL__,
     bootId,
   });
-  let bootstrapFlow: Promise<void> | null = null;
+  /** Serializes bootstrap attempts and prevents new work after shutdown begins. */
   async function runBootstrap(): Promise<void> {
+    if (bootstrapAbort.signal.aborted) return;
     if (bootstrapFlow) return await bootstrapFlow;
     bootstrapFlow = runBootstrapAttempt();
     try {
@@ -260,15 +269,20 @@ async function start(): Promise<void> {
     }
   }
 
+  /** Verifies the bundle, observes runtime boot, and publishes a window only while the shell is active. */
   async function runBootstrapAttempt(): Promise<void> {
     try {
       await verifyRuntimeBundle(resources.bundle, resources.manifest);
+      if (bootstrapAbort.signal.aborted) return;
       startUpdateConsumer(statePublisher);
       const runtime = await runner.run(async event => {
+        if (bootstrapAbort.signal.aborted) return;
         await statePublisher.publish(bootstrapSnapshot(event, paths.bootstrapLog));
-      });
+      }, bootstrapAbort.signal);
+      if (bootstrapAbort.signal.aborted) return;
       applyDefaultDenyPermissions(session.defaultSession, runtime.origin);
       await statePublisher.setRuntime(runtime.version, runtime.owned);
+      if (bootstrapAbort.signal.aborted) return;
       runtimeMonitor?.stop();
       product = new ProductWindow({
         origin: runtime.origin,
@@ -277,11 +291,13 @@ async function start(): Promise<void> {
         presentation: windowPresentation,
         links,
         onReady: async () => {
+          if (bootstrapAbort.signal.aborted) return;
           await statePublisher.publish({
             state: "product",
             origin: runtime.origin,
             owned: runtime.owned,
           });
+          if (bootstrapAbort.signal.aborted) return;
           runtimeMonitor = new RuntimeHealthMonitor({
             origin: runtime.origin,
             onDisconnected: async () => {
@@ -295,6 +311,7 @@ async function start(): Promise<void> {
           boot?.close();
         },
         onLoadFailure: async error => {
+          if (bootstrapAbort.signal.aborted) return;
           await statePublisher.publish({
             state: "error",
             error: {
@@ -308,8 +325,10 @@ async function start(): Promise<void> {
         onError: error => logger.error("product window", error),
       });
       await waitForE2EProductReady();
+      if (bootstrapAbort.signal.aborted) return;
       await product.create();
     } catch (error) {
+      if (bootstrapAbort.signal.aborted) return;
       logger.error("bootstrap runtime", error);
       const terminal = statePublisher.snapshot();
       if (terminal.state !== "error" && terminal.state !== "skew") {
@@ -329,6 +348,7 @@ async function start(): Promise<void> {
     }
   }
 
+  /** Starts one staged-update watcher after packaged runtime integrity has been established. */
   function startUpdateConsumer(state: AppStatePublisher): void {
     if (operationWatcher) return;
     updateConsumer = new AppUpdateConsumer({

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -133,7 +133,9 @@ async function cleanup(): Promise<void> {
       }
     };
     try {
-      await attempt(async () => await bootstrapFlow);
+      await attempt(async () => {
+        await bootstrapFlow;
+      });
       await attempt(async () => await product?.flushState());
       await attempt(() => productBridge?.unregister());
       await attempt(() => operationWatcher?.stop());

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -266,7 +266,6 @@ async function start(): Promise<void> {
       });
       applyDefaultDenyPermissions(session.defaultSession, runtime.origin);
       await statePublisher.setRuntime(runtime.version, runtime.owned);
-      startUpdateConsumer(statePublisher);
       runtimeMonitor?.stop();
       product = new ProductWindow({
         origin: runtime.origin,
@@ -352,6 +351,7 @@ async function start(): Promise<void> {
     operationWatcher.start();
   }
 
+  startUpdateConsumer(statePublisher);
   await runBootstrap();
 }
 

--- a/desktop/src/state/__tests__/app-state.test.ts
+++ b/desktop/src/state/__tests__/app-state.test.ts
@@ -251,7 +251,15 @@ describe("app state publisher", () => {
         boot_phase: "starting",
         started_at: "2026-08-16T00:00:00.000Z",
       });
+      const publication = recovered.publish({ state: "product" });
       await recovered.markCleanShutdown();
+      await publication;
+      await expect(access(marker)).rejects.toMatchObject({ code: "ENOENT" });
+      const cleanRecord = await readFile(path, "utf8");
+      await recovered.publish({ state: "disconnected" });
+      await recovered.setRuntime("0.3.1", true);
+      await recovered.setOperation(null);
+      expect(await readFile(path, "utf8")).toBe(cleanRecord);
       await expect(access(marker)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await rm(home, { recursive: true, force: true });

--- a/docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
+++ b/docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
@@ -57,3 +57,18 @@ The initial commit passed the full local affected gate and strict QA audit. Per 
 ## Delivery tracking
 
 Runtime recovery and the packaged app recovery slice passed with the limits above. The pull request records the final local gate, checked head, required CI, and CodeRabbit/Greptile dispositions. The lab's machine-readable strict audit is finalized with local gate evidence before delivery; `teardown.json` records `clean: true`.
+
+
+## CodeRabbit follow-up
+
+Desktop shutdown and installer handoff now cancel and await the bootstrap observer before cleanup. The detached runtime remains alive, and canceled bootstrap callbacks cannot publish a product window after cleanup. The existing shell E2E covers quitting during an unfinished bootstrap flow and verifies the same daemon PID remains running. Staged-update polling uses an explicit 30-second bound, and failed-boot fixture cleanup signals the isolated lab's lock PID before verifying exit.
+
+The CLI journal suite also covers the missing-local-record remote fallback. The restart integration's final observer wait has a 10-second deadline. A subsequent fully booted daemon reconciles older `starting` restart observations under its exclusive home lock, while preserving its own current restart operation. Cancellation alone still does not declare a live replacement failed. No schema, migration numbering, or public restart DTO changes were needed.
+
+The requested global readiness deadlines were not adopted: readiness windows are intentionally diagnostic, with caller cancellation and actual exit as termination boundaries. This behavior and lock/helper lifetimes were explicitly reviewed with the controller before publication. An elapsed deadline cannot establish migration failure; a stalled live process remains pending with PID diagnostics. The retain-runtime failure policy remains independent of this observation contract.
+
+
+The follow-up CLI race test passed (2.391 seconds); the final daemon boot integration passed with `-race -tags integration -p=1 -parallel=4` (6.120 seconds), including reconciliation of a valid abandoned restart despite corrupt historical metadata. Corrupt history is reported without blocking boot or deleting the record. CodeRabbit withdrew and resolved both deadline findings after reviewing the documented contract and existing cancellation/exit/lock evidence.
+
+
+Final packaged follow-up: the owner `build:e2e-update` generator completed, then Playwright ran under the shared machine verification lock. Four scenarios passed in 25.9 seconds: bootstrap quit preserving the daemon (2.7s), packaged security/DevTools (11.0s), staged update during boot failure (10.9s), and rejected unverified runtime execution (0.9s). All fixture teardown completed. The preceding Linux CI head had passed 27/28 desktop scenarios but lost the Electron debugging connection in E2E-034; its job log and artifact were inspected. The same security scenario passed locally on macOS, so Linux current-head CI remains required rather than claiming a proven cross-platform fix for that isolated failure.

--- a/docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
+++ b/docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
@@ -1,0 +1,51 @@
+# Issue 559: safe runtime update recovery
+
+## Scope and charter
+
+Dora updates a used local installation, waits through slow startup, and recovers a genuine boot failure without losing state. Bruno opens an older desktop shell against a newer runtime. Targeted fault injection uses an isolated home and the existing restart/update paths; it does not claim provider validation.
+
+| Journey | Status | Evidence |
+| --- | --- | --- |
+| Runtime replacement preserves migrated state after failure | Pass | Published beta.22 home upgraded from global schema 99 to 107; actual replacement exit retained the new binary and incompatible backup; recovery preserved the workspace |
+| Slow detached start and restart eventually report readiness | Pass | Existing CLI/daemon suites and a real replacement paused for 30 seconds before readiness |
+| Older desktop preserves a newer runtime | Pass (owning suites) | Bootstrap version policy and hash-verified installed provenance; no full older-app/newer-runtime UI walk claimed |
+| Staged app recovery does not depend on runtime readiness | Pass | Packaged macOS Electron scenario observed bootstrap `error` and app operation `applying`; fixture teardown passed |
+| Recovered runtime clears historical rollback projection | Pass | Existing projection suite covers equal and newer recovered versions |
+
+## Cross-surface impact
+
+- Native tools: no IDs, schemas, or permissions change. Settings restart and update HTTP/UDS routes retain their payloads; CLI observes the host-local restart journal while the daemon is offline.
+- Extensibility/hooks/config: no config keys, defaults, hook ordering, extension contracts, or provider credentials change. Required boot work still precedes readiness.
+- Workspace isolation and user state: the update journal and binary are host-global. No SQLite migration, schema version, workspace data, or released migration bytes change. A post-swap failure preserves the replacement and backup because any persisted stream may already have migrated.
+- Official skill: desktop recovery guidance is updated in `skills/compozy/references/desktop.md`.
+- Web/Docs: existing Settings update/restart projections consume unchanged status contracts. The desktop starts its app update consumer before bootstrap succeeds. Public recovery documentation and affected QA scenarios co-ship, including the intentional slow-start pending/cancellation contract in `APP-start-installed-daemon`.
+
+## Verification log
+
+- Initial `TestCoordinatorRuntimeLifecycle` regression failed because health failure restored the old binary and interrupted-swap recovery archived `rolled-back`.
+- After the first production correction, the owning coordinator suite passed with `CGO_ENABLED=1 go test -race ./internal/update -run TestCoordinatorRuntimeLifecycle -count=1`.
+- Lab: `.cache/issue-559-qa/compozy-issue-559-recovery-20260909-160037-168457-lab/qa-artifacts/qa/bootstrap-manifest.json`.
+
+## Runtime evidence and limits
+
+The lab used the existing `desktop/e2e/fixtures/runtimeupdate` coordinator, production detached restart helper, actual SQLite stores, and public CLI. The fixture stages the verified replacement directly; this walk does not retest release signature/download verification.
+
+1. Verified the published `v0.3.0-beta.22` macOS archive against its release checksum, started it in the manifest home, and registered workspace `ws_194a2b87cce1e40a` (`recovery-preserved-workspace`). The baseline reported global schema 99.
+2. Applied the current implementation (fixture runtime version `0.3.1`) and observed global schema 107. The first attempt to pause startup missed the text log marker and completed normally; it is migration evidence only.
+3. Repeated replacement with the corrected marker, suspended the owned replacement for 30 seconds after its schema stage, verified restart stayed `starting`, resumed it, and observed `finalized`/`updated`, runtime `running`, and the preserved workspace. `slow-update-result.json` records this run; both binaries in this second run have the same hash.
+4. Recreated the incompatible beta.22 backup in the isolated fixture and killed only the replacement after its schema stage. The coordinator archived `failed`, retained the new executable (SHA-256 `6b2057c6b08f07ba2b80185d2d604a375aef22d55bd3641dbb97e99b6fb0ae27`) and beta.22 backup (`3486080e2c59fd3852de47d793d10e5579cc68ee9060bbf31d74e71e88d8c0c0`), then `compozy daemon start -o json` recovered with the workspace intact. See `failed-update-result.json`, `failure-recovery-start.json`, and `failure-recovery-workspaces.json` in the lab QA directory.
+5. Targeted manifest teardown completed with `clean: true`. No operator home or credentials were changed, and no provider session was used. User-installed skill validation warnings were present during boot; no provider-health claim is made.
+
+Readiness observation is intentionally unbounded until ready, actual exit, or caller cancellation. It observes liveness, not migration progress. A stalled live child is neither killed nor marked ready. CLI cancellation reports the PID and releases the startup mutation lock; the owning test reacquires that same lock and verifies no termination. Provisioning completes before startup; the updater releases its swap lock before waiting. The detached restart helper holds neither mutation lock while observing and exits on readiness, actual exit, or its own cancellation; canceling a CLI does not cancel that helper. Periodic diagnostics make the continued wait visible.
+
+Focused race suites passed for update lifecycle/projection/provenance, CLI wait/cancellation/local journal observation, and restart cancellation. The existing integration command `CGO_ENABLED=1 go test -race -tags integration ./internal/daemon -run 'TestBootMarksRestartOperationReadyAfterFreshDaemonInfo|TestRelaunchHelperFailurePersistsAfterOldDaemonExit' -count=1` passed. Desktop root Turborepo `test typecheck --filter=@compozy/desktop` passed 137 tests; root affected desktop/web builds completed. Windows runtime cross-build passed. Subsequent heavy checks use `GOMAXPROCS=4`, `COMPOZY_GO_TEST_P=1`, `COMPOZY_GO_LINT_CONCURRENCY=2`, and pinned tools through `mise exec`.
+
+## Packaged desktop evidence
+
+`mise exec -- bun run --cwd desktop build:e2e-update` built the instrumented baseline and next-version packages. Under the shared machine verification lock, `bunx playwright test --config playwright.config.ts --grep 'A staged app update starts'` from `desktop/` passed (1 test, 17.1 seconds). The isolated fixture made `compozy.db` a directory to force a real boot failure and held the update download so no native installer/relaunch could escape the fixture home. The app reported `error` while the staged operation reached `applying`. Screenshot: `.tmp/playwright/desktop-results/__tests__-updates-A-staged-9d6fc-untime-bootstrap-is-failing/update-during-bootstrap-failure.png`.
+
+The first attempt exposed a read-before-publication race in the new assertion; the second reached both product conditions and exposed the fixture's assumption that every test has a running daemon during teardown. The existing fixture now verifies the lock PID has exited when no discovery record was published. The final run passed all assertions and cleanup. It neither changes launch-session environment nor performs a native installer relaunch. The existing installer/relaunch scenarios remain the owners of that unchanged behavior.
+
+## Delivery tracking
+
+Runtime recovery and the packaged app recovery slice passed with the limits above. The pull request records the final local gate, checked head, required CI, and CodeRabbit/Greptile dispositions. The lab's machine-readable strict audit is finalized with local gate evidence before delivery; `teardown.json` records `clean: true`.

--- a/docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
+++ b/docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
@@ -46,6 +46,14 @@ Focused race suites passed for update lifecycle/projection/provenance, CLI wait/
 
 The first attempt exposed a read-before-publication race in the new assertion; the second reached both product conditions and exposed the fixture's assumption that every test has a running daemon during teardown. The existing fixture now verifies the lock PID has exited when no discovery record was published. The final run passed all assertions and cleanup. It neither changes launch-session environment nor performs a native installer relaunch. The existing installer/relaunch scenarios remain the owners of that unchanged behavior.
 
+## Review remediation: staged bundle integrity
+
+Greptile identified that the early update consumer could invoke its transition client before bootstrap verified the runtime bundle. The existing packaged update suite reproduced this with a substituted executable that wrote a marker: the marker existed on the initial implementation even though bootstrap rejected the bundle.
+
+Startup now verifies the bundle before starting the update consumer, while retaining BootstrapRunner's own verification at its execution boundary. A verified bundle can still process a staged app update when daemon boot fails. Rebuilt baseline/next packages and reran `bunx playwright test --config playwright.config.ts --grep 'A staged app update'` under the shared verification lock: both scenarios passed (13.3 seconds), including no execution marker for the tampered bundle and clean fixture teardown.
+
+The initial commit passed the full local affected gate and strict QA audit. Per the user's subsequent delivery direction, follow-up commits retain focused behavioral checks and hook validation while the full gates run in PR CI.
+
 ## Delivery tracking
 
 Runtime recovery and the packaged app recovery slice passed with the limits above. The pull request records the final local gate, checked head, required CI, and CodeRabbit/Greptile dispositions. The lab's machine-readable strict audit is finalized with local gate evidence before delivery; `teardown.json` records `clean: true`.

--- a/docs/qa/scenarios/APP-desktop-runtime-bundle-coherence.md
+++ b/docs/qa/scenarios/APP-desktop-runtime-bundle-coherence.md
@@ -4,7 +4,7 @@ area: APP
 title: Opening an updated app replaces its stale app-owned runtime
 persona: Bruno
 journey: J-desktop-attach-daily
-expected: When the app bundle is newer than a healthy running runtime that the desktop app owns, opening the app stops only that owned process, atomically installs the bundled runtime, publishes matching provenance, starts it, and reaches the existing product state without deleting the Compozy home. If replacement or provenance publication fails, the prior binary remains recoverable and no half-published identity is trusted.
+expected: When the app bundle is newer than a healthy running runtime that the desktop app owns, opening the app stops only that owned process, atomically installs the bundled runtime, publishes matching provenance, starts it, and reaches the existing product state without deleting the Compozy home. A newer running runtime is retained and attached only if compatible; a newer verified installed runtime is never replaced by an older bundle. If replacement or provenance publication fails, the prior binary remains recoverable and no half-published identity is trusted.
 entry_points: packaged CompozyOS app after an N to N+1 app update; compozy status in the same isolated home
 qa_status: pass
 bug_ids:
@@ -12,7 +12,7 @@ fix_status:
 retest_status:
 fix_commits:
 evidence: /Users/pedronauck/dev/qa-labs/compozy-runtime-ui-regressions-20260827-155435-128437-lab/qa-artifacts/qa/runtime-ui-proof.md
-last_report: docs/qa/reports/2026-08-27-runtime-ui-regressions.md
+last_report: docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
 overlaps: APP-attach-running-daemon; APP-start-installed-daemon; APP-runtime-update-app-owned
 ---
 
@@ -21,3 +21,5 @@ comparing the installed app-owned binary with the runtime bundled by the new app
 could therefore leave the old daemon running indefinitely and surface unrelated session failures
 until the operator deleted `~/.compozy`. This scenario owns the narrower launch-time coherence
 contract; the broader consent-driven update flow remains owned by `APP-runtime-update-app-owned`.
+
+Issue 559 re-walk: `docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md`.

--- a/docs/qa/scenarios/APP-start-installed-daemon.md
+++ b/docs/qa/scenarios/APP-start-installed-daemon.md
@@ -4,7 +4,7 @@ area: APP
 title: Start my installed-but-stopped runtime by opening the app
 persona: Dora
 journey: J-desktop-attach-daily
-expected: Opening the app with the runtime installed but stopped shows visible bounded starting progress and lands in the product UI; it waits for a live recorded daemon before a bounded desktop-owned retry, never starts a conflicting second daemon, and the started runtime survives app quit with `compozy status` healthy.
+expected: Opening the app with the runtime installed but stopped shows starting progress and lands in the product UI after required boot work. Readiness polling windows do not kill a live daemon or restart its boot work. Observation continues until readiness, actual exit, or caller cancellation; actual boot failures retain bounded retries. The started runtime survives app quit with `compozy status` healthy.
 entry_points: dock/launcher icon with an installed, stopped runtime; compozy app open
 qa_status: pass
 bug_ids: BUG-20260810-desktop-runtime-stalls; BUG-20260810-initial-boot-window-absent
@@ -29,3 +29,5 @@ QA impact 2026-08-11: startup now waits for the recorded daemon and may retry on
 has proven desktop-owned. The isolated macOS working-tree walk started daemon PID `89043`, reached
 product state with one listener, and kept the daemon healthy after app quit. Packaged progress UI
 and Linux artifact evidence remain blocked for the mandatory pre-publish smoke.
+
+Issue 559 changes the slow-start expectation: a polling-window expiration alone is not a boot failure. Stalled live processes remain pending with periodic diagnostics; cancellation releases the startup mutation lock without terminating the daemon. Owning CLI cancellation/exit tests and the 30-second isolated runtime pause are recorded in `docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md`. This slice does not re-claim the historical browser/session or full OS matrix evidence.

--- a/docs/qa/scenarios/APP-update-recovery-state.md
+++ b/docs/qa/scenarios/APP-update-recovery-state.md
@@ -4,15 +4,15 @@ area: APP
 title: A failed update never strands me silently
 persona: Dora
 journey: J-desktop-update-moment
-expected: A forced app apply failure leaves the installed app intact and launchable with the failure reported and a manual-download path; a post-swap runtime health failure restores the previous runtime, archives the operation as `rolled-back` with the typed failure, and allows retry only from a newly verified candidate.
-entry_points: update surface after a forced app apply failure; compozy update -o json; update-history.jsonl after a runtime rollback
+expected: A forced app apply failure leaves the installed app intact and launchable with the failure reported and a manual-download path; a post-swap runtime failure retains the replacement and backup, archives the operation as `failed` with recovery guidance, and preserves migrated user state. A live slow boot remains in progress until ready or actual exit. Recovery to the target version or newer clears historical rollback from the live projection without editing history.
+entry_points: update surface after a forced app apply failure; compozy update -o json; update-history.jsonl after a runtime failure
 qa_status: pass
 bug_ids: BUG-20260810-healthy-retry-corrupts-state
 fix_status: fixed
 retest_status: pass
 fix_commits: f081a1e
 evidence: docs/qa/reports/2026-08-17-electron-shell.md
-last_report: docs/qa/reports/2026-08-17-electron-shell.md
+last_report: docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md
 overlaps: APP-agent-cli-app-verbs
 ---
 
@@ -28,5 +28,7 @@ clamped to `0700` (or the platform ACL equivalent) by the failed apply.
 Per-OS evidence: E2E-017 runs on macOS and Linux with the locked-dir fixture — capture the failed-
 update report, the opened release page, a fresh OS-level app launch, and the install-path
 permission listing before/after. E2E-018 forces a runtime post-swap health failure on both release
-OSes and records byte-identical restoration plus the archived `rolled-back` outcome. Overlap:
+OSes and records replacement retention plus the archived `failed` outcome. Overlap:
 APP-agent-cli-app-verbs owns the structured CLI readout of the same durable update result.
+
+Issue 559 re-walk: `docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md`.

--- a/docs/qa/scenarios/APP-update-recovery-state.md
+++ b/docs/qa/scenarios/APP-update-recovery-state.md
@@ -34,3 +34,8 @@ APP-agent-cli-app-verbs owns the structured CLI readout of the same durable upda
 Issue 559 re-walk: `docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md`.
 
 Staged recovery verifies the packaged runtime digest before any transition-client execution. The issue 559 packaged re-walk covers both a valid bundle with failing daemon boot and a tampered bundle that must never execute.
+
+
+### Bootstrap shutdown coordination
+
+A staged app installer can run before runtime readiness, after bundle verification. Before installer handoff or shell shutdown, the desktop cancels and awaits its bootstrap observer, preserves the detached daemon, and prevents late product-window publication. A later successful daemon startup reconciles superseded `starting` restart observations without changing the current restart operation or restoring an older binary. Verified by the issue #559 shell and daemon boot integration evidence in `../reports/2026-09-09-issue-559-safe-update-recovery.md`.

--- a/docs/qa/scenarios/APP-update-recovery-state.md
+++ b/docs/qa/scenarios/APP-update-recovery-state.md
@@ -32,3 +32,5 @@ OSes and records replacement retention plus the archived `failed` outcome. Overl
 APP-agent-cli-app-verbs owns the structured CLI readout of the same durable update result.
 
 Issue 559 re-walk: `docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md`.
+
+Staged recovery verifies the packaged runtime digest before any transition-client execution. The issue 559 packaged re-walk covers both a valid bundle with failing daemon boot and a tampered bundle that must never execute.

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -361,6 +361,8 @@ func acquireDaemonStartUpdateLock(path string) (*compozydaemon.UpdateLock, error
 	return lock, nil
 }
 
+// waitForDaemonStart observes readiness until success, actual exit, or caller cancellation.
+// Polling windows report slow startup without killing a possibly migrating daemon.
 func waitForDaemonStart(ctx context.Context, deps commandDeps, child daemonProcess) (DaemonStatus, error) {
 	for {
 		status, err := waitForDaemonStartWindow(ctx, deps, child)
@@ -383,6 +385,7 @@ func waitForDaemonStart(ctx context.Context, deps commandDeps, child daemonProce
 	}
 }
 
+// waitForDaemonStartWindow checks process exit and daemon readiness within one polling window.
 func waitForDaemonStartWindow(ctx context.Context, deps commandDeps, child daemonProcess) (DaemonStatus, error) {
 	if err := requirePollingContext(ctx); err != nil {
 		return DaemonStatus{}, err

--- a/internal/cli/daemon.go
+++ b/internal/cli/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -361,6 +362,28 @@ func acquireDaemonStartUpdateLock(path string) (*compozydaemon.UpdateLock, error
 }
 
 func waitForDaemonStart(ctx context.Context, deps commandDeps, child daemonProcess) (DaemonStatus, error) {
+	for {
+		status, err := waitForDaemonStartWindow(ctx, deps, child)
+		if err != nil && ctx != nil && ctx.Err() != nil && child != nil {
+			return status, fmt.Errorf(
+				"cli: stopped waiting for daemon pid=%d; it may still be starting; inspect the runtime log before retrying: %w",
+				child.PID(),
+				err,
+			)
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			return status, err
+		}
+		slog.InfoContext(
+			ctx,
+			"cli: daemon is still starting; waiting for readiness or process exit",
+			"pid",
+			child.PID(),
+		)
+	}
+}
+
+func waitForDaemonStartWindow(ctx context.Context, deps commandDeps, child daemonProcess) (DaemonStatus, error) {
 	if err := requirePollingContext(ctx); err != nil {
 		return DaemonStatus{}, err
 	}

--- a/internal/cli/daemon_bootstrap.go
+++ b/internal/cli/daemon_bootstrap.go
@@ -166,7 +166,15 @@ func (e *bootstrapExecution) resolveAndStart() error {
 				e.cmd, bootstrapPhaseResolve, bootstrapProbeUnavailable, matchErr,
 			)
 		}
-		if !matches {
+		newer, versionErr := compozyupdate.DesktopRuntimeNewerThanBundle(
+			e.homePaths,
+			runtimePath,
+			e.provenance().RuntimeVersion,
+		)
+		if versionErr != nil {
+			return writeBootstrapFailure(e.cmd, bootstrapPhaseResolve, bootstrapProbeUnavailable, versionErr)
+		}
+		if !matches && !newer {
 			resolution = bootstrapResolutionProvision
 		}
 	}
@@ -230,7 +238,7 @@ func (e *bootstrapExecution) start(resolution bootstrapResolution, runtimePath s
 		if lastErr == nil {
 			return e.writeStarted(status, resolution, attempt, owned)
 		}
-		if bootstrapShouldGiveUp(attempt) {
+		if e.cmd.Context().Err() != nil || bootstrapShouldGiveUp(attempt) {
 			break
 		}
 		delay := bootstrapBackoff(attempt)
@@ -389,27 +397,7 @@ func runBootstrapDaemonDetached(
 	if err != nil {
 		return DaemonStatus{}, err
 	}
-	return waitForBootstrapDaemonStart(ctx, deps, child)
-}
-
-func waitForBootstrapDaemonStart(
-	ctx context.Context,
-	deps commandDeps,
-	child daemonProcess,
-) (DaemonStatus, error) {
-	status, waitErr := waitForDaemonStart(ctx, deps, child)
-	if waitErr == nil {
-		return status, nil
-	}
-	terminateErr := child.Terminate()
-	reapErr := child.Wait()
-	if terminateErr != nil {
-		terminateErr = fmt.Errorf("cli: terminate unready detached daemon: %w", terminateErr)
-	}
-	if reapErr != nil {
-		reapErr = fmt.Errorf("cli: reap unready detached daemon: %w", reapErr)
-	}
-	return DaemonStatus{}, errors.Join(waitErr, terminateErr, reapErr)
+	return waitForDaemonStart(ctx, deps, child)
 }
 
 func validateBootstrapCompatibility(status DaemonStatus, minimumRuntime string, appVersion string) error {

--- a/internal/cli/daemon_bootstrap.go
+++ b/internal/cli/daemon_bootstrap.go
@@ -137,6 +137,7 @@ type bootstrapExecution struct {
 	installedPath string
 }
 
+// resolveAndStart attaches to a compatible daemon or provisions and starts the selected runtime.
 func (e *bootstrapExecution) resolveAndStart() error {
 	status, running, err := probeBootstrapDaemon(e.cmd.Context(), e.deps, e.homePaths)
 	if err == nil && running {
@@ -224,6 +225,7 @@ func writeAttachedBootstrap(cmd *cobra.Command, options bootstrapOptions, status
 	})
 }
 
+// start retries actual launch failures while preserving live daemons across readiness windows.
 func (e *bootstrapExecution) start(resolution bootstrapResolution, runtimePath string, owned bool) error {
 	var lastErr error
 	for attempt := 1; attempt <= bootstrapMaximumAttempts; attempt++ {
@@ -369,6 +371,7 @@ func probeBootstrapDaemon(
 	return status, true, nil
 }
 
+// runBootstrapDaemonDetached owns the startup mutation lock until readiness, exit, or cancellation.
 func runBootstrapDaemonDetached(
 	ctx context.Context,
 	deps commandDeps,

--- a/internal/cli/daemon_bootstrap_desktop_runtime.go
+++ b/internal/cli/daemon_bootstrap_desktop_runtime.go
@@ -15,6 +15,7 @@ import (
 	compozyversion "github.com/compozy/compozy/internal/version"
 )
 
+// replaceOutdatedDesktopRuntime replaces an older desktop runtime while preserving compatible newer versions.
 func (e *bootstrapExecution) replaceOutdatedDesktopRuntime(status DaemonStatus) (bool, error) {
 	if bootstrapRuntimeIsNewer(status.Version, e.provenance().RuntimeVersion) {
 		return false, nil
@@ -44,6 +45,7 @@ func (e *bootstrapExecution) replaceOutdatedDesktopRuntime(status DaemonStatus) 
 	return true, nil
 }
 
+// bootstrapRuntimeIsNewer compares release versions without treating development builds as newer.
 func bootstrapRuntimeIsNewer(runningVersion, bundledVersion string) bool {
 	running, runningErr := semver.NewVersion(normalizedBootstrapVersion(runningVersion))
 	bundled, bundledErr := semver.NewVersion(normalizedBootstrapVersion(bundledVersion))

--- a/internal/cli/daemon_bootstrap_desktop_runtime.go
+++ b/internal/cli/daemon_bootstrap_desktop_runtime.go
@@ -8,12 +8,17 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/Masterminds/semver/v3"
+
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	compozyupdate "github.com/compozy/compozy/internal/update"
 	compozyversion "github.com/compozy/compozy/internal/version"
 )
 
 func (e *bootstrapExecution) replaceOutdatedDesktopRuntime(status DaemonStatus) (bool, error) {
+	if bootstrapRuntimeIsNewer(status.Version, e.provenance().RuntimeVersion) {
+		return false, nil
+	}
 	if !regularFileExists(e.installedPath) ||
 		!compozyupdate.RuntimeOwnedByDesktopApp(e.homePaths, e.installedPath) {
 		return false, nil
@@ -37,6 +42,12 @@ func (e *bootstrapExecution) replaceOutdatedDesktopRuntime(status DaemonStatus) 
 		return false, err
 	}
 	return true, nil
+}
+
+func bootstrapRuntimeIsNewer(runningVersion, bundledVersion string) bool {
+	running, runningErr := semver.NewVersion(normalizedBootstrapVersion(runningVersion))
+	bundled, bundledErr := semver.NewVersion(normalizedBootstrapVersion(bundledVersion))
+	return runningErr == nil && bundledErr == nil && running.GreaterThan(bundled)
 }
 
 func (e *bootstrapExecution) provenance() compozyupdate.DesktopProvenanceMetadata {

--- a/internal/cli/daemon_bootstrap_test.go
+++ b/internal/cli/daemon_bootstrap_test.go
@@ -630,6 +630,7 @@ func TestBootstrapRemovesOnlyStaleDaemonRecords(t *testing.T) {
 	})
 }
 
+// TestBootstrapRuntimeVersionPolicy verifies that desktop bootstrap preserves compatible newer runtimes.
 func TestBootstrapRuntimeVersionPolicy(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/cli/daemon_bootstrap_test.go
+++ b/internal/cli/daemon_bootstrap_test.go
@@ -629,3 +629,23 @@ func TestBootstrapRemovesOnlyStaleDaemonRecords(t *testing.T) {
 		}
 	})
 }
+
+func TestBootstrapRuntimeVersionPolicy(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name, running, bundled string
+		newer                  bool
+	}{
+		{"Should preserve a newer prerelease daemon", "v0.3.0-beta.23", "0.3.0-beta.22", true},
+		{"Should preserve a newer stable daemon", "1.2.0", "1.1.0", true},
+		{"Should allow upgrading an older daemon", "0.3.0-beta.22", "0.3.0-beta.23", false},
+		{"Should compare equal versions without the tag prefix", "v1.0.0", "1.0.0", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := bootstrapRuntimeIsNewer(test.running, test.bundled); got != test.newer {
+				t.Fatalf("newer = %t, want %t", got, test.newer)
+			}
+		})
+	}
+}

--- a/internal/cli/daemon_wait_readiness_test.go
+++ b/internal/cli/daemon_wait_readiness_test.go
@@ -50,6 +50,7 @@ func (p *timeoutDaemonProcess) complete(err error) {
 	close(p.done)
 }
 
+// TestWaitForDaemonStartReadiness covers readiness, actual exit, and cancellation across polling windows.
 func TestWaitForDaemonStartReadiness(t *testing.T) {
 	t.Parallel()
 
@@ -160,6 +161,7 @@ func TestWaitForDaemonStartReadiness(t *testing.T) {
 	})
 }
 
+// TestStalledDaemonObservationReleasesMutationLock verifies cancellation releases ownership without killing the child.
 func TestStalledDaemonObservationReleasesMutationLock(t *testing.T) {
 	t.Parallel()
 	t.Run("Should release the startup lock on cancellation without terminating the live daemon", func(t *testing.T) {

--- a/internal/cli/daemon_wait_readiness_test.go
+++ b/internal/cli/daemon_wait_readiness_test.go
@@ -3,11 +3,14 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	compozyconfig "github.com/compozy/compozy/internal/config"
+	compozydaemon "github.com/compozy/compozy/internal/daemon"
 	"github.com/compozy/compozy/internal/testutil"
 )
 
@@ -50,7 +53,34 @@ func (p *timeoutDaemonProcess) complete(err error) {
 func TestWaitForDaemonStartReadiness(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should timeout when child stays alive and readiness never succeeds", func(t *testing.T) {
+	t.Run("Should wait through multiple readiness windows for a live child", func(t *testing.T) {
+		t.Parallel()
+		child := &timeoutDaemonProcess{done: make(chan struct{})}
+		var calls atomic.Int32
+		deps := newTestDeps(t, &stubClient{daemonStatusFn: func(context.Context) (DaemonStatus, error) {
+			if calls.Add(1) < 20 {
+				return DaemonStatus{}, errors.New("booting")
+			}
+			return DaemonStatus{Status: daemonRunningStatus, PID: child.PID()}, nil
+		}})
+		deps.pollInterval = time.Millisecond
+		deps.startTimeout = 3 * time.Millisecond
+		deps.processAlive = func(int) bool { return true }
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		stop := context.AfterFunc(t.Context(), cancel)
+		defer stop()
+		status, err := waitForDaemonStart(ctx, deps, child)
+		child.complete(nil)
+		if err != nil || status.PID != child.PID() || status.Status != daemonRunningStatus {
+			t.Fatalf("waitForDaemonStart() = %#v, %v; want eventual readiness", status, err)
+		}
+		if child.terminateCalls.Load() != 0 {
+			t.Fatal("live child was terminated")
+		}
+	})
+
+	t.Run("Should stop observing at the caller deadline without waiting for the live child", func(t *testing.T) {
 		t.Parallel()
 
 		child := &timeoutDaemonProcess{done: make(chan struct{})}
@@ -63,7 +93,9 @@ func TestWaitForDaemonStartReadiness(t *testing.T) {
 		deps.startTimeout = 5 * time.Millisecond
 		deps.processAlive = func(int) bool { return true }
 
-		_, err := waitForDaemonStart(context.Background(), deps, child)
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+		_, err := waitForDaemonStart(ctx, deps, child)
 		if err == nil || !strings.Contains(err.Error(), "daemon did not become ready before timeout") {
 			t.Fatalf("waitForDaemonStart() error = %v, want readiness timeout", err)
 		}
@@ -73,28 +105,30 @@ func TestWaitForDaemonStartReadiness(t *testing.T) {
 		child.complete(nil)
 	})
 
-	t.Run("Should terminate and reap an unready bootstrap child", func(t *testing.T) {
+	t.Run("Should reap an actual child exit after the first readiness window", func(t *testing.T) {
 		t.Parallel()
-
 		child := &timeoutDaemonProcess{done: make(chan struct{})}
-		deps := newTestDeps(t, &stubClient{
-			daemonStatusFn: func(context.Context) (DaemonStatus, error) {
-				return DaemonStatus{}, errors.New("daemon unavailable")
-			},
-		})
+		cause := errors.New("boot failed after migration")
+		var calls atomic.Int32
+		deps := newTestDeps(t, &stubClient{daemonStatusFn: func(context.Context) (DaemonStatus, error) {
+			if calls.Add(1) == 12 {
+				child.complete(cause)
+			}
+			return DaemonStatus{}, errors.New("booting")
+		}})
 		deps.pollInterval = time.Millisecond
-		deps.startTimeout = 5 * time.Millisecond
+		deps.startTimeout = 3 * time.Millisecond
 		deps.processAlive = func(int) bool { return true }
-
-		_, err := waitForBootstrapDaemonStart(context.Background(), deps, child)
-		if !errors.Is(err, context.DeadlineExceeded) {
-			t.Fatalf("waitForBootstrapDaemonStart() error = %v, want context.DeadlineExceeded", err)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		stop := context.AfterFunc(t.Context(), cancel)
+		defer stop()
+		_, err := waitForDaemonStart(ctx, deps, child)
+		if !errors.Is(err, cause) {
+			t.Fatalf("waitForDaemonStart() = %v; want actual boot failure", err)
 		}
-		if got := child.terminateCalls.Load(); got != 1 {
-			t.Fatalf("Terminate() calls = %d, want 1", got)
-		}
-		if got := child.waitCalls.Load(); got != 1 {
-			t.Fatalf("Wait() calls = %d, want 1", got)
+		if child.waitCalls.Load() != 1 || child.terminateCalls.Load() != 0 {
+			t.Fatal("actual exit was not reaped without termination")
 		}
 	})
 
@@ -122,6 +156,54 @@ func TestWaitForDaemonStartReadiness(t *testing.T) {
 		}
 		if calls := child.waitCalls.Load(); calls != 1 {
 			t.Fatalf("process.Wait() calls = %d, want 1", calls)
+		}
+	})
+}
+
+func TestStalledDaemonObservationReleasesMutationLock(t *testing.T) {
+	t.Parallel()
+	t.Run("Should release the startup lock on cancellation without terminating the live daemon", func(t *testing.T) {
+		t.Parallel()
+		child := &timeoutDaemonProcess{done: make(chan struct{})}
+		deps := newTestDeps(
+			t,
+			&stubClient{
+				daemonStatusFn: func(context.Context) (DaemonStatus, error) { return DaemonStatus{}, errors.New("boot stalled") },
+			},
+		)
+		deps.readDaemonInfo = func(string) (compozydaemon.Info, error) { return compozydaemon.Info{}, os.ErrNotExist }
+		paths, err := deps.resolveHome()
+		if err != nil {
+			t.Fatal(err)
+		}
+		deps.spawnDetached = func(context.Context, compozyconfig.HomePaths) (daemonProcess, error) {
+			if lock, err := acquireDaemonStartUpdateLock(daemonStartUpdateLockPath(paths)); err == nil {
+				if releaseErr := lock.Release(); releaseErr != nil {
+					t.Error(releaseErr)
+				}
+				t.Fatal("startup mutation lock was not held during spawn")
+			}
+			return child, nil
+		}
+		deps.pollInterval = time.Millisecond
+		deps.startTimeout = 3 * time.Millisecond
+		deps.processAlive = func(int) bool { return true }
+		ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+		defer cancel()
+		_, err = runDaemonDetached(ctx, deps)
+		if !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "may still be starting") {
+			t.Fatalf("runDaemonDetached() = %v", err)
+		}
+		if child.terminateCalls.Load() != 0 {
+			t.Fatal("canceled observer terminated live daemon")
+		}
+		child.complete(nil)
+		lock, err := acquireDaemonStartUpdateLock(daemonStartUpdateLockPath(paths))
+		if err != nil {
+			t.Fatalf("startup lock retained after cancellation: %v", err)
+		}
+		if err := lock.Release(); err != nil {
+			t.Fatal(err)
 		}
 	})
 }

--- a/internal/cli/daemon_wait_test.go
+++ b/internal/cli/daemon_wait_test.go
@@ -329,6 +329,7 @@ func TestWaitForDaemonStartReturnsStatusWhenDaemonBecomesReady(t *testing.T) {
 	})
 }
 
+// TestWaitForDaemonStartReturnsDeadlineExceededWhenReadyTimeoutExpires verifies the caller deadline remains authoritative.
 func TestWaitForDaemonStartReturnsDeadlineExceededWhenReadyTimeoutExpires(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/daemon_wait_test.go
+++ b/internal/cli/daemon_wait_test.go
@@ -345,7 +345,9 @@ func TestWaitForDaemonStartReturnsDeadlineExceededWhenReadyTimeoutExpires(t *tes
 		deps.startTimeout = 5 * time.Millisecond
 		deps.processAlive = func(int) bool { return true }
 
-		_, err := waitForDaemonStart(testutil.Context(t), deps, child)
+		ctx, cancel := context.WithTimeout(testutil.Context(t), deps.startTimeout)
+		defer cancel()
+		_, err := waitForDaemonStart(ctx, deps, child)
 		child.complete(nil)
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("waitForDaemonStart() error = %v, want context.DeadlineExceeded", err)

--- a/internal/cli/update_command_test.go
+++ b/internal/cli/update_command_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	compozyconfig "github.com/compozy/compozy/internal/config"
+	compozydaemon "github.com/compozy/compozy/internal/daemon"
 	compozyupdate "github.com/compozy/compozy/internal/update"
 )
 
@@ -447,5 +448,54 @@ func assertOrderedSubstrings(t *testing.T, output string, values []string) {
 			t.Fatalf("output %q does not contain %q after byte %d", output, value, position)
 		}
 		position += index + len(value)
+	}
+}
+
+func TestLocalRestartStatusDuringBoot(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []compozydaemon.RestartStatus{compozydaemon.RestartStatusStarting, compozydaemon.RestartStatusFailed, compozydaemon.RestartStatusReady} {
+		t.Run("Should read durable "+string(phase)+" while the API is unavailable", func(t *testing.T) {
+			t.Parallel()
+			paths := mustTestHomePaths(t)
+			if err := os.MkdirAll(paths.RestartsDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			record := compozydaemon.RestartOperation{
+				OperationID:   "offline-restart",
+				Status:        phase,
+				OldPID:        1,
+				OldStartedAt:  fixedTestNow,
+				OldSocketPath: paths.DaemonSocket,
+				StartedAt:     fixedTestNow,
+				UpdatedAt:     fixedTestNow,
+			}
+			if phase == compozydaemon.RestartStatusFailed {
+				record.FailureReason = "replacement exited"
+				completed := fixedTestNow
+				record.CompletedAt = &completed
+			}
+			if phase == compozydaemon.RestartStatusReady {
+				record.NewPID = 2
+				completed := fixedTestNow
+				record.CompletedAt = &completed
+			}
+			data, err := json.Marshal(record)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(
+				filepath.Join(paths.RestartsDir, record.OperationID+".json"),
+				data,
+				0o600,
+			); err != nil {
+				t.Fatal(err)
+			}
+			client := localRestartStatusClient{homePaths: paths, remote: &stubClient{}}
+			got, err := client.GetSettingsRestartStatus(t.Context(), record.OperationID)
+			if err != nil || string(got.Status) != string(phase) || got.FailureReason != record.FailureReason ||
+				got.NewPID != record.NewPID {
+				t.Fatalf("local restart status = %#v, %v", got, err)
+			}
+		})
 	}
 }

--- a/internal/cli/update_command_test.go
+++ b/internal/cli/update_command_test.go
@@ -451,8 +451,31 @@ func assertOrderedSubstrings(t *testing.T, output string, values []string) {
 	}
 }
 
+// TestLocalRestartStatusDuringBoot verifies offline journal status and the missing-record remote fallback.
 func TestLocalRestartStatusDuringBoot(t *testing.T) {
 	t.Parallel()
+	t.Run("Should use remote status when the local record is missing", func(t *testing.T) {
+		t.Parallel()
+		want := SettingsRestartStatusRecord{
+			OperationID: "remote-restart",
+			Status:      "ready",
+			NewPID:      42,
+		}
+		called := false
+		client := localRestartStatusClient{homePaths: mustTestHomePaths(t), remote: &stubClient{
+			getSettingsRestartStatusFn: func(_ context.Context, operationID string) (SettingsRestartStatusRecord, error) {
+				called = true
+				if operationID != want.OperationID {
+					t.Fatalf("remote operation ID = %q, want %q", operationID, want.OperationID)
+				}
+				return want, nil
+			},
+		}}
+		got, err := client.GetSettingsRestartStatus(t.Context(), want.OperationID)
+		if err != nil || !called || got != want {
+			t.Fatalf("remote restart status = %#v, %v, called = %v", got, err, called)
+		}
+	})
 	for _, phase := range []compozydaemon.RestartStatus{compozydaemon.RestartStatusStarting, compozydaemon.RestartStatusFailed, compozydaemon.RestartStatusReady} {
 		t.Run("Should read durable "+string(phase)+" while the API is unavailable", func(t *testing.T) {
 			t.Parallel()

--- a/internal/cli/update_runtime.go
+++ b/internal/cli/update_runtime.go
@@ -56,6 +56,8 @@ func (r *cliUpdateRuntime) AcquireMutationLock(context.Context) (compozyupdate.M
 	return lock, nil
 }
 
+// RestartDaemon observes the durable restart operation while the replacement API is unavailable.
+// The caller owns cancellation; elapsed polling windows do not establish boot failure.
 func (r *cliUpdateRuntime) RestartDaemon(ctx context.Context) error {
 	_, running, err := daemonInfo(r.homePaths, r.deps)
 	if err != nil {
@@ -103,6 +105,7 @@ type localRestartStatusClient struct {
 
 var _ settingsRestartStatusClient = localRestartStatusClient{}
 
+// GetSettingsRestartStatus reads the local validated journal and falls back remotely only when it is absent.
 func (c localRestartStatusClient) GetSettingsRestartStatus(
 	ctx context.Context,
 	operationID string,

--- a/internal/cli/update_runtime.go
+++ b/internal/cli/update_runtime.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/compozy/compozy/internal/api/contract"
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	compozydaemon "github.com/compozy/compozy/internal/daemon"
 	"github.com/compozy/compozy/internal/procutil"
@@ -72,8 +73,60 @@ func (r *cliUpdateRuntime) RestartDaemon(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, err = waitForSettingsRestart(ctx, r.deps, client, action.OperationID)
-	return err
+	for {
+		_, err = waitForSettingsRestart(
+			ctx,
+			r.deps,
+			localRestartStatusClient{homePaths: r.homePaths, remote: client},
+			action.OperationID,
+		)
+		if !errors.Is(err, context.DeadlineExceeded) || ctx.Err() != nil {
+			return err
+		}
+		operation, readErr := compozydaemon.ReadRestartOperation(r.homePaths, action.OperationID)
+		if readErr != nil {
+			return errors.Join(err, readErr)
+		}
+		switch operation.Status {
+		case compozydaemon.RestartStatusReady:
+			return nil
+		case compozydaemon.RestartStatusFailed:
+			return errors.New(operation.FailureReason)
+		}
+	}
+}
+
+type localRestartStatusClient struct {
+	homePaths compozyconfig.HomePaths
+	remote    settingsRestartStatusClient
+}
+
+var _ settingsRestartStatusClient = localRestartStatusClient{}
+
+func (c localRestartStatusClient) GetSettingsRestartStatus(
+	ctx context.Context,
+	operationID string,
+) (SettingsRestartStatusRecord, error) {
+	operation, err := compozydaemon.ReadRestartOperation(c.homePaths, operationID)
+	if errors.Is(err, compozydaemon.ErrRestartOperationNotFound) {
+		return c.remote.GetSettingsRestartStatus(ctx, operationID)
+	}
+	if err != nil {
+		return SettingsRestartStatusRecord{}, err
+	}
+	return SettingsRestartStatusRecord{
+		OperationID:        operation.OperationID,
+		Status:             contract.RestartOperationStatus(operation.Status),
+		OldPID:             operation.OldPID,
+		OldStartedAt:       operation.OldStartedAt,
+		OldSocketPath:      operation.OldSocketPath,
+		NewPID:             operation.NewPID,
+		ActiveSessionCount: operation.ActiveSessionCount,
+		FailureReason:      operation.FailureReason,
+		StartedAt:          operation.StartedAt,
+		UpdatedAt:          operation.UpdatedAt,
+		CompletedAt:        operation.CompletedAt,
+	}, nil
 }
 
 func (r *cliUpdateRuntime) HealthCheck(ctx context.Context) error {

--- a/internal/daemon/boot.go
+++ b/internal/daemon/boot.go
@@ -178,6 +178,7 @@ type daemonMCPToolProvider interface {
 	ForgetWorkspace(workspaceID string)
 }
 
+// boot completes migrations, required services, and restart reconciliation before publishing readiness.
 func (d *Daemon) boot(ctx context.Context) (err error) {
 	if ctx == nil {
 		return errors.New("daemon: boot context is required")
@@ -203,6 +204,9 @@ func (d *Daemon) boot(ctx context.Context) (err error) {
 	}
 	if err := d.startBackgroundUpdates(ctx, state, cleanup); err != nil {
 		return err
+	}
+	if err := d.reconcileSupersededRestarts(); err != nil {
+		state.logger.WarnContext(ctx, "daemon: reconcile abandoned restart observations", "error", err)
 	}
 	if err := d.markRestartReadyIfRequested(state.info); err != nil {
 		return err

--- a/internal/daemon/boot.go
+++ b/internal/daemon/boot.go
@@ -201,10 +201,10 @@ func (d *Daemon) boot(ctx context.Context) (err error) {
 	if err := d.publishDaemonInfo(state, cleanup); err != nil {
 		return err
 	}
-	if err := d.markRestartReadyIfRequested(state.info); err != nil {
+	if err := d.startBackgroundUpdates(ctx, state, cleanup); err != nil {
 		return err
 	}
-	if err := d.startBackgroundUpdates(ctx, state, cleanup); err != nil {
+	if err := d.markRestartReadyIfRequested(state.info); err != nil {
 		return err
 	}
 

--- a/internal/daemon/restart_environment.go
+++ b/internal/daemon/restart_environment.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 
 	"fmt"
 	"os"
@@ -67,6 +68,45 @@ func (d *Daemon) markRestartReadyIfRequested(info Info) error {
 		return fmt.Errorf("daemon: mark restart operation %q ready: %w", operationID, err)
 	}
 	return nil
+}
+
+// reconcileSupersededRestarts closes abandoned observations once another daemon owns
+// this home's lock and has completed boot. It never infers failure from elapsed time.
+func (d *Daemon) reconcileSupersededRestarts() error {
+	entries, err := os.ReadDir(d.homePaths.RestartsDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("daemon: list restart operations for recovery: %w", err)
+	}
+	currentID := restartOperationIDFromEnv(d.getenv)
+	store := newRestartStore(d.homePaths, d.now)
+	var failures []error
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		operationID := strings.TrimSuffix(entry.Name(), ".json")
+		if operationID == currentID {
+			continue
+		}
+		operation, err := store.Get(operationID)
+		if err != nil {
+			failures = append(failures, err)
+			continue
+		}
+		if operation.Status != RestartStatusStarting {
+			continue
+		}
+		if _, err := store.Transition(operationID, restartTransition{
+			status:        RestartStatusFailed,
+			failureReason: "restart observation was superseded by another daemon startup; the installed runtime was retained",
+		}); err != nil {
+			failures = append(failures, fmt.Errorf("daemon: reconcile superseded restart %q: %w", operationID, err))
+		}
+	}
+	return errors.Join(failures...)
 }
 
 func restartOperationIDFromEnv(getenv func(string) string) string {

--- a/internal/daemon/restart_integration_test.go
+++ b/internal/daemon/restart_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -156,6 +157,7 @@ func TestRelaunchHelperFailurePersistsAfterOldDaemonExit(t *testing.T) {
 	}
 }
 
+// TestBootMarksRestartOperationReadyAfterFreshDaemonInfo verifies real boot completes before readiness and reconciles abandoned restarts.
 func TestBootMarksRestartOperationReadyAfterFreshDaemonInfo(t *testing.T) {
 	t.Parallel()
 
@@ -196,6 +198,20 @@ func TestBootMarksRestartOperationReadyAfterFreshDaemonInfo(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Transition(%s) error = %v", status, err)
 			}
+		}
+
+		abandoned := operation
+		abandoned.OperationID = "restart-abandoned-observer"
+		if _, err := store.Create(abandoned); err != nil {
+			t.Fatalf("create abandoned observation: %v", err)
+		}
+		// Unreadable historical metadata must not prevent recovery of valid observations or boot.
+		if err := os.WriteFile(
+			filepath.Join(homePaths.RestartsDir, "corrupt-history.json"),
+			[]byte("{"),
+			0o600,
+		); err != nil {
+			t.Fatal(err)
 		}
 
 		d, err := New(
@@ -251,14 +267,21 @@ func TestBootMarksRestartOperationReadyAfterFreshDaemonInfo(t *testing.T) {
 			}
 		})
 
+		completion := time.NewTimer(10 * time.Second)
+		defer completion.Stop()
 		select {
 		case err := <-observed:
 			if err != nil {
 				t.Fatalf("observe completed boot: %v", err)
 			}
-		case <-t.Context().Done():
+		case <-completion.C:
 			t.Fatal("restart observer did not complete")
 		}
+		reconciled, err := store.Get(abandoned.OperationID)
+		if err != nil || reconciled.Status != RestartStatusFailed || reconciled.CompletedAt == nil {
+			t.Fatalf("superseded restart = %#v, %v", reconciled, err)
+		}
+
 		persisted, err := store.Get(operation.OperationID)
 		if err != nil {
 			t.Fatalf("store.Get() error = %v", err)

--- a/internal/daemon/restart_integration_test.go
+++ b/internal/daemon/restart_integration_test.go
@@ -221,15 +221,44 @@ func TestBootMarksRestartOperationReadyAfterFreshDaemonInfo(t *testing.T) {
 			return os.Getenv(key)
 		}
 
+		helper := newRelaunchHelper(&RelaunchHelperConfig{HomePaths: homePaths, OperationID: operation.OperationID,
+			PollInterval: time.Millisecond, ReadyTimeout: time.Millisecond, ExitDrainWait: time.Millisecond})
+		childExit := make(chan struct{})
+		observed := make(chan error, 1)
+		go func() {
+			observed <- helper.waitForReady(t.Context(), store, operation.OperationID, restartProcessStub{
+				pid: 9393, wait: func() error { <-childExit; return nil },
+			})
+		}()
+		t.Cleanup(func() { close(childExit) })
+		timer := time.NewTimer(15 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case err := <-observed:
+			t.Fatalf("restart stopped observing a live boot: %v", err)
+		case <-timer.C:
+		}
+		pending, err := store.Get(operation.OperationID)
+		if err != nil || pending.Status != RestartStatusStarting {
+			t.Fatalf("pre-boot status = %#v, %v", pending, err)
+		}
 		if err := d.boot(testutil.Context(t)); err != nil {
 			t.Fatalf("boot() error = %v", err)
 		}
 		t.Cleanup(func() {
 			if err := d.Shutdown(testutil.Context(t)); err != nil {
-				t.Fatalf("Shutdown() error = %v", err)
+				t.Errorf("Shutdown() error = %v", err)
 			}
 		})
 
+		select {
+		case err := <-observed:
+			if err != nil {
+				t.Fatalf("observe completed boot: %v", err)
+			}
+		case <-t.Context().Done():
+			t.Fatal("restart observer did not complete")
+		}
 		persisted, err := store.Get(operation.OperationID)
 		if err != nil {
 			t.Fatalf("store.Get() error = %v", err)

--- a/internal/daemon/restart_relaunch.go
+++ b/internal/daemon/restart_relaunch.go
@@ -229,6 +229,8 @@ func (h *relaunchHelper) releaseConditionsMet(operation RestartOperation) (bool,
 	}
 }
 
+// waitForReady observes the replacement until readiness, process exit, or observer cancellation.
+// ReadyTimeout is a diagnostic window, not a migration deadline or progress watchdog.
 func (h *relaunchHelper) waitForReady(
 	ctx context.Context,
 	store *restartStore,
@@ -298,6 +300,7 @@ func (h *relaunchHelper) waitForReady(
 	}
 }
 
+// handleReadyWaitDone preserves cancellation and records observed process exits without inferring failure from time.
 func (h *relaunchHelper) handleReadyWaitDone(
 	ctx context.Context,
 	store *restartStore,

--- a/internal/daemon/restart_relaunch.go
+++ b/internal/daemon/restart_relaunch.go
@@ -2,17 +2,14 @@ package daemon
 
 import (
 	"context"
-
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
-
 	"strings"
-
 	"time"
 
 	compozyconfig "github.com/compozy/compozy/internal/config"
-
 	"github.com/compozy/compozy/internal/procutil"
 )
 
@@ -241,8 +238,8 @@ func (h *relaunchHelper) waitForReady(
 	if ctx == nil {
 		return errors.New("daemon: restart readiness context is required")
 	}
-	waitCtx, cancel := withTimeoutCap(ctx, h.cfg.ReadyTimeout)
-	defer cancel()
+	readinessWindow := time.NewTimer(h.cfg.ReadyTimeout)
+	defer readinessWindow.Stop()
 
 	processErrCh := make(chan error, 1)
 	go func() {
@@ -267,8 +264,21 @@ func (h *relaunchHelper) waitForReady(
 				operationID,
 				errReplacementDaemonExitedBeforeReady,
 			)
-		case <-waitCtx.Done():
-			return h.handleReadyWaitDone(ctx, waitCtx, store, operationID, processErrCh)
+		case <-ctx.Done():
+			return h.handleReadyWaitDone(ctx, store, operationID, processErrCh)
+		case <-readinessWindow.C:
+			if err := h.handleReadyWaitDone(ctx, store, operationID, processErrCh); err != nil {
+				return err
+			}
+			slog.InfoContext(
+				ctx,
+				"daemon: replacement is still starting; continuing readiness observation",
+				"operation_id",
+				operationID,
+				"pid",
+				process.PID(),
+			)
+			readinessWindow.Reset(h.cfg.ReadyTimeout)
 		case <-ticker.C:
 			operation, err := store.Get(operationID)
 			if err != nil {
@@ -290,13 +300,15 @@ func (h *relaunchHelper) waitForReady(
 
 func (h *relaunchHelper) handleReadyWaitDone(
 	ctx context.Context,
-	waitCtx context.Context,
 	store *restartStore,
 	operationID string,
 	processErrCh <-chan error,
 ) error {
-	if err := replacementReadinessCanceledError(waitCtx); err != nil {
-		return h.fail(store, operationID, err)
+	if err := replacementReadinessCanceledError(ctx); err != nil {
+		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 	exited, err := waitForProcessExitAfterReadyTimeout(ctx, processErrCh, h.cfg.ExitDrainWait)
 	if exited {
@@ -311,7 +323,10 @@ func (h *relaunchHelper) handleReadyWaitDone(
 	}
 	if err != nil {
 		if cancelErr := replacementReadinessCanceledError(ctx); cancelErr != nil {
-			return h.fail(store, operationID, cancelErr)
+			return cancelErr
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 		return h.fail(
 			store,
@@ -319,7 +334,7 @@ func (h *relaunchHelper) handleReadyWaitDone(
 			fmt.Errorf("daemon: wait for replacement daemon exit after readiness timeout: %w", err),
 		)
 	}
-	return h.fail(store, operationID, errors.New("daemon: replacement daemon did not become ready before timeout"))
+	return nil
 }
 
 func replacementReadinessCanceledError(ctx context.Context) error {

--- a/internal/daemon/restart_store.go
+++ b/internal/daemon/restart_store.go
@@ -49,6 +49,11 @@ func newRestartStore(homePaths compozyconfig.HomePaths, now func() time.Time) *r
 	}
 }
 
+// ReadRestartOperation reads restart progress without requiring a ready daemon.
+func ReadRestartOperation(homePaths compozyconfig.HomePaths, operationID string) (RestartOperation, error) {
+	return newRestartStore(homePaths, nil).Get(operationID)
+}
+
 func (s *restartStore) Create(operation RestartOperation) (RestartOperation, error) {
 	now := s.now().UTC()
 	if operation.Status == "" {

--- a/internal/daemon/restart_test.go
+++ b/internal/daemon/restart_test.go
@@ -1087,88 +1087,94 @@ func TestWaitForReadyReturnsFailureContextWhenPollingReadBreaks(t *testing.T) {
 func TestWaitForReadyPreservesCancellationCause(t *testing.T) {
 	t.Parallel()
 
-	homePaths := testHomePaths(t)
-	store := newRestartStore(homePaths, sequentialTime([]time.Time{
-		time.Date(2026, 4, 17, 12, 1, 0, 0, time.UTC),
-		time.Date(2026, 4, 17, 12, 2, 0, 0, time.UTC),
-		time.Date(2026, 4, 17, 12, 3, 0, 0, time.UTC),
-		time.Date(2026, 4, 17, 12, 4, 0, 0, time.UTC),
-	}))
-	operation, err := store.Create(RestartOperation{
-		OperationID:        "restart-ready-canceled",
-		Status:             RestartStatusPending,
-		OldPID:             4242,
-		OldStartedAt:       time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC),
-		OldSocketPath:      homePaths.DaemonSocket,
-		ActiveSessionCount: 1,
-	})
-	if err != nil {
-		t.Fatalf("Create() error = %v", err)
-	}
-	for _, status := range []RestartStatus{
-		RestartStatusStopping,
-		RestartStatusWaitingRelease,
-		RestartStatusStarting,
-	} {
-		operation, err = store.Transition(operation.OperationID, restartTransition{status: status})
+	t.Run("Should preserve cancellation without failing a live replacement", func(t *testing.T) {
+		t.Parallel()
+		homePaths := testHomePaths(t)
+		store := newRestartStore(homePaths, sequentialTime([]time.Time{
+			time.Date(2026, 4, 17, 12, 1, 0, 0, time.UTC),
+			time.Date(2026, 4, 17, 12, 2, 0, 0, time.UTC),
+			time.Date(2026, 4, 17, 12, 3, 0, 0, time.UTC),
+			time.Date(2026, 4, 17, 12, 4, 0, 0, time.UTC),
+		}))
+		operation, err := store.Create(RestartOperation{
+			OperationID:        "restart-ready-canceled",
+			Status:             RestartStatusPending,
+			OldPID:             4242,
+			OldStartedAt:       time.Date(2026, 4, 17, 12, 0, 0, 0, time.UTC),
+			OldSocketPath:      homePaths.DaemonSocket,
+			ActiveSessionCount: 1,
+		})
 		if err != nil {
-			t.Fatalf("Transition(%s) error = %v", status, err)
+			t.Fatalf("Create() error = %v", err)
 		}
-	}
+		for _, status := range []RestartStatus{
+			RestartStatusStopping,
+			RestartStatusWaitingRelease,
+			RestartStatusStarting,
+		} {
+			operation, err = store.Transition(operation.OperationID, restartTransition{status: status})
+			if err != nil {
+				t.Fatalf("Transition(%s) error = %v", status, err)
+			}
+		}
 
-	waitBlocked := make(chan struct{})
-	helper := newRelaunchHelper(&RelaunchHelperConfig{
-		HomePaths:     homePaths,
-		OperationID:   operation.OperationID,
-		PollInterval:  5 * time.Millisecond,
-		ReadyTimeout:  time.Second,
-		ExitDrainWait: 50 * time.Millisecond,
+		waitBlocked := make(chan struct{})
+		helper := newRelaunchHelper(&RelaunchHelperConfig{
+			HomePaths:     homePaths,
+			OperationID:   operation.OperationID,
+			PollInterval:  5 * time.Millisecond,
+			ReadyTimeout:  time.Second,
+			ExitDrainWait: 50 * time.Millisecond,
+		})
+		var missingContext context.Context
+		if err := helper.waitForReady(missingContext, store, operation.OperationID, restartProcessStub{
+			pid: 9393,
+			wait: func() error {
+				return errors.New("replacement should not be observed without context")
+			},
+		}); err == nil || !strings.Contains(err.Error(), "context is required") {
+			t.Fatalf("waitForReady(nil context) error = %v", err)
+		}
+		ctx, cancel := context.WithCancelCause(testutil.Context(t))
+		cancel(errors.New("operator canceled restart"))
+
+		err = helper.waitForReady(ctx, store, operation.OperationID, restartProcessStub{
+			pid: 9393,
+			wait: func() error {
+				<-waitBlocked
+				return nil
+			},
+		})
+		close(waitBlocked)
+
+		if err == nil {
+			t.Fatal("waitForReady(canceled) error = nil, want cancellation error")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("waitForReady(canceled) error = %v, want context.Canceled", err)
+		}
+		if !strings.Contains(err.Error(), "operator canceled restart") ||
+			!strings.Contains(err.Error(), "replacement daemon readiness canceled") {
+			t.Fatalf("waitForReady(canceled) error = %v, want cancellation cause", err)
+		}
+		if strings.Contains(err.Error(), "did not become ready before timeout") {
+			t.Fatalf("waitForReady(canceled) error = %v, want cancellation instead of timeout", err)
+		}
+
+		persisted, err := store.Get(operation.OperationID)
+		if err != nil {
+			t.Fatalf("store.Get() error = %v", err)
+		}
+		if got, want := persisted.Status, RestartStatusStarting; got != want {
+			t.Fatalf("persisted.Status = %q, want %q", got, want)
+		}
+		if persisted.FailureReason != "" {
+			t.Fatalf(
+				"persisted.FailureReason = %q, want no persisted failure for an observation cancellation",
+				persisted.FailureReason,
+			)
+		}
 	})
-	var missingContext context.Context
-	if err := helper.waitForReady(missingContext, store, operation.OperationID, restartProcessStub{
-		pid: 9393,
-		wait: func() error {
-			return errors.New("replacement should not be observed without context")
-		},
-	}); err == nil || !strings.Contains(err.Error(), "context is required") {
-		t.Fatalf("waitForReady(nil context) error = %v", err)
-	}
-	ctx, cancel := context.WithCancelCause(testutil.Context(t))
-	cancel(errors.New("operator canceled restart"))
-
-	err = helper.waitForReady(ctx, store, operation.OperationID, restartProcessStub{
-		pid: 9393,
-		wait: func() error {
-			<-waitBlocked
-			return nil
-		},
-	})
-	close(waitBlocked)
-
-	if err == nil {
-		t.Fatal("waitForReady(canceled) error = nil, want cancellation error")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("waitForReady(canceled) error = %v, want context.Canceled", err)
-	}
-	if !strings.Contains(err.Error(), "operator canceled restart") ||
-		!strings.Contains(err.Error(), "replacement daemon readiness canceled") {
-		t.Fatalf("waitForReady(canceled) error = %v, want cancellation cause", err)
-	}
-	if strings.Contains(err.Error(), "did not become ready before timeout") {
-		t.Fatalf("waitForReady(canceled) error = %v, want cancellation instead of timeout", err)
-	}
-
-	persisted, err := store.Get(operation.OperationID)
-	if err != nil {
-		t.Fatalf("store.Get() error = %v", err)
-	}
-	if got, want := persisted.Status, RestartStatusFailed; got != want {
-		t.Fatalf("persisted.Status = %q, want %q", got, want)
-	}
-	if !strings.Contains(persisted.FailureReason, "operator canceled restart") {
-		t.Fatalf("persisted.FailureReason = %q, want cancellation cause", persisted.FailureReason)
-	}
 }
 
 func TestRestartOperationFreshInfoCheck(t *testing.T) {

--- a/internal/daemon/restart_test.go
+++ b/internal/daemon/restart_test.go
@@ -1084,6 +1084,7 @@ func TestWaitForReadyReturnsFailureContextWhenPollingReadBreaks(t *testing.T) {
 	}
 }
 
+// TestWaitForReadyPreservesCancellationCause verifies canceling an observer does not claim the replacement failed.
 func TestWaitForReadyPreservesCancellationCause(t *testing.T) {
 	t.Parallel()
 

--- a/internal/update/coordinator.go
+++ b/internal/update/coordinator.go
@@ -105,10 +105,9 @@ func (c *Coordinator) recoverSwap(ctx context.Context, state *coordinatorState) 
 		}
 		return fmt.Errorf("update: inspect recovery backup: %w", err)
 	}
-	return c.rollback(
+	return c.retainRuntime(
 		ctx,
 		state,
-		c.appliedFromOperation(operation),
 		errors.New("update: recovered interrupted runtime swap"),
 	)
 }

--- a/internal/update/coordinator.go
+++ b/internal/update/coordinator.go
@@ -93,6 +93,7 @@ func (c *Coordinator) runRuntime(ctx context.Context, state *coordinatorState) e
 	}
 }
 
+// recoverSwap retains an interrupted replacement whenever persisted state may already have migrated.
 func (c *Coordinator) recoverSwap(ctx context.Context, state *coordinatorState) error {
 	operation := state.snapshot()
 	backupPath := strings.TrimSpace(operation.Runtime.BackupPath)

--- a/internal/update/coordinator_runtime.go
+++ b/internal/update/coordinator_runtime.go
@@ -67,6 +67,7 @@ func (c *Coordinator) applyRuntime(ctx context.Context, state *coordinatorState)
 	return c.restartAndVerify(ctx, state, applied)
 }
 
+// restartAndVerify restarts the installed replacement and retains it if restart observation fails.
 func (c *Coordinator) restartAndVerify(
 	ctx context.Context,
 	state *coordinatorState,
@@ -99,6 +100,7 @@ func (c *Coordinator) restartAndVerify(
 	return c.healthAndFinalize(ctx, state, applied)
 }
 
+// healthAndFinalize verifies the replacement before completing the update and never restores an older schema owner.
 func (c *Coordinator) healthAndFinalize(
 	ctx context.Context,
 	state *coordinatorState,
@@ -124,6 +126,7 @@ func (c *Coordinator) healthAndFinalize(
 	return err
 }
 
+// retainRuntime archives an actionable failure while keeping the replacement and its backup for safe recovery.
 func (c *Coordinator) retainRuntime(ctx context.Context, state *coordinatorState, cause error) error {
 	// A replacement may migrate any persisted stream before it reports readiness.
 	return c.failRuntime(

--- a/internal/update/coordinator_runtime.go
+++ b/internal/update/coordinator_runtime.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"errors"
+	"fmt"
 )
 
 func (c *Coordinator) applyRuntime(ctx context.Context, state *coordinatorState) (returnErr error) {
@@ -87,7 +88,7 @@ func (c *Coordinator) restartAndVerify(
 		return err
 	}
 	if err := c.runtime.RestartDaemon(ctx); err != nil {
-		return c.rollback(ctx, state, applied, err)
+		return c.retainRuntime(ctx, state, err)
 	}
 	if _, err := state.transition(ctx, Transition{
 		Kind: TransitionPhase, Actor: updated.Holder.Surface, Target: TargetRuntime,
@@ -107,13 +108,13 @@ func (c *Coordinator) healthAndFinalize(
 		return err
 	}
 	if err := c.runtime.HealthCheck(ctx); err != nil {
-		return c.rollback(ctx, state, applied, err)
+		return c.retainRuntime(ctx, state, err)
 	}
 	if err := state.fence(ctx); err != nil {
 		return err
 	}
 	if err := c.binaryManager.Finalize(applied); err != nil {
-		return c.rollback(ctx, state, applied, err)
+		return c.retainRuntime(ctx, state, err)
 	}
 	operation := state.snapshot()
 	_, err := state.transition(ctx, Transition{
@@ -123,24 +124,16 @@ func (c *Coordinator) healthAndFinalize(
 	return err
 }
 
-func (c *Coordinator) rollback(
-	ctx context.Context,
-	state *coordinatorState,
-	applied AppliedBinary,
-	cause error,
-) error {
-	if err := state.fence(ctx); err != nil {
-		return errors.Join(cause, err)
-	}
-	if err := c.binaryManager.Restore(applied); err != nil {
-		return c.failRuntime(ctx, state, errors.Join(cause, err))
-	}
-	operation := state.snapshot()
-	_, transitionErr := state.transition(ctx, Transition{
-		Kind: TransitionPhase, Actor: operation.Holder.Surface, Target: TargetRuntime,
-		Phase: PhaseRolledBack, Percent: -1, LastError: cause.Error(), Outcome: operationOutcomeRolledBack,
-	})
-	return errors.Join(cause, transitionErr)
+func (c *Coordinator) retainRuntime(ctx context.Context, state *coordinatorState, cause error) error {
+	// A replacement may migrate any persisted stream before it reports readiness.
+	return c.failRuntime(
+		ctx,
+		state,
+		fmt.Errorf(
+			"update: keeping the replacement runtime because persisted state may already have migrated; inspect daemon logs and retry `compozy daemon start`; if the runtime cannot launch, reinstall the target release or newer: %w",
+			cause,
+		),
+	)
 }
 
 func (c *Coordinator) failRuntime(ctx context.Context, state *coordinatorState, cause error) error {

--- a/internal/update/coordinator_test.go
+++ b/internal/update/coordinator_test.go
@@ -52,29 +52,39 @@ func TestCoordinatorRuntimeLifecycle(t *testing.T) {
 		})
 	})
 
-	t.Run("Should restore and archive when the replacement daemon fails health", func(t *testing.T) {
-		t.Parallel()
-
-		store, paths, _ := newOperationTestStore(t)
-		request := operationTestRequest(testOperationNow)
-		request.Targets = []Target{TargetRuntime}
-		request.App = nil
-		operation, err := store.Acquire(t.Context(), request)
-		if err != nil {
-			t.Fatalf("Acquire() error = %v", err)
-		}
-		manager := &coordinatorManagerStub{}
-		runtime := &coordinatorRuntimeStub{healthErr: errors.New("replacement is unhealthy")}
-		coordinator := newCoordinatorForTest(t, store, manager, runtime)
-		err = coordinator.Run(t.Context(), operation.ID, "generation-1")
-		if err == nil || !errors.Is(err, runtime.healthErr) {
-			t.Fatalf("Run() error = %v, want health failure", err)
-		}
-		if manager.restoreCalls != 1 || manager.finalizeCalls != 0 {
-			t.Fatalf("manager restore/finalize = %d/%d, want 1/0", manager.restoreCalls, manager.finalizeCalls)
-		}
-		assertArchivedOperationPhase(t, paths.UpdateHistoryFile, operation.ID, PhaseRolledBack)
-	})
+	for _, stage := range []string{"restart", "health", "finalize"} {
+		t.Run("Should retain the replacement after "+stage+" failure", func(t *testing.T) {
+			t.Parallel()
+			store, paths, _ := newOperationTestStore(t)
+			request := operationTestRequest(testOperationNow)
+			request.Targets = []Target{TargetRuntime}
+			request.App = nil
+			operation, err := store.Acquire(t.Context(), request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cause := errors.New("replacement failure")
+			manager := &coordinatorManagerStub{}
+			runtime := &coordinatorRuntimeStub{}
+			switch stage {
+			case "restart":
+				runtime.restartErr = cause
+			case "health":
+				runtime.healthErr = cause
+			case "finalize":
+				manager.finalizeErr = cause
+			}
+			coordinator := newCoordinatorForTest(t, store, manager, runtime)
+			err = coordinator.Run(t.Context(), operation.ID, "generation-1")
+			if !errors.Is(err, cause) || !strings.Contains(err.Error(), "persisted state may already have migrated") {
+				t.Fatalf("Run() = %v", err)
+			}
+			if manager.restoreCalls != 0 {
+				t.Fatalf("restored incompatible backup %d times", manager.restoreCalls)
+			}
+			assertArchivedOperationPhase(t, paths.UpdateHistoryFile, operation.ID, PhaseFailed)
+		})
+	}
 
 	t.Run("Should refuse a runtime-only compatibility violation before acquiring the swap lock", func(t *testing.T) {
 		t.Parallel()
@@ -106,16 +116,16 @@ func TestCoordinatorRuntimeLifecycle(t *testing.T) {
 		t.Parallel()
 
 		for _, test := range []struct {
-			name           string
-			phase          OperationPhase
-			backupPresent  bool
-			wantRestore    int
-			wantRestart    int
-			wantHealth     int
-			wantFinalized  bool
-			wantRolledBack bool
+			name          string
+			phase         OperationPhase
+			backupPresent bool
+			wantRestore   int
+			wantRestart   int
+			wantHealth    int
+			wantFinalized bool
+			wantRetained  bool
 		}{
-			{name: "swap with backup", phase: PhaseSwapping, backupPresent: true, wantRestore: 1, wantRolledBack: true},
+			{name: "swap with backup", phase: PhaseSwapping, backupPresent: true, wantRetained: true},
 			{name: "swap without backup", phase: PhaseSwapping, wantRestart: 1, wantHealth: 1, wantFinalized: true},
 			{name: "daemon restart", phase: PhaseRestarting, backupPresent: true, wantRestart: 1, wantHealth: 1, wantFinalized: true},
 			{name: "health check", phase: PhaseHealthChecking, backupPresent: true, wantHealth: 1, wantFinalized: true},
@@ -142,11 +152,11 @@ func TestCoordinatorRuntimeLifecycle(t *testing.T) {
 				runtime := &coordinatorRuntimeStub{}
 				coordinator := newCoordinatorForTest(t, store, manager, runtime)
 				runErr := coordinator.Run(t.Context(), operation.ID, "generation-1")
-				if test.wantRolledBack {
+				if test.wantRetained {
 					if runErr == nil || !strings.Contains(runErr.Error(), "interrupted runtime swap") {
-						t.Fatalf("Run() error = %v, want interrupted-swap rollback", runErr)
+						t.Fatalf("Run() error = %v, want interrupted-swap recovery guidance", runErr)
 					}
-					assertArchivedOperationPhase(t, paths.UpdateHistoryFile, operation.ID, PhaseRolledBack)
+					assertArchivedOperationPhase(t, paths.UpdateHistoryFile, operation.ID, PhaseFailed)
 				} else if runErr != nil {
 					t.Fatalf("Run() error = %v", runErr)
 				}
@@ -175,6 +185,7 @@ type coordinatorManagerStub struct {
 	swapStarted   bool
 	restoreCalls  int
 	finalizeCalls int
+	finalizeErr   error
 	restored      AppliedBinary
 }
 
@@ -215,7 +226,7 @@ func (s *coordinatorManagerStub) Restore(applied AppliedBinary) error {
 
 func (s *coordinatorManagerStub) Finalize(AppliedBinary) error {
 	s.finalizeCalls++
-	return nil
+	return s.finalizeErr
 }
 
 type coordinatorRuntimeStub struct {

--- a/internal/update/coordinator_test.go
+++ b/internal/update/coordinator_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 )
 
+// TestCoordinatorRuntimeLifecycle verifies update completion and data-safe recovery at each failure boundary.
 func TestCoordinatorRuntimeLifecycle(t *testing.T) {
 	t.Run("Should run runtime first then leave the app staged and dormant", func(t *testing.T) {
 		t.Parallel()

--- a/internal/update/manager_apply_test.go
+++ b/internal/update/manager_apply_test.go
@@ -809,6 +809,7 @@ func newReleaseFixtureServer(
 	return release, archiveName, server
 }
 
+// TestDesktopRuntimeNewerThanBundle verifies that only a hash-verified newer desktop runtime is preserved.
 func TestDesktopRuntimeNewerThanBundle(t *testing.T) {
 	t.Parallel()
 	for _, test := range []struct {

--- a/internal/update/manager_apply_test.go
+++ b/internal/update/manager_apply_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -806,4 +807,52 @@ func newReleaseFixtureServer(
 		},
 	}
 	return release, archiveName, server
+}
+
+func TestDesktopRuntimeNewerThanBundle(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name, installed, bundled string
+		tamper, want             bool
+	}{
+		{name: "Should preserve a verified newer installed runtime", installed: "0.3.0-beta.23", bundled: "0.3.0-beta.22", want: true},
+		{name: "Should permit upgrade from an older runtime", installed: "0.3.0-beta.22", bundled: "0.3.0-beta.23"},
+		{name: "Should reject a modified ownership marker binary", installed: "0.3.0-beta.23", bundled: "0.3.0-beta.22", tamper: true},
+		{name: "Should retain development bundle provisioning", installed: "0.3.0-beta.23", bundled: "dev"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			paths, err := compozyconfig.ResolveHomePathsFrom(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(paths.BinDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			binaryName := compozyBinaryName
+			if runtime.GOOS == runtimeOSWindows {
+				binaryName = compozyWindowsBinaryName
+			}
+			binary := filepath.Join(paths.BinDir, binaryName)
+			if err := os.WriteFile(binary, []byte("installed-runtime"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if err := WriteDesktopProvenance(
+				paths,
+				binary,
+				DesktopProvenanceMetadata{AppVersion: "0.3.0-beta.22", Channel: "beta", RuntimeVersion: test.installed},
+			); err != nil {
+				t.Fatal(err)
+			}
+			if test.tamper {
+				if err := os.WriteFile(binary, []byte("different-runtime"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := DesktopRuntimeNewerThanBundle(paths, binary, test.bundled)
+			if err != nil || got != test.want {
+				t.Fatalf("DesktopRuntimeNewerThanBundle() = %t, %v; want %t", got, err, test.want)
+			}
+		})
+	}
 }

--- a/internal/update/multi_check.go
+++ b/internal/update/multi_check.go
@@ -55,6 +55,10 @@ func applyArchivedRuntimeOutcome(runtime *State, archived *Operation) {
 		archived.Runtime.Phase != PhaseRolledBack {
 		return
 	}
+	comparison, err := compareVersions(runtime.CurrentVersion, archived.Runtime.ToVersion)
+	if err == nil && comparison >= 0 {
+		return
+	}
 	runtime.Status = StatusFailed
 	runtime.RestoredVersion = strings.TrimSpace(archived.Runtime.FromVersion)
 	runtime.DaemonRestarted = archived.Runtime.DaemonRestarted

--- a/internal/update/multi_check.go
+++ b/internal/update/multi_check.go
@@ -50,6 +50,7 @@ func (m *Manager) CheckAll(ctx context.Context, opts CheckOptions) (MultiState, 
 	return ProjectMultiState(runtimeState, app, operation), release, checkErr
 }
 
+// applyArchivedRuntimeOutcome projects historical failures only until the installed runtime reaches their target.
 func applyArchivedRuntimeOutcome(runtime *State, archived *Operation) {
 	if runtime == nil || archived == nil || archived.Runtime == nil ||
 		archived.Runtime.Phase != PhaseRolledBack {

--- a/internal/update/projection_test.go
+++ b/internal/update/projection_test.go
@@ -143,6 +143,7 @@ func TestOperationPhaseToUIPhase(t *testing.T) {
 	}
 }
 
+// TestRecoveredRuntimeProjection verifies recovered versions clear obsolete rollback presentation without rewriting history.
 func TestRecoveredRuntimeProjection(t *testing.T) {
 	t.Parallel()
 	for _, current := range []string{"v1.1.0", "1.2.0"} {

--- a/internal/update/projection_test.go
+++ b/internal/update/projection_test.go
@@ -142,3 +142,20 @@ func TestOperationPhaseToUIPhase(t *testing.T) {
 		})
 	}
 }
+
+func TestRecoveredRuntimeProjection(t *testing.T) {
+	t.Parallel()
+	for _, current := range []string{"v1.1.0", "1.2.0"} {
+		t.Run("Should clear historical rollback after recovery to "+current, func(t *testing.T) {
+			t.Parallel()
+			state := State{Status: StatusUpToDate, CurrentVersion: current, Message: "current"}
+			archived := &Operation{LastError: "old failure", Runtime: &RuntimeOperationState{
+				ArtifactIdentity: ArtifactIdentity{FromVersion: "v1.0.0", ToVersion: "v1.1.0"}, Phase: PhaseRolledBack,
+			}}
+			applyArchivedRuntimeOutcome(&state, archived)
+			if state.Status != StatusUpToDate || state.LastError != "" || state.RestoredVersion != "" {
+				t.Fatalf("recovered projection = %#v", state)
+			}
+		})
+	}
+}

--- a/internal/update/provenance.go
+++ b/internal/update/provenance.go
@@ -36,6 +36,29 @@ func RuntimeOwnedByDesktopApp(paths compozyconfig.HomePaths, binaryPath string) 
 	return isDesktopAppInstall(paths.HomeDir, binaryPath, runtime.GOOS)
 }
 
+// DesktopRuntimeNewerThanBundle preserves a verified runtime installed by a newer release.
+func DesktopRuntimeNewerThanBundle(
+	paths compozyconfig.HomePaths,
+	binaryPath string,
+	bundleVersion string,
+) (bool, error) {
+	if !RuntimeOwnedByDesktopApp(paths, binaryPath) {
+		return false, nil
+	}
+	marker, err := readDesktopProvenance(desktopProvenancePath(paths, binaryPath))
+	if err != nil {
+		return false, err
+	}
+	if isDevVersion(marker.RuntimeVersion) || isDevVersion(bundleVersion) {
+		return false, nil
+	}
+	comparison, err := compareVersions(marker.RuntimeVersion, bundleVersion)
+	if err != nil {
+		return false, err
+	}
+	return comparison > 0, nil
+}
+
 // DesktopRuntimeMatchesBundle verifies the installed bytes and release identity against a bundle.
 func DesktopRuntimeMatchesBundle(
 	paths compozyconfig.HomePaths,

--- a/packages/site/content/docs/operations/desktop-app.mdx
+++ b/packages/site/content/docs/operations/desktop-app.mdx
@@ -69,15 +69,46 @@ compozy update --check -o json
 
 ## Recover a runtime update
 
+After a runtime binary has been swapped, CompozyOS keeps the replacement if restart, health
+checking, or finalization fails. Startup may already have migrated databases, so automatically
+restoring an older binary could make the home unreadable. The backup is retained for diagnosis;
+do not restore it over the replacement or delete any database.
+If an interrupted swap left the executable missing or unable to launch, reinstall the target
+release or a newer compatible release into the same home; keep the databases and backup intact.
+
+A live daemon can take longer than a readiness polling window to finish required boot work.
+`compozy daemon start` and update restart observation keep waiting while it boots. Interrupting the
+CLI stops the wait and leaves the detached daemon running. Read `compozy status -o json` and the
+runtime log before retrying. Readiness is reported only after required boot work completes.
+
+These waits observe process liveness, not migration progress. A stalled but living process keeps
+the observation open; repeated log messages say it is still starting. Cancel the CLI observation
+with Ctrl+C to release any startup mutation lock without killing the process. Provisioning finishes
+before startup, and the updater releases the swap lock before restart observation. Bootstrap's
+in-process attempt guard also releases when the caller cancels. Inspect the
+reported PID and runtime log before stopping a stalled daemon deliberately. The detached restart
+helper holds no update/provisioning lock while observing; it exits on readiness or process exit,
+and records an actual pre-readiness exit as a restart failure. Canceling the CLI does not cancel
+that detached helper or claim that the daemon has failed.
+
 When an update operation reports `failed`:
 
 1. Save the reported error code from `compozy app diagnose -o json`.
 2. Follow the reported action without deleting the active runtime, staging directory, or home data.
-3. Run `compozy app retry` after resolving the cause.
+3. Retry `compozy daemon start` after resolving the cause, then run `compozy app retry`.
 4. Confirm healthy state with `compozy app status -o json`.
 
 For an operator-managed runtime, use the package-manager command in the update result. The app never
 replaces a Homebrew, npm, Go, Linux package, or other externally managed install.
+
+An older desktop app attaches to a newer runtime when their declared versions are compatible.
+It preserves a verified newer installed runtime. Incompatible app/runtime versions report the
+required upgrade instead of downgrading the running runtime. A staged app update can be consumed
+even when runtime bootstrap has not reached readiness.
+
+After an external recovery reaches the failed update's target runtime version or a newer version,
+`compozy update --check` no longer projects that historical rollback as the current failure. The
+history remains intact.
 
 ## Recover the desktop channel
 

--- a/packages/site/content/docs/operations/desktop-app.mdx
+++ b/packages/site/content/docs/operations/desktop-app.mdx
@@ -110,6 +110,9 @@ After an external recovery reaches the failed update's target runtime version or
 `compozy update --check` no longer projects that historical rollback as the current failure. The
 history remains intact.
 
+Staged app recovery still requires a verified runtime bundle. If its integrity check fails, reinstall
+the current app package; a prepared update cannot bypass that check.
+
 ## Recover the desktop channel
 
 A release operator repairs a bad desktop channel through the GitHub-backed channel authority, not

--- a/skills/compozy/references/desktop.md
+++ b/skills/compozy/references/desktop.md
@@ -102,6 +102,14 @@ When an update reports `failed`, do not start another mutation. Run `compozy app
 preserve the reported error code and report, follow its recovery action, then run
 `compozy app retry`. Confirm the result with `compozy app status -o json`.
 
+A post-swap runtime failure keeps the replacement binary because databases may already have
+migrated. Preserve both binary copies and all databases; inspect the runtime log, resolve the
+reported cause, and retry `compozy daemon start`. A live boot continues across readiness polling
+windows; interrupting the CLI only stops observation. Confirm readiness with structured status.
+An older app preserves a newer compatible runtime, and staged app updates can run before runtime
+bootstrap succeeds. Historical rollback failures clear from live update status after recovery to
+the target runtime version or newer; do not edit the history to clear them.
+
 Automatic repair is limited to disposable desktop metadata and a runtime process proven to be
 desktop-owned. Never stop an operator-managed runtime or delete `compozy.db`, `config.toml`,
 credentials, sessions, or the full home as a recovery step. The desktop has no native-tool


### PR DESCRIPTION
## What & why

Fixes #559.

A replacement daemon can migrate persisted databases long before startup finishes. Previously the restart helper's 20-second readiness deadline recorded a failure, the update observer's deadline restored the older executable, and the older executable then refused the migrated home. Desktop bootstrap could compound the outage by killing a slow child or replacing a healthy newer runtime with its older bundle.

This change makes post-swap recovery conservative: restart, health, finalization, and ambiguous interrupted-swap failures retain the replacement and its backup, archive `failed`, and explain how to restart or reinstall the target release or newer. It never rewrites released migrations, restores an older executable over possibly migrated state, bypasses schema-ahead checks, or deletes user data. Pre-launch provisioning/application failure recovery remains owned by the existing atomic replacement paths.

The related recovery paths now behave coherently:

- CLI startup and the detached restart helper continue observing a live replacement across readiness windows. Actual child exit remains a failure and is reaped. Required background boot setup runs before restart readiness is published.
- The update observer reads the validated host-local restart journal while the daemon API is unavailable, so it sees actual helper failures and eventual readiness.
- Desktop bootstrap preserves a newer running runtime and a hash-verified newer installed runtime; attachment still enforces the existing compatibility declarations. Actual boot failures retain bounded retries, but a polling-window expiration no longer kills a live child.
- The desktop app verifies its runtime bundle before starting the update consumer, which starts before runtime bootstrap, allowing an already staged app update to proceed even when the runtime cannot start.
- Shell shutdown and installer handoff cancel and await the bootstrap observer before resource cleanup, preserving the detached daemon and suppressing late window publication. A subsequent successful daemon boot reconciles superseded `starting` restart observations; malformed historical metadata is reported without blocking recovery.
- Running the recovered target version or newer clears a historical rollback from the live update projection without editing its history.

**Stalled-but-alive behavior is deliberate:** this is liveness/readiness observation, not a progress-aware watchdog. A live stalled process remains pending until readiness, exit, or caller cancellation. Periodic diagnostics include the PID. Ctrl+C releases the CLI startup mutation lock without killing the potentially migrating daemon; provisioning has already completed and the updater releases its swap lock before restart observation. The detached helper holds neither mutation lock while observing and lives until readiness, actual exit, or its own cancellation. Canceling a CLI does not cancel that helper. This preserves data at the cost of an intentionally unbounded pending wait; the operations guide explains inspecting logs/PID and recovery.

Implemented and verified by Codex (GPT-6-Astra, HIGH) using the dedicated issue worktree.

## How you verified it

- Reproduced the coordinator regression before the production fix: the owning lifecycle suite observed an old-binary restore and `rolled-back` history after replacement failure. The corrected suite covers restart, health, finalization, and interrupted-swap failures.
- Focused Go race suites passed for retained replacement, recovered projection, installed provenance, CLI readiness/cancellation/actual exit, startup lock release, durable offline restart status, and helper cancellation.
- Existing daemon integration suite: `GOMAXPROCS=4 CGO_ENABLED=1 mise exec -- go test -p=1 -parallel=4 -race -tags integration ./internal/daemon -run 'TestBootMarksRestartOperationReadyAfterFreshDaemonInfo|TestRelaunchHelperFailurePersistsAfterOldDaemonExit' -count=1`.
- Isolated real runtime walk used the published beta.22 binary, actual SQLite stores, the existing `desktop/e2e/fixtures/runtimeupdate` fixture and production restart/update coordinator. It upgraded global schema 99 → 107, preserved a registered workspace, held a replacement with SIGSTOP for 30 seconds before readiness, then observed successful finalization after SIGCONT. A separate actual pre-readiness SIGKILL retained the new binary plus an incompatible beta.22 backup; `compozy daemon start -o json` then recovered with the workspace intact. Targeted teardown reported `clean: true`.
- Root Turborepo desktop `test typecheck` passed 137 tests; affected desktop/web builds and Windows runtime cross-build passed.
- Packaged Electron recovery: built baseline/next fixtures with `mise exec -- bun run --cwd desktop build:e2e-update`; under the shared verification lock, the existing Playwright update suite's `A staged app update starts while runtime bootstrap is failing` scenario passed in 17.1 seconds. It observed runtime bootstrap `error` and app operation `applying`, then completed teardown. The fixture's failed-boot cleanup signals only its isolated home's lock PID and verifies exit when no daemon discovery record was published.
- Initial full local gate and checked head: `GOMAXPROCS=4 COMPOZY_GO_TEST_P=1 COMPOZY_GO_LINT_CONCURRENCY=2 mise exec -- make gate` passed on tree `3e83acc9e4ca484f4b965804a8d68e49985a6908`, committed unchanged as `b6f250b10c1faf2b3a1c5fb64ba7013b7700a274`. Go lint reported 0 issues, all affected race suites passed, and desktop lint reported 0 warnings/errors with typecheck and 137 tests passing. Codegen passed inside that same desktop Turbo lane. The strict QA audit passed with no blockers/warnings and clean runtime teardown.
- Review remediation at `79a11d3493778928fe8a1983ce0eaf4bae6494cc`: fixed Greptile’s staged-bundle integrity finding. The packaged suite first reproduced unverified execution with a marker-writing executable; after the fix both staged-recovery and tampered-bundle scenarios passed (2 tests, 13.3 seconds), including teardown. Subsequent full gates run in PR CI per the owner’s updated direction. The CLI/daemon import finding was investigated and explained in its thread as an existing composition dependency, with unchanged boundary rules and passing boundary CI.
- CodeRabbit remediation at `bcdfd83853d990a5450f07861fb3bab078a05854`: added bootstrap observer cancellation/drain before shutdown and installer handoff, superseded restart reconciliation after real boot, remote-status fallback coverage, bounded integration-test completion, explicit E2E polling/teardown, and function documentation. Focused CLI race passed (2.391s), final daemon boot integration with race passed (6.120s), and four packaged E2Es passed under the shared lock (25.9s). CodeRabbit withdrew both global-deadline findings after reviewing the documented wait-until-ready/exit/cancel contract. The prior Linux CI E2E-034 debugging connection failure was inspected; that scenario passed locally on macOS, and the new head must still pass Linux CI.
- Hook tasks ran with `lint-staged --no-stash --no-hide-partially-staged`, preserving formatter/linter checks without destructive Git backup/restore operations. Commitlint remains enabled.

[Detailed QA evidence and cross-surface audit](docs/qa/reports/2026-09-09-issue-559-safe-update-recovery.md).

Limits: the runtime fault-injection fixture stages the replacement directly and does not re-test release signatures/downloads. The packaged negative scenario holds the download before installer handoff, so it verifies recovery availability without performing native installer relaunch or changing the machine launch environment. The older-app/newer-runtime policy is covered in the owning Go suites; a full older-app UI matrix is not claimed. Provider behavior is outside this lifecycle slice. The earlier web build emitted existing CSS/chunk warnings; the required local gate result is recorded separately above.

## Impact

The cross-surface audit is recorded once in the QA report. CLI startup/bootstrap and update observation, daemon restart, update projection, and desktop app recovery change behavior. HTTP/UDS payloads, native tool IDs, extension/bridge contracts, hooks, config keys/defaults, and memory defaults do not change. No schema numbering or released migration bytes change, so there is no shared migration conflict with #566. User state remains in the same home and SD-013 compatibility checks remain enforced.

The public operations guide, official Compozy skill desktop reference, and affected startup/update/coherence QA scenarios co-ship. Existing Web Settings surfaces consume the same update status contracts.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself
