### PR TITLE
fix: unify spec-cycle task completion semantics

### DIFF
--- a/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
+++ b/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
@@ -50,3 +50,41 @@ QA 2026-09-05 (loop-stability): rerunning a completed Goal uses a fresh binding 
 terminal cleanup; live run `looprun-bcd2b1ad861f8a46` completed generation 2. The prior canceled
 run's immutable next-round selection also recovers without rewriting history. Quarantined nodes
 remain parked under existing policy. See the loop-stability report, cycle 4.
+
+QA impact 2026-09-09 (#565): completion and rerun coverage now belongs to
+`TestDaemonE2EImplementTasksShouldCompleteTaskJourney` in
+`internal/daemon/daemon_implement_tasks_e2e_integration_test.go`. The affected walk starts a mixed
+set (`done`, `complete`, `in_progress`), verifies only the unfinished task is dispatched, then reruns
+with all completion aliases and verifies zero task dispatches. Orchestrated delivery must pass the
+extension completion judge and stop its workers; its finished rerun must create no new workers.
+The existing worktree-only per-task journey retains its assertions. A focused Goal scenario uses
+the real extension judge with opposite main/worktree task states, then reverses them, proving that
+approval and rejection follow the selected worktree on each evaluation. A node-level `root`
+override takes precedence over the Loop worktree default. The focused re-walk passed all three
+state/precedence combinations (36.782s) with `-race -p=1 -parallel=4`; evidence:
+`.cache/issue-565/e2e-root-precedence.log`. Its targeted teardown again reported `clean: true`.
+
+The importer and judge share YAML status parsing: canonical `completed`, accepted completion
+aliases `complete|done|finished`, case/whitespace normalization, and explicit validation errors for
+unknown or missing status. `pending|in_progress` remain executable. Unit/RPC/evaluator coverage in
+`extensions/spec-cycle/{import_tasks,provider,embed}_test.go` verifies parser and judge agreement,
+including quoted status values and YAML comments. The Goal result retains `complete|blocked`.
+
+Verified 2026-09-09: all seven cases in the existing daemon suite passed (87.429s), including
+both reruns, original category/Agent/Profile/worktree journeys, and selected-root approval/rejection.
+Command: `CGO_ENABLED=1 GOMAXPROCS=4 mise exec -- go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EImplementTasksShouldCompleteTaskJourney$' -count=1 -timeout=10m -parallel=4 -p=1 -artifacts`.
+The runner held the shared machine verification lock and retained output in
+`.cache/issue-565/e2e-round4.log`. The allocator used `/private/tmp/compozy-iso-565-drmtph` and a short
+`TMPDIR`; generated daemon socket paths stayed below the macOS limit. Targeted teardown recorded
+`clean: true` in that root's `teardown.json`, with no survivors. The targeted race-enabled extension
+suite also passed. This evidence uses real daemon/CLI/SQLite/extension processes and an ACP fixture
+subprocess; it does not claim a fresh live-provider run.
+
+A broader orchestrated-worktree attempt exposed a separate pre-existing ACP terminal-path defect
+before any judge ran: `acp: create terminal: invalid terminal cwd "<home>/worktrees/001/issue-512":
+outside workspace`. `internal/sandbox/local/provider.go` constructs `LocalTerminalScope` without
+`AllowedRoots`; the supplied local host reaches `internal/terminal/manager_open.go` with only the
+primary workspace authorized. Those paths are unchanged by #565. Reproduction: extend the existing
+worktree-only journey with `mode=orchestrated` after its per-task run, using the same selected worktree
+and conductor fixture. That broader journey is **not verified** by this change. Evidence is retained
+in `.cache/issue-565/e2e-round3.log` and the isolated round-3 daemon artifacts; its teardown was clean.

--- a/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
+++ b/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
@@ -88,3 +88,13 @@ primary workspace authorized. Those paths are unchanged by #565. Reproduction: e
 worktree-only journey with `mode=orchestrated` after its per-task run, using the same selected worktree
 and conductor fixture. That broader journey is **not verified** by this change. Evidence is retained
 in `.cache/issue-565/e2e-round3.log` and the isolated round-3 daemon artifacts; its teardown was clean.
+
+Review remediation 2026-09-09 (#565): the selected-root scenario now also creates `per_run`
+worktrees from committed task statuses while leaving opposite statuses in the primary workspace.
+Before the fix, the completed per-run pack incorrectly reached `exhausted` instead of `done`
+(`.cache/issue-565/e2e-per-run-red.log`, run `looprun-a62e45b5be9aa535`). The judge now leases the
+existing per-run worktree using the same run/generation/node/item identity as the session binder;
+it never materializes another tree. The unchanged assertions passed all five selected-root and
+precedence combinations (31.057s, `-race -p=1 -parallel=4`), including per-run approval and rejection.
+Evidence: `.cache/issue-565/e2e-per-run-green.log`; targeted teardown reported `clean: true` with
+no survivors at `2026-09-09T17:12:37Z`. The broader terminal-path limitation above remains separate.

--- a/extensions/spec-cycle/agents/orchestrator/AGENT.md
+++ b/extensions/spec-cycle/agents/orchestrator/AGENT.md
@@ -18,7 +18,9 @@ Operating contract:
   and reuse it only for that task's single corrective turn.
 - `code_implementer` is the Loop input default, not a conductor override.
 - Preserve the selected category runtime by passing every non-empty provider, model, reasoning effort, and speed field at spawn time.
-- Treat `status: completed` in the task file as the only proof that a worker finished its task.
+- Require completion on disk plus verification evidence. Workers write `status: completed`; the
+  importer also recognizes `complete`, `done`, and `finished`, ignoring case and surrounding whitespace.
+- Never dispatch a recognized completed task. Unknown task statuses require correction before dispatch.
 - Stop every worker on every terminal path before advancing or returning.
 
 Return the Goal's requested structured result. Use `complete` only when every queued task is completed on disk and no conductor-created worker remains active; use `blocked` only with concrete evidence.

--- a/extensions/spec-cycle/embed_test.go
+++ b/extensions/spec-cycle/embed_test.go
@@ -1,7 +1,9 @@
 package speccycle
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -16,6 +18,7 @@ import (
 	"github.com/compozy/compozy/internal/loop"
 	"github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/compozy/compozy/internal/loop/dsl/refs"
+	"github.com/compozy/compozy/internal/loop/gate"
 	skillspkg "github.com/compozy/compozy/internal/skills"
 	"github.com/compozy/compozy/internal/store/globaldb"
 	"github.com/compozy/compozy/internal/testutil"
@@ -89,7 +92,7 @@ func TestSpecCycleRuntimeToolDescriptorsShouldPinSchemaDigests(t *testing.T) {
 		}{
 			toolImportTasks: {
 				inputDigest:  "ff6206bbb7edbf85229a394c4752286046cdbc069b1a89b3067f139f1f68a832",
-				outputDigest: "ed61017d14c6e0cdea1846d9e418369696ccf198a37c02baa3389247f1fba4f7",
+				outputDigest: "09d75b848fbb7a6f115072d61194ebd1511a20b64581667d382990adf8d0fa62",
 				readOnly:     true,
 				risk:         toolspkg.RiskRead,
 			},
@@ -1059,20 +1062,12 @@ func TestEmbeddedLoopsShouldKeepSpecCycleRuntimeContracts(t *testing.T) {
 		if strings.Contains(customObjective, "spawn one bounded `code_implementer`") {
 			t.Fatalf("rendered custom objective prescribes default worker Agent: %q", customObjective)
 		}
-		judge := requireOrchestrateJudgeForTest(t, orchestrate)
-		if got, want := judge["type"], string(dsl.CriterionCommand); got != want {
-			t.Fatalf("orchestrate judge type = %#v, want %q", got, want)
+		judges := requireOrchestrateJudgesForTest(t, orchestrate)
+		if judges[0].Type != dsl.CriterionExtension || judges[0].Tool != "ext__spec_cycle__import_tasks" {
+			t.Fatalf("task judge = %#v, want the authoritative importer", judges[0])
 		}
-		check, ok := judge["check"].(string)
-		if !ok {
-			t.Fatalf("orchestrate judge check = %#v, want string", judge["check"])
-		}
-		if !strings.Contains(check, `task_dir=".compozy/tasks/$slug"`) ||
-			!strings.Contains(check, `"$task_dir"/task_*.md`) {
-			t.Fatalf("orchestrate judge check = %q, want a workspace-relative task glob", check)
-		}
-		if strings.Contains(check, "cd /") || strings.Contains(check, "$HOME") {
-			t.Fatalf("orchestrate judge check = %q, want no absolute or home-anchored path", check)
+		if judges[1].Type != dsl.CriterionCommand {
+			t.Fatalf("worker judge = %#v, want command", judges[1])
 		}
 		cases := []struct {
 			name         string
@@ -1108,11 +1103,25 @@ func TestEmbeddedLoopsShouldKeepSpecCycleRuntimeContracts(t *testing.T) {
 				activeWorker: true,
 			},
 		}
+		for _, status := range []string{"done", "finished", "complete", "' CoMpLeTe '", "completed # verified"} {
+			cases = append(cases, struct {
+				name         string
+				tasks        []orchestrateJudgeTaskFile
+				activeWorker bool
+				wantSuccess  bool
+			}{
+				name: "Should accept completion status " + status,
+				tasks: []orchestrateJudgeTaskFile{
+					{name: "task_01.md", content: "---\nstatus: " + status + "\n---\nDone.\n"},
+				},
+				wantSuccess: true,
+			})
+		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
-				output, err := runOrchestrateJudgeForTest(t, check, tc.tasks, tc.activeWorker)
+				output, err := runOrchestrateJudgeForTest(t, judges, tc.tasks, tc.activeWorker)
 				if tc.wantSuccess && err != nil {
 					t.Fatalf("judge command error = %v, output = %s", err, output)
 				}
@@ -1141,7 +1150,7 @@ type orchestrateJudgeTaskFile struct {
 
 func runOrchestrateJudgeForTest(
 	t *testing.T,
-	check string,
+	judges []dsl.GateCriterion,
 	tasks []orchestrateJudgeTaskFile,
 	activeWorker bool,
 ) ([]byte, error) {
@@ -1156,6 +1165,37 @@ func runOrchestrateJudgeForTest(
 		if err := os.WriteFile(filepath.Join(taskDir, task.name), []byte(task.content), 0o600); err != nil {
 			t.Fatalf("WriteFile(%q) error = %v", task.name, err)
 		}
+	}
+	manifest := "---\nschema_version: compozy.tasks/v2\nworkflow: review-fixture\ngraph:\n  nodes:\n"
+	for _, task := range tasks {
+		manifest += fmt.Sprintf("    - id: %s\n      file: %s\n", strings.TrimSuffix(task.name, ".md"), task.name)
+	}
+	manifest += "  edges: []\n---\n"
+	if err := os.WriteFile(filepath.Join(taskDir, "_tasks.md"), []byte(manifest), 0o600); err != nil {
+		t.Fatalf("WriteFile(manifest) error = %v", err)
+	}
+	criterion := judges[0]
+	patternTemplate, ok := criterion.Inputs["pattern"].(string)
+	if !ok {
+		t.Fatalf("task judge pattern = %#v, want a workspace-relative template", criterion.Inputs["pattern"])
+	}
+	pattern, err := refs.RenderTemplateString("task-judge.pattern", patternTemplate,
+		map[string]any{"inputs": map[string]any{"slug": "review-fixture"}})
+	if err != nil {
+		t.Fatalf("RenderTemplateString(pattern) error = %v", err)
+	}
+	criterion.Inputs = map[string]any{"pattern": filepath.Join(workspace, pattern)}
+	evaluator := gate.NewEvaluator(gate.WithToolCaller(importTaskJudgeCaller{provider: newRuntimeProvider()}))
+	verdict, err := evaluator.Evaluate(
+		t.Context(),
+		gate.GateFromGoalJudge("orchestrate", []dsl.GateCriterion{criterion}),
+		gate.GateInput{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if verdict.Outcome != gate.VerdictOutcomeApproved {
+		return nil, fmt.Errorf("task judge rejected: %#v", verdict)
 	}
 	fakeBin := filepath.Join(workspace, "bin")
 	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
@@ -1176,7 +1216,7 @@ printf '{"type":"list_page","page":{"total":0}}\n'
 	}
 	rendered, err := refs.RenderTemplateString(
 		"implement-tasks.orchestrate.tasks_completed.check",
-		check,
+		judges[1].Check,
 		map[string]any{"inputs": map[string]any{"slug": "review-fixture"}},
 	)
 	if err != nil {
@@ -1194,22 +1234,34 @@ printf '{"type":"list_page","page":{"total":0}}\n'
 	return command.CombinedOutput()
 }
 
-func requireOrchestrateJudgeForTest(t *testing.T, node dsl.Node) map[string]any {
-	t.Helper()
+type importTaskJudgeCaller struct {
+	provider *runtimeProvider
+}
 
-	raw, ok := node.Params["judge"].([]any)
-	if !ok || len(raw) != 1 {
-		t.Fatalf("orchestrate params.judge = %#v, want exactly one criterion", node.Params["judge"])
+func (c importTaskJudgeCaller) Call(
+	ctx context.Context,
+	_ toolspkg.Scope,
+	req toolspkg.CallRequest,
+) (toolspkg.ToolResult, error) {
+	return c.provider.CallTool(ctx, toolspkg.ExtensionToolCallRequest{
+		ToolID: req.ToolID, Handler: strings.TrimPrefix(string(req.ToolID), "ext__spec_cycle__"), Input: req.Input,
+	})
+}
+
+func requireOrchestrateJudgesForTest(t *testing.T, node dsl.Node) []dsl.GateCriterion {
+	t.Helper()
+	encoded, err := json.Marshal(node.Params["judge"])
+	if err != nil {
+		t.Fatalf("Marshal(judge) error = %v", err)
 	}
-	switch criterion := raw[0].(type) {
-	case dsl.NodeParams:
-		return map[string]any(criterion)
-	case map[string]any:
-		return criterion
-	default:
-		t.Fatalf("orchestrate judge[0] = %#v, want object", raw[0])
-		return nil
+	var judges []dsl.GateCriterion
+	if err := json.Unmarshal(encoded, &judges); err != nil {
+		t.Fatalf("Unmarshal(judge) error = %v", err)
 	}
+	if len(judges) != 2 {
+		t.Fatalf("judges = %#v, want task completion and worker settlement", judges)
+	}
+	return judges
 }
 
 func renderImplementTasksPromptForTest(

--- a/extensions/spec-cycle/embed_test.go
+++ b/extensions/spec-cycle/embed_test.go
@@ -80,6 +80,8 @@ func TestEmbeddedLoopsShouldCompileWithSpecCycleToolSchemas(t *testing.T) {
 	}
 }
 
+// TestSpecCycleRuntimeToolDescriptorsShouldPinSchemaDigests
+// Pins tool schemas and read-only permission policy together.
 func TestSpecCycleRuntimeToolDescriptorsShouldPinSchemaDigests(t *testing.T) {
 	t.Run("Should pin managed tool schema digests and policies", func(t *testing.T) {
 		t.Parallel()
@@ -551,6 +553,8 @@ func TestSpecCycleManagedInstallShouldReenrollChangedBundledSkills(t *testing.T)
 	}
 }
 
+// TestEmbeddedLoopsShouldKeepSpecCycleRuntimeContracts
+// Checks the shipped Loop graph, prompts, and executable judge contract.
 func TestEmbeddedLoopsShouldKeepSpecCycleRuntimeContracts(t *testing.T) {
 	t.Run("Should keep the internal review source and clean round termination contract", func(t *testing.T) {
 		t.Parallel()
@@ -1148,6 +1152,7 @@ type orchestrateJudgeTaskFile struct {
 	content string
 }
 
+// runOrchestrateJudgeForTest evaluates the shipped importer criterion before checking worker settlement.
 func runOrchestrateJudgeForTest(
 	t *testing.T,
 	judges []dsl.GateCriterion,
@@ -1238,6 +1243,7 @@ type importTaskJudgeCaller struct {
 	provider *runtimeProvider
 }
 
+// Call routes evaluator requests through the production spec-cycle tool handler.
 func (c importTaskJudgeCaller) Call(
 	ctx context.Context,
 	_ toolspkg.Scope,
@@ -1248,6 +1254,7 @@ func (c importTaskJudgeCaller) Call(
 	})
 }
 
+// requireOrchestrateJudgesForTest decodes the shipped completion and worker-settlement criteria.
 func requireOrchestrateJudgesForTest(t *testing.T, node dsl.Node) []dsl.GateCriterion {
 	t.Helper()
 	encoded, err := json.Marshal(node.Params["judge"])

--- a/extensions/spec-cycle/extension.json
+++ b/extensions/spec-cycle/extension.json
@@ -35,7 +35,7 @@
                 "output_schema": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["tasks", "count"],
+                    "required": ["tasks", "count", "passed"],
                     "properties": {
                         "tasks": {
                             "type": "array",
@@ -76,7 +76,8 @@
                                 }
                             }
                         },
-                        "count": { "type": "integer", "minimum": 0 }
+                        "count": { "type": "integer", "minimum": 0 },
+                        "passed": { "type": "boolean" }
                     }
                 },
                 "backend": {

--- a/extensions/spec-cycle/import_tasks.go
+++ b/extensions/spec-cycle/import_tasks.go
@@ -28,6 +28,7 @@ func (e *taskSetNotFoundError) Error() string {
 	return "spec-cycle: task set not found"
 }
 
+// importTasks returns the unfinished queue and its completion verdict from one validated task set.
 func importTasks(input importTasksInput) (importTasksOutput, error) {
 	pattern := strings.TrimSpace(input.Pattern)
 	if pattern == "" {
@@ -44,6 +45,7 @@ func importTasks(input importTasksInput) (importTasksOutput, error) {
 	}, nil
 }
 
+// importTasksToolError translates import failures into operator-facing causes and recovery steps.
 func importTasksToolError(id toolspkg.ToolID, input importTasksInput, err error) error {
 	pattern := operatorTaskPattern(input.Pattern)
 	cause := fmt.Sprintf("The task set for %s could not be imported.", pattern)

--- a/extensions/spec-cycle/import_tasks.go
+++ b/extensions/spec-cycle/import_tasks.go
@@ -15,8 +15,9 @@ type importTasksInput struct {
 }
 
 type importTasksOutput struct {
-	Tasks []markdownTaskPayload `json:"tasks"`
-	Count int                   `json:"count"`
+	Tasks  []markdownTaskPayload `json:"tasks"`
+	Count  int                   `json:"count"`
+	Passed bool                  `json:"passed"`
 }
 
 type taskSetNotFoundError struct {
@@ -37,8 +38,9 @@ func importTasks(input importTasksInput) (importTasksOutput, error) {
 		return importTasksOutput{}, err
 	}
 	return importTasksOutput{
-		Tasks: result.Tasks,
-		Count: len(result.Tasks),
+		Tasks:  result.Tasks,
+		Count:  len(result.Tasks),
+		Passed: len(result.Tasks) == 0,
 	}, nil
 }
 
@@ -46,6 +48,10 @@ func importTasksToolError(id toolspkg.ToolID, input importTasksInput, err error)
 	pattern := operatorTaskPattern(input.Pattern)
 	cause := fmt.Sprintf("The task set for %s could not be imported.", pattern)
 	recovery := "Correct the task manifest and matching task files, then retry the run."
+	if statusErr, ok := errors.AsType[*taskStatusError](err); ok {
+		cause = fmt.Sprintf("The task set for %s has an %s.", pattern, statusErr.Error())
+		recovery = "Correct the named status in the task frontmatter, then retry; no tasks were dispatched."
+	}
 	reason := toolspkg.ReasonSchemaInvalid
 	if strings.TrimSpace(input.Pattern) == "" {
 		cause = "The task import pattern is required."

--- a/extensions/spec-cycle/import_tasks_graph.go
+++ b/extensions/spec-cycle/import_tasks_graph.go
@@ -150,6 +150,7 @@ type taskStatusError struct {
 	Status string
 }
 
+// Error lists supported task statuses so invalid frontmatter can be corrected before dispatch.
 func (e *taskStatusError) Error() string {
 	return fmt.Sprintf(
 		"unknown task status %q; use pending, in_progress, or completed (completion aliases: complete, done, finished)",
@@ -157,6 +158,7 @@ func (e *taskStatusError) Error() string {
 	)
 }
 
+// normalizeCompozyTaskStatus normalizes boundary aliases while rejecting undocumented task states.
 func normalizeCompozyTaskStatus(status string) (string, error) {
 	switch normalized := strings.ToLower(strings.TrimSpace(status)); normalized {
 	case compozyTaskStatusCompletedValue, "complete", "done", "finished":

--- a/extensions/spec-cycle/import_tasks_graph.go
+++ b/extensions/spec-cycle/import_tasks_graph.go
@@ -146,12 +146,25 @@ func pathBaseSlash(path string) string {
 	return normalized
 }
 
-func compozyTaskStatusCompleted(status string) bool {
-	switch strings.ToLower(strings.TrimSpace(status)) {
-	case compozyTaskStatusCompletedValue, "done", "finished":
-		return true
+type taskStatusError struct {
+	Status string
+}
+
+func (e *taskStatusError) Error() string {
+	return fmt.Sprintf(
+		"unknown task status %q; use pending, in_progress, or completed (completion aliases: complete, done, finished)",
+		e.Status,
+	)
+}
+
+func normalizeCompozyTaskStatus(status string) (string, error) {
+	switch normalized := strings.ToLower(strings.TrimSpace(status)); normalized {
+	case compozyTaskStatusCompletedValue, "complete", "done", "finished":
+		return compozyTaskStatusCompletedValue, nil
+	case "", "pending", "in_progress":
+		return normalized, nil
 	default:
-		return false
+		return "", &taskStatusError{Status: status}
 	}
 }
 

--- a/extensions/spec-cycle/import_tasks_parser.go
+++ b/extensions/spec-cycle/import_tasks_parser.go
@@ -114,7 +114,7 @@ func importMarkdownTasks(pattern string) (markdownTasksImportResult, error) {
 	payloads := make([]markdownTaskPayload, 0, len(ordered))
 	blocksByTarget := compozyTaskBlocksByTarget(manifest.Graph.Edges)
 	for _, taskFile := range ordered {
-		if compozyTaskStatusCompleted(taskFile.Meta.Status) {
+		if taskFile.Meta.Status == compozyTaskStatusCompletedValue {
 			continue
 		}
 		payloads = append(payloads, markdownTaskPayload{
@@ -382,7 +382,10 @@ func parseCompozyTaskFile(content []byte) (compozyTaskFrontmatter, string, error
 	if err := yaml.Unmarshal(parts.Metadata, &meta); err != nil {
 		return compozyTaskFrontmatter{}, "", err
 	}
-	meta.Status = strings.TrimSpace(meta.Status)
+	meta.Status, err = normalizeCompozyTaskStatus(meta.Status)
+	if err != nil {
+		return compozyTaskFrontmatter{}, "", err
+	}
 	meta.Title = strings.TrimSpace(meta.Title)
 	meta.Type = strings.TrimSpace(meta.Type)
 	meta.Complexity = strings.TrimSpace(meta.Complexity)

--- a/extensions/spec-cycle/import_tasks_parser.go
+++ b/extensions/spec-cycle/import_tasks_parser.go
@@ -78,6 +78,7 @@ type compozyTaskFrontmatter struct {
 	Dependencies []string         `yaml:"dependencies"`
 }
 
+// importMarkdownTasks validates manifest topology and task metadata before selecting unfinished work.
 func importMarkdownTasks(pattern string) (markdownTasksImportResult, error) {
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
@@ -373,6 +374,7 @@ func resolvedCompozyPath(tasksDir string, relativePath string, subject string) (
 	return resolvedPath, nil
 }
 
+// parseCompozyTaskFile decodes YAML frontmatter and canonicalizes task status before graph validation.
 func parseCompozyTaskFile(content []byte) (compozyTaskFrontmatter, string, error) {
 	parts, err := frontmatter.Split(content)
 	if err != nil {

--- a/extensions/spec-cycle/import_tasks_test.go
+++ b/extensions/spec-cycle/import_tasks_test.go
@@ -80,6 +80,40 @@ func TestImportMarkdownTasksShouldLoadCompozyTaskManifest(t *testing.T) {
 		}
 	})
 
+	for _, status := range []string{"completed", "done", "finished", "complete", "  CoMpLeTe  "} {
+		t.Run("Should skip finished tasks with status "+status, func(t *testing.T) {
+			t.Parallel()
+			tasksDir := t.TempDir()
+			writeImportTasksManifest(t, tasksDir, compozyTaskManifestVersion, nil)
+			writeImportTaskFile(t, tasksDir, "task_01.md", status, "Finished", "# Finished\n")
+			writeImportTaskFile(t, tasksDir, "task_02.md", "pending", "Pending", "# Pending\n")
+			writeImportTaskFile(t, tasksDir, "task_03.md", "in_progress", "Started", "# Started\n")
+			result, err := importTasks(importTasksInput{Pattern: filepath.Join(tasksDir, "task_*.md")})
+			if err != nil {
+				t.Fatalf("importTasks() error = %v", err)
+			}
+			if result.Count != 2 || result.Tasks[0].ID != "task_02" || result.Tasks[1].ID != "task_03" {
+				t.Fatalf("importTasks() = %#v, want only pending and in_progress tasks", result)
+			}
+		})
+	}
+
+	for _, status := range []string{"compeleted", "blocked", "unknown"} {
+		t.Run("Should reject unknown task status "+status, func(t *testing.T) {
+			t.Parallel()
+			tasksDir := t.TempDir()
+			writeImportTasksManifest(t, tasksDir, compozyTaskManifestVersion, nil)
+			writeImportTaskFile(t, tasksDir, "task_01.md", status, "Invalid", "# Invalid\n")
+			writeImportTaskFile(t, tasksDir, "task_02.md", "pending", "Pending", "# Pending\n")
+			writeImportTaskFile(t, tasksDir, "task_03.md", "completed", "Finished", "# Finished\n")
+			_, err := importTasks(importTasksInput{Pattern: filepath.Join(tasksDir, "task_*.md")})
+			if !errors.Is(err, looppkg.ErrValidation) || !strings.Contains(err.Error(), "task_01.md") ||
+				!strings.Contains(err.Error(), status) {
+				t.Fatalf("importTasks() error = %v, want file-scoped status validation", err)
+			}
+		})
+	}
+
 	t.Run("Should publish task type complexity and runtime frontmatter", func(t *testing.T) {
 		t.Parallel()
 
@@ -529,7 +563,7 @@ func TestImportTasksToolShouldReturnStructuredPayload(t *testing.T) {
 		want := fmt.Sprintf(
 			`{"tasks":[{"id":"task_01","number":1,"title":"First task",`+
 				`"type":"","complexity":"",`+
-				`"path":%q,"body_ref":%q,"blocks":[]}],"count":1}`,
+				`"path":%q,"body_ref":%q,"blocks":[]}],"count":1,"passed":false}`,
 			task.Path,
 			task.BodyRef,
 		)

--- a/extensions/spec-cycle/import_tasks_test.go
+++ b/extensions/spec-cycle/import_tasks_test.go
@@ -12,6 +12,8 @@ import (
 	looppkg "github.com/compozy/compozy/internal/loop"
 )
 
+// TestImportMarkdownTasksShouldLoadCompozyTaskManifest
+// Covers task ordering, completion filtering, and invalid input rejection.
 func TestImportMarkdownTasksShouldLoadCompozyTaskManifest(t *testing.T) {
 	t.Parallel()
 
@@ -536,6 +538,7 @@ func TestImportMarkdownTasksShouldLoadCompozyTaskManifest(t *testing.T) {
 	})
 }
 
+// TestImportTasksToolShouldReturnStructuredPayload checks the serialized queue and completion verdict contract.
 func TestImportTasksToolShouldReturnStructuredPayload(t *testing.T) {
 	t.Parallel()
 

--- a/extensions/spec-cycle/loops/implement-tasks/loop.yaml
+++ b/extensions/spec-cycle/loops/implement-tasks/loop.yaml
@@ -157,7 +157,7 @@ graph:
           - Report exact commands and outcomes in the structured output.
 
           Tracking and commits:
-          - Update task checkboxes and status in {{ .item.path }} only after implementation,
+          - Write `status: completed` and update task checkboxes in {{ .item.path }} only after implementation,
             verification evidence, and self-review are complete.
           - Update .compozy/tasks/{{ .inputs.slug }}/_tasks.md only when this task is complete.
           - Keep tracking-only files out of automatic commits.
@@ -219,7 +219,7 @@ graph:
       class: control
       kind: route
       routes:
-        - when: "inputs.mode == 'orchestrated'"
+        - when: "inputs.mode == 'orchestrated' && size(nodes.load_tasks.output.tasks) > 0"
           to: orchestrate
       default: per_task_done
 
@@ -262,25 +262,24 @@ graph:
           - default: {{ json .inputs.default_runtime }}
 
           Return `status`, `summary`, and `tasks`, naming each task with the worker session id that
-          executed it. Use `complete` only when every task file carries `status: completed` in its
-          frontmatter and no conductor-created worker is starting, active, or stopping. If any
-          worker cannot be stopped, return `blocked`.
+          executed it. Task files must use `status: completed` after verification. Existing completion
+          aliases `complete`, `done`, and `finished` are also recognized by the task importer and
+          judge; do not dispatch those tasks again. Only `pending` and `in_progress` need work;
+          an unknown status requires correction before dispatch.
+
+          The Goal JSON result is separate from task frontmatter: return `{"status":"complete"}`
+          only after the task importer reports no pending tasks and no conductor-created worker
+          is starting, active, or stopping. If any worker cannot be stopped, return `blocked`.
         judge:
           - id: tasks_completed
+            type: extension
+            tool: ext__spec_cycle__import_tasks
+            inputs:
+              pattern: ".compozy/tasks/{{ .inputs.slug }}/task_*.md"
+          - id: workers_stopped
             type: command
             check: >-
               slug={{ .inputs.slug | shellQuote }};
-              task_dir=".compozy/tasks/$slug";
-              set -- "$task_dir"/task_*.md;
-              [ -e "$1" ] || exit 1;
-              for f in "$@"; do
-              awk '
-              NR == 1 { if ($0 != "---") exit 1; frontmatter = 1; next }
-              frontmatter && $0 == "---" { frontmatter = 0; found_end = 1; next }
-              frontmatter && /^status:/ { status_count++; completed = ($0 == "status: completed") }
-              END { if (!found_end || status_count != 1 || !completed) exit 1 }
-              ' "$f" || exit 1;
-              done;
               for state in starting active stopping; do
               sessions="$("$COMPOZY_BIN" session list --type spawned --state "$state" --query "orchestrate-${slug}-" --limit 1 -o jsonl)" || exit 1;
               if printf '%s\n' "$sessions" | grep -q '"id"[[:space:]]*:'; then exit 1; fi;

--- a/extensions/spec-cycle/provider_test.go
+++ b/extensions/spec-cycle/provider_test.go
@@ -52,6 +52,46 @@ func TestRPCServerShouldCallImportTasksTool(t *testing.T) {
 		}
 	})
 
+	t.Run("Should return a passing completion verdict over tools call", func(t *testing.T) {
+		t.Parallel()
+		tasksDir := t.TempDir()
+		writeImportTasksManifest(t, tasksDir, compozyTaskManifestVersion, nil)
+		for index, status := range []string{"complete", "done", "finished"} {
+			writeImportTaskFile(t, tasksDir, fmt.Sprintf("task_%02d.md", index+1), status, "Finished", "# Finished\n")
+		}
+		response := runToolRPC(
+			t,
+			toolImportTasks,
+			json.RawMessage(fmt.Sprintf(`{"pattern":%q}`, filepath.Join(tasksDir, "task_*.md"))),
+			nil,
+		)
+		if response.Error != nil {
+			t.Fatalf("tools/call error = %#v", response.Error)
+		}
+		if got := string(response.Result.Result.Structured); got != `{"tasks":[],"count":0,"passed":true}` {
+			t.Fatalf("tools/call output = %s, want empty tasks and passing verdict", got)
+		}
+	})
+
+	t.Run("Should report unknown status before dispatch over tools call", func(t *testing.T) {
+		t.Parallel()
+		tasksDir := t.TempDir()
+		writeImportTasksManifest(t, tasksDir, compozyTaskManifestVersion, nil)
+		writeImportTaskFile(t, tasksDir, "task_01.md", "compeleted", "Invalid", "# Invalid\n")
+		writeImportTaskFile(t, tasksDir, "task_02.md", "pending", "Pending", "# Pending\n")
+		writeImportTaskFile(t, tasksDir, "task_03.md", "completed", "Finished", "# Finished\n")
+		response := runToolRPC(
+			t,
+			toolImportTasks,
+			json.RawMessage(fmt.Sprintf(`{"pattern":%q}`, filepath.Join(tasksDir, "task_*.md"))),
+			nil,
+		)
+		if response.Error == nil || !strings.Contains(response.Error.Message, `unknown task status "compeleted"`) {
+			t.Fatalf("tools/call error = %#v, want visible unknown status", response.Error)
+		}
+		assertInvalidInputToolError(t, response.Error.Data)
+	})
+
 	t.Run("Should surface missing pattern validation over tools call", func(t *testing.T) {
 		t.Parallel()
 

--- a/extensions/spec-cycle/provider_test.go
+++ b/extensions/spec-cycle/provider_test.go
@@ -15,6 +15,7 @@ import (
 	toolspkg "github.com/compozy/compozy/internal/tools"
 )
 
+// TestRPCServerShouldCallImportTasksTool covers task import results and actionable errors through RPC.
 func TestRPCServerShouldCallImportTasksTool(t *testing.T) {
 	t.Run("Should return structured import tasks payload over tools call", func(t *testing.T) {
 		t.Parallel()

--- a/extensions/spec-cycle/schemas.go
+++ b/extensions/spec-cycle/schemas.go
@@ -25,7 +25,7 @@ var (
 	importTasksOutputSchema = json.RawMessage(`{
 		"type":"object",
 		"additionalProperties":false,
-		"required":["tasks","count"],
+		"required":["tasks","count","passed"],
 		"properties":{
 			"tasks":{
 				"type":"array",
@@ -48,7 +48,8 @@ var (
 					}
 				}
 			},
-			"count":{"type":"integer","minimum":0}
+			"count":{"type":"integer","minimum":0},
+			"passed":{"type":"boolean"}
 		}
 	}`)
 )

--- a/extensions/spec-cycle/skills/cy-create-tasks/references/task-context-schema.md
+++ b/extensions/spec-cycle/skills/cy-create-tasks/references/task-context-schema.md
@@ -1,6 +1,6 @@
 # Task Metadata Schemas
 
-Task metadata is parsed from YAML frontmatter by CompozyOS's `ParseTaskFile()` function in `internal/core/tasks/parser.go`.
+Task metadata is parsed from YAML frontmatter by the spec-cycle task importer in `extensions/spec-cycle/import_tasks_parser.go`.
 Parallel task execution also reads the canonical `_tasks.md` graph manifest.
 
 ## `_tasks.md` Graph Manifest
@@ -50,8 +50,14 @@ Valid `status` values:
 - `pending` - task has not been started.
 - `in_progress` - task is currently being worked on.
 - `completed` - task is finished and verified.
+- `complete` - treated as completed.
 - `done` - treated as completed.
 - `finished` - treated as completed.
+
+Write `completed` for verified completion. The importer normalizes surrounding whitespace and letter
+case, and the Loop completion judge calls that same importer. Unknown or missing status values
+fail validation before any task is dispatched; they do not become pending work. The Goal JSON
+result uses `complete|blocked` separately from task frontmatter.
 
 ## File Naming
 
@@ -70,4 +76,4 @@ The leading underscore prefix is reserved for meta documents:
 
 ## Parser Compatibility
 
-CompozyOS reads task files matching the regex `^task_\d+\.md$`. Files with the old `_task_` prefix are not recognized. The file MUST start with YAML frontmatter for `ParseTaskFile()` to read the metadata.
+CompozyOS reads task files matching the regex `^task_\d+\.md$`. Files with the old `_task_` prefix are not recognized. The file MUST start with YAML frontmatter for the task importer to read the metadata.

--- a/extensions/spec-cycle/skills/cy-orchestrate-tasks/SKILL.md
+++ b/extensions/spec-cycle/skills/cy-orchestrate-tasks/SKILL.md
@@ -23,7 +23,9 @@ This session is the **conductor** of the spec: it conducts, it does not play. Ev
 
 Read `.compozy/tasks/<slug>/_tasks.md` and derive the execution order from `graph.edges`. Read the
 frontmatter of every `task_NN.md`. Queue only tasks whose `status` is `pending` or `in_progress`,
-in graph order.
+in graph order. Treat `completed`, `complete`, `done`, and `finished` as already completed, ignoring
+case and surrounding whitespace. Stop on unknown or missing statuses before spawning workers;
+report the task file and invalid value instead of guessing.
 
 _Done when:_ the queue lists the id, `title`, and `status` of every queued task, in execution order.
 
@@ -92,16 +94,18 @@ _Done when:_ the command has returned and its outcome is recorded, including a f
 
 ### 4. Check the proof
 
-Re-read the task file frontmatter. `status: completed` on disk is the accepted completion state; the
+Re-read the task file frontmatter. Workers write `status: completed`; the importer also accepts
+`complete`, `done`, and `finished` (ignoring case and surrounding whitespace). The
 worker's closing message alone never completes a task. Check the referenced verification evidence
 against the task contract and current inputs; a status label is not proof that checks passed.
 Reuse valid worker evidence instead of rerunning the same suite.
 
-If the status is anything else, send one corrective prompt in the **same** session, using the same
+If the status is not a recognized completion state, send one corrective prompt in the **same** session, using the same
 blocking form, naming exactly what is missing. A second failure produces a `blocked` result citing
 `.compozy/tasks/<slug>/logs/<task_id>.jsonl` as evidence.
 
-_Done when:_ the task reads `completed` on disk, or it is marked blocked with the log path cited.
+_Done when:_ the task has a recognized completion state on disk and verified evidence, or the
+Goal result is blocked with the log path cited. Do not write Goal result statuses into task files.
 
 ### 5. Stop the worker session
 

--- a/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
+++ b/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
@@ -36,6 +36,8 @@ const (
 	implementTasksEngineerSkill = "PROFILE_ENGINEER_SENTINEL_V1"
 )
 
+// TestDaemonE2EImplementTasksShouldCompleteTaskJourney
+// Owns dispatch, rerun, and execution-root behavior through the real daemon.
 func TestDaemonE2EImplementTasksShouldCompleteTaskJourney(t *testing.T) {
 	t.Parallel()
 
@@ -127,16 +129,24 @@ func TestDaemonE2EImplementTasksShouldCompleteTaskJourney(t *testing.T) {
 		})
 		// Opposite states prove the extension reads the selected root on every evaluation.
 		for index, scenario := range []struct {
-			nodeEnvironment  map[string]any
-			mainStatuses     []string
-			worktreeStatuses []string
-			wantStatus       contract.LoopRunStatus
-			wantVerdict      string
+			committedStatuses []string
+			nodeEnvironment   map[string]any
+			mainStatuses      []string
+			worktreeStatuses  []string
+			wantStatus        contract.LoopRunStatus
+			wantVerdict       string
 		}{
-			{nil, []string{"pending", "in_progress", "pending"}, []string{"complete", "done", "finished"}, contract.LoopRunStatusDone, "approved"},
-			{nil, []string{"complete", "done", "finished"}, []string{"pending", "in_progress", "pending"}, contract.LoopRunStatusExhausted, "rejected"},
-			{map[string]any{"mode": "root"}, []string{"complete", "done", "finished"}, []string{"pending", "in_progress", "pending"}, contract.LoopRunStatusDone, "approved"},
+			{nil, nil, []string{"pending", "in_progress", "pending"}, []string{"complete", "done", "finished"}, contract.LoopRunStatusDone, "approved"},
+			{nil, nil, []string{"complete", "done", "finished"}, []string{"pending", "in_progress", "pending"}, contract.LoopRunStatusExhausted, "rejected"},
+			{nil, map[string]any{"mode": "root"}, []string{"complete", "done", "finished"}, []string{"pending", "in_progress", "pending"}, contract.LoopRunStatusDone, "approved"},
+			{[]string{"complete", "done", "finished"}, map[string]any{"mode": "per_run"}, []string{"pending", "in_progress", "pending"}, nil, contract.LoopRunStatusDone, "approved"},
+			{[]string{"pending", "in_progress", "pending"}, map[string]any{"mode": "per_run"}, []string{"complete", "done", "finished"}, nil, contract.LoopRunStatusExhausted, "rejected"},
 		} {
+			if scenario.committedStatuses != nil {
+				setImplementTasksStatuses(t, workspaceRoot, scenario.committedStatuses)
+				runWorktreeE2EGit(t, ctx, workspaceRoot, "add", ".compozy/tasks")
+				runWorktreeE2EGit(t, ctx, workspaceRoot, "commit", "-m", "seed per-run completion states")
+			}
 			definition := implementTasksCompletionJudgeDefinition()
 			definition.Meta.Name += "-" + strconv.Itoa(index)
 			if scenario.nodeEnvironment != nil {
@@ -998,6 +1008,7 @@ func unsupportedSpeedResolution(requested speed.Speed) *contract.SpeedResolution
 	}
 }
 
+// setImplementTasksStatuses changes only fixture task statuses, preserving their manifest and metadata.
 func setImplementTasksStatuses(t testing.TB, root string, statuses []string) {
 	t.Helper()
 	for index, status := range statuses {
@@ -1025,6 +1036,7 @@ func setImplementTasksStatuses(t testing.TB, root string, statuses []string) {
 	}
 }
 
+// assertImplementTasksExecutedNodes distinguishes executed workers from skipped route outputs.
 func assertImplementTasksExecutedNodes(t testing.TB, detail contract.LoopRunResponse, want []string) {
 	t.Helper()
 	var got []string
@@ -1040,6 +1052,7 @@ func assertImplementTasksExecutedNodes(t testing.TB, detail contract.LoopRunResp
 	}
 }
 
+// implementTasksCompletionJudgeDefinition isolates real extension judging from worker terminal actions.
 func implementTasksCompletionJudgeDefinition() contract.LoopDefinitionDocument {
 	return contract.LoopDefinitionDocument{
 		APIVersion: dsl.APIVersion, Kind: dsl.KindLoop,

--- a/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
+++ b/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/compozy/compozy/internal/api/contract"
 	"github.com/compozy/compozy/internal/config"
+	"github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/compozy/compozy/internal/speed"
 	"github.com/compozy/compozy/internal/testutil/acpmock"
 	e2etest "github.com/compozy/compozy/internal/testutil/e2e"
@@ -54,6 +55,17 @@ func TestDaemonE2EImplementTasksShouldCompleteTaskJourney(t *testing.T) {
 		})
 		assertImplementTasksPerTaskRuntimes(t, detail)
 		assertImplementTasksRoute(t, detail, "orchestrate", "route_not_taken:select_delivery")
+	})
+
+	t.Run("Should dispatch unfinished tasks once and skip completed aliases on rerun", func(t *testing.T) {
+		t.Parallel()
+		harness, ctx := startImplementTasksE2EHarness(t, implementTasksImplementer)
+		setImplementTasksStatuses(t, harness.WorkspaceRoot, []string{"done", "complete", "in_progress"})
+		detail := runImplementTasksE2E(t, ctx, harness, nil)
+		assertImplementTasksExecutedNodes(t, detail, []string{"execute_backend"})
+		setImplementTasksStatuses(t, harness.WorkspaceRoot, []string{"done", "complete", "finished"})
+		rerun := runImplementTasksE2E(t, ctx, harness, nil)
+		assertImplementTasksExecutedNodes(t, rerun, nil)
 	})
 
 	t.Run("Should import a worktree-only task pack and bind its workers to that worktree", func(t *testing.T) {
@@ -100,6 +112,61 @@ func TestDaemonE2EImplementTasksShouldCompleteTaskJourney(t *testing.T) {
 		assertImplementTasksWorkerWorktree(t, ctx, harness, detail, ready.Worktree.ID)
 	})
 
+	t.Run("Should judge task completion in the selected worktree instead of the main workspace", func(t *testing.T) {
+		t.Parallel()
+		workspaceRoot := initWorktreeE2ERepository(t)
+		harness, ctx := startImplementTasksE2EHarnessAt(t, implementTasksImplementer, workspaceRoot)
+		runWorktreeE2EGit(t, ctx, workspaceRoot, "add", ".")
+		runWorktreeE2EGit(t, ctx, workspaceRoot, "commit", "-m", "seed task completion judge pack")
+		created := createWorktreeE2E(t, ctx, harness, harness.WorkspaceID, "Completion Judge")
+		ready := waitForWorktreeE2EState(t, ctx, harness, harness.WorkspaceID, created.ID, worktreepkg.StateReady)
+		configureExtensionAgentFixture(t, ctx, harness, extensionAgentFixtureConfig{
+			DriverPath: acpmock.RequireDriver(t), FixturePath: mockFixturePath(t, "goal_command_fixture.json"),
+			FixtureAgentName: "goal_rejections", ExtensionAgentName: implementTasksOrchestrator,
+			DiagnosticsPath: filepath.Join(harness.HomePaths.LogsDir, "completion-judge.jsonl"),
+		})
+		// Opposite states prove the extension reads the selected root on every evaluation.
+		for index, scenario := range []struct {
+			nodeEnvironment  map[string]any
+			mainStatuses     []string
+			worktreeStatuses []string
+			wantStatus       contract.LoopRunStatus
+			wantVerdict      string
+		}{
+			{nil, []string{"pending", "in_progress", "pending"}, []string{"complete", "done", "finished"}, contract.LoopRunStatusDone, "approved"},
+			{nil, []string{"complete", "done", "finished"}, []string{"pending", "in_progress", "pending"}, contract.LoopRunStatusExhausted, "rejected"},
+			{map[string]any{"mode": "root"}, []string{"complete", "done", "finished"}, []string{"pending", "in_progress", "pending"}, contract.LoopRunStatusDone, "approved"},
+		} {
+			definition := implementTasksCompletionJudgeDefinition()
+			definition.Meta.Name += "-" + strconv.Itoa(index)
+			if scenario.nodeEnvironment != nil {
+				definition.Graph.Nodes[0].Params["environment"] = scenario.nodeEnvironment
+			}
+			createLoopViaHTTP(t, ctx, harness, definition)
+			setImplementTasksStatuses(t, workspaceRoot, scenario.mainStatuses)
+			setImplementTasksStatuses(t, ready.Worktree.Path, scenario.worktreeStatuses)
+			var response contract.RunLoopResponse
+			path := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/loops/" + definition.Meta.Name + "/run"
+			request := contract.RunLoopRequest{ConfigOverrides: &contract.LoopConfig{
+				Environment: &contract.LoopEnvironment{
+					Mode:        contract.LoopEnvironmentModeWorktree,
+					WorktreeRef: ready.Worktree.ID,
+				},
+			}}
+			if err := harness.HTTPJSON(ctx, http.MethodPost, path, request, &response); err != nil {
+				t.Fatalf("HTTP run completion judge error = %v", err)
+			}
+			if response.Run == nil {
+				t.Fatal("completion judge returned no run")
+			}
+			waitForLoopRunStatus(t, ctx, harness, response.Run.ID, scenario.wantStatus)
+			turns := waitForGoalTurns(ctx, t, harness, response.Run.ID, func(page contract.GoalTurnPage) bool {
+				return len(page.Turns) == 1 && page.Turns[0].ResultStatus != nil
+			})
+			assertGoalJudgeOutcomes(t, turns, []string{scenario.wantVerdict})
+		}
+	})
+
 	t.Run("Should complete orchestrated mode and stop every category worker", func(t *testing.T) {
 		t.Parallel()
 
@@ -107,6 +174,11 @@ func TestDaemonE2EImplementTasksShouldCompleteTaskJourney(t *testing.T) {
 		detail := runImplementTasksE2E(t, ctx, harness, []string{"--input", "mode=orchestrated"})
 		assertImplementTasksOrchestratorRuntimeFallback(t, detail)
 		assertImplementTasksRoute(t, detail, "select_category", "route_not_taken:select_mode")
+		assertImplementTasksSpawnedWorkerRuntimes(t, ctx, harness, implementTasksImplementer)
+		setImplementTasksStatuses(t, harness.WorkspaceRoot, []string{"complete", "done", "finished"})
+		rerun := runImplementTasksE2E(t, ctx, harness, []string{"--input", "mode=orchestrated"})
+		assertImplementTasksExecutedNodes(t, rerun, nil)
+		assertImplementTasksRoute(t, rerun, "orchestrate", "route_not_taken:select_delivery")
 		assertImplementTasksSpawnedWorkerRuntimes(t, ctx, harness, implementTasksImplementer)
 	})
 
@@ -923,5 +995,76 @@ func unsupportedSpeedResolution(requested speed.Speed) *contract.SpeedResolution
 		Requested: requested,
 		Status:    speed.ResolutionUnsupported,
 		Reason:    speed.ReasonCapabilityAbsent,
+	}
+}
+
+func setImplementTasksStatuses(t testing.TB, root string, statuses []string) {
+	t.Helper()
+	for index, status := range statuses {
+		path := filepath.Join(
+			root,
+			".compozy",
+			"tasks",
+			implementTasksE2ESlug,
+			fmt.Sprintf("task_%02d.md", index+1),
+		)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(task) error = %v", err)
+		}
+		lines := strings.Split(string(content), "\n")
+		for line := range lines {
+			if strings.HasPrefix(lines[line], "status:") {
+				lines[line] = "status: " + status
+				break
+			}
+		}
+		if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o600); err != nil {
+			t.Fatalf("WriteFile(task) error = %v", err)
+		}
+	}
+}
+
+func assertImplementTasksExecutedNodes(t testing.TB, detail contract.LoopRunResponse, want []string) {
+	t.Helper()
+	var got []string
+	for _, generation := range detail.Generations {
+		for _, output := range generation.Outputs {
+			if strings.HasPrefix(output.NodeID, "execute_") && output.ResolvedRuntime != nil {
+				got = append(got, output.NodeID)
+			}
+		}
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("executed task nodes = %v, want %v", got, want)
+	}
+}
+
+func implementTasksCompletionJudgeDefinition() contract.LoopDefinitionDocument {
+	return contract.LoopDefinitionDocument{
+		APIVersion: dsl.APIVersion, Kind: dsl.KindLoop,
+		Meta: dsl.Meta{Name: "task-completion-judge", Version: 1},
+		Contract: dsl.Contract{
+			Goal: "Judge the selected task pack", DefinitionOfDone: "The selected pack is complete",
+			IterationCap: 1, NoProgress: dsl.NoProgress{Window: 1},
+			Budget: dsl.Budget{WallClockSec: 60, OnExceeded: dsl.BudgetExceededHalt},
+		},
+		Graph: dsl.Graph{Nodes: []dsl.Node{{
+			ID: "completion", Class: dsl.NodeClassAction, Kind: string(dsl.ActionGoal),
+			Session: &dsl.SessionSpec{Mode: dsl.SessionModeContinuous},
+			Params: dsl.NodeParams{
+				"agent": implementTasksOrchestrator, "objective": "Report task completion for independent validation",
+				"max_turns": 1, "on_exhausted": dsl.GoalOnExhaustedHalt,
+				"judge": []any{map[string]any{
+					"id": "tasks_completed", "type": "extension", "tool": "ext__spec_cycle__import_tasks",
+					"inputs": map[string]any{"pattern": ".compozy/tasks/implement-tasks/task_*.md"},
+				}},
+				"output_schema": map[string]any{
+					"type": "object", "required": []any{"status"},
+					"properties": map[string]any{"status": map[string]any{"enum": []any{"complete", "blocked"}}},
+				},
+			},
+		}}},
+		DefinitionExtensionState: &dsl.DefinitionExtensionState{Start: []dsl.StartBinding{{Kind: "http"}}},
 	}
 }

--- a/internal/daemon/loop_action_registry_boot.go
+++ b/internal/daemon/loop_action_registry_boot.go
@@ -57,6 +57,7 @@ func newBootLoopActionRegistry(
 			goalRuntime,
 			gateEvaluator,
 			judgeExecutions,
+			&loopActionToolWorkspaceRootResolver{worktrees: worktrees},
 		)
 		if err != nil {
 			return nil, fmt.Errorf("daemon: compose Goal executor: %w", err)

--- a/internal/daemon/loop_action_registry_boot.go
+++ b/internal/daemon/loop_action_registry_boot.go
@@ -8,6 +8,7 @@ import (
 	"github.com/compozy/compozy/internal/loop/gate"
 )
 
+// newBootLoopActionRegistry wires Loop actions to daemon-owned sessions, judges, and worktree leases.
 func newBootLoopActionRegistry(
 	store taskStore,
 	state *bootState,

--- a/internal/daemon/loop_goal_executor.go
+++ b/internal/daemon/loop_goal_executor.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/compozy/compozy/internal/loop/gate"
 	goalpkg "github.com/compozy/compozy/internal/loop/goal"
 	"github.com/compozy/compozy/internal/session"
@@ -51,14 +52,17 @@ func composeLoopGoalExecutor(
 	runtime loopGoalRuntimePorts,
 	evaluator gate.GateEvaluator,
 	executions *loopJudgeExecutionRegistry,
+	workspaceRoots looppkg.ActionToolWorkspaceRootResolver,
 ) (looppkg.ActionRegistryOption, error) {
 	if store == nil || runtime == nil || evaluator == nil || executions == nil {
 		return nil, fmt.Errorf("%w: Goal runtime ports are incomplete", looppkg.ErrActionDependencyMissing)
 	}
 	executor, err := goalpkg.NewExecutor(goalpkg.Dependencies{
-		Store:    store,
-		Binder:   runtime,
-		Judge:    &loopGoalJudgeEvaluator{store: store, evaluator: evaluator, executions: executions},
+		Store:  store,
+		Binder: runtime,
+		Judge: &loopGoalJudgeEvaluator{
+			store: store, evaluator: evaluator, executions: executions, workspaceRoots: workspaceRoots,
+		},
 		Budget:   store,
 		Context:  runtime,
 		Recovery: runtime,
@@ -70,9 +74,10 @@ func composeLoopGoalExecutor(
 }
 
 type loopGoalJudgeEvaluator struct {
-	store      looppkg.Store
-	evaluator  gate.GateEvaluator
-	executions *loopJudgeExecutionRegistry
+	workspaceRoots looppkg.ActionToolWorkspaceRootResolver
+	store          looppkg.Store
+	evaluator      gate.GateEvaluator
+	executions     *loopJudgeExecutionRegistry
 }
 
 func (e *loopGoalJudgeEvaluator) EvaluateGoal(
@@ -106,9 +111,21 @@ func (e *loopGoalJudgeEvaluator) EvaluateGoal(
 	if err != nil {
 		return goalpkg.JudgeResult{}, fmt.Errorf("daemon: materialize Goal judge contract: %w", err)
 	}
+	trustedRoot, releaseRoot, err := e.acquireJudgeWorkspaceRoot(
+		ctx,
+		run.WorkspaceID,
+		req.Environment,
+	)
+	if err != nil {
+		return goalpkg.JudgeResult{}, err
+	}
+	if releaseRoot != nil {
+		defer releaseRoot()
+	}
 	usage := &loopGoalJudgeUsage{}
 	judgeGate := gate.GateFromGoalJudge(string(req.Key.NodeID), req.Criteria)
 	verdict, err := e.evaluator.Evaluate(ctx, judgeGate, gate.GateInput{
+		TrustedWorkspaceRoot:   trustedRoot,
 		LoopRunID:              string(run.ID),
 		Placement:              gate.PlacementInBody,
 		Contract:               &contract,
@@ -135,6 +152,37 @@ func (e *loopGoalJudgeEvaluator) EvaluateGoal(
 	return goalpkg.JudgeResult{
 		Verdict: verdict, TokensUsed: tokensUsed, TokensReported: tokensReported,
 	}, nil
+}
+
+func (e *loopGoalJudgeEvaluator) acquireJudgeWorkspaceRoot(
+	ctx context.Context,
+	workspaceID looppkg.WorkspaceID,
+	environment dsl.EnvironmentSpec,
+) (string, func(), error) {
+	if environment.Mode != dsl.EnvironmentWorktree {
+		return "", nil, nil
+	}
+	if e.workspaceRoots == nil {
+		return "", nil, fmt.Errorf(
+			"%w: Goal judge worktree resolver is unavailable",
+			looppkg.ErrActionDependencyMissing,
+		)
+	}
+	root, release, err := e.workspaceRoots.AcquireActionToolWorkspaceRoot(ctx, looppkg.ActionToolWorkspaceRootRequest{
+		WorkspaceID: workspaceID, Environment: environment,
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("daemon: acquire Goal judge worktree: %w", err)
+	}
+	if release == nil {
+		return "", nil, fmt.Errorf("%w: Goal judge worktree lease is unavailable", looppkg.ErrActionDependencyMissing)
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		release()
+		return "", nil, fmt.Errorf("%w: Goal judge worktree root is empty", looppkg.ErrActionDependencyMissing)
+	}
+	return root, release, nil
 }
 
 type loopGoalJudgeUsage struct {

--- a/internal/daemon/loop_goal_executor.go
+++ b/internal/daemon/loop_goal_executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/compozy/compozy/internal/session"
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/tools"
+	"github.com/compozy/compozy/internal/worktree"
 )
 
 type loopGoalRuntimePorts interface {
@@ -47,6 +48,7 @@ type loopManagedInputLifecycleInstaller interface {
 	SetManagedInputLifecycle(session.ManagedInputLifecycle)
 }
 
+// composeLoopGoalExecutor adapts daemon runtime ports into the Loop Goal executor.
 func composeLoopGoalExecutor(
 	store loopGoalExecutorStore,
 	runtime loopGoalRuntimePorts,
@@ -80,6 +82,7 @@ type loopGoalJudgeEvaluator struct {
 	executions     *loopJudgeExecutionRegistry
 }
 
+// EvaluateGoal evaluates pinned criteria with the Goal environment, usage accounting, and scoped tool identity.
 func (e *loopGoalJudgeEvaluator) EvaluateGoal(
 	ctx context.Context,
 	req goalpkg.JudgeRequest,
@@ -113,7 +116,7 @@ func (e *loopGoalJudgeEvaluator) EvaluateGoal(
 	}
 	trustedRoot, releaseRoot, err := e.acquireJudgeWorkspaceRoot(
 		ctx,
-		run.WorkspaceID,
+		req.Key,
 		req.Environment,
 	)
 	if err != nil {
@@ -154,11 +157,24 @@ func (e *loopGoalJudgeEvaluator) EvaluateGoal(
 	}, nil
 }
 
+// acquireJudgeWorkspaceRoot leases the explicit or per-run worktree for the caller to hold during judging.
 func (e *loopGoalJudgeEvaluator) acquireJudgeWorkspaceRoot(
 	ctx context.Context,
-	workspaceID looppkg.WorkspaceID,
+	key goalpkg.TurnKey,
 	environment dsl.EnvironmentSpec,
 ) (string, func(), error) {
+	if environment.Mode == dsl.EnvironmentPerRun {
+		// Reuse the binder's run identity to lease the existing tree; judging never materializes one.
+		binding := looppkg.ActionSessionBindRequest{
+			LoopRunID: key.LoopRunID, Generation: key.Generation, NodeID: key.NodeID, ItemIndex: key.ItemIndex,
+		}
+		environment = dsl.EnvironmentSpec{
+			Mode: dsl.EnvironmentWorktree,
+			WorktreeRef: worktree.RunWorktreeName(
+				loopActionWorktreeSlug(binding), loopActionWorktreeRunID(binding),
+			),
+		}
+	}
 	if environment.Mode != dsl.EnvironmentWorktree {
 		return "", nil, nil
 	}
@@ -169,7 +185,7 @@ func (e *loopGoalJudgeEvaluator) acquireJudgeWorkspaceRoot(
 		)
 	}
 	root, release, err := e.workspaceRoots.AcquireActionToolWorkspaceRoot(ctx, looppkg.ActionToolWorkspaceRootRequest{
-		WorkspaceID: workspaceID, Environment: environment,
+		WorkspaceID: key.WorkspaceID, Environment: environment,
 	})
 	if err != nil {
 		return "", nil, fmt.Errorf("daemon: acquire Goal judge worktree: %w", err)

--- a/internal/daemon/loop_goal_executor_test.go
+++ b/internal/daemon/loop_goal_executor_test.go
@@ -42,6 +42,7 @@ func TestComposeLoopGoalExecutorShouldRegisterThroughParentActionBoundary(t *tes
 			inertLoopGoalRuntime{},
 			inertGateEvaluator{},
 			newLoopJudgeExecutionRegistry(),
+			nil,
 		)
 		if err != nil {
 			t.Fatalf("composeLoopGoalExecutor() error = %v", err)
@@ -96,6 +97,7 @@ func TestComposeLoopGoalExecutorShouldRegisterThroughParentActionBoundary(t *tes
 			runtime,
 			inertGateEvaluator{},
 			newLoopJudgeExecutionRegistry(),
+			nil,
 		)
 		if err != nil {
 			t.Fatalf("composeLoopGoalExecutor(real Manager) error = %v", err)

--- a/internal/daemon/loop_goal_executor_test.go
+++ b/internal/daemon/loop_goal_executor_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/compozy/compozy/internal/transcript"
 )
 
+// TestComposeLoopGoalExecutorShouldRegisterThroughParentActionBoundary
+// Checks Goal composition through the parent action registry.
 func TestComposeLoopGoalExecutorShouldRegisterThroughParentActionBoundary(t *testing.T) {
 	t.Run("Should resolve the child executor without a parent package import", func(t *testing.T) {
 		t.Parallel()

--- a/internal/loop/gate/evaluator_extension.go
+++ b/internal/loop/gate/evaluator_extension.go
@@ -44,6 +44,7 @@ func (e *Evaluator) evaluateExtension(
 		input = []byte("{}")
 	}
 	req := tools.CallRequest{
+		TrustedWorkspaceRoot: in.TrustedWorkspaceRoot,
 		ToolID:               tools.ToolID(extensionToolID(criterion)),
 		ToolCallID:           fmt.Sprintf("%s:%s", gate.ID, criterion.ID),
 		SessionID:            in.ToolScope.SessionID,

--- a/internal/loop/gate/evaluator_extension.go
+++ b/internal/loop/gate/evaluator_extension.go
@@ -11,6 +11,7 @@ import (
 	"github.com/compozy/compozy/internal/tools"
 )
 
+// evaluateExtension calls an extension in the supplied scope and maps its structured output to a verdict.
 func (e *Evaluator) evaluateExtension(
 	ctx context.Context,
 	gate Gate,

--- a/internal/loop/gate/evaluator_test.go
+++ b/internal/loop/gate/evaluator_test.go
@@ -283,6 +283,9 @@ func TestEvaluatorEvaluateCriteriaMapping(t *testing.T) {
 				if req.ToolID != "ext__quality__gate" {
 					t.Fatalf("CallRequest.ToolID = %q, want ext__quality__gate", req.ToolID)
 				}
+				if req.TrustedWorkspaceRoot != "/worktrees/verified" {
+					t.Fatalf("TrustedWorkspaceRoot = %q, want execution worktree", req.TrustedWorkspaceRoot)
+				}
 				return tools.ToolResult{
 					Structured: []byte(
 						`{"verdict":"revise","blocking_issues":[{"id":"coverage_gap","note":"missing branch"}]}`,
@@ -299,7 +302,7 @@ func TestEvaluatorEvaluateCriteriaMapping(t *testing.T) {
 				Tool:   "ext__quality__gate",
 				Inputs: map[string]any{"path": "internal/loop"},
 			}},
-		}, GateInput{Placement: PlacementInBody})
+		}, GateInput{Placement: PlacementInBody, TrustedWorkspaceRoot: "/worktrees/verified"})
 		if err != nil {
 			t.Fatalf("Evaluate() error = %v", err)
 		}

--- a/internal/loop/gate/evaluator_test.go
+++ b/internal/loop/gate/evaluator_test.go
@@ -32,6 +32,7 @@ func (f toolCallerFunc) Call(ctx context.Context, scope tools.Scope, req tools.C
 	return f(ctx, scope, req)
 }
 
+// TestEvaluatorEvaluateCriteriaMapping checks criterion results, tool scope, and extension verdict mapping.
 func TestEvaluatorEvaluateCriteriaMapping(t *testing.T) {
 	t.Parallel()
 

--- a/internal/loop/gate/types.go
+++ b/internal/loop/gate/types.go
@@ -104,6 +104,7 @@ type GateInput struct {
 	BrokenJudgeStreakLimit   int
 	BestScore                *float64
 	HumanDecisions           map[string]HumanDecision
+	TrustedWorkspaceRoot     string
 	ToolScope                tools.Scope
 	ToolCallCorrelationID    string
 	ToolSensitiveInputFields []string

--- a/internal/loop/goal/executor_test.go
+++ b/internal/loop/goal/executor_test.go
@@ -218,6 +218,13 @@ func TestExecutorShouldMaterializeGoalParamsOnceBeforeEffects(t *testing.T) {
 		if len(judge.calls) != 1 {
 			t.Fatalf("judge calls = %d, want 1", len(judge.calls))
 		}
+		if judge.calls[0].Environment != binder.binds[0].EnvironmentValue() {
+			t.Fatalf(
+				"judge environment = %#v, want the materialized session environment %#v",
+				judge.calls[0].Environment,
+				binder.binds[0].EnvironmentValue(),
+			)
+		}
 		payload, ok := judge.calls[0].Criteria[0].Inputs["payload"].(map[string]any)
 		if !ok || payload["completed"] != true {
 			t.Fatalf("judge payload = %#v, want typed JSON object", judge.calls[0].Criteria[0].Inputs)

--- a/internal/loop/goal/executor_test.go
+++ b/internal/loop/goal/executor_test.go
@@ -165,6 +165,8 @@ func TestUsageTrackerShouldFailClosedOnOverflow(t *testing.T) {
 	})
 }
 
+// TestExecutorShouldMaterializeGoalParamsOnceBeforeEffects
+// Covers one-pass parameter resolution before session and judge effects.
 func TestExecutorShouldMaterializeGoalParamsOnceBeforeEffects(t *testing.T) {
 	t.Run("Should resolve Goal prompts and judge inputs without re-rendering input values", func(t *testing.T) {
 		t.Parallel()

--- a/internal/loop/goal/route.go
+++ b/internal/loop/goal/route.go
@@ -102,12 +102,17 @@ func (e *Executor) executeJudgeAttempt(
 	if attempt.Status != judgeAttemptStatusRunning {
 		return nil, fmt.Errorf("%w: Goal judge attempt status %q cannot execute", loop.ErrValidation, attempt.Status)
 	}
+	environment, err := loop.ResolveActionEnvironment(segment.params.Environment, segment.input.EnvironmentValue())
+	if err != nil {
+		return nil, fmt.Errorf("resolve Goal judge environment: %w", err)
+	}
 	judgeResult, evaluateErr := e.judge.EvaluateGoal(ctx, JudgeRequest{
-		AttemptID: attempt.AttemptID,
-		Key:       segment.key,
-		Turn:      attempt.Turn,
-		Criteria:  append([]dsl.GateCriterion(nil), segment.params.Judge...),
-		Result:    result,
+		Environment: environment,
+		AttemptID:   attempt.AttemptID,
+		Key:         segment.key,
+		Turn:        attempt.Turn,
+		Criteria:    append([]dsl.GateCriterion(nil), segment.params.Judge...),
+		Result:      result,
 	})
 	if evaluateErr != nil {
 		judgeResult = brokenJudgeResult(evaluateErr)

--- a/internal/loop/goal/route.go
+++ b/internal/loop/goal/route.go
@@ -76,6 +76,7 @@ func (e *Executor) judgeWorkTurn(
 	return e.executeJudgeAttempt(ctx, segment, result, attempt, operationBase)
 }
 
+// executeJudgeAttempt recovers or evaluates a durable attempt and records its sanitized verdict and usage.
 func (e *Executor) executeJudgeAttempt(
 	ctx context.Context,
 	segment *segmentState,

--- a/internal/loop/goal/types_judge.go
+++ b/internal/loop/goal/types_judge.go
@@ -67,11 +67,12 @@ type MarkJudgeAmbiguousRequest struct {
 
 // JudgeRequest carries the pinned criteria for one evaluator operation.
 type JudgeRequest struct {
-	AttemptID string
-	Key       TurnKey
-	Turn      int
-	Criteria  []dsl.GateCriterion
-	Result    loop.ActionPromptResult
+	Environment dsl.EnvironmentSpec
+	AttemptID   string
+	Key         TurnKey
+	Turn        int
+	Criteria    []dsl.GateCriterion
+	Result      loop.ActionPromptResult
 }
 
 // JudgeResult carries the evaluator verdict and nullable-token truth.

--- a/packages/site/content/docs/examples/implement-tasks-loop.mdx
+++ b/packages/site/content/docs/examples/implement-tasks-loop.mdx
@@ -177,7 +177,7 @@ graph:
           - Report exact commands and outcomes in the structured output.
 
           Tracking and commits:
-          - Update task checkboxes and status in {{ .item.path }} only after implementation,
+          - Write `status: completed` and update task checkboxes in {{ .item.path }} only after implementation,
             verification evidence, and self-review are complete.
           - Update .compozy/tasks/{{ .inputs.slug }}/_tasks.md only when this task is complete.
           - Keep tracking-only files out of automatic commits.
@@ -239,7 +239,7 @@ graph:
       class: control
       kind: route
       routes:
-        - when: "inputs.mode == 'orchestrated'"
+        - when: "inputs.mode == 'orchestrated' && size(nodes.load_tasks.output.tasks) > 0"
           to: orchestrate
       default: per_task_done
 
@@ -282,25 +282,24 @@ graph:
           - default: {{ json .inputs.default_runtime }}
 
           Return `status`, `summary`, and `tasks`, naming each task with the worker session id that
-          executed it. Use `complete` only when every task file carries `status: completed` in its
-          frontmatter and no conductor-created worker is starting, active, or stopping. If any
-          worker cannot be stopped, return `blocked`.
+          executed it. Task files must use `status: completed` after verification. Existing completion
+          aliases `complete`, `done`, and `finished` are also recognized by the task importer and
+          judge; do not dispatch those tasks again. Only `pending` and `in_progress` need work;
+          an unknown status requires correction before dispatch.
+
+          The Goal JSON result is separate from task frontmatter: return `{"status":"complete"}`
+          only after the task importer reports no pending tasks and no conductor-created worker
+          is starting, active, or stopping. If any worker cannot be stopped, return `blocked`.
         judge:
           - id: tasks_completed
+            type: extension
+            tool: ext__spec_cycle__import_tasks
+            inputs:
+              pattern: ".compozy/tasks/{{ .inputs.slug }}/task_*.md"
+          - id: workers_stopped
             type: command
             check: >-
               slug={{ .inputs.slug | shellQuote }};
-              task_dir=".compozy/tasks/$slug";
-              set -- "$task_dir"/task_*.md;
-              [ -e "$1" ] || exit 1;
-              for f in "$@"; do
-              awk '
-              NR == 1 { if ($0 != "---") exit 1; frontmatter = 1; next }
-              frontmatter && $0 == "---" { frontmatter = 0; found_end = 1; next }
-              frontmatter && /^status:/ { status_count++; completed = ($0 == "status: completed") }
-              END { if (!found_end || status_count != 1 || !completed) exit 1 }
-              ' "$f" || exit 1;
-              done;
               for state in starting active stopping; do
               sessions="$("$COMPOZY_BIN" session list --type spawned --state "$state" --query "orchestrate-${slug}-" --limit 1 -o jsonl)" || exit 1;
               if printf '%s\n' "$sessions" | grep -q '"id"[[:space:]]*:'; then exit 1; fi;
@@ -458,3 +457,16 @@ review Loop it declares no webhook start, so a signed HTTP delivery cannot begin
     meta="Bundled"
   />
 </GuideGrid>
+
+## Task completion and reruns
+
+Write `status: completed` after implementation and verification. The task importer also recognizes
+`complete`, `done`, and `finished`, ignoring case and surrounding whitespace. YAML quoting and
+inline comments do not change the meaning. Only `pending` and `in_progress` are dispatched;
+unknown or missing statuses produce validation errors before any task worker starts.
+
+The completion judge calls `ext__spec_cycle__import_tasks`, the same parser used to load the task
+graph. Its additive `passed` result is true when `count` is zero. A separate command judge verifies
+that spawned workers have stopped. Rerunning an already-finished task set starts no task workers.
+Files are read without rewriting existing status values, and no database or configuration migration
+is needed. The Goal JSON result retains `complete|blocked`; workers write `completed` in task files.

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -663,7 +663,7 @@ The `implementer` input selects the worker Agent for both paths and defaults to 
 The default path imports the task graph and runs one isolated action with that Agent per task. The
 orchestrated path runs the bundled `orchestrator` Agent continuously and instructs it to follow
 `cy-orchestrate-tasks`: start one bounded worker with the selected Agent per task, dispatch a
-blocking prompt, accept only `status: completed` on disk, and stop the worker on every path.
+blocking prompt, verify completion on disk and its evidence, and stop the worker on every path.
 
 Four optional runtime inputs select `orchestrator_runtime`, `backend_runtime`, `frontend_runtime`,
 and `default_runtime`. The category match uses exact task frontmatter type; all other types use the
@@ -671,9 +671,16 @@ default. Empty inputs fall through to agent and config defaults. Task frontmatte
 the category input field by field. The conductor passes every supplied provider, model, reasoning,
 and speed value through `compozy spawn`.
 
-A command judge passes only when every `.compozy/tasks/<slug>/task_*.md` carries
-`status: completed` and no conductor-created worker survives. The Goal's result uses status
-`complete|blocked`; task frontmatter continues to use `completed`.
+The task importer and extension completion judge share one YAML parser over the manifest's task
+files. Write `status: completed`; existing `complete`, `done`, and `finished` values also count as
+completed, ignoring case and surrounding whitespace. Only `pending` and `in_progress` are queued.
+Unknown or missing states fail validation before dispatch. Importing reads files without rewriting
+them, and rerunning a finished task set dispatches no task workers.
+
+`ext__spec_cycle__import_tasks` returns `tasks`, `count`, and `passed`; `passed` is true exactly when
+the valid task set contains no unfinished tasks. The Goal's extension judge consumes that verdict;
+a separate command judge checks that no conductor-created worker survives. The Goal JSON result
+uses `complete|blocked`, independently of task frontmatter.
 
 ## Agent-Authored Review and Fix
 


### PR DESCRIPTION
## What & why

Fixes #565.

Rerunning `implement-tasks` could dispatch an already-finished task when its frontmatter said
`status: complete`. The importer recognized `completed`, `done`, and `finished`, while the
orchestrated Goal's AWK judge recognized only the literal line `status: completed`. Quoted YAML,
comments, and the accepted aliases could therefore disagree between loading and judging.

The task YAML parser now owns completion normalization. `completed`, `complete`, `done`, and
`finished` all normalize to the canonical completed state, ignoring surrounding whitespace and
case. Only the documented unfinished states `pending` and `in_progress` enter the queue. Unknown
states produce a visible invalid-input diagnostic before any task is dispatched. Missing states
remain validation errors. Task files and manifest topology are read without being rewritten.

The existing `ext__spec_cycle__import_tasks` tool adds `passed`, true exactly when a valid task set
contains no unfinished tasks. The bundled Goal calls that tool as its extension judge, eliminating
the independent AWK status parser. A separate command criterion retains the stopped-worker check.
An empty task list now bypasses the orchestrated conductor entirely, so a finished rerun cannot
start another conductor or create more workers. Writer prompts and bundled skills require canonical `status: completed`; the Goal's public JSON
result remains `complete|blocked` and is explicitly distinguished from task frontmatter.

The Goal passes its materialized execution environment to the judge, using the same existing
resolver as session binding (including node overrides). The extension judge receives that trusted worktree root under the existing
worktree usage lease, including `per_run` trees resolved through the binder's existing run/generation/node/item identity. Judging never creates another worktree. Without this internal plumbing, a worktree-only task set would be loaded from
the right tree but judged against the primary workspace. The lease is released on every evaluation
exit and the existing extension path validation remains authoritative.

Implemented and locally reviewed by Codex, GPT-6-Astra at high reasoning. The local review covers
YAML, JSON, Markdown, prompt/skill semantics, and Go; the repository's CodeRabbit filters exclude
several of those artifact types.

## How you verified it

- Red reproduction in the existing importer suite: `complete` was reimported and unknown states
  produced no error. The same cases pass after the production fix.
- `CGO_ENABLED=1 mise exec -- go test -race ./extensions/spec-cycle -count=1` passed, including
  parser ordering/filtering, RPC output/error contracts, embedded schema digests, real extension
  evaluation of the shipped judge, YAML aliases/quoting/comments, and worker-settlement rejection.
- Focused race-enabled `internal/loop/gate` and `internal/daemon` Goal tests passed.
- `mise exec -- make codegen` and `mise exec -- make codegen-check` passed without generated drift.
- `CGO_ENABLED=1 GOMAXPROCS=4 mise exec -- go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EImplementTasksShouldCompleteTaskJourney$' -count=1 -timeout=10m -parallel=4 -p=1 -artifacts` passed all seven cases (87.429s). The runner used the shared machine verification lock. It proves per-task mixed/finished reruns, no new orchestrated conductor/workers on finished rerun, original category/Agent/Profile/worktree journeys, and Goal extension approval/rejection from opposite selected-root status content.
- `GOMAXPROCS=4 mise exec -- bunx turbo run test --filter=./packages/site -- lib/__tests__/runtime-docs-truth.test.ts` passed all 15 tests; the root codegen-check dependency also passed.
- Equivalent repository pre-commit tasks passed with `lint-staged --no-stash --no-hide-partially-staged --concurrent false`. All owned files are fully staged; no repository/global hook configuration is changed.
- The focused real-daemon selected-root re-walk passed all three combinations, including a node `root` override over the Loop worktree default (36.782s), using the same command with `/Should_judge_task_completion_in_the_selected_worktree_instead_of_the_main_workspace$` appended to `-run`. Evidence: `.cache/issue-565/e2e-root-precedence.log`; clean targeted teardown at `2026-09-09T16:59:50Z`.
- `COMPOZY_GO_TEST_P=1 COMPOZY_GO_LINT_CONCURRENCY=2 GOMAXPROCS=4 mise exec -- make gate` passed: lint **0 issues**, all affected race-enabled extension/daemon/Loop/skill suites green (go-test lane 341s). The final content refresh also passed (6s lint, 4s cached race suites), recorded in `.cache/issue-565/gate-current.log`.
- Greptile remediation: a real `per_run` scenario first reproduced `exhausted` instead of `done` when the committed worktree was complete and the primary workspace was pending. The same assertions then passed all five selected-root/precedence combinations (31.057s), including per-run approval and rejection. Evidence: `.cache/issue-565/e2e-per-run-{red,green}.log`; targeted teardown was clean at `2026-09-09T17:12:37Z`.
- CodeRabbit follow-up: documented the changed function contracts and retained local executable/template checks for YAML/Markdown excluded by its filters. Per the owner's publication instruction, the remediation uses focused runtime evidence and the current-head CI gates instead of repeating the broad local gate.
- Initial locally gated commit: `f7e421ca6dae3df88d647f1fe8167b13f34a01c4`. Local evidence: `.cache/issue-565/{e2e-round4,site-docs-final,gate-final,precommit-check}.log`; isolated runtime artifacts under `/private/tmp/compozy-iso-565-drmtph/artifacts`, with `teardown.json` reporting `clean: true` and no survivors.

QA scenario: `docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md`. The runtime walk uses the
existing real daemon/CLI/SQLite/extension/Loop harness with the ACP provider running as a subprocess.
It does not claim a fresh live-model/provider validation or a browser walk. The isolated runtime
uses dedicated temporary homes and sockets; no operator home or credentials are used.

Observed baseline limitation: an additional orchestrated-worktree journey failed **before the
judge** with `acp: create terminal: invalid terminal cwd "<home>/worktrees/001/issue-512": outside
workspace`. The unchanged `internal/sandbox/local/provider.go:99` creates the supplied ACP host's
`LocalTerminalScope` without `AllowedRoots`; `internal/acp/terminal.go` uses that supplied local host,
and `internal/terminal/manager_open.go:348` consequently permits only the primary workspace. The
same omission is present in this branch's base HEAD. Reproduce by running the existing worktree-only
journey's task pack with `mode=orchestrated` and its conductor fixture. The failed attempt is retained
in `e2e-round3.log` and daemon artifacts under `/private/tmp/compozy-iso-565-drmtph/artifacts`; targeted
teardown reports `clean: true`. This PR does not modify terminal authorization or claim that broader
journey passed. The original journeys remain intact; the selected-root invariant has a focused
real-daemon Goal/extension scenario with opposite status content in the two roots.

Current remediation head: `dcaa872faa90337679a69a426a6e3c6720d2d812`.

## Impact

Cross-surface audit, following `docs/_memory/change-impact.md`:

| Surface | Change and compatibility |
| --- | --- |
| Native tools | Existing `ext__spec_cycle__import_tasks` ID, input, read-only risk, and permissions remain. Output gains the boolean `passed`; its runtime schema, manifest schema, and pinned digest co-ship. Existing `tasks` and `count` semantics are preserved. Invalid task statuses now stop before dispatch instead of silently becoming work. No CLI verb or HTTP/UDS route changes. |
| Extensions, hooks, config | The bundled implement-tasks Goal uses the existing extension-judge mechanism plus its existing worker-stop command. No hooks, config keys, provider settings, dependencies, or extension SDK interface changes. |
| Workspace isolation | Task files remain workspace-owned and unchanged on disk. Both import and extension judging use the selected execution root; worktree judging acquires/releases the existing usage lease and retains path containment checks. No database/schema migration or user-state rewrite. |
| Official skill | `skills/compozy/references/loops.md` describes completion aliases, validation, `passed`, and reruns. Bundled conductor/task metadata guidance and the orchestrator Agent use the same contract. |
| Web and Docs | No Web route, component, cache, or DTO changes. The site example co-ships the executable Loop and explains the status contract. The affected QA scenario records runtime evidence and its scope. |

Existing supported task formats and completion aliases are retained; `complete` becomes an accepted
completion alias. Unknown task states were not part of the documented task format. There are no
removed public surfaces or migration requirements under SD-013. Immutable prior Loop definition
snapshots and historical execution records are preserved.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task completion now recognizes common status variants such as “done,” “finished,” and “complete,” including differences in capitalization and spacing.
  * Orchestrated task evaluation now combines task-import results with worker completion checks.
  * Completion checks use the correct workspace context for each run.

* **Bug Fixes**
  * Already completed tasks are skipped during task imports.
  * Invalid task statuses now produce clear, actionable validation errors.
  * Task-import results now report whether all tasks passed and enforce valid result counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->