### PR TITLE
fix: preserve profile scope across loop run views

### DIFF
--- a/docs/qa/scenarios/ET-profile-scoped-work-reads.md
+++ b/docs/qa/scenarios/ET-profile-scoped-work-reads.md
@@ -28,3 +28,9 @@ Walk:
 
 Expected evidence: paired structured CLI responses, HTTP and UDS payloads, native-tool results, and the
 foreign-detail error body.
+
+Regression #573: open a Loop run owned by a non-default Profile and verify its detail, briefing,
+roster, timeline, requests, and event stream load. Switch to another Profile and confirm the run
+and cached content disappear; direct reads of the three projections must return not found.
+From All Profiles, invoke a run control and verify it targets the run owner. This adds a QA check,
+not a completed browser verdict.

--- a/docs/qa/scenarios/ET-profile-scoped-work-reads.md
+++ b/docs/qa/scenarios/ET-profile-scoped-work-reads.md
@@ -32,5 +32,12 @@ foreign-detail error body.
 Regression #573: open a Loop run owned by a non-default Profile and verify its detail, briefing,
 roster, timeline, requests, and event stream load. Switch to another Profile and confirm the run
 and cached content disappear; direct reads of the three projections must return not found.
-From All Profiles, invoke a run control and verify it targets the run owner. This adds a QA check,
-not a completed browser verdict.
+From All Profiles, invoke a run control and verify it targets the run owner.
+
+Loop regression verified 2026-09-09 in the daemon-served browser suite:
+`web/e2e/__tests__/loop-run.spec.ts`, “Profile-scoped Loop reads and owner-bound controls survive
+reload and aggregate view”. The owning Profile can read detail, briefing, roster, and timeline;
+default-Profile requests return 404. The run remains readable after reload. Reopening it from
+All Profiles and confirming cancellation sends `profile=marketing` and reaches the canceled state.
+The paired CLI journey `TestDaemonE2ELoopRunReadCLIJourneys` also passes with race detection.
+This verifies the Loop regression; the broader non-Loop scenario above retains its own QA status.

--- a/internal/api/core/loop_read_handlers.go
+++ b/internal/api/core/loop_read_handlers.go
@@ -104,6 +104,9 @@ func (h *BaseHandlers) requireLoopRunReadService(c *gin.Context) (LoopRunReadSer
 	if !ok {
 		return nil, false
 	}
+	if !h.requireLoopRunProfile(c, service, false) {
+		return nil, false
+	}
 	readService, ok := service.(LoopRunReadService)
 	if !ok {
 		h.respondLoopError(c, errors.New("loop run read service is unavailable"))

--- a/internal/api/core/loop_read_handlers.go
+++ b/internal/api/core/loop_read_handlers.go
@@ -104,7 +104,9 @@ func (h *BaseHandlers) requireLoopRunReadService(c *gin.Context) (LoopRunReadSer
 	if !ok {
 		return nil, false
 	}
-	if !h.requireLoopRunProfile(c, service, false) {
+	if !h.requireLoopRunProfileWithResponder(c, service, c.Param("run_id"), false, func(c *gin.Context, err error) {
+		h.respondLoopRunReadError(c, c.Param("run_id"), err)
+	}) {
 		return nil, false
 	}
 	readService, ok := service.(LoopRunReadService)

--- a/internal/api/core/loop_run_profile_guard.go
+++ b/internal/api/core/loop_run_profile_guard.go
@@ -17,6 +17,16 @@ func (h *BaseHandlers) requireLoopRunProfileByID(
 	runID string,
 	mutation bool,
 ) bool {
+	return h.requireLoopRunProfileWithResponder(c, service, runID, mutation, h.respondLoopError)
+}
+
+func (h *BaseHandlers) requireLoopRunProfileWithResponder(
+	c *gin.Context,
+	service LoopService,
+	runID string,
+	mutation bool,
+	respond func(*gin.Context, error),
+) bool {
 	var (
 		scope interface{ Matches(string) bool }
 		err   error
@@ -36,11 +46,11 @@ func (h *BaseHandlers) requireLoopRunProfileByID(
 		strings.TrimSpace(runID),
 	)
 	if err != nil {
-		h.respondLoopError(c, err)
+		respond(c, err)
 		return false
 	}
 	if !scope.Matches(response.Run.ProfileID) {
-		h.respondLoopError(c, looppkg.ErrRunNotFound)
+		respond(c, looppkg.ErrRunNotFound)
 		return false
 	}
 	return true

--- a/internal/api/core/loops_test.go
+++ b/internal/api/core/loops_test.go
@@ -2724,6 +2724,9 @@ func TestLoopReadProfileScope(t *testing.T) {
 			path := "/workspaces/ws-1/loop-runs/run-1/" + endpoint
 			foreign := performRequest(t, engine, http.MethodGet, path+"?profile=default", nil)
 			assertLoopStatus(t, foreign.Code, http.StatusNotFound, foreign.Body.String())
+			if !strings.Contains(foreign.Body.String(), `"code":"loop_run_not_found"`) {
+				t.Fatalf("wrong error contract: %s", foreign.Body.String())
+			}
 			if reads != 0 {
 				t.Fatal("foreign Profile reached the projection")
 			}

--- a/internal/api/core/loops_test.go
+++ b/internal/api/core/loops_test.go
@@ -2691,3 +2691,47 @@ func assertLoopStatus(t *testing.T, got int, want int, body string) {
 		t.Fatalf("status = %d, want %d body=%s", got, want, body)
 	}
 }
+
+func TestLoopReadProfileScope(t *testing.T) {
+	t.Parallel()
+	for _, endpoint := range []string{"briefing", "nodes", "timeline"} {
+		t.Run("Should refuse a foreign Profile before reading "+endpoint, func(t *testing.T) {
+			t.Parallel()
+			service := happyLoopService(t)
+			reads := 0
+			service.getLoopRunNodesFn = func(context.Context, string, string, looppkg.RosterQuery) (contract.LoopRunNodesResponse, error) {
+				reads++
+				return contract.LoopRunNodesResponse{}, nil
+			}
+			service.getLoopBriefingFn = func(context.Context, string, string) (contract.LoopBriefingResponse, error) {
+				reads++
+				return contract.LoopBriefingResponse{}, nil
+			}
+			service.getLoopTimelineFn = func(context.Context, string, string, looppkg.TimelineQuery) (contract.LoopTimelineResponse, error) {
+				reads++
+				return contract.LoopTimelineResponse{}, nil
+			}
+			service.getLoopRunFn = func(context.Context, string, string) (contract.LoopRunResponse, error) {
+				run := loopRunPayload("run-1", looppkg.StatusDone)
+				run.ProfileID = "profile-marketing"
+				return contract.LoopRunResponse{Run: *run}, nil
+			}
+			handlers := core.NewBaseHandlers(
+				&core.BaseHandlerConfig{Loops: service, Profiles: sessionProfileServiceStub{}},
+			)
+			engine := gin.New()
+			registerLoopTestRoutes(engine, handlers)
+			path := "/workspaces/ws-1/loop-runs/run-1/" + endpoint
+			foreign := performRequest(t, engine, http.MethodGet, path+"?profile=default", nil)
+			assertLoopStatus(t, foreign.Code, http.StatusNotFound, foreign.Body.String())
+			if reads != 0 {
+				t.Fatal("foreign Profile reached the projection")
+			}
+			owned := performRequest(t, engine, http.MethodGet, path+"?profile=marketing", nil)
+			assertLoopStatus(t, owned.Code, http.StatusOK, owned.Body.String())
+			if reads != 1 {
+				t.Fatalf("projection reads = %d, want 1", reads)
+			}
+		})
+	}
+}

--- a/internal/api/spec/loop_read_operations.go
+++ b/internal/api/spec/loop_read_operations.go
@@ -12,14 +12,14 @@ func loopRunNodesOperation() OperationSpec {
 		"getLoopRunNodes",
 		"Get the computed Loop run node roster",
 		nil,
-		[]ParameterSpec{
+		withProfileScope(
 			workspaceIDParam(),
 			loopRunIDParam(),
 			enumQueryParam("state", "Filter by roster state", looppkg.NodeStateFilterValues()),
 			intQueryParam("generation", "Filter by generation"),
 			queryParam("cursor", "Opaque roster cursor", false),
 			intQueryParam("limit", "Maximum rows to return"),
-		},
+		),
 		[]ResponseSpec{
 			ok(contract.LoopRunNodesResponse{}),
 			badRequest(),
@@ -37,7 +37,7 @@ func loopRunBriefingOperation() OperationSpec {
 		"getLoopRunBriefing",
 		"Explain the current Loop run state",
 		nil,
-		[]ParameterSpec{workspaceIDParam(), loopRunIDParam()},
+		withProfileScope(workspaceIDParam(), loopRunIDParam()),
 		[]ResponseSpec{
 			ok(contract.LoopBriefingResponse{}),
 			notFound(specLoopRunNotFound),
@@ -54,7 +54,7 @@ func loopRunTimelineOperation() OperationSpec {
 		"getLoopRunTimeline",
 		"Read the durable Loop run timeline",
 		nil,
-		[]ParameterSpec{
+		withProfileScope(
 			workspaceIDParam(),
 			loopRunIDParam(),
 			enumQueryParam("view", "Timeline view: notable or all", []string{
@@ -63,7 +63,7 @@ func loopRunTimelineOperation() OperationSpec {
 			queryParam("cursor", "Opaque snapshot-fenced cursor", false),
 			intQueryParam("limit", "Maximum entries to return"),
 			afterSequenceQueryParam("Return entries after this per-run sequence"),
-		},
+		),
 		[]ResponseSpec{
 			ok(contract.LoopTimelineResponse{}),
 			badRequest(),

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -266589,6 +266589,22 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Read one profile's rows by name",
+            "in": "query",
+            "name": "profile",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Read the owner-labeled all-profiles aggregate",
+            "in": "query",
+            "name": "all_profiles",
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
@@ -270108,6 +270124,22 @@
             "schema": {
               "format": "int32",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Read one profile's rows by name",
+            "in": "query",
+            "name": "profile",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Read the owner-labeled all-profiles aggregate",
+            "in": "query",
+            "name": "all_profiles",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],
@@ -277069,6 +277101,22 @@
             "schema": {
               "format": "int64",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Read one profile's rows by name",
+            "in": "query",
+            "name": "profile",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Read the owner-labeled all-profiles aggregate",
+            "in": "query",
+            "name": "all_profiles",
+            "schema": {
+              "type": "boolean"
             }
           }
         ],

--- a/web/e2e/__tests__/knowledge.spec.ts
+++ b/web/e2e/__tests__/knowledge.spec.ts
@@ -108,6 +108,7 @@ interface TranscriptMessagePart {
 
 test.use({
   runtimeOptions: {
+    memoryEnabled: true,
     seed: {
       mockAgents: [
         {
@@ -139,7 +140,7 @@ test("operator creates edits reverts searches recalls and deletes workspace know
   await appPage.goto(runtime.url("/knowledge"), { waitUntil: "domcontentloaded" });
   const kWin = appWindow(appPage, "knowledge");
   await expect(kWin).toBeVisible();
-  const knowledgeUI = knowledgeOperatorSelectors(kWin);
+  const knowledgeUI = knowledgeOperatorSelectors(kWin, appPage);
   await expect(knowledgeUI.shell).toBeVisible();
   await expect(knowledgeUI.tabProfile).toHaveAttribute("aria-pressed", "true");
   await knowledgeUI.tabWorkspace.click();

--- a/web/e2e/__tests__/loop-run.spec.ts
+++ b/web/e2e/__tests__/loop-run.spec.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import type { Locator, Page } from "@playwright/test";
 
 import type { LoopDefinition, LoopRunDetail, RunLoopResult } from "@/systems/loops";
-import { switchWorkspace } from "../fixtures/os-navigation";
+import { openAppWindow, switchWorkspace } from "../fixtures/os-navigation";
 import type { BrowserRuntime } from "../fixtures/runtime";
 import { expect, test } from "../fixtures/test";
 import { completeOnboardingIfPrompted } from "../fixtures/workspace";
@@ -526,6 +526,7 @@ interface SeededRun {
 interface SeedOptions {
   inputs?: Record<string, unknown>;
   humanGate?: boolean;
+  profile?: string;
 }
 
 function requirePaths(runtime: BrowserRuntime) {
@@ -550,7 +551,7 @@ async function seedRun(
     body: JSON.stringify({ definition }),
   });
   const started = await runtime.requestJSON<RunLoopResult>(
-    `${workspacePath}/loops/${encodeURIComponent(name)}/run`,
+    `${workspacePath}/loops/${encodeURIComponent(name)}/run${options.profile ? `?profile=${encodeURIComponent(options.profile)}` : ""}`,
     {
       method: "POST",
       body: JSON.stringify({
@@ -823,6 +824,65 @@ function rosterRow(
 }
 
 test.describe("Loop run page — two registers", () => {
+  test("Profile-scoped Loop reads and owner-bound controls survive reload and aggregate view", async ({
+    appPage,
+    runtime,
+  }) => {
+    await runtime.requestJSON("/api/profiles", {
+      method: "POST",
+      body: JSON.stringify({ name: "marketing", color: "#2563eb", icon: "briefcase" }),
+    });
+    const { runId, runPath } = await seedRun(appPage, runtime, needsYouDefinition, NEEDS_YOU_LOOP, {
+      humanGate: true,
+      profile: "marketing",
+    });
+    await waitForRun(
+      runtime,
+      `${runPath}?profile=marketing`,
+      detail => (detail.requests ?? []).length > 0
+    );
+    for (const suffix of ["", "/briefing", "/nodes", "/timeline"]) {
+      const foreign = await appPage.request.get(runtime.url(`${runPath}${suffix}?profile=default`));
+      expect(foreign.status()).toBe(404);
+      const owned = await appPage.request.get(runtime.url(`${runPath}${suffix}?profile=marketing`));
+      expect(owned.ok()).toBe(true);
+    }
+    await appPage.getByTestId("os-menubar-profile").click();
+    await appPage.getByTestId("profile-switcher-option-marketing").click();
+    await openRun(appPage, runtime, runId);
+    await expect(appPage.getByTestId("loop-run-briefing-headline")).toBeVisible();
+    await appPage.reload({ waitUntil: "domcontentloaded" });
+    await expect(appPage.getByTestId("loop-run-briefing-headline")).toBeVisible();
+    await appPage.getByTestId("os-menubar-profile").click();
+    await appPage.getByTestId("profile-switcher-all").click();
+    const loops = await openAppWindow(appPage, "Loops", "loops");
+    await loops.getByTestId("loops-runs-link").click();
+    await loops
+      .getByTestId("loop-run-row")
+      .filter({ hasText: NEEDS_YOU_LOOP })
+      .getByRole("link", { name: NEEDS_YOU_LOOP, exact: true })
+      .click();
+    await expect(appPage.getByTestId("loop-run-detail-content")).toBeVisible();
+    const canceled = appPage.waitForResponse(
+      response =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname.endsWith(`/loop-runs/${runId}/cancel`)
+    );
+    await appPage.getByTestId("loop-run-cancel").click();
+    await appPage
+      .getByTestId("loop-run-control-dialog")
+      .getByRole("button", { name: "Cancel run", exact: true })
+      .click();
+    const response = await canceled;
+    expect(response.ok()).toBe(true);
+    expect(new URL(response.url()).searchParams.get("profile")).toBe("marketing");
+    await waitForRun(
+      runtime,
+      `${runPath}?profile=marketing`,
+      detail => detail.run.status === "canceled"
+    );
+  });
+
   test("E2E-012: the default read shows state and usage with identity in About", async ({
     appPage,
     runtime,

--- a/web/e2e/__tests__/loops-graph-eng.spec.ts
+++ b/web/e2e/__tests__/loops-graph-eng.spec.ts
@@ -71,7 +71,9 @@ test.describe("Human requests on the run page", () => {
     await expect(card.getByTestId("loop-request-field-decision")).toBeVisible();
     await card.getByRole("radio", { name: "approve" }).click();
     const responsePromise = page.waitForResponse(
-      response => response.request().method() === "POST" && response.url().endsWith("/respond")
+      response =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname.endsWith("/respond")
     );
     await card.getByTestId("loop-request-submit").click();
     const response = await responsePromise;
@@ -123,7 +125,9 @@ test.describe("Human requests on the run page", () => {
     const submit = card.getByTestId("loop-request-submit");
     await expect(submit).toBeEnabled();
     const responsePromise = page.waitForResponse(
-      response => response.request().method() === "POST" && response.url().endsWith("/respond")
+      response =>
+        response.request().method() === "POST" &&
+        new URL(response.url()).pathname.endsWith("/respond")
     );
     await submit.click();
     const response = await responsePromise;

--- a/web/e2e/__tests__/loops.spec.ts
+++ b/web/e2e/__tests__/loops.spec.ts
@@ -744,7 +744,9 @@ test("an enum ask without type crosses the real browser and daemon seam", async 
   await expect(card.getByTestId("loop-request-field-decision")).toBeVisible();
   await card.getByRole("radio", { name: "approve" }).click();
   const responsePromise = appPage.waitForResponse(
-    response => response.request().method() === "POST" && response.url().endsWith("/respond")
+    response =>
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname.endsWith("/respond")
   );
   await card.getByTestId("loop-request-submit").click();
   const response = await responsePromise;

--- a/web/e2e/fixtures/runtime-helpers.ts
+++ b/web/e2e/fixtures/runtime-helpers.ts
@@ -22,6 +22,7 @@ export interface RuntimeConfigInput {
   modelsDevEnabled?: boolean;
   marketplaceCatalogBaseURL?: string;
   networkEnabled?: boolean;
+  memoryEnabled?: boolean;
   port: number;
   skillsMarketplaceBaseURL?: string;
   socketPath: string;
@@ -73,6 +74,9 @@ export function renderRuntimeConfig(input: RuntimeConfigInput): string {
           `enabled = ${input.modelsDevEnabled ? "true" : "false"}`,
           "",
         ]),
+    ...(input.memoryEnabled === undefined
+      ? []
+      : ["[memory]", `enabled = ${input.memoryEnabled ? "true" : "false"}`, ""]),
     ...(input.networkEnabled === undefined
       ? []
       : ["[network]", `enabled = ${input.networkEnabled ? "true" : "false"}`, ""]),

--- a/web/e2e/fixtures/runtime-helpers.ts
+++ b/web/e2e/fixtures/runtime-helpers.ts
@@ -20,9 +20,9 @@ export interface RuntimeConfigInput {
   host: string;
   includeMockAgentProvider?: boolean;
   modelsDevEnabled?: boolean;
+  memoryEnabled?: boolean;
   marketplaceCatalogBaseURL?: string;
   networkEnabled?: boolean;
-  memoryEnabled?: boolean;
   port: number;
   skillsMarketplaceBaseURL?: string;
   socketPath: string;

--- a/web/e2e/fixtures/runtime.ts
+++ b/web/e2e/fixtures/runtime.ts
@@ -81,6 +81,7 @@ export interface BrowserRuntimeOptions {
   host?: string;
   modelsDevEnabled?: boolean;
   networkEnabled?: boolean;
+  memoryEnabled?: boolean;
   readyTimeoutMs?: number;
   seed?: BrowserRuntimeSeed;
   seedDefaultWorkspace?: boolean;
@@ -200,6 +201,7 @@ export async function createBrowserRuntime(
         modelsDevEnabled: options.modelsDevEnabled,
         marketplaceCatalogBaseURL: marketplaceCatalog?.baseURL,
         networkEnabled: options.networkEnabled,
+        memoryEnabled: options.memoryEnabled,
         port: httpPort,
         skillsMarketplaceBaseURL: skillMarketplace?.baseURL,
         socketPath: paths.daemonSocket,

--- a/web/e2e/fixtures/runtime.ts
+++ b/web/e2e/fixtures/runtime.ts
@@ -80,8 +80,8 @@ export interface BrowserRuntimeOptions {
   extensionsAllowUnverified?: boolean;
   host?: string;
   modelsDevEnabled?: boolean;
-  networkEnabled?: boolean;
   memoryEnabled?: boolean;
+  networkEnabled?: boolean;
   readyTimeoutMs?: number;
   seed?: BrowserRuntimeSeed;
   seedDefaultWorkspace?: boolean;
@@ -199,9 +199,9 @@ export async function createBrowserRuntime(
         host: boundHost,
         includeMockAgentProvider: (options.seed?.mockAgents?.length ?? 0) > 0,
         modelsDevEnabled: options.modelsDevEnabled,
+        memoryEnabled: options.memoryEnabled,
         marketplaceCatalogBaseURL: marketplaceCatalog?.baseURL,
         networkEnabled: options.networkEnabled,
-        memoryEnabled: options.memoryEnabled,
         port: httpPort,
         skillsMarketplaceBaseURL: skillMarketplace?.baseURL,
         socketPath: paths.daemonSocket,

--- a/web/e2e/fixtures/selectors.ts
+++ b/web/e2e/fixtures/selectors.ts
@@ -1228,28 +1228,29 @@ export function networkOperatorSelectors(
 }
 
 export function knowledgeOperatorSelectors(
-  page: Pick<Page, "getByTestId">
+  page: Pick<Page, "getByTestId">,
+  portalRoot: Pick<Page, "getByTestId"> = page
 ): KnowledgeOperatorSelectors {
   return {
     osDesktop: page.getByTestId(knowledgeOperatorTestIds.osDesktop),
-    cancelCreateMemory: page.getByTestId(knowledgeOperatorTestIds.cancelCreateMemory),
-    confirmCreateMemory: page.getByTestId(knowledgeOperatorTestIds.confirmCreateMemory),
-    confirmDeleteMemory: page.getByTestId(knowledgeOperatorTestIds.confirmDeleteMemory),
-    confirmEditMemory: page.getByTestId(knowledgeOperatorTestIds.confirmEditMemory),
+    cancelCreateMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.cancelCreateMemory),
+    confirmCreateMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmCreateMemory),
+    confirmDeleteMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmDeleteMemory),
+    confirmEditMemory: portalRoot.getByTestId(knowledgeOperatorTestIds.confirmEditMemory),
     contentPreview: page.getByTestId(knowledgeOperatorTestIds.contentPreview),
     createButton: page.getByTestId(knowledgeOperatorTestIds.createButton),
-    createContent: page.getByTestId(knowledgeOperatorTestIds.createContent),
-    createDescription: page.getByTestId(knowledgeOperatorTestIds.createDescription),
-    createDialog: page.getByTestId(knowledgeOperatorTestIds.createDialog),
-    createName: page.getByTestId(knowledgeOperatorTestIds.createName),
-    createType: page.getByTestId(knowledgeOperatorTestIds.createType),
+    createContent: portalRoot.getByTestId(knowledgeOperatorTestIds.createContent),
+    createDescription: portalRoot.getByTestId(knowledgeOperatorTestIds.createDescription),
+    createDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.createDialog),
+    createName: portalRoot.getByTestId(knowledgeOperatorTestIds.createName),
+    createType: portalRoot.getByTestId(knowledgeOperatorTestIds.createType),
     deleteButton: page.getByTestId(knowledgeOperatorTestIds.deleteButton),
-    deleteDialog: page.getByTestId(knowledgeOperatorTestIds.deleteDialog),
+    deleteDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.deleteDialog),
     detailPanel: page.getByTestId(knowledgeOperatorTestIds.detailPanel),
     editButton: page.getByTestId(knowledgeOperatorTestIds.editButton),
-    editContent: page.getByTestId(knowledgeOperatorTestIds.editContent),
-    editDescription: page.getByTestId(knowledgeOperatorTestIds.editDescription),
-    editDialog: page.getByTestId(knowledgeOperatorTestIds.editDialog),
+    editContent: portalRoot.getByTestId(knowledgeOperatorTestIds.editContent),
+    editDescription: portalRoot.getByTestId(knowledgeOperatorTestIds.editDescription),
+    editDialog: portalRoot.getByTestId(knowledgeOperatorTestIds.editDialog),
     guard: page.getByTestId(knowledgeOperatorTestIds.guard),
     item: (memoryKey: string) => page.getByTestId(`memory-item-${memoryKey}`),
     listPanel: page.getByTestId(knowledgeOperatorTestIds.listPanel),

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -108882,7 +108882,12 @@ export interface operations {
   };
   getLoopRunBriefing: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Read one profile's rows by name */
+        profile?: string;
+        /** @description Read the owner-labeled all-profiles aggregate */
+        all_profiles?: boolean;
+      };
       header?: never;
       path: {
         /** @description Workspace id */
@@ -110268,6 +110273,10 @@ export interface operations {
         cursor?: string;
         /** @description Maximum rows to return */
         limit?: number;
+        /** @description Read one profile's rows by name */
+        profile?: string;
+        /** @description Read the owner-labeled all-profiles aggregate */
+        all_profiles?: boolean;
       };
       header?: never;
       path: {
@@ -112973,6 +112982,10 @@ export interface operations {
         limit?: number;
         /** @description Return entries after this per-run sequence */
         after_sequence?: number;
+        /** @description Read one profile's rows by name */
+        profile?: string;
+        /** @description Read the owner-labeled all-profiles aggregate */
+        all_profiles?: boolean;
       };
       header?: never;
       path: {

--- a/web/src/routes/_app/-loops-preload.ts
+++ b/web/src/routes/_app/-loops-preload.ts
@@ -48,9 +48,9 @@ export async function preloadLoopDetailRoute(
   name: string,
   routeWorkspaceId?: string
 ): Promise<void> {
-  const profileScope = readProfileScopeParams(queryClient, readProfileLens());
   const workspaceId = await resolveRouteWorkspaceId(queryClient, routeWorkspaceId);
   if (!workspaceId) return;
+  const profileScope = readProfileScopeParams(queryClient, { scope: "workspace", workspaceId });
   await settleRouteQueries([
     queryClient.ensureQueryData(loopDetailOptions(workspaceId, name)),
     queryClient.ensureQueryData(loopConfigOptions(workspaceId, name)),
@@ -100,11 +100,11 @@ export async function preloadLoopRunDetailRoute(
   runId: string,
   routeWorkspaceId?: string
 ): Promise<void> {
-  const profileScope = readProfileScopeParams(queryClient, readProfileLens());
   const workspaceId = await resolveRouteWorkspaceId(queryClient, routeWorkspaceId);
   if (!workspaceId) {
     return;
   }
+  const profileScope = readProfileScopeParams(queryClient, { scope: "workspace", workspaceId });
 
   const [result] = await Promise.allSettled([
     queryClient.ensureQueryData(loopRunDetailOptions(workspaceId, runId, true, profileScope)),
@@ -126,11 +126,11 @@ export async function preloadLoopRunDiffRoute(
   runId: string,
   search: LoopRunDiffRouteSearch
 ): Promise<void> {
-  const profileScope = readProfileScopeParams(queryClient, readProfileLens());
   const workspaceId = await resolveRouteWorkspaceId(queryClient, search.workspace);
   if (!workspaceId) {
     return;
   }
+  const profileScope = readProfileScopeParams(queryClient, { scope: "workspace", workspaceId });
   await settleRouteQueries([
     queryClient.ensureQueryData(loopRunDetailOptions(workspaceId, runId, true, profileScope)),
   ]);

--- a/web/src/routes/_app/-loops-preload.ts
+++ b/web/src/routes/_app/-loops-preload.ts
@@ -100,13 +100,14 @@ export async function preloadLoopRunDetailRoute(
   runId: string,
   routeWorkspaceId?: string
 ): Promise<void> {
+  const profileScope = readProfileScopeParams(queryClient, readProfileLens());
   const workspaceId = await resolveRouteWorkspaceId(queryClient, routeWorkspaceId);
   if (!workspaceId) {
     return;
   }
 
   const [result] = await Promise.allSettled([
-    queryClient.ensureQueryData(loopRunDetailOptions(workspaceId, runId)),
+    queryClient.ensureQueryData(loopRunDetailOptions(workspaceId, runId, true, profileScope)),
   ] as const);
   if (result.status === "rejected") {
     return;
@@ -125,16 +126,19 @@ export async function preloadLoopRunDiffRoute(
   runId: string,
   search: LoopRunDiffRouteSearch
 ): Promise<void> {
+  const profileScope = readProfileScopeParams(queryClient, readProfileLens());
   const workspaceId = await resolveRouteWorkspaceId(queryClient, search.workspace);
   if (!workspaceId) {
     return;
   }
-  await settleRouteQueries([queryClient.ensureQueryData(loopRunDetailOptions(workspaceId, runId))]);
+  await settleRouteQueries([
+    queryClient.ensureQueryData(loopRunDetailOptions(workspaceId, runId, true, profileScope)),
+  ]);
   const query = loopRunDiffQuery(search);
   if (!query) {
     return;
   }
   await settleRouteQueries([
-    queryClient.ensureQueryData(loopRunDiffOptions(workspaceId, runId, query)),
+    queryClient.ensureQueryData(loopRunDiffOptions(workspaceId, runId, query, true, profileScope)),
   ]);
 }

--- a/web/src/routes/_app/__tests__/-route-preloading.integration.test.tsx
+++ b/web/src/routes/_app/__tests__/-route-preloading.integration.test.tsx
@@ -964,7 +964,8 @@ describe("route query preloading", () => {
     expect(adapterMocks.getLoopRun).toHaveBeenCalledWith(
       targetWorkspaceId,
       "run-1",
-      expect.any(AbortSignal)
+      expect.any(AbortSignal),
+      { profile: "default" }
     );
     expect(adapterMocks.getLoop).toHaveBeenCalledWith(
       targetWorkspaceId,
@@ -1154,6 +1155,29 @@ describe("route query preloading", () => {
       queryClient.clear();
     }
   );
+
+  it("Should preload a Loop run within the selected Profile and reuse it on mount", async () => {
+    const queryClient = createQueryClient();
+    setProfileView(
+      { scope: "workspace", workspaceId: workspace.id },
+      { kind: "profile", profile: "marketing" }
+    );
+    await invokeLoader(LoopRunDetailRoute, {
+      ...context(queryClient),
+      deps: { workspace: workspace.id },
+      params: { runId: "run-1" },
+    });
+    expect(adapterMocks.getLoopRun).toHaveBeenCalledWith(
+      workspace.id,
+      "run-1",
+      expect.any(AbortSignal),
+      { profile: "marketing" }
+    );
+    const unmount = mountQueries(queryClient, () => useLoopRun(workspace.id, "run-1"));
+    await waitFor(() => expect(adapterMocks.getLoopRun).toHaveBeenCalledTimes(1));
+    unmount();
+    queryClient.clear();
+  });
 
   it("Should preload the inbox badge and defer the stale inbox request until mount", async () => {
     const queryClient = createQueryClient();

--- a/web/src/routes/_app/__tests__/-route-preloading.integration.test.tsx
+++ b/web/src/routes/_app/__tests__/-route-preloading.integration.test.tsx
@@ -1179,6 +1179,30 @@ describe("route query preloading", () => {
     queryClient.clear();
   });
 
+  it("Should preload a cross-workspace run using the destination Profile lens", async () => {
+    const queryClient = createQueryClient();
+    setProfileView(
+      { scope: "workspace", workspaceId: workspace.id },
+      { kind: "profile", profile: "source" }
+    );
+    setProfileView(
+      { scope: "workspace", workspaceId: "ws-destination" },
+      { kind: "profile", profile: "destination" }
+    );
+    await invokeLoader(LoopRunDetailRoute, {
+      ...context(queryClient),
+      deps: { workspace: "ws-destination" },
+      params: { runId: "run-1" },
+    });
+    expect(adapterMocks.getLoopRun).toHaveBeenCalledWith(
+      "ws-destination",
+      "run-1",
+      expect.any(AbortSignal),
+      { profile: "destination" }
+    );
+    queryClient.clear();
+  });
+
   it("Should preload the inbox badge and defer the stale inbox request until mount", async () => {
     const queryClient = createQueryClient();
     const scope = { scope: "workspace" as const, workspace: workspace.id };

--- a/web/src/systems/loops/adapters/__tests__/loops-api.test.ts
+++ b/web/src/systems/loops/adapters/__tests__/loops-api.test.ts
@@ -48,23 +48,25 @@ const WS = "ws_1";
 describe("buildLoopStreamUrl", () => {
   it("Should build a workspace-scoped stream URL with after_sequence when a seed is provided", () => {
     expect(buildLoopStreamUrl(WS, "run_1", { after_sequence: "14" })).toBe(
-      "/api/workspaces/ws_1/loop-runs/run_1/events?after_sequence=14"
+      "/api/workspaces/ws_1/loop-runs/run_1/events?profile=default&after_sequence=14"
     );
   });
 
   it("Should keep after_sequence=0 for deterministic Last-Event-ID:0 precedence", () => {
     expect(buildLoopStreamUrl(WS, "run_1", { after_sequence: "0" })).toBe(
-      "/api/workspaces/ws_1/loop-runs/run_1/events?after_sequence=0"
+      "/api/workspaces/ws_1/loop-runs/run_1/events?profile=default&after_sequence=0"
     );
   });
 
-  it("Should omit the query string when no seed is provided", () => {
-    expect(buildLoopStreamUrl(WS, "run_1")).toBe("/api/workspaces/ws_1/loop-runs/run_1/events");
+  it("Should retain Profile scope when no stream seed is provided", () => {
+    expect(buildLoopStreamUrl(WS, "run_1")).toBe(
+      "/api/workspaces/ws_1/loop-runs/run_1/events?profile=default"
+    );
   });
 
   it("Should encode unsafe characters in both the workspace and run segments", () => {
     expect(buildLoopStreamUrl("ws a", "run/1", { after_sequence: "1" })).toBe(
-      "/api/workspaces/ws%20a/loop-runs/run%2F1/events?after_sequence=1"
+      "/api/workspaces/ws%20a/loop-runs/run%2F1/events?profile=default&after_sequence=1"
     );
   });
 
@@ -223,12 +225,15 @@ describe("loops-api (request construction + error mapping)", () => {
   it("Should GET a single run and POST run controls to the scoped endpoints", async () => {
     mockJsonResponse({ run: { id: "run_1" } });
     await getLoopRun(WS, "run_1");
-    await expectFetchRequest({ path: "/api/workspaces/ws_1/loop-runs/run_1", method: "GET" });
+    await expectFetchRequest({
+      path: "/api/workspaces/ws_1/loop-runs/run_1?profile=default",
+      method: "GET",
+    });
 
     mockJsonResponse({ ok: true });
     await pauseLoopRun(WS, "run_1");
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/pause",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/pause?profile=default",
       method: "POST",
       body: {},
       callIndex: 1,
@@ -237,7 +242,7 @@ describe("loops-api (request construction + error mapping)", () => {
     mockJsonResponse({ ok: true });
     await resumeLoopRun(WS, "run_1");
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/resume",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/resume?profile=default",
       method: "POST",
       callIndex: 2,
     });
@@ -245,7 +250,7 @@ describe("loops-api (request construction + error mapping)", () => {
     mockJsonResponse({ ok: true, run_id: "run_1" });
     await cancelLoopRun(WS, "run_1");
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/cancel",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/cancel?profile=default",
       method: "POST",
       callIndex: 3,
     });
@@ -253,7 +258,7 @@ describe("loops-api (request construction + error mapping)", () => {
     mockJsonResponse({ ok: true });
     await approveLoopRun(WS, "run_1", { decision: "approve", gate_id: "gate_1" });
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/approve",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/approve?profile=default",
       method: "POST",
       body: { decision: "approve", gate_id: "gate_1" },
       callIndex: 4,
@@ -366,7 +371,7 @@ describe("loops-api (request construction + error mapping)", () => {
     mockJsonResponse({ run_id: "r-1", status: "running" });
     await getLoopRunBriefing(WS, "r-1");
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/r-1/briefing",
+      path: "/api/workspaces/ws_1/loop-runs/r-1/briefing?profile=default",
       method: "GET",
     });
 
@@ -394,7 +399,7 @@ describe("loops-api (request construction + error mapping)", () => {
     });
     // A blank cursor is an absent cursor, exactly as elsewhere in the adapters.
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/r-1/nodes?state=running&generation=2&limit=200",
+      path: "/api/workspaces/ws_1/loop-runs/r-1/nodes?profile=default&state=running&generation=2&limit=200",
       method: "GET",
     });
 
@@ -438,7 +443,7 @@ describe("loops-api (request construction + error mapping)", () => {
     mockJsonResponse({ run_id: "r-1", head_seq: 12, entries: [] });
     await getLoopRunTimeline(WS, "r-1", { view: " all ", cursor: " tok-1 ", after_sequence: 0 });
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/r-1/timeline?view=all&cursor=tok-1&after_sequence=0",
+      path: "/api/workspaces/ws_1/loop-runs/r-1/timeline?profile=default&view=all&cursor=tok-1&after_sequence=0",
       method: "GET",
     });
 
@@ -706,7 +711,7 @@ describe("loop requests + time travel (request construction + error mapping)", (
       itemIndex: 2,
     });
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/nodes/pick_envs/request?generation=3&item_index=2",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/nodes/pick_envs/request?profile=default&generation=3&item_index=2",
       method: "GET",
       callIndex: 1,
     });
@@ -721,7 +726,7 @@ describe("loop requests + time travel (request construction + error mapping)", (
     mockJsonResponse({ ok: true });
     await respondLoopRequest({ workspaceId: WS, runId: "run_1", nodeId: "publish" }, body);
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/nodes/publish/respond",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/nodes/publish/respond?profile=default",
       method: "POST",
       body,
       callIndex: 2,
@@ -735,7 +740,7 @@ describe("loop requests + time travel (request construction + error mapping)", (
       { generation: 1, against_generation: 2 }
     );
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/diff?generation=1&against_generation=2",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/diff?generation=1&against_generation=2&profile=default",
       method: "GET",
     });
 
@@ -743,7 +748,7 @@ describe("loop requests + time travel (request construction + error mapping)", (
     mockJsonResponse({ run_id: "run_1", generation: 3 });
     await rerunLoopRun({ workspaceId: WS, runId: "run_1" }, rerunBody);
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/rerun",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/rerun?profile=default",
       method: "POST",
       body: rerunBody,
       callIndex: 1,
@@ -753,7 +758,7 @@ describe("loop requests + time travel (request construction + error mapping)", (
     mockJsonResponse({ run: { id: "run_2" } }, { status: 201 });
     await forkLoopRun({ workspaceId: WS, runId: "run_1" }, forkBody);
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/fork",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/fork?profile=default",
       method: "POST",
       body: forkBody,
       callIndex: 2,
@@ -763,7 +768,7 @@ describe("loop requests + time travel (request construction + error mapping)", (
     mockJsonResponse({ ok: true, amendment: {} });
     await amendLoopNode({ workspaceId: WS, runId: "run_1", nodeId: "classify" }, amendBody);
     await expectFetchRequest({
-      path: "/api/workspaces/ws_1/loop-runs/run_1/nodes/classify/amend",
+      path: "/api/workspaces/ws_1/loop-runs/run_1/nodes/classify/amend?profile=default",
       method: "POST",
       body: amendBody,
       callIndex: 3,

--- a/web/src/systems/loops/adapters/loop-nodes-api.ts
+++ b/web/src/systems/loops/adapters/loop-nodes-api.ts
@@ -1,3 +1,4 @@
+import type { ProfileMutationScopeParams } from "@/systems/profiles";
 import {
   apiClient,
   apiRequestFailed,
@@ -82,12 +83,13 @@ export async function listLoopNodes(
 export async function pauseLoopNode(
   { workspaceId, runId, nodeId }: NodePath,
   body: LoopNodePauseRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopNodeMutationResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/pause",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId }, query: scope },
       body,
       signal,
     }
@@ -99,12 +101,13 @@ export async function pauseLoopNode(
 export async function resumeLoopNode(
   { workspaceId, runId, nodeId }: NodePath,
   body: LoopNodeResumeRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopNodeMutationResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/resume",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId }, query: scope },
       body,
       signal,
     }
@@ -116,12 +119,13 @@ export async function resumeLoopNode(
 export async function cancelLoopNode(
   { workspaceId, runId, nodeId }: NodePath,
   body: LoopNodeMutationRequest = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopNodeMutationResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/cancel",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId }, query: scope },
       body,
       signal,
     }
@@ -133,12 +137,13 @@ export async function cancelLoopNode(
 export async function requeueLoopNode(
   { workspaceId, runId, nodeId }: NodePath,
   body: LoopNodeMutationRequest = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopNodeMutationResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/requeue",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId }, query: scope },
       body,
       signal,
     }

--- a/web/src/systems/loops/adapters/loop-requests-api.ts
+++ b/web/src/systems/loops/adapters/loop-requests-api.ts
@@ -1,3 +1,5 @@
+import type { ProfileMutationScopeParams } from "@/systems/profiles";
+import type { ProfileScopeParams } from "@/systems/profiles";
 import {
   apiClient,
   apiRequestFailed,
@@ -77,14 +79,19 @@ export async function listLoopRequests(
 
 export async function getLoopRequest(
   { workspaceId, runId, generation, nodeId, itemIndex }: RequestDetailPath,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileScopeParams = { profile: "default" }
 ): Promise<LoopRequestDetail> {
   const { data, error, response } = await apiClient.GET(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/request",
     {
       params: {
         path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId },
-        query: { generation, ...(itemIndex === undefined ? {} : { item_index: itemIndex }) },
+        query: {
+          ...scope,
+          generation,
+          ...(itemIndex === undefined ? {} : { item_index: itemIndex }),
+        },
       },
       signal,
     }
@@ -104,12 +111,13 @@ export async function getLoopRequest(
 export async function respondLoopRequest(
   { workspaceId, runId, nodeId }: RequestPath,
   body: LoopRespondRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopRespondResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/respond",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId }, query: scope },
       body,
       signal,
     }

--- a/web/src/systems/loops/adapters/loop-run-reads-api.ts
+++ b/web/src/systems/loops/adapters/loop-run-reads-api.ts
@@ -1,3 +1,4 @@
+import type { ProfileScopeParams } from "@/systems/profiles";
 import { apiClient, apiRequestFailed, defaultApiErrorMessage } from "@/lib/api-client";
 
 import {
@@ -107,12 +108,13 @@ function readData<T>(data: T | undefined, response: Response, fallback: string):
 export async function getLoopRunBriefing(
   workspaceId: string,
   runId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileScopeParams = { profile: "default" }
 ): Promise<LoopBriefing> {
   const { data, error, response } = await apiClient.GET(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/briefing",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       signal,
     }
   );
@@ -128,7 +130,8 @@ export async function getLoopRunRoster(
   workspaceId: string,
   runId: string,
   filters: LoopRosterRequestFilter = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileScopeParams = { profile: "default" }
 ): Promise<LoopRunRosterPage> {
   const { data, error, response } = await apiClient.GET(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes",
@@ -136,6 +139,7 @@ export async function getLoopRunRoster(
       params: {
         path: { workspace_id: workspaceId, run_id: runId },
         query: {
+          ...scope,
           state: rosterStateFilter(filters.state),
           generation: filters.generation,
           cursor: normalizeOptionalText(filters.cursor),
@@ -157,7 +161,8 @@ export async function getLoopRunTimeline(
   workspaceId: string,
   runId: string,
   filters: LoopTimelineRequestFilter = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileScopeParams = { profile: "default" }
 ): Promise<LoopTimelinePage> {
   const { data, error, response } = await apiClient.GET(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/timeline",
@@ -165,6 +170,7 @@ export async function getLoopRunTimeline(
       params: {
         path: { workspace_id: workspaceId, run_id: runId },
         query: {
+          ...scope,
           view: timelineViewFilter(filters.view),
           // Backward paging is the opaque cursor only; it binds
           // {run, view, fixed head, before} so appends never shift a page set.

--- a/web/src/systems/loops/adapters/loop-timetravel-api.ts
+++ b/web/src/systems/loops/adapters/loop-timetravel-api.ts
@@ -1,3 +1,5 @@
+import type { ProfileMutationScopeParams } from "@/systems/profiles";
+import type { ProfileScopeParams } from "@/systems/profiles";
 import {
   apiClient,
   apiRequestFailed,
@@ -56,12 +58,13 @@ function timetravelError(action: string, response: Response, error: unknown): Lo
 export async function diffLoopRun(
   { workspaceId, runId }: RunPath,
   query: LoopDiffQuery = {},
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileScopeParams = { profile: "default" }
 ): Promise<LoopDiff> {
   const { data, error, response } = await apiClient.GET(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/diff",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId }, query },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: { ...query, ...scope } },
       signal,
     }
   );
@@ -72,12 +75,13 @@ export async function diffLoopRun(
 export async function rerunLoopRun(
   { workspaceId, runId }: RunPath,
   body: LoopRerunRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopRerunResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/rerun",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       body,
       signal,
     }
@@ -91,12 +95,13 @@ export async function rerunLoopRun(
 export async function forkLoopRun(
   { workspaceId, runId }: RunPath,
   body: LoopForkRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopForkResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/fork",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       body,
       signal,
     }
@@ -112,12 +117,13 @@ const AMEND_REASON_STATUSES = new Set([403, 409, 422]);
 export async function amendLoopNode(
   { workspaceId, runId, nodeId }: NodePath,
   body: LoopAmendRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopAmendResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/nodes/{node_id}/amend",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId, node_id: nodeId }, query: scope },
       body,
       signal,
     }

--- a/web/src/systems/loops/adapters/loops-runs-api.ts
+++ b/web/src/systems/loops/adapters/loops-runs-api.ts
@@ -1,3 +1,5 @@
+import type { ProfileMutationScopeParams } from "@/systems/profiles";
+import type { ProfileScopeParams } from "@/systems/profiles";
 import {
   apiClient,
   apiRequestFailed,
@@ -28,7 +30,8 @@ import type {
 export function buildLoopStreamUrl(
   workspaceId: string,
   runId: string,
-  filters: LoopStreamFilter = {}
+  filters: LoopStreamFilter = {},
+  scope: ProfileScopeParams = { profile: "default" }
 ): string {
   const trimmedWorkspace = workspaceId.trim();
   if (trimmedWorkspace === "") {
@@ -41,9 +44,12 @@ export function buildLoopStreamUrl(
   const path = `/api/workspaces/${encodeURIComponent(trimmedWorkspace)}/loop-runs/${encodeURIComponent(
     trimmedRun
   )}/events`;
-  return filters.after_sequence === undefined
-    ? path
-    : `${path}?after_sequence=${encodeURIComponent(String(filters.after_sequence))}`;
+  const query = new URLSearchParams();
+  if ("profile" in scope) query.set("profile", scope.profile);
+  else query.set("all_profiles", "true");
+  if (filters.after_sequence !== undefined)
+    query.set("after_sequence", String(filters.after_sequence));
+  return `${path}?${query}`;
 }
 
 export async function runLoop(
@@ -139,12 +145,13 @@ export async function listLoopRuns(
 export async function getLoopRun(
   workspaceId: string,
   runId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileScopeParams = { profile: "default" }
 ): Promise<LoopRunDetail> {
   const { data, error, response } = await apiClient.GET(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       signal,
     }
   );
@@ -185,12 +192,13 @@ function loopRunControlError(
 export async function pauseLoopRun(
   workspaceId: string,
   runId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopRunActionResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/pause",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       body: {},
       signal,
     }
@@ -204,12 +212,13 @@ export async function pauseLoopRun(
 export async function resumeLoopRun(
   workspaceId: string,
   runId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopRunActionResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/resume",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       body: {},
       signal,
     }
@@ -223,12 +232,13 @@ export async function resumeLoopRun(
 export async function cancelLoopRun(
   workspaceId: string,
   runId: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopRunMutationResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/cancel",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       body: {},
       signal,
     }
@@ -243,12 +253,13 @@ export async function approveLoopRun(
   workspaceId: string,
   runId: string,
   body: ApproveLoopRunRequest,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  scope: ProfileMutationScopeParams = { profile: "default" }
 ): Promise<LoopRunActionResult> {
   const { data, error, response } = await apiClient.POST(
     "/api/workspaces/{workspace_id}/loop-runs/{run_id}/approve",
     {
-      params: { path: { workspace_id: workspaceId, run_id: runId } },
+      params: { path: { workspace_id: workspaceId, run_id: runId }, query: scope },
       body,
       signal,
     }

--- a/web/src/systems/loops/hooks/__tests__/use-loop-actions.test.tsx
+++ b/web/src/systems/loops/hooks/__tests__/use-loop-actions.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
-import { HttpResponse } from "msw";
+import { http, HttpResponse } from "msw";
 import { createElement, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -26,6 +26,15 @@ import {
   GRAPH_ENG_RUN_ID,
 } from "@/systems/loops/mocks/fixture-graph-eng-requests";
 
+const selection = vi.hoisted(() => ({ profile: "default" }));
+vi.mock("@/systems/profiles", async importOriginal => ({
+  ...(await importOriginal<typeof import("@/systems/profiles")>()),
+  useProfileReadScope: () => ({
+    params: selection.profile === "@all" ? { all_profiles: true } : { profile: selection.profile },
+    key: selection.profile,
+  }),
+}));
+
 const WS = "ws_1";
 
 function createWrapper(queryClient: QueryClient) {
@@ -42,6 +51,7 @@ function setup() {
 
 describe("loop mutation hooks", () => {
   beforeEach(() => {
+    selection.profile = "default";
     vi.stubGlobal(
       "fetch",
       createMswFetch(() => handlers)
@@ -51,6 +61,52 @@ describe("loop mutation hooks", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it.each(["engineering", "@all"])("Should target the run owner from %s", async profile => {
+    selection.profile = profile;
+    const controls: URL[] = [];
+    vi.stubGlobal(
+      "fetch",
+      createMswFetch(() => [
+        http.get("*/api/workspaces/ws_1/loop-runs/owned", ({ request }) => {
+          const query = new URL(request.url).searchParams;
+          expect(query.get(profile === "@all" ? "all_profiles" : "profile")).toBe(
+            profile === "@all" ? "true" : "engineering"
+          );
+          return HttpResponse.json({ run: { profile_name: "engineering" } });
+        }),
+        http.post("*/api/workspaces/ws_1/loop-runs/owned/pause", ({ request }) => {
+          controls.push(new URL(request.url));
+          return HttpResponse.json({ ok: true, run_id: "owned" });
+        }),
+      ])
+    );
+    const { wrapper } = setup();
+    const { result } = renderHook(() => usePauseLoopRun(), { wrapper });
+    await result.current.mutateAsync({ workspaceId: WS, runId: "owned" });
+    expect(controls).toHaveLength(1);
+    expect(controls[0]?.searchParams.get("profile")).toBe("engineering");
+    expect(controls[0]?.searchParams.has("all_profiles")).toBe(false);
+  });
+
+  it("Should refuse a control when the run is outside the selected Profile", async () => {
+    const control = vi.fn(() => HttpResponse.json({ ok: true }));
+    vi.stubGlobal(
+      "fetch",
+      createMswFetch(() => [
+        http.get("*/api/workspaces/ws_1/loop-runs/foreign", () =>
+          HttpResponse.json({ error: "Loop run not found" }, { status: 404 })
+        ),
+        http.post("*/api/workspaces/ws_1/loop-runs/foreign/pause", control),
+      ])
+    );
+    const { wrapper } = setup();
+    const { result } = renderHook(() => usePauseLoopRun(), { wrapper });
+    await expect(
+      result.current.mutateAsync({ workspaceId: WS, runId: "foreign" })
+    ).rejects.toMatchObject({ status: 404 });
+    expect(control).not.toHaveBeenCalled();
   });
 
   it("Should invalidate the catalog + created loop after useCreateLoop", async () => {

--- a/web/src/systems/loops/hooks/__tests__/use-loop-actions.test.tsx
+++ b/web/src/systems/loops/hooks/__tests__/use-loop-actions.test.tsx
@@ -35,6 +35,8 @@ vi.mock("@/systems/profiles", async importOriginal => ({
   }),
 }));
 
+import { loopRunDetailOptions } from "../../lib/query-options";
+
 const WS = "ws_1";
 
 function createWrapper(queryClient: QueryClient) {
@@ -88,6 +90,30 @@ describe("loop mutation hooks", () => {
     expect(controls).toHaveLength(1);
     expect(controls[0]?.searchParams.get("profile")).toBe("engineering");
     expect(controls[0]?.searchParams.has("all_profiles")).toBe(false);
+  });
+
+  it("Should refresh a cached owner before controlling a renamed Profile run", async () => {
+    selection.profile = "@all";
+    let owner = "engineering";
+    const controls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      createMswFetch(() => [
+        http.get("*/api/workspaces/ws_1/loop-runs/owned", () =>
+          HttpResponse.json({ run: { profile_name: owner } })
+        ),
+        http.post("*/api/workspaces/ws_1/loop-runs/owned/pause", ({ request }) => {
+          controls.push(new URL(request.url).searchParams.get("profile") ?? "");
+          return HttpResponse.json({ ok: true });
+        }),
+      ])
+    );
+    const { queryClient, wrapper } = setup();
+    await queryClient.fetchQuery(loopRunDetailOptions(WS, "owned", true, { all_profiles: true }));
+    owner = "renamed-engineering";
+    const { result } = renderHook(() => usePauseLoopRun(), { wrapper });
+    await result.current.mutateAsync({ workspaceId: WS, runId: "owned" });
+    expect(controls).toEqual(["renamed-engineering"]);
   });
 
   it("Should refuse a control when the run is outside the selected Profile", async () => {

--- a/web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx
+++ b/web/src/systems/loops/hooks/__tests__/use-loop-stream.test.tsx
@@ -144,7 +144,7 @@ describe("useLoopStream", () => {
 
     expect(factory).toHaveBeenCalledTimes(1);
     expect(factory).toHaveBeenCalledWith(
-      "/api/workspaces/ws_1/loop-runs/looprun_1/events?after_sequence=14"
+      "/api/workspaces/ws_1/loop-runs/looprun_1/events?profile=default&after_sequence=14"
     );
     for (const kind of LOOP_EVENT_KINDS) {
       expect(eventSource.hasListener(kind)).toBe(true);
@@ -424,11 +424,11 @@ describe("useLoopStream", () => {
     );
 
     expect(factory).toHaveBeenCalledWith(
-      "/api/workspaces/ws_1/loop-runs/looprun_1/events?after_sequence=0"
+      "/api/workspaces/ws_1/loop-runs/looprun_1/events?profile=default&after_sequence=0"
     );
   });
 
-  it("Should omit the query string when no after_sequence is provided", () => {
+  it("Should retain the Profile when no after_sequence is provided", () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const factory = vi.fn(() => new FakeLoopStreamEventSource());
 
@@ -436,7 +436,9 @@ describe("useLoopStream", () => {
       wrapper: createWrapper(queryClient),
     });
 
-    expect(factory).toHaveBeenCalledWith("/api/workspaces/ws_1/loop-runs/looprun_1/events");
+    expect(factory).toHaveBeenCalledWith(
+      "/api/workspaces/ws_1/loop-runs/looprun_1/events?profile=default"
+    );
   });
 
   it("Should still parse defensive unnamed message frames via onmessage", async () => {

--- a/web/src/systems/loops/hooks/__tests__/use-loops.test.tsx
+++ b/web/src/systems/loops/hooks/__tests__/use-loops.test.tsx
@@ -1,3 +1,5 @@
+import { http, HttpResponse } from "msw";
+import { loopRunDetailByRunId } from "../../mocks/fixtures";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
@@ -16,6 +18,11 @@ import {
 } from "@/systems/loops";
 
 const WS = "ws_1";
+const selection = vi.hoisted(() => ({ profile: "default" }));
+vi.mock("@/systems/profiles", async importOriginal => ({
+  ...(await importOriginal<typeof import("@/systems/profiles")>()),
+  useProfileReadScope: () => ({ params: { profile: selection.profile }, key: selection.profile }),
+}));
 
 function createWrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -25,6 +32,7 @@ function createWrapper() {
 
 describe("loop read hooks", () => {
   beforeEach(() => {
+    selection.profile = "default";
     vi.stubGlobal(
       "fetch",
       createMswFetch(() => handlers)
@@ -96,5 +104,42 @@ describe("loop read hooks", () => {
       wrapper: createWrapper(),
     });
     expect(result.current.isLoading).toBe(false);
+  });
+  it("Should read a completed run only in its selected Profile and isolate cached results on switch", async () => {
+    const fixture = loopRunDetailByRunId.get("looprun_running");
+    if (!fixture) throw new Error("run fixture missing");
+    selection.profile = "engineering";
+    vi.stubGlobal(
+      "fetch",
+      createMswFetch(() => [
+        http.get("*/api/workspaces/:workspace/loop-runs/:run", ({ request }) => {
+          if (new URL(request.url).searchParams.get("profile") !== "engineering") {
+            return new HttpResponse(null, { status: 404 });
+          }
+          return HttpResponse.json({
+            ...fixture,
+            run: {
+              ...fixture.run,
+              status: "done",
+              profile_id: "profile-engineering",
+              profile_name: "engineering",
+            },
+          });
+        }),
+        ...handlers,
+      ])
+    );
+    const { result, rerender } = renderHook(() => useLoopRun(WS, "looprun_running"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.run.status).toBe("done");
+    selection.profile = "default";
+    rerender();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+    selection.profile = "engineering";
+    rerender();
+    await waitFor(() => expect(result.current.data?.run.profile_name).toBe("engineering"));
   });
 });

--- a/web/src/systems/loops/hooks/use-loop-actions.ts
+++ b/web/src/systems/loops/hooks/use-loop-actions.ts
@@ -1,3 +1,4 @@
+import { useLoopRunOwner } from "./use-loop-run-owner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -189,8 +190,10 @@ export function usePutLoopAnnotations() {
 
 export function usePauseLoopRun() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId }: LoopRunParams) => pauseLoopRun(workspaceId, runId),
+    mutationFn: async ({ workspaceId, runId }: LoopRunParams) =>
+      pauseLoopRun(workspaceId, runId, undefined, await resolveOwner(workspaceId, runId)),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateLoopRunQueries(queryClient, workspaceId, runId),
   });
@@ -198,8 +201,10 @@ export function usePauseLoopRun() {
 
 export function useResumeLoopRun() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId }: LoopRunParams) => resumeLoopRun(workspaceId, runId),
+    mutationFn: async ({ workspaceId, runId }: LoopRunParams) =>
+      resumeLoopRun(workspaceId, runId, undefined, await resolveOwner(workspaceId, runId)),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateLoopRunQueries(queryClient, workspaceId, runId),
   });
@@ -207,8 +212,10 @@ export function useResumeLoopRun() {
 
 export function useCancelLoopRun() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId }: LoopRunParams) => cancelLoopRun(workspaceId, runId),
+    mutationFn: async ({ workspaceId, runId }: LoopRunParams) =>
+      cancelLoopRun(workspaceId, runId, undefined, await resolveOwner(workspaceId, runId)),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateLoopRunQueries(queryClient, workspaceId, runId),
   });
@@ -216,9 +223,10 @@ export function useCancelLoopRun() {
 
 export function useApproveLoopRun() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, data }: ApproveLoopRunParams) =>
-      approveLoopRun(workspaceId, runId, data),
+    mutationFn: async ({ workspaceId, runId, data }: ApproveLoopRunParams) =>
+      approveLoopRun(workspaceId, runId, data, undefined, await resolveOwner(workspaceId, runId)),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateLoopRunQueries(queryClient, workspaceId, runId),
   });

--- a/web/src/systems/loops/hooks/use-loop-node-actions.ts
+++ b/web/src/systems/loops/hooks/use-loop-node-actions.ts
@@ -1,3 +1,4 @@
+import { useLoopRunOwner } from "./use-loop-run-owner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -61,9 +62,15 @@ function invalidateNodeLifecycle(
 
 export function usePauseLoopNode() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, nodeId, data }: PauseNodeParams) =>
-      pauseLoopNode({ workspaceId, runId, nodeId }, data),
+    mutationFn: async ({ workspaceId, runId, nodeId, data }: PauseNodeParams) =>
+      pauseLoopNode(
+        { workspaceId, runId, nodeId },
+        data,
+        undefined,
+        await resolveOwner(workspaceId, runId)
+      ),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateNodeLifecycle(queryClient, workspaceId, runId),
   });
@@ -71,9 +78,15 @@ export function usePauseLoopNode() {
 
 export function useResumeLoopNode() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, nodeId, data }: ResumeNodeParams) =>
-      resumeLoopNode({ workspaceId, runId, nodeId }, data),
+    mutationFn: async ({ workspaceId, runId, nodeId, data }: ResumeNodeParams) =>
+      resumeLoopNode(
+        { workspaceId, runId, nodeId },
+        data,
+        undefined,
+        await resolveOwner(workspaceId, runId)
+      ),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateNodeLifecycle(queryClient, workspaceId, runId),
   });
@@ -81,9 +94,15 @@ export function useResumeLoopNode() {
 
 export function useCancelLoopNode() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, nodeId, data }: NodeMutationParams) =>
-      cancelLoopNode({ workspaceId, runId, nodeId }, data),
+    mutationFn: async ({ workspaceId, runId, nodeId, data }: NodeMutationParams) =>
+      cancelLoopNode(
+        { workspaceId, runId, nodeId },
+        data,
+        undefined,
+        await resolveOwner(workspaceId, runId)
+      ),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateNodeLifecycle(queryClient, workspaceId, runId),
   });
@@ -91,9 +110,15 @@ export function useCancelLoopNode() {
 
 export function useRequeueLoopNode() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, nodeId, data }: NodeMutationParams) =>
-      requeueLoopNode({ workspaceId, runId, nodeId }, data),
+    mutationFn: async ({ workspaceId, runId, nodeId, data }: NodeMutationParams) =>
+      requeueLoopNode(
+        { workspaceId, runId, nodeId },
+        data,
+        undefined,
+        await resolveOwner(workspaceId, runId)
+      ),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateNodeLifecycle(queryClient, workspaceId, runId),
   });

--- a/web/src/systems/loops/hooks/use-loop-node-inventory.ts
+++ b/web/src/systems/loops/hooks/use-loop-node-inventory.ts
@@ -1,3 +1,4 @@
+import { useProfileReadScope } from "@/systems/profiles";
 import { useInfiniteQuery } from "@tanstack/react-query";
 
 import { loopNodeInventoryOptions } from "../lib/query-options";
@@ -34,7 +35,10 @@ export function useLoopNodeInventory(
   filters: LoopNodeInventoryStableFilter,
   enabled = true
 ): LoopNodeInventoryView {
-  const query = useInfiniteQuery(loopNodeInventoryOptions(workspaceId, filters, enabled));
+  const { params } = useProfileReadScope();
+  const query = useInfiniteQuery(
+    loopNodeInventoryOptions(workspaceId, { ...filters, ...params }, enabled)
+  );
   const items = query.data?.pages.flatMap(page => page.items) ?? [];
   return {
     items,

--- a/web/src/systems/loops/hooks/use-loop-request-actions.ts
+++ b/web/src/systems/loops/hooks/use-loop-request-actions.ts
@@ -1,3 +1,4 @@
+import { useLoopRunOwner } from "./use-loop-run-owner";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { amendLoopNode, respondLoopRequest } from "../adapters/loops-api";
@@ -35,9 +36,15 @@ function invalidateRequestLifecycle(
 
 export function useRespondLoopRequest() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, nodeId, data }: RespondParams) =>
-      respondLoopRequest({ workspaceId, runId, nodeId }, data),
+    mutationFn: async ({ workspaceId, runId, nodeId, data }: RespondParams) =>
+      respondLoopRequest(
+        { workspaceId, runId, nodeId },
+        data,
+        undefined,
+        await resolveOwner(workspaceId, runId)
+      ),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateRequestLifecycle(queryClient, workspaceId, runId),
   });
@@ -45,9 +52,15 @@ export function useRespondLoopRequest() {
 
 export function useAmendLoopNode() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, nodeId, data }: AmendParams) =>
-      amendLoopNode({ workspaceId, runId, nodeId }, data),
+    mutationFn: async ({ workspaceId, runId, nodeId, data }: AmendParams) =>
+      amendLoopNode(
+        { workspaceId, runId, nodeId },
+        data,
+        undefined,
+        await resolveOwner(workspaceId, runId)
+      ),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateRequestLifecycle(queryClient, workspaceId, runId),
   });

--- a/web/src/systems/loops/hooks/use-loop-requests.ts
+++ b/web/src/systems/loops/hooks/use-loop-requests.ts
@@ -1,3 +1,4 @@
+import { useProfileReadScope } from "@/systems/profiles";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 
 import { loopRequestDetailOptions, loopRequestsOptions } from "../lib/query-options";
@@ -8,7 +9,10 @@ export function useLoopRequests(
   filters: LoopRequestStableFilter = {},
   enabled = true
 ) {
-  const query = useInfiniteQuery(loopRequestsOptions(workspaceId, filters, enabled));
+  const { params } = useProfileReadScope();
+  const query = useInfiniteQuery(
+    loopRequestsOptions(workspaceId, { ...filters, ...params }, enabled)
+  );
   const requests: LoopRequest[] = (query.data?.pages ?? []).flatMap(page => page.items);
   return {
     ...query,
@@ -26,7 +30,8 @@ export function useLoopRequestDetail(
   itemIndex?: number,
   enabled = true
 ) {
+  const { params } = useProfileReadScope();
   return useQuery(
-    loopRequestDetailOptions(workspaceId, runId, generation, nodeId, itemIndex, enabled)
+    loopRequestDetailOptions(workspaceId, runId, generation, nodeId, itemIndex, enabled, params)
   );
 }

--- a/web/src/systems/loops/hooks/use-loop-run-owner.ts
+++ b/web/src/systems/loops/hooks/use-loop-run-owner.ts
@@ -8,9 +8,10 @@ export function useLoopRunOwner() {
   const queryClient = useQueryClient();
   const { params } = useProfileReadScope();
   return async (workspaceId: string, runId: string): Promise<ProfileMutationScopeParams> => {
-    const detail = await queryClient.fetchQuery(
-      loopRunDetailOptions(workspaceId, runId, true, params)
-    );
+    const detail = await queryClient.fetchQuery({
+      ...loopRunDetailOptions(workspaceId, runId, true, params),
+      staleTime: 0,
+    });
     if (!detail.run.profile_name) throw new Error("The run's Profile is unavailable");
     return { profile: detail.run.profile_name };
   };

--- a/web/src/systems/loops/hooks/use-loop-run-owner.ts
+++ b/web/src/systems/loops/hooks/use-loop-run-owner.ts
@@ -1,0 +1,17 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useProfileReadScope, type ProfileMutationScopeParams } from "@/systems/profiles";
+import { loopRunDetailOptions } from "../lib/query-options";
+
+/** Resolve an existing run's owner within the current read scope before a mutation. */
+export function useLoopRunOwner() {
+  const queryClient = useQueryClient();
+  const { params } = useProfileReadScope();
+  return async (workspaceId: string, runId: string): Promise<ProfileMutationScopeParams> => {
+    const detail = await queryClient.fetchQuery(
+      loopRunDetailOptions(workspaceId, runId, true, params)
+    );
+    if (!detail.run.profile_name) throw new Error("The run's Profile is unavailable");
+    return { profile: detail.run.profile_name };
+  };
+}

--- a/web/src/systems/loops/hooks/use-loop-run-reads.ts
+++ b/web/src/systems/loops/hooks/use-loop-run-reads.ts
@@ -1,3 +1,4 @@
+import { useProfileReadScope } from "@/systems/profiles";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 
@@ -49,7 +50,8 @@ export function useLoopRunBriefing(
   runId: string,
   enabled = true
 ): LoopRunBriefingView {
-  const query = useQuery(loopRunBriefingOptions(workspaceId, runId, enabled));
+  const { params } = useProfileReadScope();
+  const query = useQuery(loopRunBriefingOptions(workspaceId, runId, enabled, params));
   return {
     briefing: query.data ?? null,
     isLoading: query.isPending,
@@ -98,8 +100,9 @@ export function useLoopRunRoster(
   runId: string,
   enabled = true
 ): LoopRunRosterView {
+  const { params } = useProfileReadScope();
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, isPending, isError, error } =
-    useInfiniteQuery(loopRunRosterOptions(workspaceId, runId, {}, enabled));
+    useInfiniteQuery(loopRunRosterOptions(workspaceId, runId, {}, enabled, params));
   const pages = data?.pages ?? [];
   const [allowance, setAllowance] = useState<RosterPageAllowance>(() => ({
     workspaceId,
@@ -177,9 +180,13 @@ export function useLoopRunTimeline(
   view: "notable" | "all" = "notable",
   enabled = true
 ): LoopRunTimelineView {
+  const { params, key: profileKey } = useProfileReadScope();
   const { data, hasNextPage, isFetchingNextPage, fetchNextPage, isPending, isError, error } =
-    useInfiniteQuery(loopRunTimelineOptions(workspaceId, runId, { view }, enabled));
-  const snapshotKey = loopTimelineSnapshotKey(workspaceId, runId, view);
+    useInfiniteQuery(loopRunTimelineOptions(workspaceId, runId, { view }, enabled, params));
+  const snapshotKey = JSON.stringify([
+    profileKey,
+    loopTimelineSnapshotKey(workspaceId, runId, view),
+  ]);
   const [snapshot, setSnapshot] = useState(() => emptyTimelineSnapshot(snapshotKey));
   // A lifecycle frame invalidates these reads, and a refetch re-reads the newest
   // window unpinned before re-deriving every backward cursor from it — so the

--- a/web/src/systems/loops/hooks/use-loop-stream.ts
+++ b/web/src/systems/loops/hooks/use-loop-stream.ts
@@ -1,3 +1,4 @@
+import { useProfileReadScope } from "@/systems/profiles";
 import { useEffect, useEffectEvent } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useStore } from "@xstate/store-react";
@@ -130,6 +131,8 @@ export function useLoopStream(
     onError,
   }: UseLoopStreamOptions = {}
 ) {
+  const { params: profileParams } = useProfileReadScope();
+  const profileName = "profile" in profileParams ? profileParams.profile : null;
   const queryClient = useQueryClient();
   const lifecycleStore = useStore(loopStreamLifecycleLogic);
   const trimmedWorkspace = workspaceId.trim();
@@ -159,9 +162,14 @@ export function useLoopStream(
       return undefined;
     }
 
-    const url = buildLoopStreamUrl(trimmedWorkspace, trimmedRun, {
-      after_sequence: afterSequence === undefined ? undefined : String(afterSequence),
-    });
+    const url = buildLoopStreamUrl(
+      trimmedWorkspace,
+      trimmedRun,
+      {
+        after_sequence: afterSequence === undefined ? undefined : String(afterSequence),
+      },
+      profileName === null ? { all_profiles: true } : { profile: profileName }
+    );
     const source = (customEventSourceFactory ?? defaultEventSourceFactory)(url);
     const subscription = {
       generation: lifecycleStore.getSnapshot().context.generation + 1,
@@ -217,6 +225,7 @@ export function useLoopStream(
     enabled,
     lifecycleStore,
     queryClient,
+    profileName,
     trimmedRun,
     trimmedWorkspace,
   ]);

--- a/web/src/systems/loops/hooks/use-loop-timetravel-actions.ts
+++ b/web/src/systems/loops/hooks/use-loop-timetravel-actions.ts
@@ -1,3 +1,5 @@
+import { useLoopRunOwner } from "./use-loop-run-owner";
+import { useProfileReadScope } from "@/systems/profiles";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { forkLoopRun, rerunLoopRun } from "../adapters/loops-api";
@@ -46,14 +48,16 @@ export function useLoopRunDiff(
   query: LoopDiffQuery = {},
   enabled = true
 ) {
-  return useQuery(loopRunDiffOptions(workspaceId, runId, query, enabled));
+  const { params } = useProfileReadScope();
+  return useQuery(loopRunDiffOptions(workspaceId, runId, query, enabled, params));
 }
 
 export function useRerunLoopRun() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, data }: RerunParams) =>
-      rerunLoopRun({ workspaceId, runId }, data),
+    mutationFn: async ({ workspaceId, runId, data }: RerunParams) =>
+      rerunLoopRun({ workspaceId, runId }, data, undefined, await resolveOwner(workspaceId, runId)),
     onSettled: (_result, _error, { workspaceId, runId }) =>
       invalidateTimetravel(queryClient, workspaceId, [runId]),
   });
@@ -61,9 +65,10 @@ export function useRerunLoopRun() {
 
 export function useForkLoopRun() {
   const queryClient = useQueryClient();
+  const resolveOwner = useLoopRunOwner();
   return useMutation({
-    mutationFn: ({ workspaceId, runId, data }: ForkParams) =>
-      forkLoopRun({ workspaceId, runId }, data),
+    mutationFn: async ({ workspaceId, runId, data }: ForkParams) =>
+      forkLoopRun({ workspaceId, runId }, data, undefined, await resolveOwner(workspaceId, runId)),
     onSettled: (result, _error, { workspaceId, runId }) =>
       invalidateTimetravel(queryClient, workspaceId, [runId, result?.run.id ?? ""]),
   });

--- a/web/src/systems/loops/hooks/use-loops.ts
+++ b/web/src/systems/loops/hooks/use-loops.ts
@@ -54,5 +54,6 @@ export function useLoopRuns(workspaceId: string, filters: LoopRunsFilter = {}, e
 }
 
 export function useLoopRun(workspaceId: string, runId: string, enabled = true) {
-  return useQuery(loopRunDetailOptions(workspaceId, runId, enabled));
+  const { params } = useProfileReadScope();
+  return useQuery(loopRunDetailOptions(workspaceId, runId, enabled, params));
 }

--- a/web/src/systems/loops/lib/__tests__/query-keys.test.ts
+++ b/web/src/systems/loops/lib/__tests__/query-keys.test.ts
@@ -115,6 +115,7 @@ describe("loopsKeys", () => {
       "pending",
       "run_1",
       "50",
+      "",
     ]);
     expect(loopsKeys.requests("ws_a", { state: "pending" })).not.toEqual(
       loopsKeys.requests("ws_a", { state: "resolved" })

--- a/web/src/systems/loops/lib/__tests__/query-options.test.ts
+++ b/web/src/systems/loops/lib/__tests__/query-options.test.ts
@@ -39,6 +39,7 @@ describe("loop query-options", () => {
       "run-detail",
       "ws_a",
       "run_1",
+      { profile: "default" },
     ]);
   });
 
@@ -72,7 +73,7 @@ describe("loop query-options", () => {
 
   it("Should default the request inventory to pending and page by cursor", () => {
     const options = loopRequestsOptions("ws_a");
-    expect(options.queryKey).toEqual(["loops", "requests", "ws_a", "pending", "", "50"]);
+    expect(options.queryKey).toEqual(["loops", "requests", "ws_a", "pending", "", "50", ""]);
     expect(options.initialPageParam).toBeUndefined();
     expect(options.enabled).toBe(true);
     expect(loopRequestsOptions("").enabled).toBe(false);
@@ -109,6 +110,7 @@ describe("loop query-options", () => {
       3,
       "ask_node",
       "1",
+      { profile: "default" },
     ]);
     expect(loopRequestDetailOptions("", "run_1", 3, "ask_node").enabled).toBe(false);
     expect(loopRequestDetailOptions("ws_a", "", 3, "ask_node").enabled).toBe(false);
@@ -133,6 +135,7 @@ describe("loop query-options", () => {
       "notable",
       "50",
       "",
+      { profile: "default" },
     ]);
   });
 
@@ -151,7 +154,14 @@ describe("loop query-options", () => {
   });
   it("Should stop polling the briefing once the run is terminal", () => {
     const options = loopRunBriefingOptions("ws_a", "run_1");
-    expect(options.queryKey).toEqual(["loops", "run-reads", "ws_a", "run_1", "briefing"]);
+    expect(options.queryKey).toEqual([
+      "loops",
+      "run-reads",
+      "ws_a",
+      "run_1",
+      "briefing",
+      { profile: "default" },
+    ]);
     const asFn = options.refetchInterval as (query: {
       state: { data?: { status: string } };
     }) => number | false;
@@ -177,6 +187,7 @@ describe("loop query-options", () => {
       "failed",
       "",
       "200",
+      { profile: "default" },
     ]);
     expect(options.initialPageParam).toBeUndefined();
     // Continuation is the daemon's opaque cursor, never a client-computed offset.

--- a/web/src/systems/loops/lib/query-keys.ts
+++ b/web/src/systems/loops/lib/query-keys.ts
@@ -138,6 +138,7 @@ export const loopsKeys = {
       normalizeText(filters.loop),
       normalizeText(filters.run_id),
       normalizeNumber(filters.limit),
+      profileLens(filters.profile, filters.all_profiles),
     ] as const,
   // Existence probe (`limit: 1`) — a distinct key so the inventory infinite
   // query never shares a cache entry with the attention-bell presence check.
@@ -155,6 +156,7 @@ export const loopsKeys = {
       normalizeText(filters.state),
       normalizeText(filters.run_id),
       normalizeNumber(filters.limit),
+      profileLens(filters.profile, filters.all_profiles),
     ] as const,
 
   requestDetail: (

--- a/web/src/systems/loops/lib/query-options.ts
+++ b/web/src/systems/loops/lib/query-options.ts
@@ -1,3 +1,4 @@
+import type { ProfileScopeParams } from "@/systems/profiles";
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { listLoopNodes } from "../adapters/loop-nodes-api";
@@ -132,10 +133,15 @@ export function loopRunsOptions(workspaceId: string, filters: LoopRunsFilter = {
   });
 }
 
-export function loopRunDetailOptions(workspaceId: string, runId: string, enabled = true) {
+export function loopRunDetailOptions(
+  workspaceId: string,
+  runId: string,
+  enabled = true,
+  scope: ProfileScopeParams = { profile: "default" }
+) {
   return queryOptions({
-    queryKey: loopsKeys.runDetail(workspaceId, runId),
-    queryFn: ({ signal }) => getLoopRun(workspaceId, runId, signal),
+    queryKey: [...loopsKeys.runDetail(workspaceId, runId), scope],
+    queryFn: ({ signal }) => getLoopRun(workspaceId, runId, signal, scope),
     staleTime: LIVE_STALE_TIME,
     // Poll only while the run is live; a terminal run's projection is immutable, so
     // the run page stops refetching once it reaches a terminal state (contract-lane
@@ -151,10 +157,15 @@ export function loopRunDetailOptions(workspaceId: string, runId: string, enabled
  * (Safety Invariant 12). A terminal run's briefing is immutable, so polling stops
  * with the run — the same rule `loopRunDetailOptions` follows.
  */
-export function loopRunBriefingOptions(workspaceId: string, runId: string, enabled = true) {
+export function loopRunBriefingOptions(
+  workspaceId: string,
+  runId: string,
+  enabled = true,
+  scope: ProfileScopeParams = { profile: "default" }
+) {
   return queryOptions({
-    queryKey: loopsKeys.runBriefing(workspaceId, runId),
-    queryFn: ({ signal }) => getLoopRunBriefing(workspaceId, runId, signal),
+    queryKey: [...loopsKeys.runBriefing(workspaceId, runId), scope],
+    queryFn: ({ signal }) => getLoopRunBriefing(workspaceId, runId, signal, scope),
     staleTime: LIVE_STALE_TIME,
     refetchInterval: query =>
       isTerminalLoopStatus(query.state.data?.status) ? false : LIVE_REFETCH_INTERVAL,
@@ -175,13 +186,20 @@ export function loopRunRosterOptions(
   workspaceId: string,
   runId: string,
   filters: LoopRosterStableFilter = {},
-  enabled = true
+  enabled = true,
+  scope: ProfileScopeParams = { profile: "default" }
 ) {
   const normalizedFilters = { ...filters, limit: filters.limit ?? ROSTER_PAGE_LIMIT };
   return infiniteQueryOptions({
-    queryKey: loopsKeys.runRoster(workspaceId, runId, normalizedFilters),
+    queryKey: [...loopsKeys.runRoster(workspaceId, runId, normalizedFilters), scope],
     queryFn: ({ pageParam, signal }) =>
-      getLoopRunRoster(workspaceId, runId, { ...normalizedFilters, cursor: pageParam }, signal),
+      getLoopRunRoster(
+        workspaceId,
+        runId,
+        { ...normalizedFilters, cursor: pageParam },
+        signal,
+        scope
+      ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: page => page.next_cursor || undefined,
     staleTime: LIVE_STALE_TIME,
@@ -208,7 +226,8 @@ export function loopRunTimelineOptions(
   workspaceId: string,
   runId: string,
   filters: LoopTimelineStableFilter = {},
-  enabled = true
+  enabled = true,
+  scope: ProfileScopeParams = { profile: "default" }
 ) {
   const normalizedFilters = {
     ...filters,
@@ -216,9 +235,15 @@ export function loopRunTimelineOptions(
     limit: filters.limit ?? TIMELINE_PAGE_LIMIT,
   };
   return infiniteQueryOptions({
-    queryKey: loopsKeys.runTimeline(workspaceId, runId, normalizedFilters),
+    queryKey: [...loopsKeys.runTimeline(workspaceId, runId, normalizedFilters), scope],
     queryFn: ({ pageParam, signal }) =>
-      getLoopRunTimeline(workspaceId, runId, { ...normalizedFilters, cursor: pageParam }, signal),
+      getLoopRunTimeline(
+        workspaceId,
+        runId,
+        { ...normalizedFilters, cursor: pageParam },
+        signal,
+        scope
+      ),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: page => page.next_cursor || undefined,
     staleTime: LIVE_STALE_TIME,
@@ -269,12 +294,16 @@ export function loopRequestDetailOptions(
   generation: number,
   nodeId: string,
   itemIndex?: number,
-  enabled = true
+  enabled = true,
+  scope: ProfileScopeParams = { profile: "default" }
 ) {
   return queryOptions({
-    queryKey: loopsKeys.requestDetail(workspaceId, runId, generation, nodeId, itemIndex),
+    queryKey: [
+      ...loopsKeys.requestDetail(workspaceId, runId, generation, nodeId, itemIndex),
+      scope,
+    ],
     queryFn: ({ signal }) =>
-      getLoopRequest({ workspaceId, runId, generation, nodeId, itemIndex }, signal),
+      getLoopRequest({ workspaceId, runId, generation, nodeId, itemIndex }, signal, scope),
     staleTime: LIVE_STALE_TIME,
     enabled: Boolean(workspaceId) && Boolean(runId) && generation > 0 && Boolean(nodeId) && enabled,
   });
@@ -284,11 +313,12 @@ export function loopRunDiffOptions(
   workspaceId: string,
   runId: string,
   query: LoopDiffQuery = {},
-  enabled = true
+  enabled = true,
+  scope: ProfileScopeParams = { profile: "default" }
 ) {
   return queryOptions({
-    queryKey: loopsKeys.runDiff(workspaceId, runId, query),
-    queryFn: ({ signal }) => diffLoopRun({ workspaceId, runId }, query, signal),
+    queryKey: [...loopsKeys.runDiff(workspaceId, runId, query), scope],
+    queryFn: ({ signal }) => diffLoopRun({ workspaceId, runId }, query, signal, scope),
     staleTime: LIVE_STALE_TIME,
     refetchInterval: settled => {
       const data = settled.state.data;

--- a/web/src/systems/os/apps/loops/use-loop-run-page.ts
+++ b/web/src/systems/os/apps/loops/use-loop-run-page.ts
@@ -1,3 +1,4 @@
+import { useProfileReadScope } from "@/systems/profiles";
 import { useState } from "react";
 import { useSelector } from "@xstate/store-react";
 
@@ -92,7 +93,8 @@ export function useLoopRunPage(
   runId: string,
   { liveDataEnabled = true }: { liveDataEnabled?: boolean } = {}
 ) {
-  const bindingKey = `${workspaceId}\u0000${runId}`;
+  const { key: profileKey } = useProfileReadScope();
+  const bindingKey = JSON.stringify([profileKey, workspaceId, runId]);
   const { store: runPageStore } = useStoreBinding(bindingKey, () =>
     loopRunPageLogic.createStore({ workspaceId, runId })
   );

--- a/web/src/systems/session/components/__tests__/session-find-bar.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-find-bar.test.tsx
@@ -133,7 +133,8 @@ describe("SessionFindBar", () => {
     expect(input).toHaveFocus();
     expect(screen.queryByTestId("session-find-next")).not.toBeInTheDocument();
 
-    await user.type(input, "lifecycle");
+    // This case verifies a committed query; intermediate keystrokes may debounce separately.
+    await user.paste("lifecycle");
     await waitFor(() => expect(bar).toHaveAttribute("data-state", "matches"));
     expect(searchCalls.at(-1)?.searchParams.get("q")).toBe("lifecycle");
     expect(searchCalls.at(-1)?.searchParams.get("limit")).toBe("200");


### PR DESCRIPTION
## What & why

Opening a Loop run owned by a non-default Profile now carries the selected Profile through detail reads, projections, requests, and the event stream. Profile changes isolate cached content. Existing-run controls resolve the actual owner within the current read scope, including All Profiles.

Fixes #573. Briefing, roster, and timeline routes also enforce the same Profile check as the run detail route.

## How you verified it

- The Loop web suite and additional owner-control and route-preloading regressions passed. Frontend validation uses Node 22 LTS.
- Added coverage for Profile switching without stale run data, controls from All Profiles, refusal of foreign-run controls, and owner/foreign HTTP responses for all three projections.
- `make gate` passed: generated contracts, API race tests, frontend lint/typecheck, and all 7,113 web tests (Node 22 LTS).
- An AI coding agent co-wrote and reviewed the changes; automated validation is recorded above. The daemon-served browser journey verifies non-default Profile reads, foreign-read refusal, reload, and confirmed owner-bound cancellation from All Profiles; the QA scenario records the bounded verdict.

## Impact

Loop pages and controls now work for non-default Profiles. Briefing, roster, and timeline OpenAPI operations expose the existing Profile scope parameters; generated contracts are updated. The HTTP/UDS guard uses the existing Profile contract; native tool IDs, hooks, stored workspace data, and official skill instructions remain unchanged. No new configuration. The Profile-scoped QA scenario records the completed Loop browser walk. Follow-up fixes refresh cached owner names, use the destination workspace lens during preload, and preserve the projection CLI error contract. Shared browser fixtures explicitly enable memory for the Knowledge journey and match owner-scoped request paths independently of query parameters.

Required CI remains the final delivery gate. Browser regression verification is complete. Reverting restores the previous request and cache behavior.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added profile-aware access controls for loop runs, requests, nodes, streams, and related actions.
  - Loop data now reflects the selected profile, with support for viewing across all profiles where applicable.
  - Switching profiles refreshes loop details, streams, cached data, and run-specific views correctly.

- **Bug Fixes**
  - Prevented access to loop runs belonging to another profile.
  - Ensured mutations target the run’s owning profile and fail safely when the run is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
