### PR TITLE
fix: make memory opt-in and preserve pressure compaction

### DIFF
--- a/.release-notes/memory-opt-in-extractor-1788969402.md
+++ b/.release-notes/memory-opt-in-extractor-1788969402.md
@@ -1,0 +1,30 @@
+---
+title: Memory and dreaming require explicit opt-in
+type: fix
+---
+
+CompozyOS is a control plane, so it no longer starts persistent memory extraction or background
+dreaming from omitted settings. `memory.enabled` and `roles.dream.enabled` now default to `false`.
+To enable memory, set `memory.enabled = true` in `config.toml` and restart the daemon. Dreaming
+requires the separate `roles.dream.enabled = true` opt-in; enabling memory alone leaves it off.
+
+The enabled extractor now requests an explicit no-candidate result, accepts conventional empty
+responses and JSONL fences, and preserves valid candidates from mixed output. Malformed lines
+remain diagnosable failures instead of silently disappearing. Extraction failures and timeouts
+appear in the configured DLQ and extractor failure listing. Child-stop details distinguish failed
+or timed-out extraction from a parsed child response; successful inbox production owns the
+`memory.extractor.completed` event.
+
+Session pressure compaction remains independently controlled by `session.compaction.enabled`.
+It reuses checkpoint coverage and may launch a summary child when an active session reaches the
+pressure threshold, even with persistent memory disabled. Idle sessions and session-end memory
+updates do not start that work. An explicit checkpoint-role opt-out or a failed summary leaves
+uncovered events unarchived.
+
+### Migration notes
+
+No configuration is rewritten and no stored memory is deleted. Existing explicit `true` or `false`
+values retain their meaning; omitted values use the new disabled defaults. Profile and workspace
+role overrides keep their precedence under the daemon memory master switch. Existing public keys,
+tools, routes, and response shapes remain available. Raw extraction failures require a new
+extraction; replay remains limited to normalized candidate inbox failures. (#561)

--- a/docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md
+++ b/docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md
@@ -1,0 +1,56 @@
+# Memory opt-in and extractor robustness
+
+Status: targeted runtime verification passed; CI/reviews pending. Issue: #561.
+
+## Scope and invariant ownership
+
+- Configuration: omitted memory/dream switches stay false; explicit global, profile, and workspace values retain precedence. Canonical suites: `internal/config/memory_v2_config_test.go`, `roles_test.go`, and `merge_test.go`.
+- Daemon extractor: explicit no-candidate output and conventional empty wrappers succeed; valid lines survive malformed batches; child failure/timeout and extraction success remain distinct. Canonical suite: `internal/daemon/memory_runtime_test.go`.
+- Inbox worker: partial candidates reach the controller while the extraction records failure. Canonical suite: `internal/memory/extractor/runtime_test.go`.
+- Dream scheduling: disabled roles do not evaluate gates or begin consolidation; explicit live/workspace opt-ins remain usable. Canonical suites: daemon lifecycle and `internal/memory/consolidation/runtime_test.go`.
+- Session compaction: pressure work is independent of persistent memory and remains controlled by `session.compaction.enabled`. The internal invocation distinguishes pressure summaries from session-end work, honors checkpoint-role opt-out, and refuses to archive uncovered events on disabled/failed summarization. Factory boot retains private checkpoint WAL storage and resume-only coverage without a public memory provider or session-end worker. Canonical suites: checkpoint summarizer/runtime, memory checkpoint coverage, session pressure compaction, and `TestDaemonE2EFactoryPressureCompaction`.
+- Real runtime: the existing daemon memory E2E suite owns CLI/HTTP/UDS status, persisted candidates, no-candidate completion, failure listing, and zero default child work. Its full-feature config fixture now explicitly opts in; factory scenarios load factory switch values.
+
+## Reproduction
+
+The same `TestMemoryExtractorOutputContract` was run with a Go overlay containing the original
+`memory_extractor_output.go` from the branch base. It reproduced the invalid `N` and `(` errors,
+discarded both valid candidates around malformed JSON, and discarded a valid candidate after prose.
+The updated parser passed these cases with `-race`. The timeout in the issue is a separate provider
+execution deadline, not a JSON decoding consequence.
+
+## Change impact
+
+- Native tools: existing memory/extractor/dream IDs and schemas remain. Disabled defaults make memory runtime tools unavailable as before; extractor status/failure listing exposes extraction-stage failures through the existing payloads.
+- Extensibility/hooks/config: no new keys, hooks, SDK shapes, or migrations. Session pressure compaction retains its independent control and its summary invocation marker is internal. `memory.enabled` and `roles.dream.enabled` default false. Extraction retains the existing persisted-message hook when enabled; dreaming checks role eligibility before its Time → Sessions → Lock gates.
+- Workspace isolation: candidate workspace/agent routing stays unchanged; failure reports retain parent session, workspace, and agent identity. Effective role configuration honors the memory switch and workspace/profile role overlays. The daemon-level memory switch controls runtime registration.
+- Official skill: `skills/compozy/references/memory.md` documents deliberate opt-in and extraction diagnostics; retrieval algorithms and startup tool-manual policy are untouched.
+- Web/Docs: no Web type or component changes; existing settings controls retain their keys. Site memory/config references and release migration notes describe defaults, enablement, and mixed-output behavior.
+- Compatibility: no state deletion or config rewrite. Explicit values survive; omissions adopt the requested default. Existing response shapes/keys remain, so no deprecation shim is introduced.
+
+## Evidence and limits
+
+- Config, extractor, and consolidation suites passed with `-race` (19.281 s, 3.001 s, 1.318 s).
+- The capped daemon rerun passed all selected extractor/lifecycle/role/reentry cases except the unchanged boot barrier timeout. Its standalone capped retry passed in 12.418 s, retaining the five-second assertion. The controller independently observed the same host-load failure and clean standalone retry in #562.
+- Canonical compaction checks passed with `-race -p=1 -parallel=4`: daemon 6.359 s, memory 1.697 s, session 4.603 s. The disabled role retains the existing checkpoint hint. The subsequent compatibility fix changes an uncovered disabled-summary request to return an error so the session cannot archive it.
+- `go run ./cmd/compozy-codegen all` completed with no generated diff.
+
+- Existing daemon memory E2E cases ran with real daemon/ACP subprocesses and SQLite under the shared machine-wide verification lock, using `-race -p=1 -parallel=4 -tags=integration`. Opted-in empty extraction passed (8.00 s), partial malformed output passed (9.34 s), and both deliberate dream routing cases passed. Existing CLI/HTTP catalog parity, next-session recall, live role apply, and crash-safe compaction integration also passed.
+- The factory case initially stopped in fixture validation because its unused synthetic response was empty. Giving that fixture a valid no-candidate response allowed the same zero-work assertions to execute and pass (2.22 s; package 4.943 s). An earlier test compilation typo used `Type` instead of the existing `SessionInfo.SessionType`; it was corrected before runtime execution.
+- The original completed lab used canonical root `/private/tmp/compozyqa-66cec21f3dea`: daemon socket 57 bytes, tmux socket 60 bytes, worst-case generated harness socket 88 bytes (limit 103). Its predecessor was torn down cleanly before replacement.
+
+- The initial gate found one trailing blank line in the touched config test; it was corrected without changing an assertion.
+- The pressure compatibility fix passed canonical memory/session checks (1.665 s / 4.132 s) and the daemon summarizer/lifecycle checks (9.930 s). Its store lifetime follows the existing catalog shutdown order after session/compaction teardown, including boot rollback.
+- The first short lab completed targeted teardown with `clean: true`. The pressure compatibility re-walk uses a fresh short lab, allocated after that teardown.
+
+The owner explicitly requested publication with the full gate running in CI. A clean full local gate is not claimed; current-head required CI remains a delivery requirement. Final pressure E2E and teardown evidence follows below. The ACP fixture run
+will verify real daemon/subprocess/protocol behavior with deterministic model output, not live
+provider reliability or timeout frequency.
+
+## Factory pressure acceptance
+
+`TestDaemonE2EFactoryPressureCompaction` passed with the actual daemon, ACP subprocesses, and SQLite (9.770 s; package 11.925 s). Factory memory/dream settings remain false. The test verifies one pressure-only checkpoint child, coverage before archive, retained historical facts, and degraded recovery after an ACP disconnect: four protocol attempts, three completed prompts, and two parent runtimes. The recovered prompt includes the checkpoint fact and excludes its archived raw event from replay. No extractor/dream/session-end memory child appears.
+
+The initial test setup failures were corrected without changing the production contract: bind the checkpoint role to the fixture agent; use automatic recovery instead of attaching a deliberately stopped terminal session; count interrupted protocol attempts separately from completed prompt diagnostics. Summary failures observed during setup left the source events unarchived.
+
+The pressure re-walk also passed the unchanged crash-safe compaction suite and the three default/opt-in extractor cases. Canonical test-convention checks passed. Pressure lab `/private/tmp/compozyqa-232d0fe5b103` completed targeted teardown with `clean: true`; logs and provider/event artifacts are retained in its QA output. No live-provider reliability claim is made.

--- a/docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md
+++ b/docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md
@@ -54,3 +54,9 @@ provider reliability or timeout frequency.
 The initial test setup failures were corrected without changing the production contract: bind the checkpoint role to the fixture agent; use automatic recovery instead of attaching a deliberately stopped terminal session; count interrupted protocol attempts separately from completed prompt diagnostics. Summary failures observed during setup left the source events unarchived.
 
 The pressure re-walk also passed the unchanged crash-safe compaction suite and the three default/opt-in extractor cases. Canonical test-convention checks passed. Pressure lab `/private/tmp/compozyqa-232d0fe5b103` completed targeted teardown with `clean: true`; logs and provider/event artifacts are retained in its QA output. No live-provider reliability claim is made.
+
+## Review remediation
+
+Greptile identified terminal-less extractor success and raw role status. The collector now requires a successful semantic terminal, retains partial diagnostic output on errors, and refuses candidate admission after interruption. Background role projections and invocations share the effective daemon/workspace memory gate; pressure summaries retain their internal exception. Existing unit suites cover these boundaries, and the memory E2E suite adds interrupted-output and public-role-status assertions. CI health fixtures now opt in explicitly where their invariant requires active memory; assertions remain unchanged. The scoped runtime test added in this round is pending the next CI head.
+
+Review regression checks passed with `-race -p=1 -parallel=4`: daemon roles/extractor/checkpoints 6.990 s; API core memory health 13.388 s; UDS health 1.299 s; HTTP health 1.288 s; settings 1.071 s. The read-only test-shape checker reports existing direct-test shapes in untouched test bodies; comparison against the prior head found zero new findings.

--- a/docs/qa/scenarios/MS-016.md
+++ b/docs/qa/scenarios/MS-016.md
@@ -35,3 +35,5 @@ QA 2026-07-24: disabling `roles.dream.enabled` live returned skipped with `dream
 QA impact 2026-07-24 (final review remediation): Dream enablement now resolves per workspace even
 when the global role is disabled, and rollback failures remain observable instead of being reported
 as clean skips. The next QA cycle owns both corrected branches.
+
+QA 2026-09-09 (#561): the isolated daemon E2E walk verified that factory settings and memory-only opt-in return a disabled dream-trigger reason and create no dream sessions. Existing built-in and workspace dream routing walks passed after deliberate opt-in. Web interaction was not repeated. Evidence and scope: `docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md`.

--- a/docs/qa/scenarios/MS-019.md
+++ b/docs/qa/scenarios/MS-019.md
@@ -28,3 +28,5 @@ verb plus the absence of the removed alias.
 src: docs/qa/_seeds/feature-stories/05_analysis_memory-settings.md
 
 inventory: Implemented
+
+QA 2026-09-09 (#561): the isolated daemon E2E walk verified CLI stopped status with factory settings, UDS drain, HTTP extraction-failure listing with parent identity, explicit no-candidate success, and a malformed batch that persists its valid candidate while recording failure instead of completion. The canonical extractor suite also verifies that raw model output cannot replay as a normalized inbox. Evidence and scope: `docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md`.

--- a/docs/qa/scenarios/RT-migrate-memory-stream-when-disabled.md
+++ b/docs/qa/scenarios/RT-migrate-memory-stream-when-disabled.md
@@ -18,3 +18,5 @@ overlaps: RT-inspect-schema-streams;MS-011
 
 Peer-review round 5 added the mandatory shared-file branch: schema durability is independent of the optional memory
 runtime. The next QA cycle must prove structured status parity and the absence of memory runtime behavior together.
+
+QA 2026-09-09 (#561): factory-memory E2E boot reached readiness and retained the memory-domain tables while creating zero extractor or dream sessions. The existing skills-only boot integration checks current shared schema-stream heads with memory disabled. The prior broader CLI/HTTP/UDS schema-status parity status remains unchanged. Evidence and scope: `docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md`.

--- a/docs/qa/scenarios/RT-pressure-context-compaction.md
+++ b/docs/qa/scenarios/RT-pressure-context-compaction.md
@@ -39,3 +39,13 @@ Forensic evidence contract (SD-006) — each item cites timestamp, exact command
   work), and a `pressure_threshold = 0` run with zero hook dispatch.
 
 src: .compozy/tasks/hermes-comparison/_user_stories.md#us-004-compaction-under-pressure-crash-safe
+
+QA impact 2026-09-09 (#561): factory memory is now opt-in, while pressure compaction remains under
+`session.compaction.enabled`. The factory-boot E2E must cover pressure, checkpoint WAL/coverage,
+archive preservation, and degraded resume without idle extraction/dream or session-end memory work.
+A disabled checkpoint role must not authorize archiving an uncovered span. Verification:
+`docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md`.
+
+### Issue #561 factory-default verification (2026-09-09)
+
+PASS: the real daemon/ACP `TestDaemonE2EFactoryPressureCompaction` exercised pressure with persistent memory and dreaming disabled. Checkpoint coverage preceded archive; retained history survived runtime disconnect/recovery without replaying archived raw facts. Only one pressure summary child was created. The canonical crash-safe compaction integration also passed. See [the scoped report](../reports/2026-09-09-issue-561-memory-opt-in.md).

--- a/internal/api/core/handler_edge_cases_test.go
+++ b/internal/api/core/handler_edge_cases_test.go
@@ -1011,6 +1011,7 @@ func TestBaseHandlersHealthAndDaemonStatusErrorBranches(t *testing.T) {
 			&stubDreamTrigger{EnabledFn: true, LastErr: errors.New("dream status failed")},
 		)
 
+		fixture.Handlers.Config.Memory.Enabled = true
 		resp := performRequest(t, fixture.Engine, http.MethodGet, "/status", nil)
 		if resp.Code != http.StatusOK {
 			t.Fatalf(

--- a/internal/api/core/memory_workspace_test.go
+++ b/internal/api/core/memory_workspace_test.go
@@ -85,14 +85,16 @@ func TestMemoryHandlersAndHelpers(t *testing.T) {
 			},
 		}
 
-		return newHandlerFixture(
+		fixture := newHandlerFixture(
 			t,
 			manager,
 			observer,
 			testutil.StubWorkspaceService{},
 			store,
 			trigger,
-		), workspace, trigger
+		)
+		fixture.Handlers.Config.Memory.Enabled = true
+		return fixture, workspace, trigger
 	}
 
 	t.Run("Should project profile memory through the selected API lens", func(t *testing.T) {
@@ -717,6 +719,7 @@ func TestMemoryHandlersAndHelpers(t *testing.T) {
 			nil,
 			nil,
 		)
+		fixture.Handlers.Config.Memory.Enabled = true
 		healthResp := performRequest(t, fixture.Engine, http.MethodGet, "/memory/health", nil)
 		if healthResp.Code != http.StatusOK {
 			t.Fatalf("memory health status = %d, want %d", healthResp.Code, http.StatusOK)
@@ -790,6 +793,7 @@ func TestMemoryHandlersAndHelpers(t *testing.T) {
 			store,
 			nil,
 		)
+		fixture.Handlers.Config.Memory.Enabled = true
 		query := url.Values{}
 		query.Set("workspace_id", workspace)
 		healthResp := performRequest(t, fixture.Engine, http.MethodGet, "/memory/health?"+query.Encode(), nil)

--- a/internal/api/httpapi/memory_test.go
+++ b/internal/api/httpapi/memory_test.go
@@ -723,6 +723,7 @@ func newTestMemoryHandlers(
 
 	homePaths := newTestHomePaths(t)
 	cfg := compozyconfig.DefaultWithHome(homePaths)
+	cfg.Memory.Enabled = true
 	cfg.HTTP.Host = "127.0.0.1"
 	cfg.HTTP.Port = 2123
 

--- a/internal/api/udsapi/memory_test.go
+++ b/internal/api/udsapi/memory_test.go
@@ -635,6 +635,7 @@ func newTestMemoryHandlers(
 
 	homePaths := newTestHomePaths(t)
 	cfg := compozyconfig.DefaultWithHome(homePaths)
+	cfg.Memory.Enabled = true
 
 	return newHandlers(&handlerConfig{
 		sessions:     manager,

--- a/internal/config/config_memory_defaults.go
+++ b/internal/config/config_memory_defaults.go
@@ -6,10 +6,10 @@ import (
 	"time"
 )
 
-// DefaultMemoryConfig returns the approved Memory v2 Slice 1 defaults.
+// DefaultMemoryConfig returns opt-in persistent memory defaults.
 func DefaultMemoryConfig(homePaths HomePaths) MemoryConfig {
 	return MemoryConfig{
-		Enabled:    true,
+		Enabled:    false,
 		GlobalDir:  homePaths.MemoryDir,
 		Controller: defaultMemoryControllerConfig(),
 		Recall:     defaultMemoryRecallConfig(),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2726,36 +2726,38 @@ func TestLoadMissingConfigReturnsDefaults(t *testing.T) {
 }
 
 func TestDefaultConfigUsesResolvedHomePaths(t *testing.T) {
-	t.Setenv("COMPOZY_HOME", "")
+	t.Run("Should resolve factory defaults from the operator home", func(t *testing.T) {
+		t.Setenv("COMPOZY_HOME", "")
 
-	cfg, err := defaultConfig()
-	if err != nil {
-		t.Fatalf("defaultConfig() error = %v", err)
-	}
-	if cfg.HTTP.Port != 2123 || cfg.Defaults.Agent != DefaultAgentName {
-		t.Fatalf("defaultConfig() = %#v", cfg)
-	}
-	if cfg.Permissions.Mode != PermissionModeApproveAll {
-		t.Fatalf("defaultConfig() Permissions.Mode = %q, want %q", cfg.Permissions.Mode, PermissionModeApproveAll)
-	}
-	if !cfg.Roles.Dream.Enabled || cfg.Roles.Dream.Agent != "" {
-		t.Fatalf("defaultConfig() Roles.Dream = %#v, want enabled builtin routing", cfg.Roles.Dream)
-	}
-	if !cfg.Skills.Enabled {
-		t.Fatal("defaultConfig() Skills.Enabled = false, want true")
-	}
-	if got, want := cfg.Skills.PollInterval, 3*time.Second; got != want {
-		t.Fatalf("defaultConfig() Skills.PollInterval = %s, want %s", got, want)
-	}
-	if !cfg.Network.Enabled {
-		t.Fatal("defaultConfig() Network.Enabled = false, want true")
-	}
-	if got, want := cfg.Network.Live.Defaults.MaxWakes, 8; got != want {
-		t.Fatalf("defaultConfig() Network.Live.Defaults.MaxWakes = %d, want %d", got, want)
-	}
-	if got, want := cfg.Network.Live.Limits.MaxWakes, 64; got != want {
-		t.Fatalf("defaultConfig() Network.Live.Limits.MaxWakes = %d, want %d", got, want)
-	}
+		cfg, err := defaultConfig()
+		if err != nil {
+			t.Fatalf("defaultConfig() error = %v", err)
+		}
+		if cfg.HTTP.Port != 2123 || cfg.Defaults.Agent != DefaultAgentName {
+			t.Fatalf("defaultConfig() = %#v", cfg)
+		}
+		if cfg.Permissions.Mode != PermissionModeApproveAll {
+			t.Fatalf("defaultConfig() Permissions.Mode = %q, want %q", cfg.Permissions.Mode, PermissionModeApproveAll)
+		}
+		if cfg.Roles.Dream.Enabled || cfg.Roles.Dream.Agent != "" {
+			t.Fatalf("defaultConfig() Roles.Dream = %#v, want disabled builtin routing", cfg.Roles.Dream)
+		}
+		if !cfg.Skills.Enabled {
+			t.Fatal("defaultConfig() Skills.Enabled = false, want true")
+		}
+		if got, want := cfg.Skills.PollInterval, 3*time.Second; got != want {
+			t.Fatalf("defaultConfig() Skills.PollInterval = %s, want %s", got, want)
+		}
+		if !cfg.Network.Enabled {
+			t.Fatal("defaultConfig() Network.Enabled = false, want true")
+		}
+		if got, want := cfg.Network.Live.Defaults.MaxWakes, 8; got != want {
+			t.Fatalf("defaultConfig() Network.Live.Defaults.MaxWakes = %d, want %d", got, want)
+		}
+		if got, want := cfg.Network.Live.Limits.MaxWakes, 64; got != want {
+			t.Fatalf("defaultConfig() Network.Live.Limits.MaxWakes = %d, want %d", got, want)
+		}
+	})
 }
 
 func TestLoadRespectsExplicitNetworkDisable(t *testing.T) {

--- a/internal/config/memory_v2_config_test.go
+++ b/internal/config/memory_v2_config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestMemoryV2ConfigDefaultsAndOverlay(t *testing.T) {
-	t.Run("Should expose approved Slice 1 defaults", func(t *testing.T) {
+	t.Run("Should default to opt-in memory while preserving its configuration", func(t *testing.T) {
 		t.Parallel()
 
 		homePaths, err := ResolveHomePathsFrom(filepath.Join(t.TempDir(), "home"))
@@ -19,8 +19,11 @@ func TestMemoryV2ConfigDefaultsAndOverlay(t *testing.T) {
 		cfg := DefaultWithHome(homePaths)
 		memory := cfg.Memory
 
-		if !memory.Enabled || memory.GlobalDir != homePaths.MemoryDir {
-			t.Fatalf("DefaultWithHome() Memory = %#v, want enabled global memory dir", memory)
+		if memory.Enabled || cfg.Roles.Dream.Enabled || memory.GlobalDir != homePaths.MemoryDir {
+			t.Fatalf(
+				"DefaultWithHome() Memory = %#v, want disabled memory and dreaming with retained memory directory",
+				memory,
+			)
 		}
 		if memory.Controller.Mode != "hybrid" ||
 			memory.Controller.MaxLatency != 300*time.Millisecond ||
@@ -226,6 +229,55 @@ auto_create = false
 			t.Fatalf("Load() normalized paths = %q/%q", memory.Extractor.InboxPath, memory.Session.LedgerRoot)
 		}
 	})
+}
+
+func TestMemoryOptInLayering(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, content string
+		memory, dream bool
+	}{
+		{name: "Should keep omitted switches disabled", content: "[memory.dream]\nmin_sessions = 7\n"},
+		{name: "Should enable memory independently", content: "[memory]\nenabled = true\n", memory: true},
+		{name: "Should preserve both explicit opt-ins", content: "[memory]\nenabled = true\n[roles.dream]\nenabled = true\n", memory: true, dream: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			home, err := ResolveHomePathsFrom(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, home.ConfigFile, tc.content)
+			cfg, err := LoadForHome(home)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.Memory.Enabled != tc.memory || cfg.Roles.Dream.Enabled != tc.dream {
+				t.Fatalf(
+					"switches = %t/%t, want %t/%t",
+					cfg.Memory.Enabled,
+					cfg.Roles.Dream.Enabled,
+					tc.memory,
+					tc.dream,
+				)
+			}
+			path := filepath.Join(t.TempDir(), "overlay.toml")
+			writeFile(t, path, "[memory]\nenabled = true\n[roles.dream]\nenabled = false\n")
+			if err := applyProfileConfigOverlayFile(path, &cfg, "profile"); err != nil {
+				t.Fatal(err)
+			}
+			if !cfg.Memory.Enabled || cfg.Roles.Dream.Enabled {
+				t.Fatal("profile switches were not applied")
+			}
+			writeFile(t, path, "[roles.dream]\nenabled = true\n")
+			if err := ApplyConfigOverlayFile(path, &cfg); err != nil {
+				t.Fatal(err)
+			}
+			if !cfg.Memory.Enabled || !cfg.Roles.Dream.Enabled {
+				t.Fatal("workspace opt-in was not applied")
+			}
+		})
+	}
 }
 
 func TestMemoryV2ConfigValidationRejectsInvalidValues(t *testing.T) {

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -601,8 +601,8 @@ func TestRolesOverlayPreservesLayeredMergeSemantics(t *testing.T) {
 		if err := ApplyConfigOverlayFile(path, &cfg); err != nil {
 			t.Fatalf("ApplyConfigOverlayFile() error = %v", err)
 		}
-		if cfg.Roles.Dream.Model != "model-x" || !cfg.Roles.Dream.Enabled {
-			t.Fatalf("Roles.Dream = %#v, want model override with enabled default", cfg.Roles.Dream)
+		if cfg.Roles.Dream.Model != "model-x" || cfg.Roles.Dream.Enabled {
+			t.Fatalf("Roles.Dream = %#v, want model override with disabled default", cfg.Roles.Dream)
 		}
 		if !reflect.DeepEqual(cfg.Roles.CheckpointSummary, DefaultRolesConfig().CheckpointSummary) {
 			t.Fatalf("Roles.CheckpointSummary = %#v, want defaults", cfg.Roles.CheckpointSummary)
@@ -618,8 +618,8 @@ func TestRolesOverlayPreservesLayeredMergeSemantics(t *testing.T) {
 		if err := ApplyConfigOverlayFile(path, &cfg); err != nil {
 			t.Fatalf("ApplyConfigOverlayFile() error = %v", err)
 		}
-		if !cfg.Roles.Dream.Enabled {
-			t.Fatal("Roles.Dream.Enabled = false, want default true")
+		if cfg.Roles.Dream.Enabled {
+			t.Fatal("Roles.Dream.Enabled = true, want default false")
 		}
 	})
 

--- a/internal/config/roles.go
+++ b/internal/config/roles.go
@@ -178,7 +178,7 @@ func DefaultResolvedCoordinatorRole() ResolvedCoordinatorRole {
 	}
 }
 
-// DefaultRolesConfig preserves the effective routing defaults from the pre-roles config.
+// DefaultRolesConfig returns routing defaults with background dreaming disabled.
 func DefaultRolesConfig() RolesConfig {
 	return RolesConfig{
 		Coordinator: CoordinatorRoleConfig{
@@ -187,7 +187,7 @@ func DefaultRolesConfig() RolesConfig {
 			MaxChildren:                   DefaultCoordinatorMaxChildren,
 			MaxActiveSessionsPerWorkspace: DefaultCoordinatorMaxActiveSessionsPerWorkspace,
 		},
-		Dream:             RoleConfig{Enabled: true},
+		Dream:             RoleConfig{Enabled: false},
 		CheckpointSummary: RoleConfig{Enabled: true},
 		MemoryExtractor:   RoleConfig{Enabled: true},
 		AutoTitle:         RoleConfig{Enabled: true},

--- a/internal/config/roles_test.go
+++ b/internal/config/roles_test.go
@@ -50,8 +50,8 @@ func TestDefaultRolesConfigPreservesRoleBehavior(t *testing.T) {
 			{name: RoleMemoryExtractor, role: got.MemoryExtractor},
 			{name: RoleAutoTitle, role: got.AutoTitle},
 		} {
-			if !item.role.Enabled {
-				t.Errorf("DefaultRolesConfig().%s.Enabled = false, want true", item.name)
+			if want := item.name != RoleDream; item.role.Enabled != want {
+				t.Errorf("DefaultRolesConfig().%s.Enabled = %t, want %t", item.name, item.role.Enabled, want)
 			}
 			if item.role.Agent != "" {
 				t.Errorf("DefaultRolesConfig().%s.Agent = %q, want empty", item.name, item.role.Agent)

--- a/internal/daemon/boot.go
+++ b/internal/daemon/boot.go
@@ -70,6 +70,7 @@ type bootState struct {
 	memoryExtractor        *daemonMemoryExtractor
 	runtimeWorkers         daemonRuntimeWorkers
 	checkpointRuntime      *checkpointSummaryRuntime
+	checkpointStore        *memory.Store
 	ledgerMaterializer     session.LedgerMaterializer
 	skillsRegistry         *skills.Registry
 	mcpResolver            *skills.MCPResolver

--- a/internal/daemon/boot_checkpoint.go
+++ b/internal/daemon/boot_checkpoint.go
@@ -1,0 +1,70 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/compozy/compozy/internal/memory"
+)
+
+func (d *Daemon) bootCheckpointSummaryRuntime(
+	ctx context.Context,
+	state *bootState,
+	sessions SessionManager,
+	cleanup *bootCleanup,
+) error {
+	if state == nil || (!state.cfg.Memory.Enabled && !state.cfg.Session.Compaction.Enabled) {
+		return nil
+	}
+	checkpointSessions, ok := sessions.(checkpointSummarySessionManager)
+	if !ok {
+		return errors.New("daemon: session manager does not implement checkpoint summary lifecycle")
+	}
+	checkpointStore := state.memoryStore
+	if checkpointStore == nil {
+		checkpointStore = state.checkpointStore
+		if checkpointStore == nil {
+			return errors.New("daemon: compaction checkpoint store is unavailable")
+		}
+		// Only degraded replay reads this coverage; normal prompts still have no memory provider.
+		assembler, ok := state.promptAssembler.(*ComposedAssembler)
+		if !ok {
+			return errors.New("daemon: compaction requires the composed prompt assembler")
+		}
+		assembler.resumeOnlyProvider = memory.NewAssembler(checkpointStore)
+	}
+	summarizer := newDaemonCheckpointSummarizer(
+		checkpointSessions,
+		roleResolverForState(state),
+	)
+	service := memory.NewCheckpointSummaryService(
+		checkpointStore,
+		state.workspaceResolver,
+		summarizer,
+		memory.WithCheckpointSummaryClock(d.now),
+	)
+	if state.localMemoryProvider != nil {
+		state.localMemoryProvider.SetSessionEndHandler(service)
+		state.localMemoryProvider.SetPreCompressHandler(service)
+	}
+	runtime := newCheckpointSummaryRuntime(
+		sessions,
+		state.memoryProviderRegistry,
+		state.cfg.Memory.Provider.Timeout,
+		state.cfg.Memory.Extractor.Deadline,
+		state.logger,
+		service,
+	)
+	if state.cfg.Memory.Enabled {
+		if err := runtime.Start(ctx); err != nil {
+			return fmt.Errorf("daemon: start checkpoint summary runtime: %w", err)
+		}
+	}
+	cleanup.add(runtime.Shutdown)
+	if binder, ok := sessions.(sessionCompactionBinder); ok {
+		binder.SetCompactionHandler(runtime)
+	}
+	state.checkpointRuntime = runtime
+	return nil
+}

--- a/internal/daemon/boot_memory_catalog.go
+++ b/internal/daemon/boot_memory_catalog.go
@@ -8,7 +8,7 @@ import (
 )
 
 // bootMemoryCatalog applies the shared memory stream on every boot while
-// retaining a long-lived catalog only when the memory runtime is enabled.
+// retaining private checkpoint storage when session compaction needs it.
 func (d *Daemon) bootMemoryCatalog(
 	ctx context.Context,
 	state *bootState,
@@ -25,11 +25,17 @@ func (d *Daemon) bootMemoryCatalog(
 	}
 
 	migrationStore := memory.NewStore(
-		d.homePaths.MemoryDir,
+		firstNonEmptyString(state.cfg.Memory.GlobalDir, d.homePaths.MemoryDir),
 		memory.WithCatalogDatabasePath(d.homePaths.DatabaseFile),
+		memory.WithFileLimits(state.cfg.Memory.File),
 	)
 	if err := migrationStore.OpenCatalog(ctx); err != nil {
 		return fmt.Errorf("daemon: migrate disabled memory catalog database %q: %w", d.homePaths.DatabaseFile, err)
+	}
+	if state.cfg.Session.Compaction.Enabled {
+		state.checkpointStore = migrationStore
+		cleanup.add(migrationStore.CloseCatalog)
+		return nil
 	}
 	if err := migrationStore.CloseCatalog(ctx); err != nil {
 		return fmt.Errorf("daemon: close disabled memory catalog database %q: %w", d.homePaths.DatabaseFile, err)

--- a/internal/daemon/boot_memory_session.go
+++ b/internal/daemon/boot_memory_session.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/compozy/compozy/internal/memory"
 	"github.com/compozy/compozy/internal/session"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 )
@@ -154,50 +153,6 @@ func (d *Daemon) bootAutoTitleRuntime(
 	}
 	cleanup.add(runtime.Shutdown)
 	state.runtimeWorkers.autoTitle = runtime
-	return nil
-}
-
-func (d *Daemon) bootCheckpointSummaryRuntime(
-	ctx context.Context,
-	state *bootState,
-	sessions SessionManager,
-	cleanup *bootCleanup,
-) error {
-	if state == nil || state.localMemoryProvider == nil || state.memoryProviderRegistry == nil {
-		return nil
-	}
-	checkpointSessions, ok := sessions.(checkpointSummarySessionManager)
-	if !ok {
-		return errors.New("daemon: session manager does not implement checkpoint summary lifecycle")
-	}
-	summarizer := newDaemonCheckpointSummarizer(
-		checkpointSessions,
-		roleResolverForState(state),
-	)
-	service := memory.NewCheckpointSummaryService(
-		state.memoryStore,
-		state.workspaceResolver,
-		summarizer,
-		memory.WithCheckpointSummaryClock(d.now),
-	)
-	state.localMemoryProvider.SetSessionEndHandler(service)
-	state.localMemoryProvider.SetPreCompressHandler(service)
-	runtime := newCheckpointSummaryRuntime(
-		sessions,
-		state.memoryProviderRegistry,
-		state.cfg.Memory.Provider.Timeout,
-		state.cfg.Memory.Extractor.Deadline,
-		state.logger,
-		service,
-	)
-	if err := runtime.Start(ctx); err != nil {
-		return fmt.Errorf("daemon: start checkpoint summary runtime: %w", err)
-	}
-	cleanup.add(runtime.Shutdown)
-	if binder, ok := sessions.(sessionCompactionBinder); ok {
-		binder.SetCompactionHandler(runtime)
-	}
-	state.checkpointRuntime = runtime
 	return nil
 }
 

--- a/internal/daemon/boot_publish.go
+++ b/internal/daemon/boot_publish.go
@@ -8,24 +8,18 @@ func (d *Daemon) publishBootState(state *bootState) {
 	d.logger = state.logger
 	d.closeLogger = state.closeLogger
 	d.booting = false
-	var localMemoryProvider memoryProviderShutdowner
-	if state.localMemoryProvider != nil {
-		localMemoryProvider = checkpointMemoryShutdowner{
-			runtime:  state.checkpointRuntime,
-			provider: state.localMemoryProvider,
-		}
-	}
 	d.daemonRuntimeState = daemonRuntimeState{
 		lock:                   state.lock,
 		harnessResolver:        state.harnessResolver,
 		registry:               state.registry,
 		profiles:               state.profiles,
 		memoryStore:            state.memoryStore,
+		checkpointStore:        state.checkpointStore,
 		memoryProviderRegistry: state.memoryProviderRegistry,
 		memoryExtractor:        state.memoryExtractor,
 		runtimeWorkers:         state.runtimeWorkers,
 		terminals:              state.terminals,
-		localMemoryProvider:    localMemoryProvider,
+		localMemoryProvider:    state.memoryProviderShutdowner(),
 		situationContext:       state.situationContext,
 		sessions:               state.sessions,
 		sessionWakeBridge:      state.sessionWakeBridge,
@@ -80,5 +74,15 @@ func (d *Daemon) publishBootState(state *bootState) {
 	if !d.readyClosed {
 		close(d.readyCh)
 		d.readyClosed = true
+	}
+}
+
+func (state *bootState) memoryProviderShutdowner() memoryProviderShutdowner {
+	if state.localMemoryProvider == nil {
+		return nil
+	}
+	return checkpointMemoryShutdowner{
+		runtime:  state.checkpointRuntime,
+		provider: state.localMemoryProvider,
 	}
 }

--- a/internal/daemon/checkpoint_summary_runtime.go
+++ b/internal/daemon/checkpoint_summary_runtime.go
@@ -297,7 +297,7 @@ func (r *checkpointSummaryRuntime) CompactSessionContext(
 	if ctx == nil {
 		return session.CompactionResult{}, errors.New("daemon: checkpoint compaction context is required")
 	}
-	if r.providers == nil || r.lifecycle == nil {
+	if r.lifecycle == nil {
 		return session.CompactionResult{}, errors.New("daemon: checkpoint compaction lifecycle is unavailable")
 	}
 	if strings.TrimSpace(request.WorkspaceID) == "" || strings.TrimSpace(request.SessionID) == "" {
@@ -317,9 +317,12 @@ func (r *checkpointSummaryRuntime) CompactSessionContext(
 	if len(snapshot.Messages) == 0 {
 		return session.CompactionResult{}, errors.New("daemon: checkpoint compaction snapshot is empty")
 	}
-	registration, err := r.providers.Select(ctx, request.WorkspaceID, "")
-	if err != nil {
-		return session.CompactionResult{}, fmt.Errorf("daemon: select compaction provider: %w", err)
+	registration := extensionpkg.MemoryProviderRegistration{Bundled: true}
+	if r.providers != nil {
+		registration, err = r.providers.Select(ctx, request.WorkspaceID, "")
+		if err != nil {
+			return session.CompactionResult{}, fmt.Errorf("daemon: select compaction provider: %w", err)
+		}
 	}
 	timeout := r.providerTimeout
 	if registration.Bundled {
@@ -339,11 +342,14 @@ func (r *checkpointSummaryRuntime) CompactSessionContext(
 		Snapshot:     snapshot,
 	}
 	var canonicalHint memcontract.PreCompressHint
-	if !registration.Bundled {
+	if !registration.Bundled || r.providers == nil {
 		canonicalHint, err = r.lifecycle.OnPreCompress(compactCtx, providerRequest)
 		if err != nil {
 			return session.CompactionResult{}, fmt.Errorf("daemon: update canonical compaction checkpoint: %w", err)
 		}
+	}
+	if r.providers == nil {
+		return session.CompactionResult{Summary: canonicalHint.Markdown}, nil
 	}
 	providerHint, err := registration.Provider.OnPreCompress(compactCtx, providerRequest)
 	if err != nil {

--- a/internal/daemon/checkpoint_summary_summarizer.go
+++ b/internal/daemon/checkpoint_summary_summarizer.go
@@ -52,9 +52,10 @@ func (s *daemonCheckpointSummarizer) Summarize(
 		return "", errors.New("daemon: checkpoint summary role resolver is not configured")
 	}
 	correlation := roleInvocationCorrelation{
-		WorkspaceID: strings.TrimSpace(request.WorkspaceID),
-		SessionID:   strings.TrimSpace(request.SessionID),
-		AgentName:   strings.TrimSpace(request.AgentName),
+		SessionCompaction: request.Compaction,
+		WorkspaceID:       strings.TrimSpace(request.WorkspaceID),
+		SessionID:         strings.TrimSpace(request.SessionID),
+		AgentName:         strings.TrimSpace(request.AgentName),
 	}
 	roleCtx := withRoleInvocationCorrelation(ctx, correlation)
 	role, err := s.roles.Resolve(roleCtx, request.WorkspaceID, compozyconfig.RoleCheckpointSummary)

--- a/internal/daemon/checkpoint_summary_summarizer_test.go
+++ b/internal/daemon/checkpoint_summary_summarizer_test.go
@@ -35,6 +35,36 @@ func TestDaemonCheckpointSummarizer(t *testing.T) {
 		}
 	})
 
+	for _, tc := range []struct {
+		name                               string
+		compaction, roleEnabled, wantChild bool
+	}{
+		{name: "Should suppress session-end work with factory memory settings", roleEnabled: true},
+		{name: "Should allow pressure compaction independently of memory opt-in", compaction: true, roleEnabled: true, wantChild: true},
+		{name: "Should honor checkpoint role opt-out during pressure compaction", compaction: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := compozyconfig.DefaultWithHome(compozyconfig.HomePaths{HomeDir: t.TempDir()})
+			cfg.Roles.CheckpointSummary.Enabled = tc.roleEnabled
+			manager := &checkpointSummarySessionManagerStub{
+				events: []acp.AgentEvent{{Type: acp.EventTypeAgentMessage, Text: "pressure summary"}},
+			}
+			summarizer := newDaemonCheckpointSummarizer(manager, newRoleResolver(&cfg, nil, nil))
+			request := checkpointSummaryRequestFixture()
+			request.WorkspaceID = ""
+			request.Compaction = tc.compaction
+			_, err := summarizer.Summarize(testutil.Context(t), request)
+			if tc.wantChild {
+				if err != nil || manager.createCalls != 1 {
+					t.Fatalf("pressure summary error=%v children=%d, want one child", err, manager.createCalls)
+				}
+			} else if !errors.Is(err, memory.ErrCheckpointSummaryDisabled) || manager.createCalls != 0 {
+				t.Fatalf("disabled summary error=%v children=%d, want no child", err, manager.createCalls)
+			}
+		})
+	}
+
 	t.Run("Should collect agent output and stop the internal dream session", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/compaction_resume_integration_test.go
+++ b/internal/daemon/compaction_resume_integration_test.go
@@ -4,6 +4,8 @@ package daemon
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -24,10 +26,219 @@ import (
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/store/sessiondb"
 	"github.com/compozy/compozy/internal/testutil"
+	"github.com/compozy/compozy/internal/testutil/acpmock"
+	e2etest "github.com/compozy/compozy/internal/testutil/e2e"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 )
 
 const compactionIntegrationFact = "cobalt-archive-fact"
+
+func TestDaemonE2EFactoryPressureCompaction(t *testing.T) {
+	t.Run(
+		"Should preserve factory pressure coverage and resume without enabling background memory",
+		func(t *testing.T) {
+			acpmock.RequireDriver(t)
+			fixture, err := acpmock.LoadFixture(mockFixturePath(t, "agent_roles_fixture.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			loadSession := false
+			fixture.Agents[0].LoadSession = &loadSession
+			fixture.Agents[0].Turns = []acpmock.TurnFixture{
+				{
+					Name:  "fact",
+					Match: acpmock.TurnMatch{UserText: "remember the archive fact"},
+					Steps: []acpmock.Step{
+						{
+							Kind: acpmock.StepKindAssistant,
+							Text: strings.Repeat("archive-padding ", 2048) + compactionIntegrationFact,
+						},
+					},
+				},
+				{
+					Name:  "pressure",
+					Match: acpmock.TurnMatch{UserText: "cross the pressure threshold"},
+					Steps: []acpmock.Step{
+						{Kind: acpmock.StepKindAssistant, Text: "current turn remains raw"},
+						{
+							Kind: acpmock.StepKindDriverControl,
+							DriverControl: &acpmock.DriverControlStep{
+								Action:     acpmock.DriverControlWriteRawJSONRPC,
+								RawJSONRPC: `{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"role-agent-session-1","update":{"sessionUpdate":"usage_update","used":90,"size":100}}}`,
+							},
+						},
+					},
+				},
+				{
+					Name:  "summary",
+					Match: acpmock.TurnMatch{TurnSource: "synthetic"},
+					Steps: []acpmock.Step{
+						{Kind: acpmock.StepKindAssistant, Text: compactionCheckpointBody(compactionIntegrationFact)},
+					},
+				},
+				{
+					Name: "resume",
+					Match: acpmock.TurnMatch{
+						UserText:            "recover the archive fact",
+						RawUserTextContains: "<compozy_context_replay>",
+					},
+					Steps: []acpmock.Step{{Kind: acpmock.StepKindAssistant, Text: "recovered"}},
+				},
+				{
+					Name:  "lost-runtime",
+					Match: acpmock.TurnMatch{UserText: "recover the archive fact"},
+					Steps: []acpmock.Step{
+						{Kind: acpmock.StepKindAssistant, Text: "recovering context"},
+						{
+							Kind:          acpmock.StepKindDriverControl,
+							DriverControl: &acpmock.DriverControlStep{Action: acpmock.DriverControlDisconnect},
+						},
+					},
+				},
+			}
+			data, err := json.Marshal(fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fixturePath := filepath.Join(t.TempDir(), "pressure.json")
+			if err := os.WriteFile(fixturePath, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			harness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+				ConfigSeed: e2etest.ConfigSeedOptions{Mutate: func(cfg *compozyconfig.Config) {
+					cfg.Memory.Enabled = compozyconfig.DefaultMemoryConfig(compozyconfig.HomePaths{}).Enabled
+					cfg.Roles.Dream.Enabled = compozyconfig.DefaultRolesConfig().Dream.Enabled
+					cfg.Roles.AutoTitle.Enabled = false
+					cfg.Roles.CheckpointSummary.Provider = acpmock.ProviderName
+					cfg.Roles.CheckpointSummary.Agent = "pressure-agent"
+				}},
+				MockAgents: []e2etest.MockAgentSpec{
+					{FixturePath: fixturePath, FixtureAgent: "role-agent", AgentName: "pressure-agent"},
+				},
+			})
+			ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+			defer cancel()
+			root := createFixtureBackedSession(t, ctx, harness, "pressure-agent", "")
+			defer func() {
+				captureCtx, captureCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+				defer captureCancel()
+				if err := harness.CaptureSessionEvents(captureCtx, root.ID); err != nil {
+					t.Errorf("capture pressure events: %v", err)
+				}
+				if registration, ok := harness.MockAgentRegistration("pressure-agent"); ok {
+					if err := harness.CaptureProviderCallsFile(
+						registration.DiagnosticsPath,
+						"application/x-ndjson",
+					); err != nil {
+						t.Errorf("capture pressure provider calls: %v", err)
+					}
+				}
+				logs, err := os.ReadFile(harness.HomePaths.LogFile)
+				if err != nil {
+					t.Errorf("read pressure daemon log: %v", err)
+					return
+				}
+				if err := os.WriteFile(
+					filepath.Join(harness.Artifacts.RootDir(), "daemon.log"),
+					logs,
+					0o600,
+				); err != nil {
+					t.Errorf("capture pressure daemon log: %v", err)
+				}
+			}()
+			if _, err := harness.PromptSession(ctx, root.ID, "remember the archive fact"); err != nil {
+				t.Fatal(err)
+			}
+			for _, info := range readWorkspaceRoleSessions(t, ctx, harness) {
+				if info.ID != root.ID {
+					t.Fatalf("unexpected idle child: %#v", info)
+				}
+			}
+			db, err := sql.Open("sqlite", store.SessionDBFile(filepath.Join(harness.HomePaths.SessionsDir, root.ID)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+			if _, err := harness.PromptSession(ctx, root.ID, "cross the pressure threshold"); err != nil {
+				t.Fatal(err)
+			}
+			waitForRuntimeCondition(t, "factory pressure archives covered facts", 20*time.Second, func() bool {
+				var count int
+				err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events WHERE type = 'agent_message' AND archived = 1 AND content LIKE ?", "%"+compactionIntegrationFact+"%").
+					Scan(&count)
+				if err != nil {
+					t.Fatalf("read compacted events: %v", err)
+				}
+				return count > 0
+			})
+			checkpoint := readCompactionCheckpoint(t, harness.WorkspaceRoot)
+			if !strings.Contains(checkpoint, compactionIntegrationFact) ||
+				!strings.Contains(checkpoint, "compozy:checkpoint-compaction:v1") {
+				t.Fatalf("checkpoint lacks covered fact: %q", checkpoint)
+			}
+			var raw, history int
+			if err := db.QueryRowContext(ctx, "SELECT COUNT(*), COALESCE(SUM(CASE WHEN archived = 0 THEN 1 ELSE 0 END), 0) FROM events WHERE type = 'agent_message' AND content LIKE ?", "%"+compactionIntegrationFact+"%").
+				Scan(&history, &raw); err != nil {
+				t.Fatal(err)
+			}
+			if history == 0 || raw != 0 {
+				t.Fatalf("fact history=%d replay=%d, want retained history and compacted replay", history, raw)
+			}
+			if _, err := harness.PromptSession(ctx, root.ID, "recover the archive fact"); err != nil {
+				t.Fatal(err)
+			}
+			registration, ok := harness.MockAgentRegistration("pressure-agent")
+			if !ok {
+				t.Fatal("missing pressure agent registration")
+			}
+			records, err := acpmock.ReadDiagnostics(registration.DiagnosticsPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			parentRecords := acpmock.DiagnosticsForCompozySession(records, root.ID)
+			var calls, starts int
+			for _, record := range parentRecords {
+				if record.ProtocolMethod == "session/prompt" {
+					calls++
+				}
+				if record.LifecycleEvent == "session_new" {
+					starts++
+				}
+			}
+			prompts := acpmock.PromptDiagnostics(parentRecords)
+			if len(prompts) != 3 || calls != 4 || starts != 2 {
+				t.Fatalf(
+					"parent completed=%d calls=%d starts=%d, want 3 completions, 4 attempts and 2 runtimes",
+					len(prompts),
+					calls,
+					starts,
+				)
+			}
+			last := prompts[2].Prompt
+			if !strings.Contains(last, compactionIntegrationFact) ||
+				strings.Contains(compactionReplayPayload(t, last), compactionIntegrationFact) {
+				t.Fatal("degraded resume lost checkpoint coverage or replayed archived raw facts")
+			}
+			children := 0
+			for _, info := range readWorkspaceRoleSessions(t, ctx, harness) {
+				if info.ID == root.ID {
+					continue
+				}
+				if info.Name != checkpointSummarySessionName {
+					t.Fatalf("unexpected background session: %#v", info)
+				}
+				children++
+			}
+			if children != 1 {
+				t.Fatalf("checkpoint children=%d, want pressure-only child", children)
+			}
+		},
+	)
+}
 
 func TestDaemonE2ECompactionResumeSafety(t *testing.T) {
 	t.Run(

--- a/internal/daemon/composed_assembler.go
+++ b/internal/daemon/composed_assembler.go
@@ -15,8 +15,9 @@ import (
 // ComposedAssembler assembles selected startup prompt sections around the base
 // agent prompt.
 type ComposedAssembler struct {
-	selector    *SectionSelector
-	descriptors []PromptSectionDescriptor
+	selector           *SectionSelector
+	descriptors        []PromptSectionDescriptor
+	resumeOnlyProvider session.ResumeContextProvider
 }
 
 // ComposedAssemblerOption customizes the prompt section chain for a
@@ -207,7 +208,16 @@ func (a *ComposedAssembler) ResumeContextSection(
 	if err != nil {
 		return "", err
 	}
-	sections := make([]string, 0, len(selected))
+	sections := make([]string, 0, len(selected)+1)
+	if a.resumeOnlyProvider != nil {
+		section, err := a.resumeOnlyProvider.ResumeContextSection(ctx, startup)
+		if err != nil {
+			return "", fmt.Errorf("daemon: resume compaction coverage: %w", err)
+		}
+		if trimmed := strings.TrimSpace(section); trimmed != "" {
+			sections = append(sections, trimmed)
+		}
+	}
 	for _, descriptor := range selected {
 		provider, ok := descriptor.Provider.(session.ResumeContextProvider)
 		if !ok || provider == nil {

--- a/internal/daemon/daemon_memory_e2e_integration_test.go
+++ b/internal/daemon/daemon_memory_e2e_integration_test.go
@@ -36,12 +36,14 @@ const (
 func TestDaemonE2EMemoryOptInAndExtractorOutput(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
-		name, output    string
-		enabled, failed bool
+		name, output                string
+		enabled, failed, disconnect bool
+		decisions                   int
 	}{
 		{name: "Should keep factory memory idle through a managed turn", output: `{"no_candidates":true}`},
 		{name: "Should complete an opted-in no-candidate extraction without dreaming", enabled: true, output: `{"no_candidates":true}`},
-		{name: "Should persist valid candidates and expose malformed output", enabled: true, failed: true, output: `{"type":"user","content":"Pedro prefers concise updates.","evidence":"seq=1"}` + "\n{broken"},
+		{name: "Should persist valid candidates and expose malformed output", enabled: true, failed: true, decisions: 1, output: `{"type":"user","content":"Pedro prefers concise updates.","evidence":"seq=1"}` + "\n{broken"},
+		{name: "Should fail interrupted extraction without persisting partial candidates", enabled: true, failed: true, disconnect: true, output: `{"type":"user","content":"Pedro prefers concise updates.","evidence":"seq=1"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -53,6 +55,12 @@ func TestDaemonE2EMemoryOptInAndExtractorOutput(t *testing.T) {
 			for i := range fixture.Agents[0].Turns {
 				if fixture.Agents[0].Turns[i].Match.TurnSource == "synthetic" {
 					fixture.Agents[0].Turns[i].Steps[0].Text = tc.output
+					if tc.disconnect {
+						fixture.Agents[0].Turns[i].Steps = append(fixture.Agents[0].Turns[i].Steps, acpmock.Step{
+							Kind:          acpmock.StepKindDriverControl,
+							DriverControl: &acpmock.DriverControlStep{Action: acpmock.DriverControlDisconnect},
+						})
+					}
 				}
 			}
 			data, err := json.Marshal(fixture)
@@ -81,6 +89,16 @@ func TestDaemonE2EMemoryOptInAndExtractorOutput(t *testing.T) {
 			})
 			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 			defer cancel()
+			var roles compozycontract.RolesResponse
+			if err := harness.HTTPJSON(ctx, http.MethodGet, "/api/roles", nil, &roles); err != nil {
+				t.Fatal(err)
+			}
+			for _, role := range roles.Roles {
+				if role.Role == string(compozyconfig.RoleMemoryExtractor) && role.Enabled != tc.enabled {
+					t.Fatalf("public extractor enabled=%t, want %t", role.Enabled, tc.enabled)
+				}
+			}
+
 			root := createFixtureBackedSession(t, ctx, harness, "opt-in-agent", "")
 			if _, err := harness.PromptSession(ctx, root.ID, "Record the extractor routing decision"); err != nil {
 				t.Fatal(err)
@@ -172,8 +190,8 @@ func TestDaemonE2EMemoryOptInAndExtractorOutput(t *testing.T) {
 					Scan(&decisions); err != nil {
 					t.Fatal(err)
 				}
-				if decisions != 1 {
-					t.Fatalf("preserved candidate decisions=%d, want 1", decisions)
+				if decisions != tc.decisions {
+					t.Fatalf("preserved candidate decisions=%d, want %d", decisions, tc.decisions)
 				}
 			} else if tc.enabled && (completed != 1 || failed != 0) {
 				t.Fatalf("empty extraction completed=%d failed=%d", completed, failed)

--- a/internal/daemon/daemon_memory_e2e_integration_test.go
+++ b/internal/daemon/daemon_memory_e2e_integration_test.go
@@ -33,6 +33,165 @@ const (
 	roleDreamModel        = "routed-dream-model"
 )
 
+func TestDaemonE2EMemoryOptInAndExtractorOutput(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, output    string
+		enabled, failed bool
+	}{
+		{name: "Should keep factory memory idle through a managed turn", output: `{"no_candidates":true}`},
+		{name: "Should complete an opted-in no-candidate extraction without dreaming", enabled: true, output: `{"no_candidates":true}`},
+		{name: "Should persist valid candidates and expose malformed output", enabled: true, failed: true, output: `{"type":"user","content":"Pedro prefers concise updates.","evidence":"seq=1"}` + "\n{broken"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			acpmock.RequireDriver(t)
+			fixture, err := acpmock.LoadFixture(mockFixturePath(t, "agent_roles_fixture.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for i := range fixture.Agents[0].Turns {
+				if fixture.Agents[0].Turns[i].Match.TurnSource == "synthetic" {
+					fixture.Agents[0].Turns[i].Steps[0].Text = tc.output
+				}
+			}
+			data, err := json.Marshal(fixture)
+			if err != nil {
+				t.Fatal(err)
+			}
+			fixturePath := filepath.Join(t.TempDir(), "extractor.json")
+			if err := os.WriteFile(fixturePath, data, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			harness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+				ConfigSeed: e2etest.ConfigSeedOptions{Mutate: func(cfg *compozyconfig.Config) {
+					cfg.Memory.Enabled = compozyconfig.DefaultMemoryConfig(compozyconfig.HomePaths{}).Enabled
+					if tc.enabled {
+						cfg.Memory.Enabled = true
+					}
+					cfg.Roles.Dream.Enabled = compozyconfig.DefaultRolesConfig().Dream.Enabled
+					cfg.Roles.AutoTitle.Enabled = false
+					cfg.Roles.CheckpointSummary.Enabled = false
+					cfg.Memory.Dream.CheckInterval = 10 * time.Millisecond
+					cfg.Roles.MemoryExtractor.Provider = acpmock.ProviderName
+				}},
+				MockAgents: []e2etest.MockAgentSpec{
+					{FixturePath: fixturePath, FixtureAgent: "role-agent", AgentName: "opt-in-agent"},
+				},
+			})
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			root := createFixtureBackedSession(t, ctx, harness, "opt-in-agent", "")
+			if _, err := harness.PromptSession(ctx, root.ID, "Record the extractor routing decision"); err != nil {
+				t.Fatal(err)
+			}
+			if tc.enabled {
+				var drain compozycontract.MemoryExtractorDrainResponse
+				if err := harness.UDSJSON(
+					ctx,
+					http.MethodPost,
+					"/api/memory/extractor/drain",
+					nil,
+					&drain,
+				); err != nil {
+					t.Fatal(err)
+				}
+				if drain.Remaining != 0 {
+					t.Fatalf("drain=%#v", drain)
+				}
+			}
+			var status compozycontract.MemoryExtractorStatusResponse
+			if err := harness.CLI.RunJSON(ctx, &status, "memory", "extractor", "status", "-o", "json"); err != nil {
+				t.Fatal(err)
+			}
+			if !tc.enabled && status.Extractor.Status != compozycontract.MemoryExtractorStateStopped {
+				t.Fatalf("status=%#v", status)
+			}
+			var failures compozycontract.MemoryExtractorFailuresResponse
+			if err := harness.HTTPJSON(
+				ctx,
+				http.MethodGet,
+				"/api/memory/extractor/failures",
+				nil,
+				&failures,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if (len(failures.Failures) > 0) != tc.failed {
+				t.Fatalf("failures=%#v", failures)
+			}
+			if tc.failed && failures.Failures[0].SessionID != root.ID {
+				t.Fatalf("failure lost parent identity: %#v", failures)
+			}
+			var dream compozycontract.MemoryDreamTriggerResponse
+			if err := harness.UDSJSON(
+				ctx,
+				http.MethodPost,
+				"/api/memory/dreams/trigger",
+				compozycontract.MemoryDreamTriggerRequest{WorkspaceID: harness.WorkspaceID},
+				&dream,
+			); err != nil {
+				t.Fatal(err)
+			}
+			if dream.Triggered || !strings.Contains(dream.Reason, "disabled") {
+				t.Fatalf("dream=%#v, want explicitly disabled", dream)
+			}
+			children := 0
+			for _, info := range readWorkspaceRoleSessions(t, ctx, harness) {
+				if info.SessionType == "dream" {
+					t.Fatalf("unexpected dream session: %#v", info)
+				}
+				if info.Lineage != nil && info.Lineage.SpawnRole == sessionpkg.SpawnRoleMemoryExtractor {
+					children++
+				}
+			}
+			db, err := sql.Open("sqlite", harness.HomePaths.DatabaseFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := db.Close(); err != nil {
+					t.Error(err)
+				}
+			})
+			var completed, failed int
+			if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM memory_events WHERE session_id = ? AND op = 'memory.extractor.completed'", root.ID).
+				Scan(&completed); err != nil {
+				t.Fatal(err)
+			}
+			if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM memory_events WHERE session_id = ? AND op = 'memory.extractor.failed'", root.ID).
+				Scan(&failed); err != nil {
+				t.Fatal(err)
+			}
+			if tc.failed {
+				if failed != 1 || completed != 0 {
+					t.Fatalf("events completed=%d failed=%d", completed, failed)
+				}
+				var decisions int
+				if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM memory_decisions WHERE post_content LIKE ?", "%Pedro prefers concise updates.%").
+					Scan(&decisions); err != nil {
+					t.Fatal(err)
+				}
+				if decisions != 1 {
+					t.Fatalf("preserved candidate decisions=%d, want 1", decisions)
+				}
+			} else if tc.enabled && (completed != 1 || failed != 0) {
+				t.Fatalf("empty extraction completed=%d failed=%d", completed, failed)
+			}
+			if !tc.enabled && (completed != 0 || failed != 0) {
+				t.Fatalf("disabled extraction ran: completed=%d failed=%d", completed, failed)
+			}
+			wantChildren := 0
+			if tc.enabled {
+				wantChildren = 1
+			}
+			if children != wantChildren {
+				t.Fatalf("extractor children=%d, want %d", children, wantChildren)
+			}
+		})
+	}
+}
+
 func TestDaemonE2ERolesLiveApplyChangesNextMemoryExtractorModel(t *testing.T) {
 	t.Parallel()
 

--- a/internal/daemon/daemon_runtime_state.go
+++ b/internal/daemon/daemon_runtime_state.go
@@ -31,6 +31,7 @@ type daemonRuntimeState struct {
 	registry               Registry
 	profiles               *profile.Manager
 	memoryStore            *memory.Store
+	checkpointStore        *memory.Store
 	memoryProviderRegistry *extensionpkg.MemoryProviderRegistry
 	memoryExtractor        *daemonMemoryExtractor
 	runtimeWorkers         daemonRuntimeWorkers

--- a/internal/daemon/daemon_shutdown_resources.go
+++ b/internal/daemon/daemon_shutdown_resources.go
@@ -21,6 +21,13 @@ func (d *Daemon) shutdownPersistentResources(ctx context.Context, targets *shutd
 	if err := RemoveInfo(targets.infoPath); err != nil {
 		*errs = append(*errs, err)
 	}
+	if targets.checkpointStore != nil {
+		appendWrappedError(
+			errs,
+			"daemon: close compaction checkpoint catalog",
+			targets.checkpointStore.CloseCatalog(ctx),
+		)
+	}
 	if targets.memoryStore != nil {
 		appendWrappedError(errs, "daemon: close memory catalog database", targets.memoryStore.CloseCatalog(ctx))
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5787,6 +5787,13 @@ func runDreamRuntimeLifecycleCases(t *testing.T) {
 		wantRuntime bool
 	}{
 		{
+			name: "Should keep memory and dream runtimes absent under factory defaults",
+			patch: func(cfg *compozyconfig.Config) {
+				cfg.Memory.Enabled = compozyconfig.DefaultMemoryConfig(compozyconfig.HomePaths{}).Enabled
+				cfg.Roles = compozyconfig.DefaultRolesConfig()
+			},
+		},
+		{
 			name: "Should keep the dream runtime absent when memory is disabled",
 			patch: func(cfg *compozyconfig.Config) {
 				cfg.Memory.Enabled = false
@@ -5837,7 +5844,11 @@ func runDreamRuntimeLifecycleCases(t *testing.T) {
 			})
 			d.mu.Lock()
 			dreamRuntime := d.dreamRuntime
+			memoryExtractor := d.memoryExtractor
 			d.mu.Unlock()
+			if !cfg.Memory.Enabled && memoryExtractor != nil {
+				t.Fatal("disabled memory registered an extractor")
+			}
 			if tc.wantRuntime && !dreamRuntime.Enabled() {
 				t.Fatal("dream runtime Enabled() = false, want memory-backed scheduling for workspace role resolution")
 			}
@@ -5909,6 +5920,7 @@ func TestSessionStopNotifierQueuesDreamCheck(t *testing.T) {
 
 	homePaths := testHomePaths(t)
 	cfg := testConfig(t, homePaths)
+	writeDaemonFile(t, homePaths.ConfigFile, "[memory]\nenabled = true\n[roles.dream]\nenabled = true\n")
 	cfg.Memory.Dream.CheckInterval = time.Hour
 
 	workspace := filepath.Join(t.TempDir(), "workspace")
@@ -6235,6 +6247,9 @@ func testConfig(t *testing.T, homePaths compozyconfig.HomePaths) compozyconfig.C
 	t.Helper()
 
 	cfg := compozyconfig.DefaultWithHome(homePaths)
+	// Runtime fixtures explicitly opt in; default boot coverage uses factory values.
+	cfg.Memory.Enabled = true
+	cfg.Roles.Dream.Enabled = true
 	cfg.HTTP.Host = "127.0.0.1"
 	cfg.HTTP.Port = freeTCPPort(t)
 	cfg.Daemon.Socket = homePaths.DaemonSocket

--- a/internal/daemon/memory_extractor_failure.go
+++ b/internal/daemon/memory_extractor_failure.go
@@ -1,0 +1,43 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/compozy/compozy/internal/fileutil"
+	memcontract "github.com/compozy/compozy/internal/memory/contract"
+	"github.com/compozy/compozy/internal/redact"
+	"github.com/google/uuid"
+)
+
+func (e *forkedMemoryExtractor) recordExtractionFailure(turn memcontract.TurnRecord, output string, cause error) error {
+	if e.failuresDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(e.failuresDir, 0o700); err != nil {
+		return fmt.Errorf("daemon: create extraction failure directory: %w", err)
+	}
+	now := e.nowUTC()
+	report := extractorFailureReport{
+		Stage:       "extract",
+		Source:      "memory extractor child",
+		Error:       redact.String(cause.Error()),
+		Content:     redact.String(output),
+		RecordedAt:  now.Format(time.RFC3339Nano),
+		SessionID:   turn.SessionID,
+		WorkspaceID: turn.WorkspaceID,
+		AgentName:   turn.AgentID,
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("daemon: encode extraction failure: %w", err)
+	}
+	path := filepath.Join(e.failuresDir, "extraction-"+uuid.NewString()+".json")
+	if err := fileutil.AtomicWriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return fmt.Errorf("daemon: write extraction failure: %w", err)
+	}
+	return nil
+}

--- a/internal/daemon/memory_extractor_fork.go
+++ b/internal/daemon/memory_extractor_fork.go
@@ -134,18 +134,28 @@ type forkedMemoryExtractor struct {
 	logger         *slog.Logger
 	now            func() time.Time
 	workspaceRoots *sync.Map
+	failuresDir    string
 }
 
 func (e *forkedMemoryExtractor) Extract(
 	ctx context.Context,
 	turn memcontract.TurnRecord,
-) ([]memcontract.Candidate, error) {
+) (candidates []memcontract.Candidate, resultErr error) {
 	if e == nil || e.sessions == nil {
 		return nil, errors.New("daemon: memory extractor sessions are not configured")
 	}
 	if e.roles == nil {
 		return nil, errors.New("daemon: memory extractor role resolver is not configured")
 	}
+	if e.workspaceRoots != nil {
+		defer e.workspaceRoots.Delete(turn.SessionID)
+	}
+	var output string
+	defer func() {
+		if resultErr != nil {
+			resultErr = errors.Join(resultErr, e.recordExtractionFailure(turn, output, resultErr))
+		}
+	}()
 	correlation := roleInvocationCorrelation{
 		WorkspaceID:     strings.TrimSpace(turn.WorkspaceID),
 		SessionID:       strings.TrimSpace(turn.SessionID),
@@ -176,7 +186,7 @@ func (e *forkedMemoryExtractor) Extract(
 	}
 	child, err := e.spawnExtractorSession(runCtx, role, correlation, turn)
 	if child != nil {
-		defer e.stopChild(ctx, child.ID)
+		defer func() { e.stopChild(ctx, child.ID, resultErr) }()
 	}
 	if err != nil {
 		return nil, fmt.Errorf("daemon: spawn memory extractor session: %w", err)
@@ -193,15 +203,11 @@ func (e *forkedMemoryExtractor) Extract(
 	if err != nil {
 		return nil, fmt.Errorf("daemon: prompt memory extractor session: %w", err)
 	}
-	output, err := collectMemoryExtractorOutput(runCtx, events)
+	output, err = collectMemoryExtractorOutput(runCtx, events)
 	if err != nil {
 		return nil, err
 	}
-	candidates, err := parseMemoryExtractorCandidates(output, turn, e.workspaceRoot(turn.SessionID), e.nowUTC())
-	if err != nil {
-		return nil, err
-	}
-	return candidates, nil
+	return parseMemoryExtractorCandidates(output, turn, e.workspaceRoot(turn.SessionID), e.nowUTC())
 }
 
 func (e *forkedMemoryExtractor) spawnExtractorSession(
@@ -246,10 +252,17 @@ func (e *forkedMemoryExtractor) extractorTTL() time.Duration {
 	return 2 * time.Minute
 }
 
-func (e *forkedMemoryExtractor) stopChild(parentCtx context.Context, id string) {
+func (e *forkedMemoryExtractor) stopChild(parentCtx context.Context, id string, extractionErr error) {
 	stopCtx, cancel := context.WithTimeout(context.WithoutCancel(parentCtx), memoryExtractorStopTimeout)
 	defer cancel()
-	if err := e.sessions.StopWithCause(stopCtx, id, session.CauseCompleted, "memory extractor completed"); err != nil &&
+	cause, detail := session.CauseCompleted, "memory extractor child finished; output parsed"
+	if extractionErr != nil {
+		cause, detail = session.CauseFailed, "memory extractor child failed; see extraction failure diagnostics"
+		if errors.Is(extractionErr, context.DeadlineExceeded) {
+			cause, detail = session.CauseTimeout, "memory extractor child timed out"
+		}
+	}
+	if err := e.sessions.StopWithCause(stopCtx, id, cause, detail); err != nil &&
 		e.logger != nil {
 		e.logger.Warn("daemon: stop memory extractor child failed", "session_id", id, "error", err)
 	}

--- a/internal/daemon/memory_extractor_output.go
+++ b/internal/daemon/memory_extractor_output.go
@@ -78,17 +78,26 @@ func collectMemoryExtractorOutput(ctx context.Context, events <-chan acp.AgentEv
 	for {
 		select {
 		case <-ctx.Done():
-			return "", fmt.Errorf("daemon: collect memory extractor output: %w", ctx.Err())
+			return output.String(), fmt.Errorf("daemon: collect memory extractor output: %w", ctx.Err())
 		case event, ok := <-events:
 			if !ok {
-				return output.String(), nil
+				return output.String(), errors.New("daemon: memory extractor stream closed without a terminal event")
 			}
 			switch event.Type {
 			case acp.EventTypeAgentMessage:
 				// Agent messages are stream chunks; inserting separators can corrupt JSONL.
 				output.WriteString(event.Text)
 			case acp.EventTypeError:
-				return "", fmt.Errorf("daemon: memory extractor agent error: %s", strings.TrimSpace(event.Error))
+				return output.String(), fmt.Errorf(
+					"daemon: memory extractor agent error: %s",
+					strings.TrimSpace(event.Error),
+				)
+			case acp.EventTypeDone:
+				reason := firstNonEmptyString(string(event.PromptStopReason), event.StopReason)
+				if reason != "" && reason != string(acp.PromptStopReasonEndTurn) {
+					return output.String(), fmt.Errorf("daemon: memory extractor stopped before completion: %s", reason)
+				}
+				return output.String(), nil
 			}
 		}
 	}

--- a/internal/daemon/memory_extractor_output.go
+++ b/internal/daemon/memory_extractor_output.go
@@ -68,6 +68,7 @@ func memoryExtractorOverlay() string {
 	return strings.TrimSpace(`
 You are an Compozy internal Memory v2 extractor child session.
 Return only JSONL candidates that match the requested schema.
+If there are no candidates, return exactly {"no_candidates":true}.
 Do not modify files, run commands, or include commentary outside JSONL.
 `)
 }
@@ -94,13 +95,14 @@ func collectMemoryExtractorOutput(ctx context.Context, events <-chan acp.AgentEv
 }
 
 type extractedMemoryLine struct {
-	Type      string `json:"type"`
-	Scope     string `json:"scope"`
-	AgentTier string `json:"agent_tier"`
-	Content   string `json:"content"`
-	Evidence  string `json:"evidence"`
-	Entity    string `json:"entity"`
-	Attribute string `json:"attribute"`
+	NoCandidates bool   `json:"no_candidates"`
+	Type         string `json:"type"`
+	Scope        string `json:"scope"`
+	AgentTier    string `json:"agent_tier"`
+	Content      string `json:"content"`
+	Evidence     string `json:"evidence"`
+	Entity       string `json:"entity"`
+	Attribute    string `json:"attribute"`
 }
 
 func parseMemoryExtractorCandidates(
@@ -113,6 +115,7 @@ func parseMemoryExtractorCandidates(
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	candidates := make([]memcontract.Candidate, 0)
 	lineNumber := 0
+	var failures []error
 	for scanner.Scan() {
 		lineNumber++
 		raw := normalizeExtractorJSONLLine(scanner.Text())
@@ -121,24 +124,41 @@ func parseMemoryExtractorCandidates(
 		}
 		var line extractedMemoryLine
 		if err := json.Unmarshal([]byte(raw), &line); err != nil {
-			return nil, fmt.Errorf("daemon: decode memory extractor line %d: %w", lineNumber, err)
+			failures = append(failures, fmt.Errorf("daemon: decode memory extractor line %d: %w", lineNumber, err))
+			continue
+		}
+		if line.NoCandidates {
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+				return candidates, err
+			}
+			if len(fields) == 1 {
+				continue
+			}
+			failures = append(
+				failures,
+				fmt.Errorf("daemon: memory extractor line %d mixes no_candidates with candidate fields", lineNumber),
+			)
+			continue
 		}
 		candidate, err := candidateFromExtractedLine(line, turn, workspaceRoot, submittedAt)
 		if err != nil {
-			return nil, fmt.Errorf("daemon: normalize memory extractor line %d: %w", lineNumber, err)
+			failures = append(failures, fmt.Errorf("daemon: normalize memory extractor line %d: %w", lineNumber, err))
+			continue
 		}
 		candidates = append(candidates, candidate)
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("daemon: scan memory extractor output: %w", err)
+		failures = append(failures, fmt.Errorf("daemon: scan memory extractor output: %w", err))
 	}
-	return candidates, nil
+	return candidates, errors.Join(failures...)
 }
 
 func normalizeExtractorJSONLLine(raw string) string {
 	line := strings.TrimSpace(raw)
-	switch line {
-	case "", "```", "```json", "```jsonl":
+	switch strings.ToLower(line) {
+	case "", "```", "```json", "```jsonl", "[]", "(none)", "none", "no memories", "no memories.",
+		"no memories to save", "no memories to save.", "no candidates", "no candidates.":
 		return ""
 	default:
 		return line

--- a/internal/daemon/memory_runtime.go
+++ b/internal/daemon/memory_runtime.go
@@ -84,6 +84,7 @@ func newDaemonMemoryExtractor(
 		logger:         state.logger,
 		now:            now,
 		workspaceRoots: workspaceRoots,
+		failuresDir:    extractorFailureDir(state),
 	}
 	runtime, err := extractorpkg.NewRuntime(
 		context.WithoutCancel(ctx),
@@ -376,11 +377,14 @@ type extractorFailure struct {
 }
 
 type extractorFailureReport struct {
-	Stage      string `json:"stage"`
-	Source     string `json:"source"`
-	Error      string `json:"error"`
-	Content    string `json:"content"`
-	RecordedAt string `json:"recorded_at"`
+	SessionID   string `json:"session_id,omitempty"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	AgentName   string `json:"agent_name,omitempty"`
+	Stage       string `json:"stage"`
+	Source      string `json:"source"`
+	Error       string `json:"error"`
+	Content     string `json:"content"`
+	RecordedAt  string `json:"recorded_at"`
 }
 
 func readExtractorFailure(path string) (extractorFailure, error) {
@@ -405,9 +409,9 @@ func readExtractorFailure(path string) (extractorFailure, error) {
 	return extractorFailure{
 		Payload: contract.MemoryExtractorFailurePayload{
 			ID:          strings.TrimSuffix(filepath.Base(path), ".json"),
-			SessionID:   sessionID,
-			WorkspaceID: workspaceID,
-			AgentName:   agentName,
+			SessionID:   firstNonEmptyString(report.SessionID, sessionID),
+			WorkspaceID: firstNonEmptyString(report.WorkspaceID, workspaceID),
+			AgentName:   firstNonEmptyString(report.AgentName, agentName),
 			Reason:      firstNonEmptyString(report.Error, report.Stage),
 			Path:        path,
 			CreatedAt:   createdAt,
@@ -417,6 +421,11 @@ func readExtractorFailure(path string) (extractorFailure, error) {
 }
 
 func (f extractorFailure) Candidates() ([]memcontract.Candidate, error) {
+	if f.Report.Stage == "extract" {
+		return nil, errors.New(
+			"daemon: extraction failures require a new extraction; raw output is not a candidate inbox",
+		)
+	}
 	scanner := bufio.NewScanner(strings.NewReader(f.Report.Content))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	candidates := make([]memcontract.Candidate, 0)

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -200,6 +200,46 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 	})
 }
 
+func TestMemoryExtractorOutputContract(t *testing.T) {
+	t.Parallel()
+	candidate := `{"type":"user","content":"Pedro prefers concise updates."}`
+	for _, tc := range []struct {
+		name, output string
+		count        int
+		failure      bool
+	}{
+		{name: "Should accept explicit no candidates", output: `{"no_candidates":true}`},
+		{name: "Should accept an empty array", output: `[]`},
+		{name: "Should accept conventional no memory prose", output: "No memories to save."},
+		{name: "Should accept parenthesized none", output: "(none)"},
+		{name: "Should accept fenced candidates", output: "```jsonl\n" + candidate + "\n```", count: 1},
+		{name: "Should preserve candidates around invalid JSON", output: candidate + "\n{broken\n" + candidate, count: 2, failure: true},
+		{name: "Should preserve candidates around unknown prose", output: "Here are the candidates:\n" + candidate, count: 1, failure: true},
+		{name: "Should reject unknown prose alone", output: "Unable to determine memories", failure: true},
+		{name: "Should reject invalid candidate fields", output: `{"type":"user","content":""}`, failure: true},
+		{name: "Should reject null", output: `null`, failure: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			candidates, err := parseMemoryExtractorCandidates(
+				tc.output,
+				memcontract.TurnRecord{SessionID: "parent"},
+				"",
+				time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC),
+			)
+			if len(candidates) != tc.count || (err != nil) != tc.failure {
+				t.Fatalf(
+					"parse = %d candidates, %v; want %d candidates, failure=%t",
+					len(candidates),
+					err,
+					tc.count,
+					tc.failure,
+				)
+			}
+		})
+	}
+}
+
 func TestDaemonMemoryProviderService(t *testing.T) {
 	t.Parallel()
 
@@ -241,6 +281,64 @@ func TestForkedMemoryExtractor(t *testing.T) {
 			t.Fatalf("Extract() = %#v with %d spawn calls, want skipped", candidates, sessions.spawnCalls)
 		}
 	})
+
+	for _, tc := range []struct {
+		name, output string
+		cause        session.StopCause
+		count        int
+		promptErr    error
+	}{
+		{name: "Should stop a parsed empty child without a failure report", output: `{"no_candidates":true}`, cause: session.CauseCompleted},
+		{name: "Should preserve partial output and expose its failure", output: `{"type":"user","content":"Pedro prefers concise updates."}` + "\n{broken", cause: session.CauseFailed, count: 1},
+		{name: "Should classify deadline failure separately from parsing", cause: session.CauseTimeout, promptErr: context.DeadlineExceeded},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			failuresDir := t.TempDir()
+			sessions := &recordingMemoryExtractorSessions{output: tc.output, promptErr: tc.promptErr}
+			extractor := &forkedMemoryExtractor{
+				sessions:    sessions,
+				roles:       resolvedRoleResolver(ResolvedRole{Enabled: true}),
+				deadline:    time.Second,
+				failuresDir: failuresDir,
+			}
+			candidates, err := extractor.Extract(
+				t.Context(),
+				memcontract.TurnRecord{SessionID: "parent", WorkspaceID: "workspace", AgentID: "agent"},
+			)
+			if (err != nil) != (tc.cause != session.CauseCompleted) || len(candidates) != tc.count {
+				t.Fatalf("Extract=%#v, %v", candidates, err)
+			}
+			if sessions.stopCause != tc.cause || strings.Contains(sessions.stopDetail, "extractor completed") {
+				t.Fatalf("stop=%v %q", sessions.stopCause, sessions.stopDetail)
+			}
+			inspector := &daemonMemoryExtractor{failuresDir: failuresDir}
+			failures, listErr := inspector.ListFailures(t.Context())
+			if listErr != nil {
+				t.Fatal(listErr)
+			}
+			if err == nil {
+				if len(failures) != 0 {
+					t.Fatalf("unexpected failures: %#v", failures)
+				}
+				return
+			}
+			if len(failures) != 1 || failures[0].SessionID != "parent" || failures[0].WorkspaceID != "workspace" ||
+				failures[0].AgentName != "agent" {
+				t.Fatalf("failures=%#v", failures)
+			}
+			failure, readErr := readExtractorFailure(failures[0].Path)
+			if readErr != nil {
+				t.Fatal(readErr)
+			}
+			if _, decodeErr := failure.Candidates(); decodeErr == nil {
+				t.Fatal("raw extraction failure must not replay as normalized candidates")
+			}
+			if tc.promptErr != nil && !errors.Is(err, tc.promptErr) {
+				t.Fatalf("error lost deadline identity: %v", err)
+			}
+		})
+	}
 
 	t.Run("Should pass the configured model to the extractor child spawn", func(t *testing.T) {
 		t.Parallel()
@@ -308,6 +406,10 @@ type recordingMemoryExtractorSessions struct {
 	spawnCalls int
 	spawnOpts  session.SpawnOpts
 	stoppedID  string
+	output     string
+	promptErr  error
+	stopCause  session.StopCause
+	stopDetail string
 }
 
 func (s *recordingMemoryExtractorSessions) Spawn(
@@ -324,7 +426,11 @@ func (s *recordingMemoryExtractorSessions) PromptSynthetic(
 	_ string,
 	_ session.SyntheticPromptOpts,
 ) (<-chan acp.AgentEvent, error) {
-	events := make(chan acp.AgentEvent)
+	if s.promptErr != nil {
+		return nil, s.promptErr
+	}
+	events := make(chan acp.AgentEvent, 1)
+	events <- acp.AgentEvent{Type: acp.EventTypeAgentMessage, Text: s.output}
 	close(events)
 	return events, nil
 }
@@ -332,9 +438,10 @@ func (s *recordingMemoryExtractorSessions) PromptSynthetic(
 func (s *recordingMemoryExtractorSessions) StopWithCause(
 	_ context.Context,
 	id string,
-	_ session.StopCause,
-	_ string,
+	cause session.StopCause,
+	detail string,
 ) error {
 	s.stoppedID = id
+	s.stopCause, s.stopDetail = cause, detail
 	return nil
 }

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -109,6 +109,7 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 			Type: acp.EventTypeAgentMessage,
 			Text: ",\"entity\":\"ws-test\",\"attribute\":\"network_channel_marketing_exists\"}\n```",
 		}
+		events <- acp.AgentEvent{Type: acp.EventTypeDone, PromptStopReason: acp.PromptStopReasonEndTurn}
 		close(events)
 
 		output, err := collectMemoryExtractorOutput(testutil.Context(t), events)
@@ -170,6 +171,27 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 			)
 		}
 	})
+
+	for _, tc := range []struct {
+		name     string
+		terminal acp.AgentEvent
+	}{
+		{name: "Should retain output on provider error", terminal: acp.AgentEvent{Type: acp.EventTypeError, Error: "disconnected"}},
+		{name: "Should reject a cancelled terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: "cancelled"}},
+		{name: "Should reject a truncated terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: "max_tokens"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			events := make(chan acp.AgentEvent, 2)
+			events <- acp.AgentEvent{Type: acp.EventTypeAgentMessage, Text: "partial output"}
+			events <- tc.terminal
+			close(events)
+			output, err := collectMemoryExtractorOutput(t.Context(), events)
+			if err == nil || output != "partial output" {
+				t.Fatalf("collected=%q error=%v, want diagnostic output and failure", output, err)
+			}
+		})
+	}
 
 	t.Run("Should discard agent tier outside agent-scoped candidates", func(t *testing.T) {
 		t.Parallel()
@@ -287,15 +309,21 @@ func TestForkedMemoryExtractor(t *testing.T) {
 		cause        session.StopCause
 		count        int
 		promptErr    error
+		incomplete   bool
 	}{
 		{name: "Should stop a parsed empty child without a failure report", output: `{"no_candidates":true}`, cause: session.CauseCompleted},
 		{name: "Should preserve partial output and expose its failure", output: `{"type":"user","content":"Pedro prefers concise updates."}` + "\n{broken", cause: session.CauseFailed, count: 1},
+		{name: "Should reject an interrupted candidate and retain diagnostic output", output: `{"type":"user","content":"partial fact"}`, incomplete: true, cause: session.CauseFailed},
 		{name: "Should classify deadline failure separately from parsing", cause: session.CauseTimeout, promptErr: context.DeadlineExceeded},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			failuresDir := t.TempDir()
-			sessions := &recordingMemoryExtractorSessions{output: tc.output, promptErr: tc.promptErr}
+			sessions := &recordingMemoryExtractorSessions{
+				output:     tc.output,
+				promptErr:  tc.promptErr,
+				incomplete: tc.incomplete,
+			}
 			extractor := &forkedMemoryExtractor{
 				sessions:    sessions,
 				roles:       resolvedRoleResolver(ResolvedRole{Enabled: true}),
@@ -330,6 +358,9 @@ func TestForkedMemoryExtractor(t *testing.T) {
 			failure, readErr := readExtractorFailure(failures[0].Path)
 			if readErr != nil {
 				t.Fatal(readErr)
+			}
+			if tc.incomplete && !strings.Contains(failure.Report.Content, "partial fact") {
+				t.Fatalf("incomplete output missing from diagnostic: %#v", failure)
 			}
 			if _, decodeErr := failure.Candidates(); decodeErr == nil {
 				t.Fatal("raw extraction failure must not replay as normalized candidates")
@@ -410,6 +441,7 @@ type recordingMemoryExtractorSessions struct {
 	promptErr  error
 	stopCause  session.StopCause
 	stopDetail string
+	incomplete bool
 }
 
 func (s *recordingMemoryExtractorSessions) Spawn(
@@ -429,8 +461,11 @@ func (s *recordingMemoryExtractorSessions) PromptSynthetic(
 	if s.promptErr != nil {
 		return nil, s.promptErr
 	}
-	events := make(chan acp.AgentEvent, 1)
+	events := make(chan acp.AgentEvent, 2)
 	events <- acp.AgentEvent{Type: acp.EventTypeAgentMessage, Text: s.output}
+	if !s.incomplete {
+		events <- acp.AgentEvent{Type: acp.EventTypeDone, PromptStopReason: acp.PromptStopReasonEndTurn}
+	}
 	close(events)
 	return events, nil
 }

--- a/internal/daemon/role_fallback.go
+++ b/internal/daemon/role_fallback.go
@@ -25,14 +25,15 @@ type roleEventSummaryWriter interface {
 }
 
 type roleInvocationCorrelation struct {
-	ProfileID       string
-	WorkspaceID     string
-	SessionID       string
-	AgentName       string
-	ParentSessionID string
-	RootSessionID   string
-	SpawnDepth      int
-	Event           store.EventCorrelation
+	SessionCompaction bool
+	ProfileID         string
+	WorkspaceID       string
+	SessionID         string
+	AgentName         string
+	ParentSessionID   string
+	RootSessionID     string
+	SpawnDepth        int
+	Event             store.EventCorrelation
 }
 
 type roleInvocationCorrelationContextKey struct{}

--- a/internal/daemon/role_fallback_test.go
+++ b/internal/daemon/role_fallback_test.go
@@ -252,6 +252,8 @@ func TestRoleObservabilityCoverageMatrix(t *testing.T) {
 		t.Parallel()
 
 		cfg := compozyconfig.DefaultWithHome(compozyconfig.HomePaths{})
+		cfg.Memory.Enabled = true
+		cfg.Roles.Dream.Enabled = true
 		cfg.Roles.Dream.Agent = "missing-curator"
 		recorder := &roleEventRecorder{}
 		resolver := newRoleResolver(&cfg, nil, nil, recorder)

--- a/internal/daemon/role_resolver.go
+++ b/internal/daemon/role_resolver.go
@@ -135,11 +135,8 @@ func (r *roleResolver) resolveEffective(
 		ReasoningEffort: strings.TrimSpace(common.ReasoningEffort),
 	}
 	compaction := roleInvocationCorrelationFromContext(ctx, workspaceID).SessionCompaction
-	if role == compozyconfig.RoleDream || role == compozyconfig.RoleMemoryExtractor ||
-		(role == compozyconfig.RoleCheckpointSummary && !compaction) ||
-		role == compozyconfig.RoleMemoryController {
-		resolved.Enabled = resolved.Enabled && effectiveConfig.Memory.Enabled
-	}
+	memoryEnabled := r.config.Memory.Enabled && effectiveConfig.Memory.Enabled
+	resolved.Enabled = effectiveRoleEnabled(role, common.Enabled, memoryEnabled, compaction)
 	resolved.setRuntime(speedpkg.Speed(strings.TrimSpace(string(common.Speed))), common.ACPOptions)
 	if !resolved.Enabled {
 		populateDisabledRoleIdentity(role, common, &resolved)
@@ -380,4 +377,20 @@ func firstRoleValue(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// effectiveRoleEnabled keeps background status and invocation under the same memory gate.
+// Pressure summaries belong to the session lifecycle and use their explicit role switch.
+func effectiveRoleEnabled(role compozyconfig.RoleName, enabled, memoryEnabled, compaction bool) bool {
+	if !enabled {
+		return false
+	}
+	switch role {
+	case compozyconfig.RoleDream, compozyconfig.RoleMemoryExtractor, compozyconfig.RoleMemoryController:
+		return memoryEnabled
+	case compozyconfig.RoleCheckpointSummary:
+		return memoryEnabled || compaction
+	default:
+		return true
+	}
 }

--- a/internal/daemon/role_resolver.go
+++ b/internal/daemon/role_resolver.go
@@ -134,6 +134,12 @@ func (r *roleResolver) resolveEffective(
 		Model:           strings.TrimSpace(common.Model),
 		ReasoningEffort: strings.TrimSpace(common.ReasoningEffort),
 	}
+	compaction := roleInvocationCorrelationFromContext(ctx, workspaceID).SessionCompaction
+	if role == compozyconfig.RoleDream || role == compozyconfig.RoleMemoryExtractor ||
+		(role == compozyconfig.RoleCheckpointSummary && !compaction) ||
+		role == compozyconfig.RoleMemoryController {
+		resolved.Enabled = resolved.Enabled && effectiveConfig.Memory.Enabled
+	}
 	resolved.setRuntime(speedpkg.Speed(strings.TrimSpace(string(common.Speed))), common.ACPOptions)
 	if !resolved.Enabled {
 		populateDisabledRoleIdentity(role, common, &resolved)

--- a/internal/daemon/role_resolver_integration_test.go
+++ b/internal/daemon/role_resolver_integration_test.go
@@ -38,11 +38,11 @@ func TestRoleResolverIntegration(t *testing.T) {
 			model   string
 		}{
 			{role: compozyconfig.RoleCoordinator, agent: compozyconfig.BuiltinCoordinatorAgentName, builtin: true},
-			{role: compozyconfig.RoleDream, agent: compozyconfig.BuiltinDreamingCuratorAgentName, enabled: true, builtin: true},
-			{role: compozyconfig.RoleCheckpointSummary, agent: compozyconfig.BuiltinDreamingCuratorAgentName, enabled: true, builtin: true},
-			{role: compozyconfig.RoleMemoryExtractor, enabled: true, inherit: true},
+			{role: compozyconfig.RoleDream, agent: compozyconfig.BuiltinDreamingCuratorAgentName, builtin: true},
+			{role: compozyconfig.RoleCheckpointSummary, agent: compozyconfig.BuiltinDreamingCuratorAgentName, builtin: true},
+			{role: compozyconfig.RoleMemoryExtractor, inherit: true},
 			{role: compozyconfig.RoleAutoTitle, enabled: true, inherit: true},
-			{role: compozyconfig.RoleMemoryController, enabled: defaults.MemoryController.Enabled, model: defaults.MemoryController.Model},
+			{role: compozyconfig.RoleMemoryController, model: defaults.MemoryController.Model},
 		} {
 			t.Run("Should resolve "+string(testCase.role), func(t *testing.T) {
 				t.Parallel()

--- a/internal/daemon/role_resolver_test.go
+++ b/internal/daemon/role_resolver_test.go
@@ -369,5 +369,8 @@ func (s roleWorkspaceResolverStub) ResolveOrRegister(
 }
 
 func roleResolverConfig() compozyconfig.Config {
-	return compozyconfig.DefaultWithHome(compozyconfig.HomePaths{})
+	cfg := compozyconfig.DefaultWithHome(compozyconfig.HomePaths{})
+	cfg.Memory.Enabled = true
+	cfg.Roles.Dream.Enabled = true
+	return cfg
 }

--- a/internal/daemon/role_status.go
+++ b/internal/daemon/role_status.go
@@ -62,9 +62,10 @@ func (r *roleResolver) projectRoleStatus(
 	if err != nil {
 		return contract.RoleStatus{}, err
 	}
+	memoryEnabled := r.config.Memory.Enabled && effective.Memory.Enabled
 	status := contract.RoleStatus{
 		Role:            string(role),
-		Enabled:         common.Enabled,
+		Enabled:         effectiveRoleEnabled(role, common.Enabled, memoryEnabled, false),
 		ResolutionMode:  mode,
 		Agent:           agent,
 		Provider:        roleStatusString(common.Provider),

--- a/internal/daemon/role_status_test.go
+++ b/internal/daemon/role_status_test.go
@@ -41,6 +41,65 @@ func TestRoleStatusProjection(t *testing.T) {
 		}
 	})
 
+	for _, tc := range []struct {
+		name                        string
+		memoryEnabled, rolesEnabled bool
+	}{
+		{name: "Should project memory master suppression", rolesEnabled: true},
+		{name: "Should project deliberate memory opt-in", memoryEnabled: true, rolesEnabled: true},
+		{name: "Should retain explicit role opt-out", memoryEnabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := roleResolverConfig()
+			cfg.Roles.Coordinator.Enabled = true
+			cfg.Memory.Enabled = tc.memoryEnabled
+			cfg.Roles.Dream.Enabled = tc.rolesEnabled
+			cfg.Roles.MemoryExtractor.Enabled = tc.rolesEnabled
+			cfg.Roles.MemoryController.Enabled = tc.rolesEnabled
+			cfg.Roles.CheckpointSummary.Enabled = tc.rolesEnabled
+			resolver := newRoleResolver(&cfg, nil, nil)
+			statuses, err := resolver.RoleStatuses(t.Context(), "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, status := range statuses {
+				want := true
+				switch compozyconfig.RoleName(status.Role) {
+				case compozyconfig.RoleDream, compozyconfig.RoleMemoryExtractor,
+					compozyconfig.RoleMemoryController, compozyconfig.RoleCheckpointSummary:
+					want = tc.memoryEnabled && tc.rolesEnabled
+				}
+				if status.Enabled != want {
+					t.Fatalf("role %s enabled=%t, want %t", status.Role, status.Enabled, want)
+				}
+				single, err := resolver.RoleStatus(t.Context(), "", status.Role)
+				if err != nil || single.Enabled != status.Enabled {
+					t.Fatalf("single role=%#v error=%v", single, err)
+				}
+			}
+		})
+	}
+
+	t.Run("Should keep workspace opt-in behind the daemon memory master", func(t *testing.T) {
+		t.Parallel()
+		global := roleResolverConfig()
+		global.Memory.Enabled = false
+		workspace := roleResolverConfig()
+		workspace.Memory.Enabled = true
+		resolver := newRoleResolver(&global, roleWorkspaceResolverStub{configs: map[string]compozyconfig.Config{
+			"ws-memory": workspace,
+		}}, nil)
+		status, err := resolver.RoleStatus(t.Context(), "ws-memory", string(compozyconfig.RoleMemoryExtractor))
+		if err != nil || status.Enabled {
+			t.Fatalf("workspace status=%#v error=%v", status, err)
+		}
+		resolved, err := resolver.Resolve(t.Context(), "ws-memory", compozyconfig.RoleMemoryExtractor)
+		if err != nil || resolved.Enabled {
+			t.Fatalf("workspace invocation=%#v error=%v", resolved, err)
+		}
+	})
+
 	t.Run("Should report a missing catalog agent without failing projection", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/runtime_dream_dependencies.go
+++ b/internal/daemon/runtime_dream_dependencies.go
@@ -38,6 +38,7 @@ func (d *Daemon) initializeDreamRuntime(state *bootState, sessions SessionManage
 		func() (time.Time, error) {
 			return memory.NewConsolidationLock(lockPath).LastConsolidatedAt()
 		},
+		consolidation.WithEligibility(dreamRoleEligibility(sessions, roles)),
 	)
 }
 
@@ -79,5 +80,37 @@ func dreamSessionRouteResolver(roles RoleResolver) consolidation.SessionRouteRes
 				})
 			},
 		}, nil
+	}
+}
+
+func dreamRoleEligibility(sessions SessionManager, roles RoleResolver) func(context.Context, string) (bool, error) {
+	return func(ctx context.Context, workspace string) (bool, error) {
+		role, err := roles.Resolve(ctx, workspace, compozyconfig.RoleDream)
+		if err != nil {
+			return false, err
+		}
+		if strings.TrimSpace(workspace) != "" || role.Enabled {
+			return role.Enabled, nil
+		}
+		infos, err := sessions.ListAll(ctx)
+		if err != nil {
+			return false, err
+		}
+		seen := make(map[string]bool)
+		for _, info := range infos {
+			if info == nil || info.Type == session.SessionTypeDream || info.WorkspaceID == "" ||
+				seen[info.WorkspaceID] {
+				continue
+			}
+			seen[info.WorkspaceID] = true
+			role, err := roles.Resolve(ctx, info.WorkspaceID, compozyconfig.RoleDream)
+			if err != nil {
+				return false, err
+			}
+			if role.Enabled {
+				return true, nil
+			}
+		}
+		return false, nil
 	}
 }

--- a/internal/memory/checkpoint_summary.go
+++ b/internal/memory/checkpoint_summary.go
@@ -56,6 +56,8 @@ var (
 
 // CheckpointSummaryRequest is the bounded input supplied to a checkpoint summarizer.
 type CheckpointSummaryRequest struct {
+	// Compaction distinguishes pressure-driven session lifecycle work from session-end memory updates.
+	Compaction      bool
 	WorkspaceID     string
 	WorkspaceRoot   string
 	SessionID       string

--- a/internal/memory/checkpoint_summary_test.go
+++ b/internal/memory/checkpoint_summary_test.go
@@ -286,52 +286,55 @@ func TestCheckpointSummaryServiceUpdate(t *testing.T) {
 func TestCheckpointSummaryServiceCompactionCoverage(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Should preserve the existing hint when the workspace role is disabled", func(t *testing.T) {
-		t.Parallel()
+	t.Run(
+		"Should preserve the existing hint but reject uncovered compaction when the workspace role is disabled",
+		func(t *testing.T) {
+			t.Parallel()
 
-		env := newCheckpointSummaryTestEnv(t)
-		seedService := NewCheckpointSummaryService(
-			env.store,
-			env.resolver,
-			&checkpointSummarizerStub{outputs: []string{
-				checkpointSummaryFixture("Stable checkpoint fact."),
-			}},
-		)
-		if _, err := seedService.Update(
-			testutil.Context(t),
-			env.sessionEndRecord("sess-prior", "stable"),
-		); err != nil {
-			t.Fatalf("Update(prior) error = %v", err)
-		}
-		workspaceStore := env.store.ForWorkspace(env.workspaceRoot)
-		before, err := workspaceStore.Read(t.Context(), memcontract.ScopeWorkspace, CheckpointSummaryFilename)
-		if err != nil {
-			t.Fatalf("Read(before disabled compaction) error = %v", err)
-		}
+			env := newCheckpointSummaryTestEnv(t)
+			seedService := NewCheckpointSummaryService(
+				env.store,
+				env.resolver,
+				&checkpointSummarizerStub{outputs: []string{
+					checkpointSummaryFixture("Stable checkpoint fact."),
+				}},
+			)
+			if _, err := seedService.Update(
+				testutil.Context(t),
+				env.sessionEndRecord("sess-prior", "stable"),
+			); err != nil {
+				t.Fatalf("Update(prior) error = %v", err)
+			}
+			workspaceStore := env.store.ForWorkspace(env.workspaceRoot)
+			before, err := workspaceStore.Read(t.Context(), memcontract.ScopeWorkspace, CheckpointSummaryFilename)
+			if err != nil {
+				t.Fatalf("Read(before disabled compaction) error = %v", err)
+			}
 
-		service := NewCheckpointSummaryService(
-			env.store,
-			env.resolver,
-			&checkpointSummarizerStub{errAt: map[int]error{0: ErrCheckpointSummaryDisabled}},
-		)
-		result, err := service.Compact(
-			testutil.Context(t),
-			env.preCompressRequest("sess-disabled", 1, 4, "must not persist"),
-		)
-		if err != nil {
-			t.Fatalf("Compact(disabled role) error = %v", err)
-		}
-		if result.Decision.Applied || !strings.Contains(result.Hint.Markdown, "Stable checkpoint fact.") {
-			t.Fatalf("Compact(disabled role) = %#v, want prior hint and no decision", result)
-		}
-		after, err := workspaceStore.Read(t.Context(), memcontract.ScopeWorkspace, CheckpointSummaryFilename)
-		if err != nil {
-			t.Fatalf("Read(after disabled compaction) error = %v", err)
-		}
-		if !bytes.Equal(after, before) {
-			t.Fatalf("disabled compaction changed checkpoint\nbefore:\n%s\nafter:\n%s", before, after)
-		}
-	})
+			service := NewCheckpointSummaryService(
+				env.store,
+				env.resolver,
+				&checkpointSummarizerStub{errAt: map[int]error{0: ErrCheckpointSummaryDisabled}},
+			)
+			result, err := service.Compact(
+				testutil.Context(t),
+				env.preCompressRequest("sess-disabled", 1, 4, "must not persist"),
+			)
+			if !errors.Is(err, ErrCheckpointSummaryDisabled) {
+				t.Fatalf("Compact(disabled role) error = %v, want disabled sentinel to prevent archive", err)
+			}
+			if result.Decision.Applied || !strings.Contains(result.Hint.Markdown, "Stable checkpoint fact.") {
+				t.Fatalf("Compact(disabled role) = %#v, want prior hint and no decision", result)
+			}
+			after, err := workspaceStore.Read(t.Context(), memcontract.ScopeWorkspace, CheckpointSummaryFilename)
+			if err != nil {
+				t.Fatalf("Read(after disabled compaction) error = %v", err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("disabled compaction changed checkpoint\nbefore:\n%s\nafter:\n%s", before, after)
+			}
+		},
+	)
 
 	t.Run("Should record one idempotent covered range before archive", func(t *testing.T) {
 		t.Parallel()

--- a/internal/memory/checkpoint_summary_update.go
+++ b/internal/memory/checkpoint_summary_update.go
@@ -61,6 +61,7 @@ func (s *CheckpointSummaryService) Compact(
 	}
 
 	summaryRequest := CheckpointSummaryRequest{
+		Compaction:      true,
 		WorkspaceID:     workspaceID,
 		WorkspaceRoot:   workspaceRoot,
 		SessionID:       strings.TrimSpace(request.SessionID),
@@ -74,7 +75,7 @@ func (s *CheckpointSummaryService) Compact(
 		if errors.Is(err, ErrCheckpointSummaryDisabled) {
 			return CheckpointCompactionResult{Hint: memcontract.PreCompressHint{
 				Markdown: firstCheckpointValue(state.coverage.ResumeSummary, state.body),
-			}}, nil
+			}}, ErrCheckpointSummaryDisabled
 		}
 		return CheckpointCompactionResult{}, err
 	}

--- a/internal/memory/consolidation/runtime.go
+++ b/internal/memory/consolidation/runtime.go
@@ -39,6 +39,7 @@ type SessionManager interface {
 // Runtime owns dream scheduling, trigger behavior, and session spawning.
 type Runtime struct {
 	enabled            func() bool
+	eligible           func(context.Context, string) (bool, error)
 	service            Service
 	spawner            memory.SessionSpawner
 	logger             *slog.Logger
@@ -86,11 +87,12 @@ func NewRuntime(
 	interval time.Duration,
 	logger *slog.Logger,
 	lastConsolidatedAt func() (time.Time, error),
+	options ...RuntimeOption,
 ) *Runtime {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Runtime{
+	runtime := &Runtime{
 		enabled:            enabled,
 		service:            service,
 		spawner:            spawner,
@@ -98,6 +100,10 @@ func NewRuntime(
 		interval:           interval,
 		lastConsolidatedAt: lastConsolidatedAt,
 	}
+	for _, option := range options {
+		option(runtime)
+	}
+	return runtime
 }
 
 // Start launches the background dream check loop when the runtime is configured.
@@ -200,6 +206,16 @@ func (r *Runtime) runCheck(
 		logger = slog.Default()
 	}
 
+	if r.eligible != nil {
+		eligible, err := r.eligible(ctx, workspaceRef)
+		if err != nil {
+			logger.Warn("daemon: resolve dream enablement failed", "workspace_ref", workspaceRef, "error", err)
+			return
+		}
+		if !eligible {
+			return
+		}
+	}
 	logger.Debug("daemon: evaluating dream consolidation gates", "reason", reason, "workspace_ref", workspaceRef)
 	shouldRun, err := service.ShouldRun()
 	if err != nil {

--- a/internal/memory/consolidation/runtime_test.go
+++ b/internal/memory/consolidation/runtime_test.go
@@ -22,6 +22,31 @@ import (
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 )
 
+func TestRuntimeEligibility(t *testing.T) {
+	t.Parallel()
+	t.Run("Should skip all consolidation work until explicitly enabled", func(t *testing.T) {
+		t.Parallel()
+		service := &fakeDreamService{shouldRun: true}
+		enabled := false
+		runtime := NewRuntime(func() bool { return true }, service,
+			func(context.Context, string, string, string, time.Time) error { return nil },
+			time.Minute, nil, nil, WithEligibility(func(context.Context, string) (bool, error) { return enabled, nil }))
+		triggered, _, err := runtime.Trigger(t.Context(), "workspace")
+		if err != nil || triggered {
+			t.Fatalf("disabled trigger=%t error=%v", triggered, err)
+		}
+		runtime.runCheck(t.Context(), nil, service, runtime.spawner, "ticker", "workspace")
+		if service.shouldRunCalls != 0 || service.runCount() != 0 {
+			t.Fatal("disabled dreaming evaluated gates or ran consolidation")
+		}
+		enabled = true
+		triggered, _, err = runtime.Trigger(t.Context(), "workspace")
+		if err != nil || !triggered || service.runCount() != 1 {
+			t.Fatalf("enabled trigger=%t error=%v runs=%d", triggered, err, service.runCount())
+		}
+	})
+}
+
 func TestRuntimeTriggerReturnsAlreadyRunningWhenLockUnavailable(t *testing.T) {
 	t.Parallel()
 	t.Run("Should report an already-running lock conflict as a clean skip", func(t *testing.T) {

--- a/internal/memory/consolidation/runtime_trigger.go
+++ b/internal/memory/consolidation/runtime_trigger.go
@@ -28,6 +28,15 @@ func (r *Runtime) Trigger(ctx context.Context, workspace string) (bool, string, 
 		return false, "dream consolidation is disabled", nil
 	}
 
+	if r.eligible != nil {
+		eligible, err := r.eligible(ctx, workspace)
+		if err != nil {
+			return false, "", err
+		}
+		if !eligible {
+			return false, "dream role is disabled", nil
+		}
+	}
 	shouldRun, err := r.service.ShouldRun()
 	if err != nil {
 		return false, "", err
@@ -49,4 +58,12 @@ func (r *Runtime) Trigger(ctx context.Context, workspace string) (bool, string, 
 	}
 
 	return true, "", nil
+}
+
+// RuntimeOption customizes dream scheduling before it starts.
+type RuntimeOption func(*Runtime)
+
+// WithEligibility gates both scheduled and manual work before consolidation touches state.
+func WithEligibility(eligible func(context.Context, string) (bool, error)) RuntimeOption {
+	return func(r *Runtime) { r.eligible = eligible }
 }

--- a/internal/memory/contract/types.go
+++ b/internal/memory/contract/types.go
@@ -332,7 +332,7 @@ type TurnRecord struct {
 	Trigger         Trigger            `json:"trigger"`
 }
 
-// Extractor produces memory candidates from transcript turns.
+// Extractor may return valid partial candidates with an error diagnosing the rejected output.
 type Extractor interface {
 	Extract(ctx context.Context, turn TurnRecord) ([]Candidate, error)
 	Drain(ctx context.Context) error

--- a/internal/memory/extractor/runtime_process.go
+++ b/internal/memory/extractor/runtime_process.go
@@ -63,16 +63,22 @@ func (r *Runtime) process(req request) bool {
 			"coalesced_count": strconv.Itoa(req.coalesceCount),
 		},
 	})
-	candidates, err := r.extractor.Extract(r.workerCtx, req.turn)
-	if err != nil {
-		r.recordEvent(r.workerCtx, Event{Op: EventFailed, Turn: req.turn, Error: err.Error()})
-		r.logger.Warn("memory extractor: extract failed", "session_id", req.turn.SessionID, "error", err)
-		return true
+	candidates, extractionErr := r.extractor.Extract(r.workerCtx, req.turn)
+	if extractionErr != nil {
+		r.recordEvent(r.workerCtx, Event{Op: EventFailed, Turn: req.turn, Error: extractionErr.Error(),
+			Metadata: map[string]string{"candidate_count": strconv.Itoa(len(candidates))}})
+		r.logger.Warn("memory extractor: extract failed", "session_id", req.turn.SessionID, "error", extractionErr)
+		if len(candidates) == 0 {
+			return true
+		}
 	}
 	path, count, err := r.producer.Write(r.workerCtx, req.turn, candidates)
 	if err != nil {
 		r.recordEvent(r.workerCtx, Event{Op: EventFailed, Turn: req.turn, Error: err.Error()})
 		r.logger.Warn("memory extractor: write inbox failed", "session_id", req.turn.SessionID, "error", err)
+		return true
+	}
+	if extractionErr != nil {
 		return true
 	}
 	r.recordEvent(r.workerCtx, Event{

--- a/internal/memory/extractor/runtime_test.go
+++ b/internal/memory/extractor/runtime_test.go
@@ -484,6 +484,35 @@ func TestRuntime(t *testing.T) {
 		}
 	})
 
+	t.Run("Should preserve partial candidates without reporting extraction success", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		fake := newFakeExtractor()
+		fake.setResult([]memcontract.Candidate{testCandidate("Pedro prefers brief updates.")})
+		fake.setError(errors.New("decode memory extractor line 2"))
+		events := &recordingEventSink{}
+		runtime := newTestRuntime(t, root, fake, events)
+		if err := runtime.Enqueue(testutil.Context(t), testTurn("partial", 1)); err != nil {
+			t.Fatal(err)
+		}
+		if err := runtime.Drain(testutil.Context(t)); err != nil {
+			t.Fatal(err)
+		}
+		sink := &recordingProposalSink{}
+		consumer, err := extractor.NewInboxConsumer(root, sink)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := consumer.ConsumeOnce(testutil.Context(t))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Proposed != 1 || !events.containsOp(extractor.EventFailed) ||
+			events.containsOp(extractor.EventCompleted) {
+			t.Fatalf("result=%#v events=%#v, want one preserved candidate and failure only", result, events.ops())
+		}
+	})
+
 	t.Run("Should record extractor failures without producing inbox files", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/memory/prompts/extract.v1.tmpl
+++ b/internal/memory/prompts/extract.v1.tmpl
@@ -2,7 +2,8 @@
 
 You are extracting candidate Compozy Memory v2 facts from a completed assistant turn.
 
-Return JSONL. Each line is one candidate with:
+Return JSONL. If there are no durable candidates, return exactly `{"no_candidates":true}`.
+Do not describe the empty result in prose. Each candidate line has:
 
 ```json
 {"type":"user|feedback|project|reference","scope":"global|workspace|agent","agent_tier":"","content":"","evidence":"","entity":"","attribute":""}

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -38,7 +38,7 @@ func TestGetSectionBuildsSupportedSections(t *testing.T) {
 
 	ctx := context.Background()
 	homePaths := testHomePaths(t)
-	writeFile(t, homePaths.ConfigFile, baseSettingsConfig())
+	writeFile(t, homePaths.ConfigFile, baseSettingsConfig()+"\n[roles.dream]\nenabled = true\n")
 
 	service := testService(t, homePaths, Dependencies{
 		GeneralRuntime: fakeGeneralRuntimeProvider{

--- a/internal/testutil/e2e/config_seed.go
+++ b/internal/testutil/e2e/config_seed.go
@@ -109,6 +109,9 @@ func SeedConfig(t testing.TB, homePaths compozyconfig.HomePaths, opts ConfigSeed
 	t.Helper()
 
 	cfg := compozyconfig.DefaultWithHome(homePaths)
+	// Full-feature runtime fixtures opt in; factory-default scenarios override these switches.
+	cfg.Memory.Enabled = true
+	cfg.Roles.Dream.Enabled = true
 	cfg.HTTP.Host = defaultString(opts.Host, "127.0.0.1")
 	if opts.HTTPPort > 0 {
 		cfg.HTTP.Port = opts.HTTPPort

--- a/packages/site/content/docs/configuration/config-toml.mdx
+++ b/packages/site/content/docs/configuration/config-toml.mdx
@@ -39,7 +39,7 @@ Unknown TOML keys are errors. Sandbox profiles are implemented under `[sandboxes
 | `[window_manager]`                   | Live virtual-desktop, focus, snap, layout, transition, and shortcut defaults.        | floating windows, adaptive stacks, 50-entry history, slide transition                                 |
 | `[defaults]`                         | Default agent, provider, and sandbox resolution.                                     | `agent = "general"`, `provider = ""`, `sandbox = ""`                                                  |
 | `[roles.coordinator]`                | Coordinator routing plus coordinator-owned session limits.                           | disabled, builtin `coordinator`, TTL 2 hours, 5 children, 5 active sessions/workspace                 |
-| `[roles.dream]`                      | Dream-session routing.                                                               | enabled, builtin `dreaming-curator`                                                                   |
+| `[roles.dream]`                      | Dream-session routing.                                                               | disabled, builtin `dreaming-curator`                                                                  |
 | `[roles.checkpoint_summary]`         | Checkpoint-summary session routing.                                                  | enabled, builtin `dreaming-curator`                                                                   |
 | `[roles.memory_extractor]`           | Memory-extractor session routing.                                                    | enabled, inherits the invoking agent                                                                  |
 | `[roles.auto_title]`                 | Automatic-title session routing.                                                     | enabled, inherits the invoking agent                                                                  |
@@ -66,7 +66,7 @@ Unknown TOML keys are errors. Sandbox profiles are implemented under `[sandboxes
 | `[observability.transcripts]`        | Transcript segment sizing and per-session cap.                                       | enabled, 1 MiB segments, 256 MiB per session                                                          |
 | `[log]`                              | Structured log level and daemon-owned rotation.                                      | `level = "info"`, 10 MiB, 5 backups, 30 days, compression off                                         |
 | `[redact]`                           | Additive secret heuristics for agent-visible content, logs, and persisted events.    | `enabled = true`                                                                                      |
-| `[memory]`                           | Persistent memory runtime and profile memory directory.                              | enabled, `$COMPOZY_HOME/profiles/default/memory`                                                      |
+| `[memory]`                           | Persistent memory runtime and profile memory directory.                              | disabled, `$COMPOZY_HOME/profiles/default/memory`                                                     |
 | `[memory.controller]`                | Hybrid write controller mode, latency, and fallback op.                              | hybrid, 300 ms, noop                                                                                  |
 | `[memory.controller.policy]`         | Content/rate caps and allowed write origins.                                         | 4096 chars, 60 writes/min, all canonical origins                                                      |
 | `[memory.recall]`                    | Deterministic recall: top-K, weights, freshness, signal queue.                       | top-K 5, raw 50, weighted fusion                                                                      |
@@ -236,8 +236,8 @@ max_children = 5
 max_active_sessions_per_workspace = 5
 
 [roles.dream]
-# Route dreaming work to a custom authored curator instead of the builtin dreaming-curator.
-enabled = true
+# Explicitly enable background dreaming after enabling memory.
+enabled = false
 agent = "memory-curator"
 
 [roles.checkpoint_summary]
@@ -504,7 +504,7 @@ compress_backups = false
 enabled = true
 
 [memory]
-enabled = true
+enabled = false
 global_dir = "~/.compozy/profiles/default/memory"
 
 [memory.controller]
@@ -1870,11 +1870,22 @@ process.
 The `[memory]` tree is the Memory v2 runtime configuration. Memory v2 is the only memory subsystem;
 there is no `[memory.v2] enabled` flag and no parallel compatibility namespace. Disabling
 `[memory] enabled` short-circuits prompt assembly, the controller, recall, dreaming, the extractor,
-and the bundled local provider.
+and the bundled local provider. Memory and `roles.dream.enabled` both default to `false`:
+CompozyOS is a control plane, so persistent memory and background consolidation require deliberate
+opt-in. Set `memory.enabled = true` in the daemon configuration and restart to activate memory.
+Enable `roles.dream.enabled = true` separately to allow dreaming. Explicit saved values and stored
+memory files are preserved; omitted settings take the disabled defaults. Profile/workspace role
+overlays retain their normal precedence when the daemon memory runtime is enabled.
+
+Session pressure compaction remains controlled separately by `session.compaction.enabled`. It can
+create a checkpoint summary child on actual context pressure while memory is disabled, without
+registering a public memory provider, extractor, dream scheduler, or session-end memory worker.
+An explicit `roles.checkpoint_summary.enabled = false` prevents new summaries and leaves uncovered
+events unarchived.
 
 | Field        | Type        | Default                                 | Valid values                              | Description                                                                                       |
 | ------------ | ----------- | --------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `enabled`    | boolean     | `true`                                  | `true` or `false`                         | Master switch for the Memory v2 runtime.                                                          |
+| `enabled`    | boolean     | `false`                                 | `true` or `false`                         | Master switch for the Memory v2 runtime.                                                          |
 | `global_dir` | string path | `$COMPOZY_HOME/profiles/default/memory` | Non-empty path when set. `~` is expanded. | The `default` profile's memory directory. Blank overlays are ignored and keep the previous value. |
 
 ## `[memory.controller]`

--- a/packages/site/content/docs/memory/dream.mdx
+++ b/packages/site/content/docs/memory/dream.mdx
@@ -23,7 +23,8 @@ gone. Use `compozy memory dream trigger` and `POST /api/memory/dreams/trigger`. 
 
 ## What Triggers A Dream
 
-Dreaming is enabled by default when memory is enabled.
+Dreaming is disabled by default, including when memory is enabled. Opt in with both
+`memory.enabled = true` and `roles.dream.enabled = true`; restart after changing the memory master switch.
 
 | Trigger path      | Behavior                                                                                                   |
 | ----------------- | ---------------------------------------------------------------------------------------------------------- |
@@ -114,7 +115,12 @@ and from default recall. Operators browse them with `compozy memory dream show <
 
 ## Configuration
 
+The following example explicitly enables both memory and dreaming:
+
 ```toml
+[memory]
+enabled = true
+
 [roles.dream]
 enabled = true
 # Empty selects the builtin dreaming-curator. Set a name to route to an authored curator.

--- a/packages/site/content/docs/memory/index.mdx
+++ b/packages/site/content/docs/memory/index.mdx
@@ -3,6 +3,11 @@ title: Memory
 description: How CompozyOS stores durable Markdown memory across profile, workspace, and agent scopes, gates dreaming runs, and routes every write through the controller.
 ---
 
+Memory is disabled by default. CompozyOS is a control plane: persistent knowledge and background
+consolidation are explicit choices. To enable memory, set `memory.enabled = true` in the daemon's
+`config.toml` and restart. Dreaming remains off until `roles.dream.enabled = true` is also set.
+Existing explicit settings and stored memory are preserved.
+
 Memory is the durable layer that survives a session. CompozyOS stores curated facts as Markdown files
 behind typed indexes so agents can rediscover knowledge without replaying past transcripts. The
 runtime keeps three scopes — profile, workspace, and agent — and a dreaming loop that promotes
@@ -20,6 +25,13 @@ enough that one project does not leak into another.
   understand what the controller is allowed to rewrite, then use best practices to keep future
   memories short and verifiable.
 </OperatorNote>
+
+
+Session pressure compaction remains independently controlled by `session.compaction.enabled`.
+It reuses checkpoint coverage and may launch a summary child when an active session reaches the
+pressure threshold, even with persistent memory disabled. Idle sessions and session-end memory
+updates do not start that work. An explicit checkpoint-role opt-out or a failed summary leaves
+uncovered events unarchived.
 
 ## In this section
 

--- a/packages/site/content/docs/memory/index.mdx
+++ b/packages/site/content/docs/memory/index.mdx
@@ -26,7 +26,6 @@ enough that one project does not leak into another.
   memories short and verifiable.
 </OperatorNote>
 
-
 Session pressure compaction remains independently controlled by `session.compaction.enabled`.
 It reuses checkpoint coverage and may launch a summary child when an active session reaches the
 pressure threshold, even with persistent memory disabled. Idle sessions and session-end memory
@@ -65,3 +64,5 @@ uncovered events unarchived.
     meta="Authoring"
   />
 </RouteList>
+
+Background role status reflects the daemon memory master switch as well as effective role settings. Pressure compaction still uses `session.compaction.enabled` and the checkpoint role switch independently. An interrupted extractor stream is a failure even when its partial text looks like valid JSON; the diagnostic retains that text without admitting it as a candidate.

--- a/packages/site/content/docs/memory/system.mdx
+++ b/packages/site/content/docs/memory/system.mdx
@@ -391,6 +391,19 @@ Every controller decision and recall outcome is observable.
 `memory.extractor.completed`, `memory.provider.collision`, etc.). They are queryable through the
 event store and feed `compozy memory health` and the web Memory inspector.
 
+The extractor requests `{"no_candidates":true}` for an empty result. It also accepts an empty
+response, `[]`, Markdown JSON/JSONL fences, and conventional empty replies such as `(none)` or
+`No memories to save.`. Unknown prose, malformed JSON, and invalid candidate fields remain failures
+with line-number diagnostics. Valid candidates in a mixed batch still reach the controller, while
+that batch records `memory.extractor.failed` rather than `memory.extractor.completed`.
+
+Extraction failures, including provider errors and timeouts, appear in the configured extractor DLQ
+and `list-failures` with session/workspace identity. A timeout means the child did not finish within
+its deadline; it is distinct from a parse failure. Extraction-stage reports require a new extraction;
+the retry surface only replays normalized candidate inbox failures and does not treat raw model
+output as validated candidates. Child-stop details describe child completion separately from the
+runtime's successful extraction-and-inbox event.
+
 Skipped empty extractor turns are recorded as `memory.extractor.dropped` with
 `metadata.reason = "empty_snapshot"` and redaction-safe counters only. Extractor completion events
 carry `candidate_count`, and controller write decisions remain under `memory.write.*`.

--- a/skills/compozy/references/memory.md
+++ b/skills/compozy/references/memory.md
@@ -177,3 +177,5 @@ Do not write memory for raw transcripts, secrets, claim tokens, OAuth material, 
 Memory v2 tool IDs (`compozy__memory_*`), operation or event IDs (`memory.*`), and scanner rule IDs (`policy_memory_*`) are operational state. The controller rejects candidates that include them.
 
 Memory should reduce future ambiguity. It should not become another source of stale context.
+
+Background role status reflects the daemon memory master switch as well as effective role settings. Pressure compaction still uses `session.compaction.enabled` and the checkpoint role switch independently. An interrupted extractor stream is a failure even when its partial text looks like valid JSON; the diagnostic retains that text without admitting it as a candidate.

--- a/skills/compozy/references/memory.md
+++ b/skills/compozy/references/memory.md
@@ -1,5 +1,18 @@
 # Memory
 
+Session pressure compaction remains independently controlled by `session.compaction.enabled`.
+It reuses checkpoint coverage and may launch a summary child when an active session reaches the
+pressure threshold, even with persistent memory disabled. Idle sessions and session-end memory
+updates do not start that work. An explicit checkpoint-role opt-out or a failed summary leaves
+uncovered events unarchived.
+
+## Enablement
+
+Memory and background dreaming are disabled by default. Respect the operator's choice: do not enable
+them implicitly. To opt in, set `memory.enabled = true` in the daemon configuration and restart.
+Set `roles.dream.enabled = true` separately for dreaming; profile/workspace role overrides apply
+when the daemon memory runtime is enabled. Existing explicit settings and memory files are preserved.
+
 ## What Memory Stores
 
 CompozyOS memory is durable Markdown outside transient session prompts. Use it for facts that should survive across sessions: project context, user preferences, durable decisions, and reusable references.
@@ -139,6 +152,12 @@ Inspect asynchronous extractor pressure before retrying or tuning Memory runs:
     compozy memory extractor list-failures -o json
 
 `skipped_turns` counts transcript turns that had no non-whitespace content and were suppressed before provider work. `active_provider_sessions` shows extractor child sessions currently consuming provider work. `backpressured_sessions` increments when `memory.extractor.queue.capacity` is saturated and a session waits instead of spawning another child. `coalesced_turns`, `dropped_turns`, `failure_count`, and pending failures explain queue pressure and failed extractor handoff without exposing raw transcript text.
+
+Extraction-stage failures, including invalid model output and timeouts, are visible through
+`list-failures` and the configured DLQ. Valid candidates from a partially malformed response still
+reach the controller, but the extraction records failure. A no-candidate result is successful.
+Retry replays normalized inbox candidates only; extraction-stage failures require a new extraction.
+A child process ending does not by itself mean extraction and inbox production succeeded.
 
 ## Hygiene
 


### PR DESCRIPTION
## What & why

Fixes #561.

CompozyOS is a control plane. Starting a daemon or completing an ordinary turn should not opt an operator into persistent memory extraction or background dreaming. `memory.enabled` and the existing independent `roles.dream.enabled` now default to `false`. To opt in, set `[memory] enabled = true` in the daemon configuration and restart; enable `[roles.dream] enabled = true` separately for dreaming. Existing explicit settings retain their meaning, and no user configuration or stored memory is rewritten or deleted.

The opt-in path is also repaired. Previously, the extractor discarded the entire JSONL batch on its first invalid line, treated common no-memory answers as parse failures, and stopped the child with a misleading completion detail before parsing was accounted for. The timeout reported in the issue is a separate execution deadline, not a JSON-parser consequence.

- The prompt requests `{"no_candidates":true}`. Conventional empty answers, an empty array, and JSONL fences are handled deliberately. Unknown prose and malformed candidates remain line-numbered failures.
- Valid candidates survive a mixed batch and reach the existing inbox/controller. The batch records `memory.extractor.failed`, not a false completed event.
- A successful semantic terminal is required before candidate admission. Interrupted/error output remains in redacted diagnostics; cancellation, truncation, or missing terminal is a failure.
- Child stop causes distinguish parsed output, extraction failure, and timeout. Extraction-stage failures enter the existing DLQ and failure listing with parent session/workspace/agent identity and redacted diagnostics. Raw model output cannot be replayed as a normalized candidate inbox.
- Session pressure compaction remains under `session.compaction.enabled`, independently of persistent memory. Factory boot retains private checkpoint WAL storage and resume-only coverage. Only actual pressure can launch its summary child; no public memory provider or session-end worker is registered. An explicit checkpoint-role opt-out or failed summary leaves uncovered events unarchived.
- Public background-role status and invocation use the same daemon/workspace memory gate. Effective memory roles honor the memory switch. Dream eligibility is checked before consolidation gates or state-changing work; enabling memory alone leaves dreaming off, and enabled runtime instances retain live/workspace dream routing.

## How you verified it

Implemented and reviewed with Codex, GPT-6-Astra, high reasoning. Checked head: 5e90cd60607e2d543ef610b93678d29de7a80b62.

- Reproduced the original parser defect using a Go source overlay and the same canonical output-contract test: invalid `N`/`(` responses and loss of valid candidates around malformed output. The fixed cases passed with `-race`.
- Full config, extractor, and consolidation suites passed. Capped daemon reruns covered changed extractor, role, and lifecycle behavior. An unchanged boot-barrier timeout under shared host load passed its standalone retry without changing the deadline or assertions.
- Canonical checkpoint/compaction suites passed, including factory-role suppression, rejection of uncovered disabled-summary requests, session hook/archive behavior, and crash-safe compaction integration. Scope detail is in the QA report below.
- Real daemon/ACP-subprocess E2E verified zero default extractor/dream sessions and extraction events, opted-in no-candidate success, persistence of a valid candidate beside malformed output, HTTP failure identity, CLI extractor status, UDS drain/trigger behavior, deliberate built-in/workspace dreaming, live model application, catalog parity, and next-session recall.
- Factory boot + pressure + ACP disconnect/recovery passed (9.770 s; package 11.925 s): one pressure summary child, covered archive, retained history, checkpoint-backed replay without raw duplication, and no background memory children.
- Existing skills-only daemon boot integration verified current shared schema-stream heads while memory remains disabled.
- Review remediation race checks passed: daemon roles/extractor/checkpoints (6.990 s), core/HTTP/UDS health and settings. Active-memory health fixtures explicitly opt in, preserving all original assertions.
- The owner generator `go run ./cmd/compozy-codegen all` completed without generated drift.
- The initial local `make gate` found a trailing blank line, which was corrected. The owner explicitly requested publication with the full gate delegated to CI; a clean full local gate is not claimed. All required CI checks remain delivery requirements.

Final heavy checks used `GOMAXPROCS=4`, `COMPOZY_GO_TEST_P=1`, and `COMPOZY_GO_LINT_CONCURRENCY=2` through `mise exec`. Manual Go tests retained `-race -p=1 -parallel=4`; integration also used the repository's modernc checkptr setting. The E2E runner acquired the repository's machine-wide verification lock. The short isolated lab used 57-byte daemon and at-most-88-byte harness sockets. Both labs completed targeted teardown with `clean: true`. The strict QA audit has one remaining criterion, C14 (full local gate), delegated to CI by the owner; it found zero other blockers or warnings.

[QA evidence and cross-surface audit](docs/qa/reports/2026-09-09-issue-561-memory-opt-in.md).

## Impact

Existing keys, CLI verbs, HTTP/UDS routes, native tool IDs, and response shapes remain. Global/profile/workspace configuration precedence is retained under the daemon memory master switch. No SQLite shape or migration changes are required; disabled boot still applies memory schema migrations. This preserves SD-013 user state and public-surface compatibility while intentionally changing omitted defaults.

Site configuration/memory references, the official Compozy skill reference, affected QA scenarios, and a release note co-ship. Web uses the existing controls and contracts. Retrieval algorithms (#562) and startup tool-manual policy (#563) are unchanged.

Limits: deterministic ACP fixtures prove daemon/process/protocol behavior, not live-provider reliability or timeout frequency. Provider-native compaction was not exercised; the factory pressure/resume check exercises Compozy checkpoint coverage and degraded replay.

---

- [ ] Full local gate delegated to CI at the owner's explicit request; required current-head CI checks must pass before delivery
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself
