### PR TITLE
fix: reserve shutdown time for required cleanup

### DIFF
--- a/docs/qa/scenarios/MS-workspace-checkpoint-continuity.md
+++ b/docs/qa/scenarios/MS-workspace-checkpoint-continuity.md
@@ -31,3 +31,8 @@ Phase C planning 2026-07-19: persona normalized to Théo and linked to J-11; com
 the in-place summary update with both source sessions in provenance, the byte-identical file after
 an injected provider failure, the decision-WAL revert restoring prior content, and the
 workspace-isolation probe.
+
+Regression #577: with memory explicitly enabled, queue multiple checkpoint summaries and block the
+active summary provider. Stop the daemon and verify cancellation stops pending summaries while
+leaving time for the memory provider and required resources to close before the outer deadline.
+Primary transcripts must remain readable after restart. This adds a QA check, not a completed verdict.

--- a/internal/daemon/checkpoint_summary_runtime.go
+++ b/internal/daemon/checkpoint_summary_runtime.go
@@ -210,6 +210,9 @@ func (r *checkpointSummaryRuntime) run(ctx context.Context) {
 		close(r.done)
 	}()
 	for {
+		if ctx.Err() != nil {
+			return
+		}
 		job, ok, closing := r.nextJob()
 		if ok {
 			r.process(ctx, job)
@@ -450,9 +453,22 @@ type checkpointMemoryShutdowner struct {
 }
 
 func (s checkpointMemoryShutdowner) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("checkpoint memory shutdown requires context")
+	}
 	var errs []error
 	if s.runtime != nil {
-		errs = append(errs, s.runtime.Shutdown(ctx))
+		// Background summaries must leave time to stop their child and close required resources.
+		runtimeCtx := ctx
+		if deadline, ok := ctx.Deadline(); ok {
+			var cancel context.CancelFunc
+			runtimeCtx, cancel = context.WithDeadline(
+				ctx,
+				deadline.Add(-checkpointSummaryStopTimeout-defaultShutdownTimeout),
+			)
+			defer cancel()
+		}
+		errs = append(errs, s.runtime.Shutdown(runtimeCtx))
 	}
 	if s.provider != nil {
 		errs = append(errs, s.provider.Shutdown(ctx))

--- a/internal/daemon/checkpoint_summary_runtime_test.go
+++ b/internal/daemon/checkpoint_summary_runtime_test.go
@@ -432,3 +432,94 @@ func (s *checkpointLifecycleStub) OnPreCompress(
 	}
 	return s.onPreCompress(ctx, request)
 }
+
+func TestCheckpointMemoryShutdownBudget(t *testing.T) {
+	t.Parallel()
+	t.Run("Should cancel optional work while required cleanup still has a live context", func(t *testing.T) {
+		t.Parallel()
+		started := make(chan struct{})
+		calls := 0
+		provider := &checkpointProviderStub{
+			onSessionEnd: func(ctx context.Context, _ memcontract.SessionEndRecord) error {
+				calls++
+				if calls == 1 {
+					close(started)
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+		registry := extensionpkg.NewMemoryProviderRegistry()
+		if err := registry.Register(
+			t.Context(),
+			extensionpkg.MemoryProviderRegistration{Name: "fixture", Provider: provider},
+		); err != nil {
+			t.Fatal(err)
+		}
+		if err := registry.SetActive(t.Context(), "ws-alpha", "fixture"); err != nil {
+			t.Fatal(err)
+		}
+		runtime := newCheckpointSummaryRuntime(
+			&checkpointRuntimeSessionStub{events: []store.SessionEvent{checkpointRuntimeEvent(t, "decision")}},
+			registry,
+			time.Minute,
+			time.Minute,
+			slog.Default(),
+			&checkpointLifecycleStub{},
+		)
+		if err := runtime.Start(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		runtime.OnSessionStopped(
+			t.Context(),
+			&session.Session{
+				ID:          "sess-alpha",
+				AgentName:   "coder",
+				WorkspaceID: "ws-alpha",
+				Workspace:   "/workspace/alpha",
+				Type:        session.SessionTypeUser,
+			},
+		)
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("provider did not start")
+		}
+		runtime.OnSessionStopped(t.Context(), &session.Session{
+			ID: "sess-pending", AgentName: "coder", WorkspaceID: "ws-alpha",
+			Workspace: "/workspace/alpha", Type: session.SessionTypeUser,
+		})
+		cleanupCalled := false
+		shutdown := checkpointMemoryShutdowner{
+			runtime: runtime,
+			provider: checkpointShutdownFunc(func(ctx context.Context) error {
+				cleanupCalled = true
+				if ctx.Err() != nil {
+					t.Errorf("required provider cleanup received expired context: %v", ctx.Err())
+				}
+				return ctx.Err()
+			}),
+		}
+		ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+		defer cancel()
+		// Optional summarization may report cancellation; the process still must have time to close stores and servers.
+		if err := shutdown.Shutdown(ctx); !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Shutdown() error = %v, want optional drain deadline", err)
+		}
+		if calls != 1 {
+			t.Fatalf("processed %d summaries, want pending summary skipped", calls)
+		}
+		if !cleanupCalled || ctx.Err() != nil {
+			t.Fatal("checkpoint work consumed the required cleanup budget")
+		}
+		select {
+		case <-runtime.done:
+		default:
+			t.Fatal("checkpoint worker was not joined")
+		}
+	})
+}
+
+type checkpointShutdownFunc func(context.Context) error
+
+func (f checkpointShutdownFunc) Shutdown(ctx context.Context) error { return f(ctx) }

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -177,7 +177,7 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 		terminal acp.AgentEvent
 	}{
 		{name: "Should retain output on provider error", terminal: acp.AgentEvent{Type: acp.EventTypeError, Error: "disconnected"}},
-		{name: "Should reject a cancelled terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: "cancelled"}},
+		{name: "Should reject a canceled terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: string(acp.PromptStopReasonCancelled)}},
 		{name: "Should reject a truncated terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: "max_tokens"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -187,6 +187,10 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 			events <- tc.terminal
 			close(events)
 			output, err := collectMemoryExtractorOutput(t.Context(), events)
+			if tc.terminal.StopReason == string(acp.PromptStopReasonCancelled) &&
+				(err == nil || !strings.Contains(err.Error(), string(acp.PromptStopReasonCancelled))) {
+				t.Fatalf("error = %v, want cancellation reason", err)
+			}
 			if err == nil || output != "partial output" {
 				t.Fatalf("collected=%q error=%v, want diagnostic output and failure", output, err)
 			}

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -2667,7 +2667,7 @@ func TestDaemonNativeTools(t *testing.T) {
 					path        string
 					wantOffload bool
 				}{
-					{path: "references/memory.md"},
+					{path: "references/memory.md", wantOffload: true},
 					{path: "references/tools-and-skills.md", wantOffload: true},
 					{path: "references/native-tools.md", wantOffload: true},
 				} {

--- a/web/e2e/__tests__/knowledge.spec.ts
+++ b/web/e2e/__tests__/knowledge.spec.ts
@@ -108,6 +108,7 @@ interface TranscriptMessagePart {
 
 test.use({
   runtimeOptions: {
+    memoryEnabled: true,
     seed: {
       mockAgents: [
         {
@@ -139,7 +140,7 @@ test("operator creates edits reverts searches recalls and deletes workspace know
   await appPage.goto(runtime.url("/knowledge"), { waitUntil: "domcontentloaded" });
   const kWin = appWindow(appPage, "knowledge");
   await expect(kWin).toBeVisible();
-  const knowledgeUI = knowledgeOperatorSelectors(kWin);
+  const knowledgeUI = knowledgeOperatorSelectors(kWin, appPage);
   await expect(knowledgeUI.shell).toBeVisible();
   await expect(knowledgeUI.tabProfile).toHaveAttribute("aria-pressed", "true");
   await knowledgeUI.tabWorkspace.click();

--- a/web/e2e/fixtures/runtime-helpers.ts
+++ b/web/e2e/fixtures/runtime-helpers.ts
@@ -22,6 +22,7 @@ export interface RuntimeConfigInput {
   modelsDevEnabled?: boolean;
   marketplaceCatalogBaseURL?: string;
   networkEnabled?: boolean;
+  memoryEnabled?: boolean;
   port: number;
   skillsMarketplaceBaseURL?: string;
   socketPath: string;
@@ -73,6 +74,9 @@ export function renderRuntimeConfig(input: RuntimeConfigInput): string {
           `enabled = ${input.modelsDevEnabled ? "true" : "false"}`,
           "",
         ]),
+    ...(input.memoryEnabled === undefined
+      ? []
+      : ["[memory]", `enabled = ${input.memoryEnabled ? "true" : "false"}`, ""]),
     ...(input.networkEnabled === undefined
       ? []
       : ["[network]", `enabled = ${input.networkEnabled ? "true" : "false"}`, ""]),

--- a/web/e2e/fixtures/runtime-helpers.ts
+++ b/web/e2e/fixtures/runtime-helpers.ts
@@ -20,9 +20,9 @@ export interface RuntimeConfigInput {
   host: string;
   includeMockAgentProvider?: boolean;
   modelsDevEnabled?: boolean;
+  memoryEnabled?: boolean;
   marketplaceCatalogBaseURL?: string;
   networkEnabled?: boolean;
-  memoryEnabled?: boolean;
   port: number;
   skillsMarketplaceBaseURL?: string;
   socketPath: string;

--- a/web/e2e/fixtures/runtime.ts
+++ b/web/e2e/fixtures/runtime.ts
@@ -81,6 +81,7 @@ export interface BrowserRuntimeOptions {
   host?: string;
   modelsDevEnabled?: boolean;
   networkEnabled?: boolean;
+  memoryEnabled?: boolean;
   readyTimeoutMs?: number;
   seed?: BrowserRuntimeSeed;
   seedDefaultWorkspace?: boolean;
@@ -200,6 +201,7 @@ export async function createBrowserRuntime(
         modelsDevEnabled: options.modelsDevEnabled,
         marketplaceCatalogBaseURL: marketplaceCatalog?.baseURL,
         networkEnabled: options.networkEnabled,
+        memoryEnabled: options.memoryEnabled,
         port: httpPort,
         skillsMarketplaceBaseURL: skillMarketplace?.baseURL,
         socketPath: paths.daemonSocket,

--- a/web/e2e/fixtures/runtime.ts
+++ b/web/e2e/fixtures/runtime.ts
@@ -80,8 +80,8 @@ export interface BrowserRuntimeOptions {
   extensionsAllowUnverified?: boolean;
   host?: string;
   modelsDevEnabled?: boolean;
-  networkEnabled?: boolean;
   memoryEnabled?: boolean;
+  networkEnabled?: boolean;
   readyTimeoutMs?: number;
   seed?: BrowserRuntimeSeed;
   seedDefaultWorkspace?: boolean;
@@ -199,9 +199,9 @@ export async function createBrowserRuntime(
         host: boundHost,
         includeMockAgentProvider: (options.seed?.mockAgents?.length ?? 0) > 0,
         modelsDevEnabled: options.modelsDevEnabled,
+        memoryEnabled: options.memoryEnabled,
         marketplaceCatalogBaseURL: marketplaceCatalog?.baseURL,
         networkEnabled: options.networkEnabled,
-        memoryEnabled: options.memoryEnabled,
         port: httpPort,
         skillsMarketplaceBaseURL: skillMarketplace?.baseURL,
         socketPath: paths.daemonSocket,

--- a/web/e2e/fixtures/selectors.ts
+++ b/web/e2e/fixtures/selectors.ts
@@ -1228,28 +1228,29 @@ export function networkOperatorSelectors(
 }
 
 export function knowledgeOperatorSelectors(
-  page: Pick<Page, "getByTestId">
+  page: Pick<Page, "getByTestId">,
+  portalRoot: Pick<Page, "getByTestId"> = page
 ): KnowledgeOperatorSelectors {
   return {
     osDesktop: page.getByTestId(knowledgeOperatorTestIds.osDesktop),
-    cancelCreateMemory: page.getByTestId(knowledgeOperatorTestIds.cancelCreateMemory),
-    confirmCreateMemory: page.getByTestId(knowledgeOperatorTestIds.confirmCreateMemory),
-    confirmDeleteMemory: page.getByTestId(knowledgeOperatorTestIds.confirmDeleteMemory),
-    confirmEditMemory: page.getByTestId(knowledgeOperatorTestIds.confirmEditMemory),
+    cancelCreateMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.cancelCreateMemory),
+    confirmCreateMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmCreateMemory),
+    confirmDeleteMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmDeleteMemory),
+    confirmEditMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmEditMemory),
     contentPreview: page.getByTestId(knowledgeOperatorTestIds.contentPreview),
     createButton: page.getByTestId(knowledgeOperatorTestIds.createButton),
-    createContent: page.getByTestId(knowledgeOperatorTestIds.createContent),
-    createDescription: page.getByTestId(knowledgeOperatorTestIds.createDescription),
-    createDialog: page.getByTestId(knowledgeOperatorTestIds.createDialog),
-    createName: page.getByTestId(knowledgeOperatorTestIds.createName),
-    createType: page.getByTestId(knowledgeOperatorTestIds.createType),
+    createContent: portalRoot.getByTestId(knowledgeOperatorTestIds.createContent),
+    createDescription: portalRoot.getByTestId(knowledgeOperatorTestIds.createDescription),
+    createDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.createDialog),
+    createName: portalRoot.getByTestId(knowledgeOperatorTestIds.createName),
+    createType: portalRoot.getByTestId(knowledgeOperatorTestIds.createType),
     deleteButton: page.getByTestId(knowledgeOperatorTestIds.deleteButton),
-    deleteDialog: page.getByTestId(knowledgeOperatorTestIds.deleteDialog),
+    deleteDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.deleteDialog),
     detailPanel: page.getByTestId(knowledgeOperatorTestIds.detailPanel),
     editButton: page.getByTestId(knowledgeOperatorTestIds.editButton),
-    editContent: page.getByTestId(knowledgeOperatorTestIds.editContent),
-    editDescription: page.getByTestId(knowledgeOperatorTestIds.editDescription),
-    editDialog: page.getByTestId(knowledgeOperatorTestIds.editDialog),
+    editContent: portalRoot.getByTestId(knowledgeOperatorTestIds.editContent),
+    editDescription: portalRoot.getByTestId(knowledgeOperatorTestIds.editDescription),
+    editDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.editDialog),
     guard: page.getByTestId(knowledgeOperatorTestIds.guard),
     item: (memoryKey: string) => page.getByTestId(`memory-item-${memoryKey}`),
     listPanel: page.getByTestId(knowledgeOperatorTestIds.listPanel),


### PR DESCRIPTION
## What & why

When optional checkpoint summaries are still running during shutdown, reserve time to stop their child session and close required resources. Once the drain deadline expires, cancel the worker and skip queued summaries instead of starting more work against an expired context.

Fixes #577. Based on main after #580 merged. This remains relevant when memory is explicitly enabled.

## How you verified it

- The regression blocks an active summary, queues another, and verifies the worker joins without processing the queued summary while required provider cleanup still receives a live context.
- `make gate` passed on merged main: Go lint and the complete daemon race suite.
- An AI coding agent co-wrote and reviewed the changes; automated validation is recorded above. Live daemon stop/start QA remains pending.

## Impact

Daemon shutdown reserves its existing cleanup budget. Optional summary drain timeout remains observable; primary transcripts are not removed. No native tool, hook, configuration, or API changes. Workspace/session ownership is unchanged, and the official skill requires no new instructions. The checkpoint continuity QA scenario includes backlog shutdown and restart checks.

Two inherited test expectations are corrected: cancellation uses the existing protocol constant, and the enlarged memory reference uses result paging under the reduced test budget while still verifying its complete content. Reverting restores the previous drain behavior. Required CI remains pending.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shutdown handling so optional summarization work stops promptly while required cleanup continues within the available shutdown time.
  - Prevented queued summarization tasks from running after cancellation.
  - Improved responsiveness when background processing is canceled.

- **Tests**
  - Added coverage for shutdown deadlines, task cancellation, resource cleanup, and worker completion.
  - Updated test expectations for standardized cancellation reporting and resource offloading behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->