### PR TITLE
fix: preserve provider command routing for spawned sessions

### DIFF
--- a/docs/qa/reports/2026-09-09-issue-564-provider-routing.md
+++ b/docs/qa/reports/2026-09-09-issue-564-provider-routing.md
@@ -1,0 +1,77 @@
+# Issue #564: spawned provider command routing
+
+## Scope and result
+
+The Session Manager reproducer selected global command A instead of creator command B for a
+commandless child, including an explicit same-provider selection. Explicit child command C and a
+different provider already worked. The fix preserves those overrides and inherits B only across
+compatible native CLI routing within the same workspace and profile, with operator-home policy.
+
+A live session retains its resolved command in memory. Resume with a stopped creator resolves the
+existing lineage against current configuration. Deleted creator metadata retains the child's
+configured fallback with an explicit `session.provider_route.creator_unavailable` log. No raw
+commands or credentials are added to persisted metadata.
+
+Startup failures now record the existing provider failure marker after canonical error/stop events.
+Provider failure markers and session logs carry a SHA-256 command fingerprint. The selected-route
+log has exactly one authoritative fingerprint, computed before adapter command rewriting. A
+fingerprint identifies command configuration, not a provider account, login success, or profile.
+Expected unsupported/missing ACP session loads retain their existing replay recovery markers,
+without inserting a transient startup failure into the replay transcript.
+
+## Executed evidence
+
+- A fixed Go overlay disabling only the inheritance call reproduced two expected failures in
+  `TestSpawnProviderCommandPrecedence`: actual `account-a`, expected `account-b`. The three explicit
+  override/different-provider cases passed.
+- `CGO_ENABLED=1 go test -race ./internal/session -run
+  'TestSpawnProviderCommandPrecedence|TestPromptGenericFailureKeepsSessionActive|TestPromptRuntimeReplacementLifecycle'
+  -count=1` passed.
+- `CGO_ENABLED=1 go test -race -tags=integration ./internal/session -run
+  'TestManagerIntegrationSpawnProviderCommandRouting|TestManagerIntegrationProviderPersistsAcrossCreateStatusListAndResume|TestManagerIntegrationFullStopResumeStopPersistsStopReasons'
+  -count=1` passed in 11.414s. The existing integration suite launched real ACP helper subprocesses
+  through account-labelled wrapper executables and used real SQLite. Files written by the executed
+  wrappers proved B/B/C, no A launch for those sessions, and successful child resume with both live
+  and stopped creators. Editing the creator definition after launch did not change its live route.
+- `CGO_ENABLED=1 mise exec -- go test -race ./internal/session -run
+  'TestSpawnProviderCommandPrecedence|TestSpawnProviderRouteDiagnostics|TestPromptGenericFailureKeepsSessionActive'
+  -count=1` passed in 10.888s after the startup-marker fix. It checks isolated-home/environment
+  boundaries, durable authentication-error recovery, startup failure retention, JSON log key
+  uniqueness, matching route fingerprints, and absence of the private command value in logs.
+- A broad uncapped `internal/session` race run had one one-second stop-deadline failure in
+  `TestStopWithCauseLifecycle/Should_escalate_and_verify_exit_after_driver_stop_failure` under host
+  contention. That unchanged case passed three isolated repetitions in 11.209s. No assertion or
+  timeout was changed. The required scoped gate remains the delivery authority.
+
+The final combined verification used `GOMAXPROCS=4 CGO_ENABLED=1 mise exec -- go test -race
+-p=1 -parallel=4 -tags=integration ./internal/session` with the six focused tests listed above
+(`TestSpawnProviderCommandPrecedence`, `TestSpawnProviderRouteDiagnostics`,
+`TestPromptGenericFailureKeepsSessionActive`, and the three integration tests), `-count=1`.
+It passed in 16.902s after the final routing-helper extraction and foreign-workspace case.
+The targeted teardown was repeated afterward and remained clean.
+
+The scoped gate exposed a replay regression from recording transient ACP load negotiation as a
+provider transcript failure. Production marker emission was corrected; existing replay assertions
+were unchanged. `GOMAXPROCS=4 CGO_ENABLED=1 mise exec -- go test -race -p=1 -parallel=4
+./internal/session -run
+'TestResumeReplayFallback|TestSpawnProviderRouteDiagnostics|TestPromptRuntimeReplacementLifecycle'
+-count=1` then passed in 8.166s. This also verifies the final launch-time log and failed replacement
+correlation: the failure identifies the attempted route while the prior runtime binding survives.
+
+The test convention checker accepts the changed spawn suite. The other three existing test files
+report the same pre-existing findings as their HEAD versions; the changed cases use parallel
+`Should ...` subtests. Unrelated tests were preserved.
+
+## Isolation and limits
+
+The integration run used a uniquely allocated `issue-564-provider-routing` envelope, separate from
+operator Compozy state, and each harness owned temporary directories and subprocess cleanup. The
+run did not log in, log out, copy credentials, or change operator accounts. Targeted envelope
+teardown is retained in `.cache/issue-564/teardown.json` with `clean: true`, no survivors,
+and no processes requiring forced termination.
+
+The account-labelled processes are controlled ACP fixtures. This proves command routing through
+the real process boundary; it does not claim live two-account OAuth refresh or provider-service
+availability. Prompt authentication failure is exercised at the unit I/O boundary. Web rendering
+and unrelated wake/attention journeys were not repeated; the broader scenario's prior status is
+unchanged. PR delivery additionally requires current-head CI and both bot review dispositions.

--- a/docs/qa/scenarios/RT-session-spawn-wake.md
+++ b/docs/qa/scenarios/RT-session-spawn-wake.md
@@ -30,3 +30,26 @@ cleanup. The focused lifecycle contract verifies one clean stopped wake; a provi
 public-surface walk remains blocked pending an isolated ACP provider and human verification.
 
 QA 2026-08-16 Herdr parity: The isolated browser journey, focused attention Playwright lane, and full Web E2E exercised cross-workspace landing, permission resolution, counts, channel suppression, task canary, catalog scope/order, finished presence clearing, and honest quiet/stale states. The lab browser exposed its real notification capability; deterministic granted and denied branches ran in the canonical browser suite.
+
+### Provider routing regression (issue #564)
+
+Use one isolated workspace with global native provider command A, creator command B, a commandless
+child, and an explicit child command C. Check that the actual ACP processes launch B/B/C, including
+when the creator definition changes after its process starts. Change the selected provider and
+confirm its own command wins. Change the child home/environment policy and confirm inheritance does
+not override that boundary. Resume the child with a live and a stopped creator.
+
+Spawn acceptance is not proof of future prompt authentication. Inject a provider authentication
+failure at the ACP boundary and inspect the durable error and provider failure marker. Its
+`provider_command_fingerprint` must match the selected route; the logical session remains available
+for a later recovery prompt. Raw commands and account-directory values must not appear in markers.
+
+Owning automated evidence: `TestSpawnProviderCommandPrecedence`,
+`TestManagerIntegrationSpawnProviderCommandRouting`, and
+`TestPromptGenericFailureKeepsSessionActive`. The integration case executes real ACP subprocesses
+with isolated routing wrappers and SQLite; the controlled routes are not live OAuth accounts.
+
+Routing-slice verification: [2026-09-09 issue #564 report](../reports/2026-09-09-issue-564-provider-routing.md).
+`TestSpawnProviderRouteDiagnostics` additionally verifies that a startup auth failure is stopped,
+retained for inspection, and correlated with exactly one fingerprint per selected/error JSON log.
+This slice does not replace the unrelated wake-delivery walkthroughs above.

--- a/internal/session/manager_helpers.go
+++ b/internal/session/manager_helpers.go
@@ -174,6 +174,7 @@ func (m *Manager) rollbackActivation(session *Session, proc *AgentProcess, now t
 	return m.driver.Stop(stopCtx, proc)
 }
 
+// sessionLogger identifies the bound route, which can differ from an attempted replacement route.
 func (m *Manager) sessionLogger(session *Session) *slog.Logger {
 	logger := m.logger
 	if logger == nil {

--- a/internal/session/manager_helpers.go
+++ b/internal/session/manager_helpers.go
@@ -184,7 +184,8 @@ func (m *Manager) sessionLogger(session *Session) *slog.Logger {
 	}
 
 	info := session.Info()
-	return logger.With("session_id", info.ID, "agent_name", info.AgentName, "provider", info.Provider)
+	return logger.With("session_id", info.ID, "agent_name", info.AgentName, "provider", info.Provider,
+		"provider_command_fingerprint", providerCommandFingerprint(session.providerRoutingSnapshot().Command))
 }
 
 func derefString(value *string) string {

--- a/internal/session/manager_lifecycle.go
+++ b/internal/session/manager_lifecycle.go
@@ -316,6 +316,7 @@ func sessionStoppedTranscriptMarker(event acp.AgentEvent) (string, string, map[s
 	}
 }
 
+// persistFailedStart retains failed sessions so asynchronous startup errors remain inspectable.
 func (m *Manager) persistFailedStart(
 	ctx context.Context,
 	session *Session,
@@ -359,6 +360,7 @@ func (m *Manager) notifyFailedStart(ctx context.Context, session *Session) {
 	m.notifier.OnSessionStopped(ctx, session)
 }
 
+// recordFailedStartEvents keeps recoverable ACP load negotiation out of the replay transcript.
 func (m *Manager) recordFailedStartEvents(
 	ctx context.Context,
 	session *Session,
@@ -397,8 +399,6 @@ func (m *Manager) recordFailedStartEvents(
 	); err != nil {
 		return err
 	}
-	// Unsupported or missing ACP sessions recover through the existing context replay path.
-	// Keep that negotiation failure out of the transcript being replayed.
 	if acp.IsLoadSessionResourceMissing(startErr) || errors.Is(startErr, acp.ErrAgentDoesNotSupportSession) {
 		return nil
 	}

--- a/internal/session/manager_lifecycle.go
+++ b/internal/session/manager_lifecycle.go
@@ -344,7 +344,7 @@ func (m *Manager) persistFailedStart(
 	var errs []error
 	errs = appendLifecycleErr(errs, bundleErr)
 	errs = appendLifecycleErr(errs, m.persistSessionLifecycleState(ctx, session, true))
-	errs = appendLifecycleErr(errs, m.recordFailedStartEvents(ctx, session, failure, summary, stopReason))
+	errs = appendLifecycleErr(errs, m.recordFailedStartEvents(ctx, session, failure, startErr, stopReason))
 	if notify {
 		m.notifyFailedStart(ctx, session)
 	}
@@ -363,7 +363,7 @@ func (m *Manager) recordFailedStartEvents(
 	ctx context.Context,
 	session *Session,
 	failure *store.SessionFailure,
-	summary string,
+	startErr error,
 	stopReason store.StopReason,
 ) error {
 	turnID, err := m.newPromptTurnID()
@@ -374,6 +374,7 @@ func (m *Manager) recordFailedStartEvents(
 	if err != nil {
 		return err
 	}
+	summary := failureSummary(failure, startErr.Error())
 	now := m.now()
 	errorEvent := m.normalizeEvent(session, turnID, acp.AgentEvent{
 		Type:      acp.EventTypeError,
@@ -390,10 +391,21 @@ func (m *Manager) recordFailedStartEvents(
 		Error:      summary,
 		Failure:    store.CloneSessionFailure(failure),
 	})
-	return errors.Join(
+	if err := errors.Join(
 		m.recordEvent(ctx, session, errorEvent),
 		m.recordEvent(ctx, session, stopEvent),
-	)
+	); err != nil {
+		return err
+	}
+	// Unsupported or missing ACP sessions recover through the existing context replay path.
+	// Keep that negotiation failure out of the transcript being replayed.
+	if acp.IsLoadSessionResourceMissing(startErr) || errors.Is(startErr, acp.ErrAgentDoesNotSupportSession) {
+		return nil
+	}
+	if kind, summary, evidence, ok := sessionStoppedTranscriptMarker(stopEvent); ok {
+		return m.recordTranscriptMarker(ctx, session, stopTurnID, kind, summary, evidence)
+	}
+	return nil
 }
 
 func (m *Manager) closeSessionRecorder(session *Session) error {

--- a/internal/session/manager_prompt_contract_test.go
+++ b/internal/session/manager_prompt_contract_test.go
@@ -767,6 +767,11 @@ func TestPromptGenericFailureKeepsSessionActive(t *testing.T) {
 			if err != nil || replayed.ProviderError == nil || replayed.ProviderError.Code != code {
 				t.Fatalf("replayed provider error = %#v, error = %v", replayed.ProviderError, err)
 			}
+			marker := requireTranscriptMarker(t, h.manager, session.ID, transcript.MarkerProviderFailure)
+			wantFingerprint := providerCommandFingerprint(h.driver.startCalls[0].Command)
+			if got := marker.Evidence["provider_command_fingerprint"]; got != wantFingerprint {
+				t.Fatalf("provider failure route = %v, want %s", got, wantFingerprint)
+			}
 		})
 	}
 	t.Run("Should keep generic prompt failures active", func(t *testing.T) {

--- a/internal/session/manager_prompt_runtime.go
+++ b/internal/session/manager_prompt_runtime.go
@@ -131,6 +131,7 @@ func (m *Manager) configurePromptRuntime(
 	return nil
 }
 
+// replacePromptRuntime keeps the previous route authoritative until the new binding commits.
 func (m *Manager) replacePromptRuntime(
 	ctx context.Context,
 	session *Session,
@@ -244,6 +245,7 @@ func (m *Manager) stopReplacedRuntime(session *Session, proc *AgentProcess, emit
 	return nil
 }
 
+// preparePromptRuntimePlan leaves the running binding unchanged until the selected plan is applied.
 func (m *Manager) preparePromptRuntimePlan(
 	ctx context.Context,
 	session *Session,

--- a/internal/session/manager_prompt_runtime.go
+++ b/internal/session/manager_prompt_runtime.go
@@ -176,6 +176,7 @@ func (m *Manager) replacePromptRuntime(
 		return nil, errors.Join(err, restoreErr, stopErr)
 	}
 
+	session.setProviderRouting(runtime.agent)
 	if plan.spec.resumeReplay {
 		m.stageResumeReplay(session.ID, plan.spec.resumeReplayBlock)
 	}
@@ -282,7 +283,7 @@ func (m *Manager) preparePromptRuntimePlan(
 	spec.reasoningEffort = selection.ReasoningEffort
 	spec.speed = selection.Speed
 	spec.acpOptions = acp.CloneSessionConfigOptionSelections(selection.ACPOptions)
-	runtime, err := m.resolveSessionStartRuntime(&spec)
+	runtime, err := m.resolveSessionStartRuntime(ctx, &spec)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/session/manager_start.go
+++ b/internal/session/manager_start.go
@@ -110,6 +110,7 @@ func (m *Manager) startSession(ctx context.Context, spec *sessionStartSpec) (_ *
 	return accepted.session, nil
 }
 
+// startAgentProcess attributes launch failures to the attempted route rather than the previous binding.
 func (m *Manager) startAgentProcess(
 	ctx context.Context,
 	spec *sessionStartSpec,

--- a/internal/session/manager_start.go
+++ b/internal/session/manager_start.go
@@ -116,10 +116,12 @@ func (m *Manager) startAgentProcess(
 	session *Session,
 	startOpts acp.StartOpts,
 ) (*AgentProcess, error) {
+	logger := spec.startLogger(m).With("resolved_provider", startOpts.ProviderName)
+	logger.Info("session.provider_route.selected", "phase", spec.startAction)
 	transportStarted := time.Now()
 	proc, err := m.driver.Start(ctx, startOpts)
 	if err != nil {
-		m.sessionLogger(session).Warn("session.start.driver_start_failed", "phase", spec.startAction, "error", err)
+		logger.Warn("session.start.driver_start_failed", "phase", spec.startAction, "error", err)
 		m.logSandboxTransport(session, sandboxEventTransportError, err, time.Since(transportStarted))
 		return proc, startupFailure(
 			"agent runtime startup failed",

--- a/internal/session/manager_start_accept.go
+++ b/internal/session/manager_start_accept.go
@@ -17,6 +17,7 @@ type acceptedSessionStart struct {
 	persistFailure bool
 }
 
+// acceptSessionStart resolves routing before persistence so invalid configuration cannot create sessions.
 func (m *Manager) acceptSessionStart(
 	acceptCtx context.Context,
 	runBaseCtx context.Context,

--- a/internal/session/manager_start_accept.go
+++ b/internal/session/manager_start_accept.go
@@ -29,7 +29,7 @@ func (m *Manager) acceptSessionStart(
 		return nil, errors.New("session: start spec is required")
 	}
 
-	runtime, err := m.resolveSessionStartRuntime(spec)
+	runtime, err := m.resolveSessionStartRuntime(acceptCtx, spec)
 	if err != nil {
 		spec.startLogger(m).Warn(
 			"session.start.runtime_prepare_failed",

--- a/internal/session/manager_start_runtime.go
+++ b/internal/session/manager_start_runtime.go
@@ -11,6 +11,7 @@ import (
 )
 
 func (m *Manager) resolveSessionStartRuntime(
+	ctx context.Context,
 	spec *sessionStartSpec,
 ) (sessionStartRuntime, error) {
 	artifacts, err := m.resolveWorkspaceAgentArtifactsForSession(spec.agentName, spec.sessionType, &spec.workspace)
@@ -23,6 +24,10 @@ func (m *Manager) resolveSessionStartRuntime(
 	})
 	if err != nil {
 		return sessionStartRuntime{}, fmt.Errorf("session: resolve session agent %q: %w", spec.agentName, err)
+	}
+	resolved, err = m.resolveSpawnProviderCommand(ctx, spec, agentDef, resolved, map[string]bool{spec.sessionID: true})
+	if err != nil {
+		return sessionStartRuntime{}, err
 	}
 	resolved.ProfileName = strings.TrimSpace(spec.workspace.ProfileName)
 	if err := spec.validateRuntimeOverrides(); err != nil {
@@ -47,6 +52,7 @@ func (m *Manager) resolveSessionStartRuntime(
 			err,
 		)
 	}
+	spec.commandFingerprint = providerCommandFingerprint(resolved.Command)
 	return sessionStartRuntime{
 		agent:               resolved,
 		agentDef:            compozyconfig.CloneAgentDef(agentDef),
@@ -156,5 +162,6 @@ func (s *sessionStartSpec) startLogger(m *Manager) *slog.Logger {
 		"agent_name", strings.TrimSpace(s.agentName),
 		"provider", strings.TrimSpace(s.provider),
 		"workspace_id", strings.TrimSpace(s.workspace.ID),
+		"provider_command_fingerprint", s.commandFingerprint,
 	)
 }

--- a/internal/session/manager_start_runtime.go
+++ b/internal/session/manager_start_runtime.go
@@ -10,6 +10,7 @@ import (
 	compozyconfig "github.com/compozy/compozy/internal/config"
 )
 
+// resolveSessionStartRuntime fingerprints the configured command before adapter rewriting.
 func (m *Manager) resolveSessionStartRuntime(
 	ctx context.Context,
 	spec *sessionStartSpec,
@@ -152,6 +153,7 @@ func (s *sessionStartSpec) validateRuntimeOverrides() error {
 	return ValidateReasoningEffort(reasoningEffort)
 }
 
+// startLogger retains the attempted route even while an existing session holds its previous binding.
 func (s *sessionStartSpec) startLogger(m *Manager) *slog.Logger {
 	logger := slog.Default()
 	if m != nil && m.logger != nil {

--- a/internal/session/manager_start_session.go
+++ b/internal/session/manager_start_session.go
@@ -9,6 +9,7 @@ import (
 	"github.com/compozy/compozy/internal/store"
 )
 
+// newStartingSession retains routing in memory so later configuration edits cannot redirect children.
 func (s *sessionStartSpec) newStartingSession(
 	resolved compozyconfig.ResolvedAgent,
 	agentDef compozyconfig.AgentDef,

--- a/internal/session/manager_start_session.go
+++ b/internal/session/manager_start_session.go
@@ -43,6 +43,7 @@ func (s *sessionStartSpec) newStartingSession(
 		creationOptions:  cloneCreationOptions(s.creationOptions),
 		creationIdentity: cloneCreationIdentity(s.creationIdentity), sessionDir: storage.sessionDir,
 		metaPath: storage.metaPath, dbPath: storage.dbPath, recorder: storage.recorder,
+		providerRoute:        resolved,
 		agentDef:             compozyconfig.CloneAgentDef(agentDef),
 		sandboxDestroyOnStop: !s.sandboxDisabled && s.workspace.Sandbox.DestroyOnStop,
 	}

--- a/internal/session/manager_start_types.go
+++ b/internal/session/manager_start_types.go
@@ -23,6 +23,7 @@ type sessionStartSpec struct {
 	sessionName              string
 	agentName                string
 	provider                 string
+	commandFingerprint       string
 	model                    string
 	transportModel           string
 	reasoningEffort          string

--- a/internal/session/manager_stop_integration_test.go
+++ b/internal/session/manager_stop_integration_test.go
@@ -1027,3 +1027,99 @@ func waitForStubbornSessionPrompts(ctx context.Context, t *testing.T, path strin
 		}
 	}
 }
+
+func TestManagerIntegrationSpawnProviderCommandRouting(t *testing.T) {
+	t.Parallel()
+	t.Run("Should launch inherited and explicit native routes and preserve routing on resume", func(t *testing.T) {
+		t.Parallel()
+		routes := t.TempDir()
+		commands := map[string]string{}
+		for _, account := range []string{"a", "b", "c"} {
+			directory := filepath.Join(routes, account)
+			if err := os.MkdirAll(directory, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			wrapper := filepath.Join(directory, "provider")
+			script := "#!/bin/sh\n" + "touch " + shellquote.Join(
+				directory,
+			) + "/\"$COMPOZY_SESSION_ID\"\nexec " + sessionStopHelperCommand(
+				t,
+			) + "\n"
+			if err := os.WriteFile(wrapper, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			commands[account] = shellquote.Join(wrapper)
+		}
+		h := newRealACPIntegrationHarness(t, commands["a"])
+		workspace, err := h.resolver.Resolve(t.Context(), h.workspaceID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		provider := acpmock.ProviderConfig(commands["a"])
+		provider.AuthMode = compozyconfig.ProviderAuthModeNativeCLI
+		provider.NoneSecurity = ""
+		workspace.Config.Providers[acpmock.ProviderName] = provider
+		workspace.Agents = []compozyconfig.AgentDef{
+			{Name: "parent", Provider: acpmock.ProviderName, Command: commands["b"], Prompt: "Delegate."},
+			{Name: "child", Provider: acpmock.ProviderName, Prompt: "Review."},
+			{Name: "explicit", Provider: acpmock.ProviderName, Command: commands["c"], Prompt: "Review."},
+		}
+		h.resolver.upsert(&workspace)
+		parent, err := h.manager.Create(t.Context(), CreateOpts{AgentName: "parent", Workspace: h.workspaceID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { stopActiveIntegrationSession(t, h, parent.ID) })
+		workspace.Agents[0].Command = commands["c"]
+		h.resolver.upsert(&workspace)
+		child, err := h.manager.Spawn(
+			t.Context(),
+			SpawnOpts{ParentSessionID: parent.ID, AgentName: "child", TTL: time.Minute},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { stopActiveIntegrationSession(t, h, child.ID) })
+		explicit, err := h.manager.Spawn(
+			t.Context(),
+			SpawnOpts{ParentSessionID: parent.ID, AgentName: "explicit", TTL: time.Minute},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { stopActiveIntegrationSession(t, h, explicit.ID) })
+		for _, route := range []struct{ sessionID, account string }{{parent.ID, "b"}, {child.ID, "b"}, {explicit.ID, "c"}} {
+			if _, err := os.Stat(filepath.Join(routes, route.account, route.sessionID)); err != nil {
+				t.Fatalf("provider route %s/%s was not executed: %v", route.account, route.sessionID, err)
+			}
+			if _, err := os.Stat(filepath.Join(routes, "a", route.sessionID)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("global route unexpectedly executed for %s: %v", route.sessionID, err)
+			}
+		}
+		if err := h.manager.Stop(t.Context(), child.ID); err != nil {
+			t.Fatal(err)
+		}
+		resumed, err := h.manager.Resume(t.Context(), child.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := resumed.providerRoutingSnapshot().Command; got != commands["b"] {
+			t.Fatalf("resumed command = %q, want creator launch snapshot", got)
+		}
+		if err := h.manager.Stop(t.Context(), child.ID); err != nil {
+			t.Fatal(err)
+		}
+		if err := h.manager.Stop(t.Context(), parent.ID); err != nil {
+			t.Fatal(err)
+		}
+		workspace.Agents[0].Command = commands["b"]
+		h.resolver.upsert(&workspace)
+		resumed, err = h.manager.Resume(t.Context(), child.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := resumed.providerRoutingSnapshot().Command; got != commands["b"] {
+			t.Fatalf("resumed command = %q, want persisted creator route resolution", got)
+		}
+	})
+}

--- a/internal/session/manager_transcript_marker.go
+++ b/internal/session/manager_transcript_marker.go
@@ -3,6 +3,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/compozy/compozy/internal/transcript"
@@ -34,6 +35,13 @@ func (m *Manager) recordTranscriptMarker(
 	summary string,
 	evidence map[string]any,
 ) error {
+	if kind == transcript.MarkerProviderFailure && session != nil {
+		evidence = maps.Clone(evidence)
+		if evidence == nil {
+			evidence = make(map[string]any)
+		}
+		evidence["provider_command_fingerprint"] = providerCommandFingerprint(session.providerRoutingSnapshot().Command)
+	}
 	marker, err := transcript.NewMarker(kind, summary, m.now(), evidence)
 	if err != nil {
 		return fmt.Errorf("session: build transcript marker %q: %w", kind, err)

--- a/internal/session/manager_transcript_marker.go
+++ b/internal/session/manager_transcript_marker.go
@@ -27,6 +27,7 @@ func (m *Manager) emitTranscriptMarker(
 	}
 }
 
+// recordTranscriptMarker correlates provider failures without persisting raw command credentials.
 func (m *Manager) recordTranscriptMarker(
 	ctx context.Context,
 	session *Session,

--- a/internal/session/provider_lifecycle_test.go
+++ b/internal/session/provider_lifecycle_test.go
@@ -135,7 +135,8 @@ func TestPromptRuntimeReplacementLifecycle(t *testing.T) {
 	t.Run("Should preserve the prior binding and transcript when replacement startup fails", func(t *testing.T) {
 		t.Parallel()
 
-		h := newHarness(t)
+		logs := newCaptureLogHandler()
+		h := newHarness(t, WithLogger(slog.New(logs)))
 		session := createSession(t, h)
 		t.Cleanup(func() {
 			if err := h.manager.Stop(testutil.Context(t), session.ID); err != nil {
@@ -143,7 +144,17 @@ func TestPromptRuntimeReplacementLifecycle(t *testing.T) {
 			}
 		})
 
+		workspace, err := h.resolver.Resolve(t.Context(), h.workspaceID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		provider := workspace.Config.Providers["codex"]
+		provider.Command = "replacement-route"
+		workspace.Config.Providers["codex"] = provider
+		h.resolver.upsert(&workspace)
+
 		previous := session.Info()
+		previousRoute := session.providerRoutingSnapshot().Command
 		previousProcess := session.processHandle()
 		if previousProcess == nil {
 			t.Fatal("initial runtime process = nil")
@@ -158,7 +169,7 @@ func TestPromptRuntimeReplacementLifecycle(t *testing.T) {
 		}
 		h.driver.mu.Unlock()
 
-		_, err := h.manager.SendPrompt(testutil.Context(t), session.ID, SendPromptOpts{
+		_, err = h.manager.SendPrompt(testutil.Context(t), session.ID, SendPromptOpts{
 			Message: "This prompt must not become durable",
 			Runtime: &RuntimeSelection{Provider: "codex"},
 		})
@@ -171,6 +182,14 @@ func TestPromptRuntimeReplacementLifecycle(t *testing.T) {
 		}
 		if got := session.processHandle(); got != previousProcess {
 			t.Fatalf("runtime process after failed replacement = %p, want %p", got, previousProcess)
+		}
+		record, ok := logs.FindByMessage("session.start.driver_start_failed")
+		if !ok {
+			t.Fatal("missing replacement failure route log")
+		}
+		assertCapturedLogAttr(t, record, "provider_command_fingerprint", providerCommandFingerprint(provider.Command))
+		if got := session.providerRoutingSnapshot().Command; got != previousRoute {
+			t.Fatalf("failed replacement changed bound route to %q", got)
 		}
 		restored := readMeta(t, session.MetaPath())
 		if restored.Provider != previous.Provider || restored.Model != previous.Model ||

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -203,6 +203,7 @@ type Session struct {
 	creationProfile           *store.SessionCreationProfile
 	creationOptions           *store.SessionCreationOptions
 	creationIdentity          *store.SessionCreationIdentity
+	providerRoute             compozyconfig.ResolvedAgent
 	agentDef                  compozyconfig.AgentDef
 
 	sessionDir string

--- a/internal/session/spawn_provider.go
+++ b/internal/session/spawn_provider.go
@@ -1,0 +1,131 @@
+package session
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"strings"
+
+	compozyconfig "github.com/compozy/compozy/internal/config"
+)
+
+// resolveSpawnProviderCommand preserves native account routing within one authority scope.
+func (m *Manager) resolveSpawnProviderCommand(
+	ctx context.Context,
+	spec *sessionStartSpec,
+	agent compozyconfig.AgentDef,
+	resolved compozyconfig.ResolvedAgent,
+	visited map[string]bool,
+) (compozyconfig.ResolvedAgent, error) {
+	if normalizeSessionType(spec.sessionType) != SessionTypeSpawned || strings.TrimSpace(agent.Command) != "" ||
+		spec.lineage == nil ||
+		spec.lineage.ParentSessionID == "" ||
+		resolved.AuthMode != compozyconfig.ProviderAuthModeNativeCLI ||
+		resolved.HomePolicy != compozyconfig.ProviderHomePolicyOperator {
+		return resolved, nil
+	}
+	if current, ok := m.Get(spec.sessionID); ok {
+		route := current.providerRoutingSnapshot()
+		if compatibleSpawnProviderRoute(route, resolved) {
+			resolved.Command = route.Command
+			return resolved, nil
+		}
+	}
+	parentID := spec.lineage.ParentSessionID
+	if visited[parentID] {
+		return compozyconfig.ResolvedAgent{}, fmt.Errorf(
+			"session: invalid provider routing lineage for %q",
+			spec.sessionID,
+		)
+	}
+	visited[parentID] = true
+	parentRoute, err := m.creatorProviderRoute(ctx, spec, resolved.Provider, parentID, visited)
+	if err != nil {
+		return compozyconfig.ResolvedAgent{}, err
+	}
+	if compatibleSpawnProviderRoute(parentRoute, resolved) {
+		resolved.Command = parentRoute.Command
+	}
+	return resolved, nil
+}
+
+func (m *Manager) creatorProviderRoute(
+	ctx context.Context,
+	spec *sessionStartSpec,
+	provider string,
+	parentID string,
+	visited map[string]bool,
+) (compozyconfig.ResolvedAgent, error) {
+	if parent, ok := m.Get(parentID); ok {
+		info := parent.Info()
+		if info.Provider != provider || info.WorkspaceID != spec.workspace.ID || info.ProfileID != spec.profileID {
+			return compozyconfig.ResolvedAgent{}, nil
+		}
+		return parent.providerRoutingSnapshot(), nil
+	}
+	meta, err := m.readMetaWithContext(ctx, parentID)
+	if errors.Is(err, ErrSessionNotFound) {
+		spec.startLogger(m).Info("session.provider_route.creator_unavailable", "creator_session_id", parentID)
+		return compozyconfig.ResolvedAgent{}, nil
+	}
+	if err != nil {
+		return compozyconfig.ResolvedAgent{}, fmt.Errorf(
+			"session: resolve creator provider route for %q: %w",
+			spec.sessionID,
+			err,
+		)
+	}
+	if meta.Provider != provider || meta.WorkspaceID != spec.workspace.ID || meta.ProfileID != spec.profileID {
+		return compozyconfig.ResolvedAgent{}, nil
+	}
+	workspace, err := m.resolveResumeWorkspace(ctx, meta)
+	if err != nil {
+		return compozyconfig.ResolvedAgent{}, err
+	}
+	parentSpec, err := sessionStartSpecFromMeta(meta, &workspace, workspace.RootDir)
+	if err != nil {
+		return compozyconfig.ResolvedAgent{}, err
+	}
+	artifacts, err := m.resolveWorkspaceAgentArtifactsForSession(
+		parentSpec.agentName,
+		parentSpec.sessionType,
+		&workspace,
+	)
+	if err != nil {
+		return compozyconfig.ResolvedAgent{}, err
+	}
+	parentRoute, err := workspace.Config.ResolveSessionAgent(artifacts.Agent, meta.Provider)
+	if err != nil {
+		return compozyconfig.ResolvedAgent{}, err
+	}
+	return m.resolveSpawnProviderCommand(ctx, &parentSpec, artifacts.Agent, parentRoute, visited)
+}
+
+func compatibleSpawnProviderRoute(parent, child compozyconfig.ResolvedAgent) bool {
+	return strings.TrimSpace(parent.Command) != "" && parent.Provider == child.Provider &&
+		parent.AuthMode == child.AuthMode && parent.HomePolicy == child.HomePolicy &&
+		parent.EnvPolicy == child.EnvPolicy && parent.Harness == child.Harness &&
+		parent.RuntimeProvider == child.RuntimeProvider && parent.Transport == child.Transport &&
+		parent.BaseURL == child.BaseURL && parent.AuthStatusCmd == child.AuthStatusCmd &&
+		parent.AuthLoginCmd == child.AuthLoginCmd
+}
+
+func (s *Session) providerRoutingSnapshot() compozyconfig.ResolvedAgent {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.providerRoute
+}
+
+func (s *Session) setProviderRouting(resolved compozyconfig.ResolvedAgent) {
+	s.mu.Lock()
+	s.providerRoute = resolved
+	s.mu.Unlock()
+}
+
+func providerCommandFingerprint(command string) string {
+	if strings.TrimSpace(command) == "" {
+		return ""
+	}
+	return fmt.Sprintf("sha256:%x", sha256.Sum256([]byte(command)))
+}

--- a/internal/session/spawn_provider.go
+++ b/internal/session/spawn_provider.go
@@ -50,6 +50,7 @@ func (m *Manager) resolveSpawnProviderCommand(
 	return resolved, nil
 }
 
+// creatorProviderRoute uses live state because configuration edits must not redirect a running creator.
 func (m *Manager) creatorProviderRoute(
 	ctx context.Context,
 	spec *sessionStartSpec,
@@ -102,6 +103,7 @@ func (m *Manager) creatorProviderRoute(
 	return m.resolveSpawnProviderCommand(ctx, &parentSpec, artifacts.Agent, parentRoute, visited)
 }
 
+// compatibleSpawnProviderRoute prevents commands from crossing authentication or isolation boundaries.
 func compatibleSpawnProviderRoute(parent, child compozyconfig.ResolvedAgent) bool {
 	return strings.TrimSpace(parent.Command) != "" && parent.Provider == child.Provider &&
 		parent.AuthMode == child.AuthMode && parent.HomePolicy == child.HomePolicy &&
@@ -111,18 +113,21 @@ func compatibleSpawnProviderRoute(parent, child compozyconfig.ResolvedAgent) boo
 		parent.AuthLoginCmd == child.AuthLoginCmd
 }
 
+// providerRoutingSnapshot preserves launch-time routing despite later configuration changes.
 func (s *Session) providerRoutingSnapshot() compozyconfig.ResolvedAgent {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.providerRoute
 }
 
+// setProviderRouting must run only after the replacement binding is committed.
 func (s *Session) setProviderRouting(resolved compozyconfig.ResolvedAgent) {
 	s.mu.Lock()
 	s.providerRoute = resolved
 	s.mu.Unlock()
 }
 
+// providerCommandFingerprint correlates routes without exposing secret-bearing command text.
 func providerCommandFingerprint(command string) string {
 	if strings.TrimSpace(command) == "" {
 		return ""

--- a/internal/session/spawn_test.go
+++ b/internal/session/spawn_test.go
@@ -2,18 +2,23 @@ package session
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/compozy/compozy/internal/acp"
+	compozyconfig "github.com/compozy/compozy/internal/config"
 	hookspkg "github.com/compozy/compozy/internal/hooks"
 	"github.com/compozy/compozy/internal/network/participation"
 	speedpkg "github.com/compozy/compozy/internal/speed"
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/testutil"
+	"github.com/compozy/compozy/internal/transcript"
 	"github.com/compozy/compozy/internal/workspaceaccess"
 )
 
@@ -1262,4 +1267,190 @@ func (h *recordingSessionSpawnHooks) DispatchSpawnReaped(
 	payload hookspkg.SpawnReapedPayload,
 ) (hookspkg.SpawnReapedPayload, error) {
 	return payload, nil
+}
+
+func TestSpawnProviderCommandPrecedence(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name             string
+		childCommand     string
+		childProvider    string
+		override         string
+		want             string
+		isolatedHome     bool
+		isolatedEnv      bool
+		foreignWorkspace bool
+	}{
+		{name: "Should inherit the resolved creator command for the same provider", childProvider: "claude", want: "account-b"},
+		{name: "Should preserve an explicit child command", childProvider: "claude", childCommand: "account-c", want: "account-c"},
+		{name: "Should preserve inheritance with an explicit same provider selection", childProvider: "claude", override: "claude", want: "account-b"},
+		{name: "Should use the selected different provider command", childProvider: "claude", override: "codex", want: "test-acp-driver"},
+		{name: "Should preserve a named child with a different provider", childProvider: "codex", want: "test-acp-driver"},
+		{name: "Should keep isolated child home routing", childProvider: "claude", isolatedHome: true, want: "account-a"},
+		{name: "Should keep changed child environment routing", childProvider: "claude", isolatedEnv: true, want: "account-a"},
+		{name: "Should keep an authorized foreign workspace routing", childProvider: "claude", foreignWorkspace: true, want: "account-a"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := newHarness(t)
+			workspace, err := h.resolver.Resolve(t.Context(), h.workspaceID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			provider := workspace.Config.Providers["claude"]
+			provider.Command = "account-a"
+			workspace.Config.Providers["claude"] = provider
+			workspace.Agents = append(
+				workspace.Agents,
+				compozyconfig.AgentDef{
+					Name:     "parent",
+					Provider: "claude",
+					Command:  "account-b",
+					Prompt:   "Delegate work.",
+				},
+				compozyconfig.AgentDef{
+					Name:     "child",
+					Provider: tt.childProvider,
+					Command:  tt.childCommand,
+					Prompt:   "Review work.",
+				},
+			)
+			h.resolver.upsert(&workspace)
+			parent, err := h.manager.Create(t.Context(), CreateOpts{AgentName: "parent", Workspace: h.workspaceID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanupSessionStop(t, h, parent.ID)
+			if tt.isolatedHome {
+				provider.HomePolicy = compozyconfig.ProviderHomePolicyIsolated
+			}
+			if tt.isolatedEnv {
+				provider.EnvPolicy = compozyconfig.ProviderEnvPolicyIsolated
+			}
+			workspace.Config.Providers["claude"] = provider
+			if tt.foreignWorkspace {
+				workspace.ID = "ws-foreign"
+				h.manager.SetWorkspaceAccessPolicy(
+					&recordingSpawnWorkspaceAccessPolicy{decision: workspaceaccess.Decision{Allowed: true}},
+				)
+			}
+			h.resolver.upsert(&workspace)
+			child, err := h.manager.Spawn(
+				t.Context(),
+				SpawnOpts{
+					ParentSessionID: parent.ID,
+					AgentName:       "child",
+					Provider:        tt.override,
+					Workspace:       workspace.ID,
+					TTL:             time.Minute,
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanupSessionStop(t, h, child.ID)
+			if got := h.driver.startCalls[1].Command; got != tt.want {
+				t.Fatalf("spawn command = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpawnProviderRouteDiagnostics(t *testing.T) {
+	t.Parallel()
+	t.Run(
+		"Should correlate startup failure and selected route without duplicate keys or raw commands",
+		func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "routing.jsonl")
+			logFile, err := os.Create(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := logFile.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+			h := newHarness(t, WithLogger(slog.New(slog.NewJSONHandler(logFile, nil))))
+			workspace, err := h.resolver.Resolve(t.Context(), h.workspaceID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			command := "env ROUTING_TEST_SECRET=private-routing-value account-b"
+			workspace.Agents = append(workspace.Agents,
+				compozyconfig.AgentDef{Name: "parent", Provider: "claude", Command: command, Prompt: "Delegate."},
+				compozyconfig.AgentDef{Name: "child", Provider: "claude", Prompt: "Review."})
+			h.resolver.upsert(&workspace)
+			parent, err := h.manager.Create(t.Context(), CreateOpts{AgentName: "parent", Workspace: h.workspaceID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			cleanupSessionStop(t, h, parent.ID)
+			denied := errors.New("authentication required")
+			h.driver.startHook = func(_ acp.StartOpts, _ int) (*fakeProcess, error) {
+				return nil, acp.WrapFailure(store.FailureProviderAuth, "native authentication failed", denied)
+			}
+			if _, err := h.manager.Spawn(
+				t.Context(),
+				SpawnOpts{ParentSessionID: parent.ID, AgentName: "child", TTL: time.Minute},
+			); !errors.Is(
+				err,
+				denied,
+			) {
+				t.Fatalf("spawn error = %v, want authentication failure", err)
+			}
+			infos, err := h.manager.ListAll(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			childID := ""
+			for _, info := range infos {
+				if info.AgentName == "child" {
+					childID = info.ID
+					if info.State != StateStopped || info.Failure == nil {
+						t.Fatalf("failed child = %#v", info)
+					}
+				}
+			}
+			if childID == "" {
+				t.Fatal("failed child was not retained for inspection")
+			}
+			fingerprint := providerCommandFingerprint(command)
+			marker := requireTranscriptMarker(t, h.manager, childID, transcript.MarkerProviderFailure)
+			if marker.Evidence["provider_command_fingerprint"] != fingerprint {
+				t.Fatalf("failure marker = %#v", marker)
+			}
+			contents, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(contents), "private-routing-value") {
+				t.Fatal("raw routing command leaked to logs")
+			}
+			selected, failed := false, false
+			for line := range strings.SplitSeq(strings.TrimSpace(string(contents)), "\n") {
+				var record map[string]any
+				if err := json.Unmarshal([]byte(line), &record); err != nil {
+					t.Fatal(err)
+				}
+				if record["session_id"] != childID {
+					continue
+				}
+				message := record["msg"]
+				if message != "session.provider_route.selected" && message != "session.start.driver_start_failed" {
+					continue
+				}
+				if strings.Count(line, "\"provider_command_fingerprint\":") != 1 ||
+					record["provider_command_fingerprint"] != fingerprint {
+					t.Fatalf("ambiguous or incorrect route fingerprint: %s", line)
+				}
+				selected = selected || message == "session.provider_route.selected"
+				failed = failed || message == "session.start.driver_start_failed"
+			}
+			if !selected || !failed {
+				t.Fatalf("route logs selected=%t failed=%t", selected, failed)
+			}
+		},
+	)
 }

--- a/packages/site/content/docs/agents/spawning.mdx
+++ b/packages/site/content/docs/agents/spawning.mdx
@@ -57,6 +57,33 @@ The ACP driver validates these before launch:
 - An additional dir equal to the primary workspace root is skipped.
 - Permissions must be `deny-all`, `approve-reads`, or `approve-all`.
 
+## Delegated provider commands
+
+For governed children created by `compozy spawn` or `compozy__session_spawn`, an explicit child
+agent command remains authoritative. A runtime selection of a different provider resolves that
+provider's command instead of carrying a command from the original provider.
+
+A child without its own command inherits its creator's resolved command when both use the same
+native CLI provider, operator-home policy, compatible runtime/environment policies, workspace,
+and profile. For example, a parent pinned to account B delegates to B even when the global
+provider command points to account A. A child explicitly pinned to account C still uses C.
+Bound-secret and isolated-home providers keep their own configured authentication boundaries.
+
+A live runtime keeps its resolved command snapshot. After stop or daemon restart, resume resolves
+the creator lineage against current agent/provider configuration. If the creator was deleted, the
+child uses its own configuration and logs `session.provider_route.creator_unavailable`; no raw
+command or credential is persisted to preserve a deleted creator.
+
+Provider routing does not imply readiness. Spawn success confirms creation and ACP startup;
+authentication may still fail on a later prompt. Inspect the child's events and provider failure
+markers. A recoverable authentication error can leave the logical session active so it can accept
+another prompt after native login is repaired.
+
+The `session.provider_route.selected` log records a `provider_command_fingerprint` alongside the
+session and provider IDs. Provider failure markers carry the same fingerprint. Compare fingerprints
+to distinguish command routes without exposing raw commands or account-directory values. The
+fingerprint identifies command configuration, not an authenticated account or a profile.
+
 ## Launch
 
 CompozyOS parses the provider command with shell-style quoting:

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -528,6 +528,13 @@ The session catalog is counted and workspace-scoped. Dream sessions are internal
 
 Sessions created from inside another session record creation provenance in `lineage`: `compozy__session_create` links the calling session automatically (same-workspace only), and `session new --parent <id>` / `parent_session_id` on `POST /api/sessions` link explicitly. Provenance keeps `type=user` and carries no TTL, auto-stop, budget, or permission narrowing — governed children still come only from `compozy spawn`. Query hierarchy with `parent=<id>` (direct children) or `root=<id>` (whole tree, root included) on the catalog — CLI `session list --parent/--root`, same fields on `compozy__session_list`.
 
+Governed children without an explicit agent command inherit the creator's resolved command only
+for the same native CLI provider, operator-home policy, compatible environment/runtime policies,
+workspace, and profile. Explicit child commands and different-provider selections retain their
+own routing. Spawn success does not guarantee authentication on subsequent prompts: inspect child
+error events and provider failure markers. `provider_command_fingerprint` in route logs and failure
+markers lets you compare selected commands without revealing credentials; it is not an account ID.
+
 `compozy spawn` and `compozy__session_spawn` create governed children with a required TTL and
 permission subsets. Both accept optional provider, model, reasoning-effort, and speed overrides for
 the child runtime. The parent receives one sanitized synthetic turn when an eligible child stops,


### PR DESCRIPTION
## What & why

Fixes #564.

A creator pinned to native provider command B could spawn a commandless reviewer on global command
A. The child runtime was resolved from its agent definition and provider defaults without using
the creator's resolved command. An explicit child command and a different named provider were
already legitimate overrides; forcing the parent command onto every child would break them.

This change makes governed spawn precedence explicit:

1. The selected child's explicit command remains authoritative. A different runtime provider
   selection continues to discard the original agent's provider-specific command.
2. A commandless child inherits the creator's resolved command only for the same native CLI
   provider, workspace and profile, with operator-home policy and compatible auth, environment,
   harness, runtime provider, transport, base URL and auth probe/login settings.
3. Otherwise the child's own provider configuration resolves its command as before.

Live sessions retain an internal resolved routing snapshot, so editing an agent definition after
its process starts does not redirect its delegated work. Runtime replacement updates the snapshot
only after the replacement is committed. On resume, a live creator supplies its snapshot; a stopped
creator is resolved through the existing persisted lineage and current configuration. Deleted
creator metadata preserves the child's configured fallback and emits an explicit diagnostic.
Commands and credentials are not added to persisted session metadata, DTOs or logs.

Observability is separate from account authentication. The selected-route log and provider failure
markers carry a SHA-256 `provider_command_fingerprint`, allowing correlation without exposing raw
commands or account directories. The launch-time JSON selection log has one authoritative fingerprint field. A failed replacement
logs its attempted route while preserving the prior runtime binding.
Startup failures now emit the existing provider failure marker after their canonical error and
stop events. Unsupported or missing ACP session loads continue through the established replay
fallback without inserting a transient failure into the replay transcript. Prompt auth errors retain the established recoverable logical-session behavior:
`active` and successful spawn do not promise that the provider will authenticate a later prompt.
The fingerprint identifies command configuration; it does not identify a login account or profile.

## How you verified it

Implementation and verification owner: Codex, GPT-6-Astra at High reasoning.

- Regression reproduced with a fixed Go overlay disabling only the inheritance call: two inherited
  cases launched A instead of B; explicit child and different-provider cases passed.
- Focused race suites cover explicit/same/different provider precedence, isolated home/environment
  policies, authorized foreign workspace routing, runtime replacement, recoverable prompt auth
  diagnostics, failed-start retention and route fingerprint correlation. JSON logs are checked
  for duplicate fingerprint keys and private command-value leakage.
- Final combined verification: `GOMAXPROCS=4 CGO_ENABLED=1 mise exec -- go test -race -p=1
  -parallel=4 -tags=integration ./internal/session` with the six focused routing/diagnostic and
  integration tests named in the QA report, `-count=1`: PASS in 16.902s.
- Real ACP subprocess integration ran through the existing Session Manager harness and SQLite:
  parent B / inherited child B / explicit child C, no unexpected A execution, live creator snapshot
  after config edits, and child resume with live and stopped creators. Existing provider persistence
  and full stop/resume/stop integration cases passed alongside it.
- One broad uncapped race run encountered an existing one-second stop deadline under heavy shared
  host contention. The unchanged case passed three isolated repetitions; no assertions or timeout
  values were weakened.
- The scoped gate exposed a transient resume-load marker in the replay transcript; production
  emission was corrected without changing the existing replay assertions. The final targeted
  `-race -p=1 -parallel=4` run of `TestResumeReplayFallback`,
  `TestSpawnProviderRouteDiagnostics` and `TestPromptRuntimeReplacementLifecycle` passed in 8.166s.
- Final `GOMAXPROCS=4 COMPOZY_GO_TEST_P=1 COMPOZY_GO_LINT_CONCURRENCY=2 mise exec -- make gate`: PASS.
  Go lint/format: zero issues; full affected Session Manager race suite: PASS in 147.115s;
  `internal/session/inputqueue` and `skills`: PASS. `make gate-status` confirmed CURRENT-PASS after
  commit for tree `730ae879b38c3d791797eee0eaea0e942de13acb`, head
  `7f8ad1cf49b89f386b85971a078b1f0927488f2a`. Repo-pinned golangci-lint: 2.13.1.
- Original lint-staged tasks and commitlint passed using a temporary per-commit hooksPath and
  `--no-stash --no-hide-partially-staged`; the commit left the validated tree unchanged.
- QA report: `docs/qa/reports/2026-09-09-issue-564-provider-routing.md`; affected scenario:
  `docs/qa/scenarios/RT-session-spawn-wake.md`. Targeted teardown recorded `clean: true`, no survivors,
  and no killed unrelated processes.

The routing processes are controlled ACP fixtures, not two live OAuth accounts. This proves command
selection and actual subprocess execution, not live OAuth refresh or provider-service availability.
No operator login state was changed or copied. Web rendering and unrelated wake journeys were not
repeated. CodeRabbit, Greptile and current-head required CI are tracked after publication.

## Impact

Cross-surface audit under `docs/_memory/change-impact.md`:

- **Native tools / CLI / HTTP / UDS:** `compozy__session_spawn`, `compozy spawn` and agent spawn routes
  share the corrected Session Manager resolution. No IDs, input/output schemas, flags, permission
  gates, risk classifications or readiness promises are changed. Existing event consumers gain
  the fingerprint in the extensible provider-marker evidence map.
- **Extensibility / hooks / config:** agent and provider command configuration retains its current
  shape. Explicit child overrides and different-provider selection remain authoritative. Spawn
  hooks, permission narrowing, TTL, caps and role selection still run through their existing owners.
  No credentials are copied or injected beyond the child's existing auth/home/environment policy.
- **Workspace isolation:** inheritance requires equal workspace and profile IDs. An authorized
  foreign-workspace spawn still uses that workspace's routing. Provider ID, profile scope and
  command/account identity remain distinct; no account registry is introduced.
- **Official skill:** `skills/compozy/references/runtime-operations.md` documents precedence,
  diagnostics and the acceptance/authentication boundary.
- **Web / Docs:** existing transcript-marker consumers receive the additive evidence through their
  current schema. No Web component or cache key changes are needed. The site spawning guide and
  owning QA scenario/report co-ship the behavior and resume/fallback limits.
- **Compatibility / state:** no SQLite, `config.toml`, persisted layout or session metadata shape
  changes; no migration, deletion or compatibility shim. Existing orphan-child fallback remains
  available and becomes observable. Internal snapshot fields are not public DTO fields.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Spawned sessions now preserve compatible provider routing from their creator when no explicit command is provided.
  - Provider routing remains consistent when sessions are stopped, resumed, or started through replacement runtimes.
  - Session diagnostics now correlate provider routes using non-sensitive fingerprints without exposing raw commands.

- **Bug Fixes**
  - Failed session starts now record provider-failure markers in session transcripts.
  - Negotiation failures that cannot load a session resource or lack session support remain excluded from replayed transcripts.
  - Failed runtime replacements preserve the previously working provider route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->