### PR TITLE
fix: preserve profile ownership in loop and memory runtimes

### DIFF
--- a/docs/qa/scenarios/LP-loop-environment-resolution.md
+++ b/docs/qa/scenarios/LP-loop-environment-resolution.md
@@ -29,3 +29,9 @@ that implement-tasks worker sessions retain the same Worktree id.
 QA follow-up 2026-09-01: while the real extension task run was claimed and blocked inside
 `ext__spec_cycle__import_tasks`, CLI removal returned `worktree_operation_in_progress`. After the
 tool completed with the worktree-only task path, the same CLI removal succeeded.
+
+Profile policy regression (#570): repeat worker creation with a Profile-scoped Agent in a
+non-default Profile, using both Workspace ID and root path. Verify the same Profile layer supplies
+the Agent, sandbox, permissions, and runtime settings for action, pinned, and judge sessions.
+An unknown or unavailable Profile must fail before session creation, even if a same-named global
+Agent exists. Retain the default Profile and worktree environment canaries above.

--- a/docs/qa/scenarios/MS-profile-memory-tier-scope.md
+++ b/docs/qa/scenarios/MS-profile-memory-tier-scope.md
@@ -48,3 +48,9 @@ Expected evidence: paired per-profile catalog, search, and recall output on ever
 refused aggregate response; workspace-tier and agent-tier reads from both profiles; the scope
 vocabulary as printed by CLI and API; the pending-move refusal and the post-move success; the
 migrated entry read under default; and the delete preview beside the delete result with entry counts.
+
+Background extraction regression (#571): complete a root session using a Profile-scoped Agent in
+each of two Profiles. Verify queued turns, extractor role resolution, profile-tier proposals, and
+diagnostic events retain the source Profile. A missing Profile must refuse extraction/storage;
+it must not resolve the other Profile's Agent or write into default memory. Keep Workspace memory
+shared as specified above. Repeat after replaying the durable extractor inbox.

--- a/internal/daemon/boot_memory_session.go
+++ b/internal/daemon/boot_memory_session.go
@@ -72,7 +72,7 @@ func (d *Daemon) bootMemorySessionRuntime(
 	if err := configureWorkspaceDeletionLifecycle(ctx, state, sessions, cleanup); err != nil {
 		return err
 	}
-	memoryExtractor, err := newDaemonMemoryExtractor(ctx, state, sessions, d.now)
+	memoryExtractor, err := d.newDaemonMemoryExtractor(ctx, state, sessions, d.now)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/boot_profile_name_resolver.go
+++ b/internal/daemon/boot_profile_name_resolver.go
@@ -3,6 +3,10 @@ package daemon
 import (
 	"context"
 	"errors"
+	"strings"
+
+	"github.com/compozy/compozy/internal/session"
+	workspacepkg "github.com/compozy/compozy/internal/workspace"
 
 	profilepkg "github.com/compozy/compozy/internal/profile"
 )
@@ -27,4 +31,27 @@ func (r bootProfileNameResolver) ProfileName(ctx context.Context, profileID stri
 		return "", errors.New("daemon: profile manager is not booted")
 	}
 	return r.state.profiles.ProfileName(ctx, profileID)
+}
+
+// resolveRuntimeProfileWorkspace resolves resources using the durable work owner.
+func resolveRuntimeProfileWorkspace(
+	ctx context.Context,
+	workspaces workspacepkg.RuntimeResolver,
+	profiles session.ProfileNameResolver,
+	ref, profileID string,
+) (workspacepkg.ResolvedWorkspace, error) {
+	if strings.TrimSpace(profileID) == "" {
+		return workspaces.Resolve(ctx, ref)
+	}
+	name, err := resolvePromptSkillsProfileName(ctx, profiles, profileID)
+	if err != nil {
+		return workspacepkg.ResolvedWorkspace{}, err
+	}
+	resolver, ok := workspaces.(workspacepkg.ProfileRuntimeResolver)
+	if !ok {
+		return workspacepkg.ResolvedWorkspace{}, errors.New(
+			"daemon: runtime workspace resolver does not support profile layers",
+		)
+	}
+	return resolver.ResolveForProfile(ctx, ref, name)
 }

--- a/internal/daemon/loop_action_policy.go
+++ b/internal/daemon/loop_action_policy.go
@@ -19,6 +19,7 @@ type loopSessionAgentResolver interface {
 }
 
 type loopSessionPolicyGate struct {
+	profileNames      session.ProfileNameResolver
 	workspaceResolver workspacepkg.RuntimeResolver
 	agentResolver     loopSessionAgentResolver
 }
@@ -153,7 +154,13 @@ func (g *loopSessionPolicyGate) resolveWorkspace(
 		return workspacepkg.ResolvedWorkspace{}, workspacepkg.ErrWorkspaceResolverUnavailable
 	}
 	if workspaceID := strings.TrimSpace(opts.Workspace); workspaceID != "" {
-		resolved, err := g.workspaceResolver.Resolve(ctx, workspaceID)
+		resolved, err := resolveRuntimeProfileWorkspace(
+			ctx,
+			g.workspaceResolver,
+			g.profileNames,
+			workspaceID,
+			opts.ProfileID,
+		)
 		if err != nil {
 			return workspacepkg.ResolvedWorkspace{}, fmt.Errorf(
 				"daemon: resolve loop session workspace %q: %w",
@@ -167,7 +174,13 @@ func (g *loopSessionPolicyGate) resolveWorkspace(
 	if workspacePath == "" {
 		return workspacepkg.ResolvedWorkspace{}, errors.New("daemon: loop session workspace is required")
 	}
-	resolved, err := g.workspaceResolver.Resolve(ctx, workspacePath)
+	resolved, err := resolveRuntimeProfileWorkspace(
+		ctx,
+		g.workspaceResolver,
+		g.profileNames,
+		workspacePath,
+		opts.ProfileID,
+	)
 	if err != nil {
 		return workspacepkg.ResolvedWorkspace{}, fmt.Errorf(
 			"daemon: resolve loop session workspace path %q: %w",

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -2134,8 +2134,14 @@ func TestLoopSessionPolicyProfile(t *testing.T) {
 			profileNames: loopProfileNameResolverStub{},
 		}
 		opts := session.CreateOpts{ProfileID: "profile-missing", Workspace: "ws-loop"}
-		if _, err := gate.applyResolved(t.Context(), &opts, "profile-worker", nil); err == nil {
-			t.Fatal("missing Profile must not use global Agent")
+		if _, err := gate.applyResolved(
+			t.Context(),
+			&opts,
+			"profile-worker",
+			nil,
+		); err == nil ||
+			!strings.Contains(err.Error(), "profile not found") {
+			t.Fatalf("error = %v, want profile not found", err)
 		}
 	})
 }

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -339,9 +339,12 @@ func TestLoopActionSessionBinderShouldApplyPolicyGate(t *testing.T) {
 		sessions := &loopActionBinderSessionManager{sessionID: "sess-loop-agent-runtime"}
 		binder := &loopActionSessionBinder{
 			sessions: sessions,
-			policyGate: &loopSessionPolicyGate{workspaceResolver: loopActionBinderWorkspaceResolver{
-				byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
-			}},
+			policyGate: &loopSessionPolicyGate{
+				profileNames: loopProfileNameResolverStub{"profile-marketing": "marketing"},
+				workspaceResolver: loopActionBinderWorkspaceResolver{
+					byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
+				},
+			},
 		}
 
 		binding, err := binder.BindActionSession(context.Background(), looppkg.ActionSessionBindRequest{
@@ -378,9 +381,12 @@ func TestLoopActionSessionBinderShouldApplyPolicyGate(t *testing.T) {
 		binder := &loopActionSessionBinder{
 			sessions:  sessions,
 			worktrees: worktrees,
-			policyGate: &loopSessionPolicyGate{workspaceResolver: loopActionBinderWorkspaceResolver{
-				byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
-			}},
+			policyGate: &loopSessionPolicyGate{
+				profileNames: loopProfileNameResolverStub{"profile-marketing": "marketing"},
+				workspaceResolver: loopActionBinderWorkspaceResolver{
+					byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
+				},
+			},
 		}
 
 		for itemIndex := range 3 {
@@ -442,9 +448,12 @@ func TestLoopActionSessionBinderShouldApplyPolicyGate(t *testing.T) {
 		binder := &loopActionSessionBinder{
 			sessions:  sessions,
 			worktrees: worktrees,
-			policyGate: &loopSessionPolicyGate{workspaceResolver: loopActionBinderWorkspaceResolver{
-				byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
-			}},
+			policyGate: &loopSessionPolicyGate{
+				profileNames: loopProfileNameResolverStub{"profile-marketing": "marketing"},
+				workspaceResolver: loopActionBinderWorkspaceResolver{
+					byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
+				},
+			},
 		}
 
 		_, err := binder.BindActionSession(context.Background(), looppkg.ActionSessionBindRequest{
@@ -487,9 +496,12 @@ func TestLoopActionSessionBinderShouldApplyPolicyGate(t *testing.T) {
 		binder := &loopActionSessionBinder{
 			sessions:  sessions,
 			worktrees: worktrees,
-			policyGate: &loopSessionPolicyGate{workspaceResolver: loopActionBinderWorkspaceResolver{
-				byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
-			}},
+			policyGate: &loopSessionPolicyGate{
+				profileNames: loopProfileNameResolverStub{"profile-marketing": "marketing"},
+				workspaceResolver: loopActionBinderWorkspaceResolver{
+					byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
+				},
+			},
 		}
 
 		_, err := binder.BindActionSession(context.Background(), looppkg.ActionSessionBindRequest{
@@ -1552,6 +1564,16 @@ func (r loopActionBinderWorkspaceResolver) Resolve(
 	return resolved, nil
 }
 
+func (r loopActionBinderWorkspaceResolver) ResolveForProfile(
+	ctx context.Context,
+	ref, name string,
+) (workspacepkg.ResolvedWorkspace, error) {
+	if name != "default" && name != "marketing" {
+		return workspacepkg.ResolvedWorkspace{}, workspacepkg.ErrWorkspaceNotFound
+	}
+	return r.Resolve(ctx, ref)
+}
+
 func (r loopActionBinderWorkspaceResolver) ResolveOrRegister(
 	_ context.Context,
 	path string,
@@ -2061,4 +2083,74 @@ func TestLoopActionSessionBinderACPOptionsPropagation(t *testing.T) {
 			t.Fatalf("createCall.Speed = %q, want fast", createCall.Speed)
 		}
 	})
+}
+
+// Loop policy resolution owns selecting the resource layer before resolving an Agent.
+func TestLoopSessionPolicyProfile(t *testing.T) {
+	t.Parallel()
+	for _, byPath := range []bool{false, true} {
+		t.Run(fmt.Sprintf("Should resolve the owning Profile policy with path %t", byPath), func(t *testing.T) {
+			t.Parallel()
+			scoped := loopActionBinderWorkspace(
+				t,
+				[]compozyconfig.AgentDef{
+					{Name: "profile-worker", Provider: "mock", Prompt: "Work", Permissions: "deny-all"},
+				},
+			)
+			scoped.ProfileID = "profile-engineering"
+			resolver := &loopPolicyProfileWorkspaceResolver{scoped: scoped}
+			gate := &loopSessionPolicyGate{
+				workspaceResolver: resolver,
+				profileNames:      loopProfileNameResolverStub{"profile-engineering": "engineering"},
+			}
+			opts := session.CreateOpts{ProfileID: "profile-engineering", Workspace: "ws-loop"}
+			if byPath {
+				opts.Workspace = ""
+				opts.WorkspacePath = scoped.RootDir
+			}
+			result, err := gate.applyResolved(t.Context(), &opts, "profile-worker", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.workspace.ProfileID != opts.ProfileID || opts.Permissions != compozyconfig.PermissionModeDenyAll {
+				t.Fatalf(
+					"wrong profile or policy: workspace=%q permissions=%q",
+					result.workspace.ProfileID,
+					opts.Permissions,
+				)
+			}
+		})
+	}
+	t.Run("Should refuse an unknown Profile even when the Agent exists globally", func(t *testing.T) {
+		t.Parallel()
+		resolved := loopActionBinderWorkspace(
+			t,
+			[]compozyconfig.AgentDef{{Name: "profile-worker", Provider: "mock", Prompt: "Work"}},
+		)
+		gate := &loopSessionPolicyGate{
+			workspaceResolver: loopActionBinderWorkspaceResolver{
+				byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": resolved},
+			},
+			profileNames: loopProfileNameResolverStub{},
+		}
+		opts := session.CreateOpts{ProfileID: "profile-missing", Workspace: "ws-loop"}
+		if _, err := gate.applyResolved(t.Context(), &opts, "profile-worker", nil); err == nil {
+			t.Fatal("missing Profile must not use global Agent")
+		}
+	})
+}
+
+type loopPolicyProfileWorkspaceResolver struct {
+	loopActionBinderWorkspaceResolver
+	scoped workspacepkg.ResolvedWorkspace
+}
+
+func (r *loopPolicyProfileWorkspaceResolver) ResolveForProfile(
+	_ context.Context,
+	ref, name string,
+) (workspacepkg.ResolvedWorkspace, error) {
+	if name != "engineering" || (ref != "ws-loop" && ref != r.scoped.RootDir) {
+		return workspacepkg.ResolvedWorkspace{}, workspacepkg.ErrWorkspaceNotFound
+	}
+	return r.scoped, nil
 }

--- a/internal/daemon/memory_controller_role_test.go
+++ b/internal/daemon/memory_controller_role_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/compozy/compozy/internal/memory/controller"
 	"github.com/compozy/compozy/internal/session"
 	speedpkg "github.com/compozy/compozy/internal/speed"
+	workspacepkg "github.com/compozy/compozy/internal/workspace"
 )
 
 func TestMemoryControllerRoleCallOptions(t *testing.T) {
@@ -94,6 +95,56 @@ func TestMemoryControllerRoleCallOptions(t *testing.T) {
 
 func TestMemoryControllerTiebreakerUsesTheLiveRoleCallContract(t *testing.T) {
 	t.Parallel()
+	t.Run(
+		"Should resolve the candidate owner with a live config snapshot and reject unknown owners",
+		func(t *testing.T) {
+			t.Parallel()
+			cfg := roleResolverConfig()
+			scoped := loopActionBinderWorkspace(t, nil)
+			scoped.ProfileID = "profile-engineering"
+			scoped.Config = cfg
+			scoped.Config.Roles.MemoryController.Model = "profile-controller"
+			workspaces := &loopPolicyProfileWorkspaceResolver{scoped: scoped}
+			roles := newRoleResolver(&cfg, workspaces, nil)
+			roles.profileNames = loopProfileNameResolverStub{"profile-engineering": "engineering"}
+			invoker := &memoryControllerInvokerStub{result: session.TransientModelResult{
+				Output: `{"op":"noop","target_id":"","confidence":0.5,"reason":"ambiguous"}`, Accepted: true,
+			}}
+			tiebreaker := &daemonMemoryControllerTiebreaker{
+				invoker:        invoker,
+				roles:          roles,
+				configSnapshot: func() compozyconfig.Config { return cfg },
+				workspaceResolver: loopActionBinderWorkspaceResolver{
+					byID: map[string]workspacepkg.ResolvedWorkspace{"ws-loop": scoped},
+				},
+			}
+			request := controller.TiebreakerRequest{Candidate: memcontract.Candidate{
+				Scope:       memcontract.ScopeProfile,
+				Content:     "candidate",
+				WorkspaceID: "ws-loop",
+				ProfileID:   "profile-engineering",
+			}}
+			result, err := tiebreaker.BreakTie(t.Context(), request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Call == nil || result.Call.Model != "profile-controller" || len(invoker.calls) != 1 ||
+				invoker.calls[0].Model != "profile-controller" {
+				t.Fatalf("wrong controller: result=%#v calls=%#v", result, invoker.calls)
+			}
+			request.Candidate.ProfileID = "profile-missing"
+			if _, err := tiebreaker.BreakTie(
+				t.Context(),
+				request,
+			); err == nil ||
+				!strings.Contains(err.Error(), "profile not found") {
+				t.Fatalf("error = %v, want profile not found", err)
+			}
+			if len(invoker.calls) != 1 {
+				t.Fatal("unknown Profile invoked a controller")
+			}
+		},
+	)
 	t.Run("Should invoke the configured live role with bounded targets", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/daemon/memory_controller_tiebreaker.go
+++ b/internal/daemon/memory_controller_tiebreaker.go
@@ -127,7 +127,8 @@ func (t *daemonMemoryControllerTiebreaker) prepareCall(
 		snapshot.config = &cfg
 		roles = &snapshot
 	}
-	options, err := roles.resolveMemoryControllerCallOptions(ctx, request.Candidate.WorkspaceID)
+	roleCtx := withRoleInvocationCorrelation(ctx, memoryControllerCorrelation(request.Candidate))
+	options, err := roles.resolveMemoryControllerCallOptions(roleCtx, request.Candidate.WorkspaceID)
 	if err != nil {
 		return memoryControllerPreparedCall{}, err
 	}
@@ -260,6 +261,7 @@ func memoryControllerCallContext(
 
 func memoryControllerCorrelation(candidate memcontract.Candidate) roleInvocationCorrelation {
 	correlation := roleInvocationCorrelation{
+		ProfileID:   strings.TrimSpace(candidate.ProfileID),
 		WorkspaceID: strings.TrimSpace(candidate.WorkspaceID),
 		AgentName:   strings.TrimSpace(candidate.AgentName),
 	}

--- a/internal/daemon/memory_controller_tiebreaker.go
+++ b/internal/daemon/memory_controller_tiebreaker.go
@@ -123,7 +123,9 @@ func (t *daemonMemoryControllerTiebreaker) prepareCall(
 	roles := t.roles
 	if t.configSnapshot != nil {
 		cfg := t.configSnapshot()
-		roles = newRoleResolver(&cfg, t.roles.workspaceResolver, t.roles.agents, t.roles.events)
+		snapshot := *t.roles
+		snapshot.config = &cfg
+		roles = &snapshot
 	}
 	options, err := roles.resolveMemoryControllerCallOptions(ctx, request.Candidate.WorkspaceID)
 	if err != nil {

--- a/internal/daemon/memory_extractor_events.go
+++ b/internal/daemon/memory_extractor_events.go
@@ -1,0 +1,34 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+
+	"github.com/compozy/compozy/internal/memory"
+	extractorpkg "github.com/compozy/compozy/internal/memory/extractor"
+)
+
+// daemonMemoryExtractorEvents routes delayed telemetry by the source session's owner.
+type daemonMemoryExtractorEvents struct {
+	stores         memory.RecallStoreResolver
+	sessionProfile func(context.Context, string) (string, error)
+}
+
+func (s *daemonMemoryExtractorEvents) RecordExtractorEvent(ctx context.Context, event extractorpkg.Event) error {
+	profileID := event.Turn.ProfileID
+	if profileID == "" {
+		var err error
+		profileID, err = s.sessionProfile(ctx, event.Normalize(nil).SessionID)
+		if err != nil {
+			return err
+		}
+	}
+	if profileID == "" {
+		return errors.New("daemon: extractor event profile is required")
+	}
+	store, err := s.stores(ctx, profileID)
+	if err != nil {
+		return err
+	}
+	return store.RecordExtractorEvent(ctx, event)
+}

--- a/internal/daemon/memory_extractor_fork.go
+++ b/internal/daemon/memory_extractor_fork.go
@@ -44,6 +44,8 @@ func failureCandidateMetadata(content string) (sessionID string, workspaceID str
 }
 
 type daemonMemoryProposalSink struct {
+	sessionProfile    func(context.Context, string) (string, error)
+	profileStores     memory.RecallStoreResolver
 	base              *memory.Store
 	workspaceResolver workspacepkg.RuntimeResolver
 }
@@ -66,6 +68,27 @@ func (s *daemonMemoryProposalSink) targetStore(
 	ctx context.Context,
 	candidate memcontract.Candidate,
 ) (*memory.Store, memcontract.Candidate, error) {
+	base := s.base
+	if candidate.ProfileID == "" && candidate.Metadata["session_id"] != "" && s.sessionProfile != nil {
+		var err error
+		candidate.ProfileID, err = s.sessionProfile(ctx, candidate.Metadata["session_id"])
+		if err != nil {
+			return nil, candidate, err
+		}
+		if candidate.ProfileID == "" {
+			return nil, candidate, errors.New("daemon: memory candidate source profile is required")
+		}
+	}
+	if candidate.ProfileID != "" {
+		if s.profileStores == nil {
+			return nil, candidate, errors.New("daemon: memory candidate profile resolver is unavailable")
+		}
+		var err error
+		base, err = s.profileStores(ctx, candidate.ProfileID)
+		if err != nil {
+			return nil, candidate, err
+		}
+	}
 	scope := candidate.Scope.Normalize()
 	if scope == "" {
 		scope = candidate.Frontmatter.Scope.Normalize()
@@ -74,7 +97,7 @@ func (s *daemonMemoryProposalSink) targetStore(
 	case "", memcontract.ScopeProfile:
 		candidate.Scope = memcontract.ScopeProfile
 		candidate.Frontmatter.Scope = memcontract.ScopeProfile
-		return s.base, candidate, nil
+		return base, candidate, nil
 	case memcontract.ScopeWorkspace, memcontract.ScopeAgent:
 		workspaceRoot, workspaceID, err := s.resolveWorkspace(ctx, candidate)
 		if err != nil {
@@ -83,7 +106,7 @@ func (s *daemonMemoryProposalSink) targetStore(
 		candidate.WorkspaceID = workspaceID
 		candidate.Scope = scope
 		candidate.Frontmatter.Scope = scope
-		store := s.base.ForWorkspace(workspaceRoot)
+		store := base.ForWorkspace(workspaceRoot)
 		if scope == memcontract.ScopeAgent {
 			tier := candidate.AgentTier.Normalize()
 			if tier == "" {
@@ -157,6 +180,7 @@ func (e *forkedMemoryExtractor) Extract(
 		}
 	}()
 	correlation := roleInvocationCorrelation{
+		ProfileID:       turn.ProfileID,
 		WorkspaceID:     strings.TrimSpace(turn.WorkspaceID),
 		SessionID:       strings.TrimSpace(turn.SessionID),
 		AgentName:       strings.TrimSpace(turn.AgentID),

--- a/internal/daemon/memory_extractor_output.go
+++ b/internal/daemon/memory_extractor_output.go
@@ -218,6 +218,7 @@ func candidateFromExtractedLine(
 		metadata["workspace_root"] = workspaceRoot
 	}
 	return memcontract.Candidate{
+		ProfileID:   turn.ProfileID,
 		WorkspaceID: strings.TrimSpace(turn.WorkspaceID),
 		Scope:       scope,
 		AgentName:   agentName,

--- a/internal/daemon/memory_runtime.go
+++ b/internal/daemon/memory_runtime.go
@@ -58,7 +58,7 @@ type daemonMemoryExtractor struct {
 	done   chan struct{}
 }
 
-func newDaemonMemoryExtractor(
+func (d *Daemon) newDaemonMemoryExtractor(
 	ctx context.Context,
 	state *bootState,
 	sessions SessionManager,
@@ -77,6 +77,11 @@ func newDaemonMemoryExtractor(
 		}
 	}
 	workspaceRoots := &sync.Map{}
+	profileStores := d.memoryRecallStoreResolver(state)
+	profileEvents := &daemonMemoryExtractorEvents{
+		stores:         profileStores,
+		sessionProfile: daemonSessionProfileResolver(sessions, "daemon: extractor session profile is unavailable"),
+	}
 	forked := &forkedMemoryExtractor{
 		sessions:       forkSessions,
 		roles:          roleResolverForState(state),
@@ -90,7 +95,7 @@ func newDaemonMemoryExtractor(
 		context.WithoutCancel(ctx),
 		state.globalMemoryDir,
 		forked,
-		extractorpkg.WithEventSink(state.memoryStore),
+		extractorpkg.WithEventSink(profileEvents),
 		extractorpkg.WithLogger(state.logger),
 		extractorpkg.WithClock(now),
 		extractorpkg.WithCoalesceMax(state.cfg.Memory.Extractor.Queue.CoalesceMax),
@@ -102,13 +107,15 @@ func newDaemonMemoryExtractor(
 		return nil, fmt.Errorf("daemon: create memory extractor runtime: %w", err)
 	}
 	sink := &daemonMemoryProposalSink{
+		sessionProfile:    profileEvents.sessionProfile,
+		profileStores:     profileStores,
 		base:              state.memoryStore,
 		workspaceResolver: state.workspaceResolver,
 	}
 	consumer, err := extractorpkg.NewInboxConsumer(
 		state.globalMemoryDir,
 		sink,
-		extractorpkg.WithConsumerEventSink(state.memoryStore),
+		extractorpkg.WithConsumerEventSink(profileEvents),
 		extractorpkg.WithConsumerLogger(state.logger),
 		extractorpkg.WithConsumerClock(now),
 		extractorpkg.WithConsumerInboxPath(state.cfg.Memory.Extractor.InboxPath),

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -49,6 +49,37 @@ func TestDaemonMemoryExtractorSkipsSubagentWorkspaceRootCache(t *testing.T) {
 func TestDaemonMemoryProposalSinkTargetStore(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should route profile candidates without falling back on missing owners", func(t *testing.T) {
+		t.Parallel()
+		base := memory.NewStore(t.TempDir())
+		scoped := base.ForProfile("profile-engineering", t.TempDir())
+		sink := daemonMemoryProposalSink{
+			base: base,
+			profileStores: func(_ context.Context, id string) (*memory.Store, error) {
+				if id != "profile-engineering" {
+					return nil, errors.New("unknown profile")
+				}
+				return scoped, nil
+			},
+		}
+		target, _, err := sink.targetStore(
+			t.Context(),
+			memcontract.Candidate{ProfileID: "profile-engineering", Scope: memcontract.ScopeProfile},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if target != scoped {
+			t.Fatal("candidate selected another Profile store")
+		}
+		if _, _, err := sink.targetStore(
+			t.Context(),
+			memcontract.Candidate{ProfileID: "missing", Scope: memcontract.ScopeProfile},
+		); err == nil {
+			t.Fatal("unknown Profile must fail")
+		}
+	})
+
 	t.Run("Should normalize workspace-root candidates to the stable workspace identity", func(t *testing.T) {
 		t.Parallel()
 
@@ -177,7 +208,7 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 		terminal acp.AgentEvent
 	}{
 		{name: "Should retain output on provider error", terminal: acp.AgentEvent{Type: acp.EventTypeError, Error: "disconnected"}},
-		{name: "Should reject a cancelled terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: "cancelled"}},
+		{name: "Should reject a canceled terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: string(acp.PromptStopReasonCancelled)}},
 		{name: "Should reject a truncated terminal", terminal: acp.AgentEvent{Type: acp.EventTypeDone, StopReason: "max_tokens"}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -286,6 +317,30 @@ func TestDaemonMemoryProviderService(t *testing.T) {
 
 func TestForkedMemoryExtractor(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Should retain the source Profile in background role resolution", func(t *testing.T) {
+		t.Parallel()
+		extractor := &forkedMemoryExtractor{
+			sessions: &recordingMemoryExtractorSessions{},
+			roles: roleResolverFunc(
+				func(ctx context.Context, workspaceID string, _ compozyconfig.RoleName) (ResolvedRole, error) {
+					if got := roleInvocationCorrelationFromContext(
+						ctx,
+						workspaceID,
+					).ProfileID; got != "profile-engineering" {
+						t.Errorf("ProfileID = %q", got)
+					}
+					return ResolvedRole{Enabled: false}, nil
+				},
+			),
+		}
+		if _, err := extractor.Extract(
+			t.Context(),
+			memcontract.TurnRecord{ProfileID: "profile-engineering", SessionID: "source", WorkspaceID: "ws-test"},
+		); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	t.Run("Should skip the child session when the role is disabled", func(t *testing.T) {
 		t.Parallel()

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -75,8 +75,8 @@ func TestDaemonMemoryProposalSinkTargetStore(t *testing.T) {
 		if _, _, err := sink.targetStore(
 			t.Context(),
 			memcontract.Candidate{ProfileID: "missing", Scope: memcontract.ScopeProfile},
-		); err == nil {
-			t.Fatal("unknown Profile must fail")
+		); err == nil || !strings.Contains(err.Error(), "unknown profile") {
+			t.Fatalf("error = %v, want unknown profile", err)
 		}
 	})
 
@@ -218,6 +218,10 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 			events <- tc.terminal
 			close(events)
 			output, err := collectMemoryExtractorOutput(t.Context(), events)
+			if tc.terminal.StopReason == string(acp.PromptStopReasonCancelled) &&
+				(err == nil || !strings.Contains(err.Error(), string(acp.PromptStopReasonCancelled))) {
+				t.Fatalf("error = %v, want cancellation reason", err)
+			}
 			if err == nil || output != "partial output" {
 				t.Fatalf("collected=%q error=%v, want diagnostic output and failure", output, err)
 			}

--- a/internal/daemon/native_tools_test.go
+++ b/internal/daemon/native_tools_test.go
@@ -2667,7 +2667,7 @@ func TestDaemonNativeTools(t *testing.T) {
 					path        string
 					wantOffload bool
 				}{
-					{path: "references/memory.md"},
+					{path: "references/memory.md", wantOffload: true},
 					{path: "references/tools-and-skills.md", wantOffload: true},
 					{path: "references/native-tools.md", wantOffload: true},
 				} {

--- a/internal/daemon/role_dependencies.go
+++ b/internal/daemon/role_dependencies.go
@@ -19,4 +19,5 @@ func initializeRoleResolver(state *bootState) {
 		}),
 		state.registry,
 	)
+	state.roleResolver.profileNames = bootProfileNameResolver{state: state}
 }

--- a/internal/daemon/role_resolver.go
+++ b/internal/daemon/role_resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/compozy/compozy/internal/api/contract"
 	compozyconfig "github.com/compozy/compozy/internal/config"
+	"github.com/compozy/compozy/internal/session"
 	speedpkg "github.com/compozy/compozy/internal/speed"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 )
@@ -77,6 +78,7 @@ type RoleResolver interface {
 }
 
 type roleResolver struct {
+	profileNames      session.ProfileNameResolver
 	config            *compozyconfig.Config
 	workspaceResolver workspacepkg.RuntimeResolver
 	agents            coordinatorAgentResolver
@@ -209,7 +211,13 @@ func (r *roleResolver) effectiveRoleConfig(
 	if r.workspaceResolver == nil {
 		return nil, nil, errors.New("daemon: workspace resolver is required for workspace role resolution")
 	}
-	resolved, err := r.workspaceResolver.Resolve(ctx, target)
+	resolved, err := resolveRuntimeProfileWorkspace(
+		ctx,
+		r.workspaceResolver,
+		r.profileNames,
+		target,
+		roleInvocationCorrelationFromContext(ctx, workspaceID).ProfileID,
+	)
 	if err != nil {
 		return nil, nil, fmt.Errorf("daemon: resolve role workspace %q: %w", target, err)
 	}

--- a/internal/daemon/role_resolver_test.go
+++ b/internal/daemon/role_resolver_test.go
@@ -374,3 +374,61 @@ func roleResolverConfig() compozyconfig.Config {
 	cfg.Roles.Dream.Enabled = true
 	return cfg
 }
+
+func TestRoleResolverProfile(t *testing.T) {
+	t.Parallel()
+	t.Run("Should inherit the Agent from the source Profile", func(t *testing.T) {
+		t.Parallel()
+		cfg := roleResolverConfig()
+		scoped := loopActionBinderWorkspace(
+			t,
+			[]compozyconfig.AgentDef{{Name: "profile-worker", Provider: "mock", Model: "scoped-model", Prompt: "Work"}},
+		)
+		scoped.ProfileID = "profile-engineering"
+		scoped.Config.Memory.Enabled = true
+		resolver := newRoleResolver(
+			&cfg,
+			&loopPolicyProfileWorkspaceResolver{scoped: scoped},
+			profileRoleAgentResolver{},
+		)
+		resolver.profileNames = loopProfileNameResolverStub{"profile-engineering": "engineering"}
+		ctx := withRoleInvocationCorrelation(
+			t.Context(),
+			roleInvocationCorrelation{
+				ProfileID: "profile-engineering",
+				AgentName: "profile-worker",
+				SessionID: "session-worker",
+			},
+		)
+		role, err := resolver.Resolve(ctx, "ws-loop", compozyconfig.RoleMemoryExtractor)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if role.AgentName != "profile-worker" || role.Model != "scoped-model" {
+			t.Fatalf("wrong role: %#v", role)
+		}
+		ctx = withRoleInvocationCorrelation(
+			t.Context(),
+			roleInvocationCorrelation{ProfileID: "profile-missing", AgentName: "profile-worker"},
+		)
+		if _, err := resolver.Resolve(ctx, "ws-loop", compozyconfig.RoleMemoryExtractor); err == nil {
+			t.Fatal("unknown Profile must fail")
+		}
+	})
+}
+
+type profileRoleAgentResolver struct{}
+
+func (profileRoleAgentResolver) ResolveAgent(
+	name string,
+	resolved *workspacepkg.ResolvedWorkspace,
+) (compozyconfig.AgentDef, error) {
+	if resolved != nil && resolved.ProfileID == "profile-engineering" {
+		for _, agent := range resolved.Agents {
+			if agent.Name == name {
+				return agent, nil
+			}
+		}
+	}
+	return compozyconfig.AgentDef{}, workspacepkg.ErrAgentNotAvailable
+}

--- a/internal/daemon/role_resolver_test.go
+++ b/internal/daemon/role_resolver_test.go
@@ -411,8 +411,13 @@ func TestRoleResolverProfile(t *testing.T) {
 			t.Context(),
 			roleInvocationCorrelation{ProfileID: "profile-missing", AgentName: "profile-worker"},
 		)
-		if _, err := resolver.Resolve(ctx, "ws-loop", compozyconfig.RoleMemoryExtractor); err == nil {
-			t.Fatal("unknown Profile must fail")
+		if _, err := resolver.Resolve(
+			ctx,
+			"ws-loop",
+			compozyconfig.RoleMemoryExtractor,
+		); err == nil ||
+			!strings.Contains(err.Error(), "profile not found") {
+			t.Fatalf("error = %v, want profile not found", err)
 		}
 	})
 }

--- a/internal/daemon/task_runtime_boot_roles.go
+++ b/internal/daemon/task_runtime_boot_roles.go
@@ -280,6 +280,7 @@ func newBootLoopCoordinatorRuntime(
 		return state.deps.ToolRegistry
 	}}
 	policyGate := &loopSessionPolicyGate{
+		profileNames:      bootProfileNameResolver{state: state},
 		workspaceResolver: workspaceResolver,
 		agentResolver: agentCatalogDependency(state.agentCatalog, agentSidecarCatalogs{
 			soul:      state.soulCatalog,

--- a/internal/memory/contract/types.go
+++ b/internal/memory/contract/types.go
@@ -209,6 +209,7 @@ type LLMCall struct {
 
 // Candidate carries one fact proposed for the curated layer.
 type Candidate struct {
+	ProfileID         string            `json:"profile_id,omitempty"`
 	WorkspaceID       string            `json:"workspace_id,omitempty"`
 	Scope             Scope             `json:"scope"`
 	AgentName         string            `json:"agent_name,omitempty"`
@@ -320,6 +321,7 @@ type TranscriptSnapshot struct {
 
 // TurnRecord describes the message range inspected by the extractor.
 type TurnRecord struct {
+	ProfileID       string             `json:"profile_id,omitempty"`
 	SessionID       string             `json:"session_id"`
 	RootSessionID   string             `json:"root_session_id"`
 	ParentSessionID string             `json:"parent_session_id,omitempty"`

--- a/internal/memory/extractor/runtime_queue.go
+++ b/internal/memory/extractor/runtime_queue.go
@@ -46,6 +46,7 @@ func (r *Runtime) HandleSessionMessagePersisted(
 	rootSessionID := firstNonEmpty(payload.RootSessionID, sessionID)
 	actorKind := firstNonEmpty(payload.ActorKind, actorKindRoot)
 	turn := memcontract.TurnRecord{
+		ProfileID:       payload.ProfileID,
 		SessionID:       sessionID,
 		RootSessionID:   rootSessionID,
 		AgentID:         firstNonEmpty(payload.AgentName, payload.ActorID, sessionID),

--- a/internal/memory/extractor/runtime_test.go
+++ b/internal/memory/extractor/runtime_test.go
@@ -37,6 +37,7 @@ func TestRuntime(t *testing.T) {
 				Timestamp: time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC),
 			},
 			SessionContext: hooks.SessionContext{
+				ProfileID:   "profile-engineering",
 				SessionID:   "sess-root",
 				WorkspaceID: "ws-1",
 			},
@@ -72,7 +73,8 @@ func TestRuntime(t *testing.T) {
 			t.Fatalf("extracted turns = %d, want 1 root turn", len(turns))
 		}
 		got := turns[0]
-		if got.SessionID != "sess-root" || got.UntilMessageSeq != 7 || got.Trigger != memcontract.TriggerPostMessage {
+		if got.ProfileID != "profile-engineering" || got.SessionID != "sess-root" || got.UntilMessageSeq != 7 ||
+			got.Trigger != memcontract.TriggerPostMessage {
 			t.Fatalf("turn = %#v, want root persisted message turn", got)
 		}
 		if len(got.Snapshot.Messages) != 1 || got.Snapshot.Messages[0].Content != rootPayload.Text {

--- a/internal/memory/extractor/runtime_turn.go
+++ b/internal/memory/extractor/runtime_turn.go
@@ -18,6 +18,7 @@ func normalizeTurn(turn memcontract.TurnRecord, now func() time.Time) (memcontra
 			return time.Now().UTC()
 		}
 	}
+	turn.ProfileID = strings.TrimSpace(turn.ProfileID)
 	turn.SessionID = strings.TrimSpace(turn.SessionID)
 	turn.RootSessionID = firstNonEmpty(turn.RootSessionID, turn.SessionID)
 	turn.ParentSessionID = strings.TrimSpace(turn.ParentSessionID)
@@ -85,6 +86,7 @@ func enrichCandidate(
 			return time.Now().UTC()
 		}
 	}
+	candidate.ProfileID = turn.ProfileID
 	candidate.WorkspaceID = firstNonEmpty(candidate.WorkspaceID, turn.WorkspaceID)
 	candidate.Origin = candidate.Origin.Normalize()
 	if candidate.Origin == "" {

--- a/web/e2e/__tests__/knowledge.spec.ts
+++ b/web/e2e/__tests__/knowledge.spec.ts
@@ -108,6 +108,7 @@ interface TranscriptMessagePart {
 
 test.use({
   runtimeOptions: {
+    memoryEnabled: true,
     seed: {
       mockAgents: [
         {
@@ -139,7 +140,7 @@ test("operator creates edits reverts searches recalls and deletes workspace know
   await appPage.goto(runtime.url("/knowledge"), { waitUntil: "domcontentloaded" });
   const kWin = appWindow(appPage, "knowledge");
   await expect(kWin).toBeVisible();
-  const knowledgeUI = knowledgeOperatorSelectors(kWin);
+  const knowledgeUI = knowledgeOperatorSelectors(kWin, appPage);
   await expect(knowledgeUI.shell).toBeVisible();
   await expect(knowledgeUI.tabProfile).toHaveAttribute("aria-pressed", "true");
   await knowledgeUI.tabWorkspace.click();

--- a/web/e2e/fixtures/runtime-helpers.ts
+++ b/web/e2e/fixtures/runtime-helpers.ts
@@ -20,6 +20,7 @@ export interface RuntimeConfigInput {
   host: string;
   includeMockAgentProvider?: boolean;
   modelsDevEnabled?: boolean;
+  memoryEnabled?: boolean;
   marketplaceCatalogBaseURL?: string;
   networkEnabled?: boolean;
   port: number;
@@ -73,6 +74,9 @@ export function renderRuntimeConfig(input: RuntimeConfigInput): string {
           `enabled = ${input.modelsDevEnabled ? "true" : "false"}`,
           "",
         ]),
+    ...(input.memoryEnabled === undefined
+      ? []
+      : ["[memory]", `enabled = ${input.memoryEnabled ? "true" : "false"}`, ""]),
     ...(input.networkEnabled === undefined
       ? []
       : ["[network]", `enabled = ${input.networkEnabled ? "true" : "false"}`, ""]),

--- a/web/e2e/fixtures/runtime.ts
+++ b/web/e2e/fixtures/runtime.ts
@@ -80,6 +80,7 @@ export interface BrowserRuntimeOptions {
   extensionsAllowUnverified?: boolean;
   host?: string;
   modelsDevEnabled?: boolean;
+  memoryEnabled?: boolean;
   networkEnabled?: boolean;
   readyTimeoutMs?: number;
   seed?: BrowserRuntimeSeed;
@@ -198,6 +199,7 @@ export async function createBrowserRuntime(
         host: boundHost,
         includeMockAgentProvider: (options.seed?.mockAgents?.length ?? 0) > 0,
         modelsDevEnabled: options.modelsDevEnabled,
+        memoryEnabled: options.memoryEnabled,
         marketplaceCatalogBaseURL: marketplaceCatalog?.baseURL,
         networkEnabled: options.networkEnabled,
         port: httpPort,

--- a/web/e2e/fixtures/selectors.ts
+++ b/web/e2e/fixtures/selectors.ts
@@ -1228,28 +1228,29 @@ export function networkOperatorSelectors(
 }
 
 export function knowledgeOperatorSelectors(
-  page: Pick<Page, "getByTestId">
+  page: Pick<Page, "getByTestId">,
+  portalRoot: Pick<Page, "getByTestId"> = page
 ): KnowledgeOperatorSelectors {
   return {
     osDesktop: page.getByTestId(knowledgeOperatorTestIds.osDesktop),
-    cancelCreateMemory: page.getByTestId(knowledgeOperatorTestIds.cancelCreateMemory),
-    confirmCreateMemory: page.getByTestId(knowledgeOperatorTestIds.confirmCreateMemory),
-    confirmDeleteMemory: page.getByTestId(knowledgeOperatorTestIds.confirmDeleteMemory),
-    confirmEditMemory: page.getByTestId(knowledgeOperatorTestIds.confirmEditMemory),
+    cancelCreateMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.cancelCreateMemory),
+    confirmCreateMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmCreateMemory),
+    confirmDeleteMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmDeleteMemory),
+    confirmEditMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmEditMemory),
     contentPreview: page.getByTestId(knowledgeOperatorTestIds.contentPreview),
     createButton: page.getByTestId(knowledgeOperatorTestIds.createButton),
-    createContent: page.getByTestId(knowledgeOperatorTestIds.createContent),
-    createDescription: page.getByTestId(knowledgeOperatorTestIds.createDescription),
-    createDialog: page.getByTestId(knowledgeOperatorTestIds.createDialog),
-    createName: page.getByTestId(knowledgeOperatorTestIds.createName),
-    createType: page.getByTestId(knowledgeOperatorTestIds.createType),
+    createContent: portalRoot.getByTestId(knowledgeOperatorTestIds.createContent),
+    createDescription: portalRoot.getByTestId(knowledgeOperatorTestIds.createDescription),
+    createDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.createDialog),
+    createName: portalRoot.getByTestId(knowledgeOperatorTestIds.createName),
+    createType: portalRoot.getByTestId(knowledgeOperatorTestIds.createType),
     deleteButton: page.getByTestId(knowledgeOperatorTestIds.deleteButton),
-    deleteDialog: page.getByTestId(knowledgeOperatorTestIds.deleteDialog),
+    deleteDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.deleteDialog),
     detailPanel: page.getByTestId(knowledgeOperatorTestIds.detailPanel),
     editButton: page.getByTestId(knowledgeOperatorTestIds.editButton),
-    editContent: page.getByTestId(knowledgeOperatorTestIds.editContent),
-    editDescription: page.getByTestId(knowledgeOperatorTestIds.editDescription),
-    editDialog: page.getByTestId(knowledgeOperatorTestIds.editDialog),
+    editContent: portalRoot.getByTestId(knowledgeOperatorTestIds.editContent),
+    editDescription: portalRoot.getByTestId(knowledgeOperatorTestIds.editDescription),
+    editDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.editDialog),
     guard: page.getByTestId(knowledgeOperatorTestIds.guard),
     item: (memoryKey: string) => page.getByTestId(`memory-item-${memoryKey}`),
     listPanel: page.getByTestId(knowledgeOperatorTestIds.listPanel),


### PR DESCRIPTION
## What & why

Loop child sessions and background memory extraction now resolve Agents and configuration through the work's owning Profile. Extracted candidates and delayed telemetry retain that Profile through queuing, replay, and storage; an unknown owner fails instead of falling back to another Profile.

Fixes #570. Fixes #571. Based on main after #580 merged; its memory opt-in and extraction changes remain intact.

## How you verified it

- Focused race tests cover non-default Profile Agent lookup, missing-owner rejection, extraction correlation, and Profile-specific candidate storage.
- `make gate` passed on merged main: Go lint plus the complete daemon and memory race suites.
- An AI coding agent co-wrote and reviewed the changes; automated validation is recorded above. Live activation has not been retested.

## Impact

Runtime Profile resolution and background memory writes change. The durable extraction records gain optional `profile_id`; older candidates with a source session recover its owner. Existing workspace memory sharing remains unchanged. Native Loop/session dispatch and memory hooks retain the existing owner; tool IDs and hook schemas do not change. No new configuration is required. Memory remains opt-in as specified by #580. The existing Profile guidance in the official skill remains applicable; no instruction changes are needed.

Two inherited test expectations are corrected: cancellation uses the existing protocol constant, and the enlarged memory reference uses result paging under the reduced test budget while still verifying its complete content. Reverting this PR restores the previous Profile resolution behavior. Required CI and a live non-default Profile smoke test remain pending.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Memory extraction and storage now support profile-specific routing.
  - Profile-aware workspace and agent resolution improves behavior for profile-scoped sessions.
  - Memory candidates and turn records retain their associated profile information.

- **Bug Fixes**
  - Unknown profiles are rejected during workspace, agent, and memory-store resolution.
  - Delayed memory events are routed to the correct profile store.

- **Tests**
  - Added coverage for profile-aware policy resolution, role resolution, memory routing, and profile propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->