### PR TITLE
fix: allow resizing maximized internal windows

### DIFF
--- a/COPY.md
+++ b/COPY.md
@@ -485,6 +485,11 @@ Avoid:
 
 Goal: tell the person what is true and what they can do next.
 
+Internal window controls use `Zoom window` to maximize and `Restore window` while
+zoomed to return to the saved placement and size. These labels describe internal
+CompozyOS windows, not native browser or application fullscreen. Resizing a zoomed
+window adopts the resized geometry instead of restoring its saved placement.
+
 Use:
 
 - current state, next action, and consequence.

--- a/docs/qa/scenarios/ET-window-manager-layout-gestures.md
+++ b/docs/qa/scenarios/ET-window-manager-layout-gestures.md
@@ -87,3 +87,17 @@ qa-impact: 2026-09-01 zoom is structural: the zoomed unit is the only full-frame
 qa-impact: 2026-09-01 review remediation keeps stale drag rebases tied to the gesture's captured source node for both snap and free-drop commands, including queued top-center zoom. Reset for a focused stale-gesture walk on the current head.
 
 qa-impact: 2026-09-01 focused current-head walk passed normal top-center zoom, edge snap, lifted-desktop paging, and exact unzoom return through the public web/API/CLI surfaces. The owning hook regressions then changed the live window node mid-gesture and proved free-drop and queued top-center zoom still submit the captured source node and revision.
+
+qa-impact: 2026-09-10 issue #585 exposes all borders and corners while an internal window is
+maximized. The zoom control shows a restore icon and the label "Restore window"; clicking it
+returns the saved floating rect or tiled slot. Dragging a maximized border/corner instead commits
+`window.resize`, ends zoom, and keeps the new tiled zone on the current desktop. Verify repeated
+floating maximize/restore cycles, southeast and west resize gestures while maximized, then
+maximize/restore/reload of the resized zone. Compare the peer window and source layout before and
+after; no peer may move. Owner: `web/e2e/__tests__/os-shell.spec.ts`, issue #585 regression plus
+E2E-003 and E2E-137. Passed on macOS/Chromium against a worktree-built daemon with isolated
+homes/ports/sockets (2026-09-10): E2E-003 and E2E-137 passed, and the final issue #585 regression
+passed in 4.8s. Logs: `.tmp/issue-585/e2e.log` (existing scenarios) and
+`.tmp/issue-585/e2e-resize.log` (final regression); trace and final screenshot under
+`.tmp/playwright/test-results/__tests__-os-shell-Issue-5-8963a-across-repeated-zoom-cycles/compozy-artifacts/`.
+Fixture teardown completed successfully. Linux and Electron were not run locally.

--- a/docs/qa/scenarios/ET-window-manager-layout-gestures.md
+++ b/docs/qa/scenarios/ET-window-manager-layout-gestures.md
@@ -97,7 +97,7 @@ maximize/restore/reload of the resized zone. Compare the peer window and source 
 after; no peer may move. Owner: `web/e2e/__tests__/os-shell.spec.ts`, issue #585 regression plus
 E2E-003 and E2E-137. Passed on macOS/Chromium against a worktree-built daemon with isolated
 homes/ports/sockets (2026-09-10): E2E-003 and E2E-137 passed, and the final issue #585 regression
-passed in 4.8s. Logs: `.tmp/issue-585/e2e.log` (existing scenarios) and
+passed in 5.1s, including exact pointer-delta geometry for the window's own tiled group. Logs: `.tmp/issue-585/e2e.log` (existing scenarios) and
 `.tmp/issue-585/e2e-resize.log` (final regression); trace and final screenshot under
 `.tmp/playwright/test-results/__tests__-os-shell-Issue-5-8963a-across-repeated-zoom-cycles/compozy-artifacts/`.
 Fixture teardown completed successfully. Linux and Electron were not run locally.

--- a/docs/qa/scenarios/ET-window-zoom-in-place.md
+++ b/docs/qa/scenarios/ET-window-zoom-in-place.md
@@ -42,3 +42,17 @@ qa-impact: 2026-09-01 walked on the structural model: A0–A8 pass 11/11 (solo z
 qa-impact: 2026-09-01 review remediation enforces the full-desktop invariant at every durable boundary: opening a separate visible peer ends zoom immediately, minimized zoom desktops survive until restore, restore selects an unoccupied desktop after any competing zoom returns, desktop transfer clears the stale zoom anchor, and the solo-frame traffic light receives the pressed state. Reset for a focused current-head walk.
 
 qa-impact: 2026-09-01 focused current-head walk passed solo zoom and pressed state, visible-peer teardown, edge tiling, lift/pager/unzoom return, and API minimize/restore. The minimized window retained its lifted desktop and zoom return anchor, then restored zoomed on that same unoccupied desktop. The legacy walk's later deck step was not reused because it opens a separate visible peer before grouping, which now intentionally ends zoom; direct tab insertion remains covered by the owning Go suite.
+
+qa-impact: 2026-09-10 issue #585 exposes all borders and corners while an internal window is
+maximized. The zoom control shows a restore icon and the label "Restore window"; clicking it
+returns the saved floating rect or tiled slot. Dragging a maximized border/corner instead commits
+`window.resize`, ends zoom, and keeps the new tiled zone on the current desktop. Verify repeated
+floating maximize/restore cycles, southeast and west resize gestures while maximized, then
+maximize/restore/reload of the resized zone. Compare the peer window and source layout before and
+after; no peer may move. Owner: `web/e2e/__tests__/os-shell.spec.ts`, issue #585 regression plus
+E2E-003 and E2E-137. Passed on macOS/Chromium against a worktree-built daemon with isolated
+homes/ports/sockets (2026-09-10): E2E-003 and E2E-137 passed, and the final issue #585 regression
+passed in 4.8s. Logs: `.tmp/issue-585/e2e.log` (existing scenarios) and
+`.tmp/issue-585/e2e-resize.log` (final regression); trace and final screenshot under
+`.tmp/playwright/test-results/__tests__-os-shell-Issue-5-8963a-across-repeated-zoom-cycles/compozy-artifacts/`.
+Fixture teardown completed successfully. Linux and Electron were not run locally.

--- a/docs/qa/scenarios/ET-window-zoom-in-place.md
+++ b/docs/qa/scenarios/ET-window-zoom-in-place.md
@@ -52,7 +52,7 @@ maximize/restore/reload of the resized zone. Compare the peer window and source 
 after; no peer may move. Owner: `web/e2e/__tests__/os-shell.spec.ts`, issue #585 regression plus
 E2E-003 and E2E-137. Passed on macOS/Chromium against a worktree-built daemon with isolated
 homes/ports/sockets (2026-09-10): E2E-003 and E2E-137 passed, and the final issue #585 regression
-passed in 4.8s. Logs: `.tmp/issue-585/e2e.log` (existing scenarios) and
+passed in 5.1s, including exact pointer-delta geometry for the window's own tiled group. Logs: `.tmp/issue-585/e2e.log` (existing scenarios) and
 `.tmp/issue-585/e2e-resize.log` (final regression); trace and final screenshot under
 `.tmp/playwright/test-results/__tests__-os-shell-Issue-5-8963a-across-repeated-zoom-cycles/compozy-artifacts/`.
 Fixture teardown completed successfully. Linux and Electron were not run locally.

--- a/packages/site/content/docs/workspaces/window-management.mdx
+++ b/packages/site/content/docs/workspaces/window-management.mdx
@@ -78,6 +78,12 @@ zoom, and arranging, moving, swapping, resizing, or floating ends it in place. A
 was zoomed comes back zoomed. Bottom-center is reserved for the Dock unless remapped. Both behavior and
 thresholds are validated under `[window_manager]` in `config.toml`.
 
+To restore an internal maximized window, click its **Restore window** control (the zoom button
+changes its icon and label while maximized). This returns the saved size and placement. You can
+also drag any border or corner to resize it directly: resizing ends zoom and saves the new tiled
+size on its current desktop. The same internal window controls serve Web and Electron; they are
+separate from native browser or operating-system fullscreen.
+
 ## Persistent desktops
 
 ```bash

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -384,6 +384,8 @@ test("Issue 585: internal windows restore and resize across repeated zoom cycles
       );
     await expect(handle).toBeVisible();
     await handle.hover();
+    const zoomRect = await windowRect(appPage, tasks);
+    await expect(tasks).toHaveAttribute("data-window-placement", "tiled");
     const box = await handle.boundingBox();
     if (!box) throw new Error("Maximized window resize handle must have a layout box");
     const x = box.x + box.width / 2;
@@ -402,9 +404,17 @@ test("Issue 585: internal windows restore and resize across repeated zoom cycles
     expect(resized.windows[settingsID]).toEqual(before.windows[settingsID]);
     const desktopID = resized.windows[tasksID]!.desktop_id;
     const signature = layoutSignature(resized, desktopID);
-    expect(
-      resized.desktops.find(desktop => desktop.id === desktopID)!.groups[0]!.frame.width
-    ).toBeLessThan(1);
+    const ownGroup = resized.desktops
+      .find(desktop => desktop.id === desktopID)!
+      .groups.find(group => group.root.window_id === tasksID);
+    expect(ownGroup).toBeDefined();
+    expect(ownGroup!.frame.x).toBeCloseTo(cursor === "col-resize" ? 160 / zoomRect.w : 0, 5);
+    expect(ownGroup!.frame.y).toBe(0);
+    expect(ownGroup!.frame.width).toBeCloseTo(1 - 160 / zoomRect.w, 5);
+    expect(ownGroup!.frame.height).toBeCloseTo(
+      cursor === "se-resize" ? 1 - 100 / zoomRect.h : 1,
+      5
+    );
 
     await tasks.getByRole("button", { name: "Zoom window", exact: true }).click();
     await expect(windowFrame(tasks)).toHaveAttribute("data-zoomed");

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -299,7 +299,7 @@ test("E2E-003: zoom lifts a window off a shared desktop and unzoom restores the 
   const before = await windowManagerSnapshot(runtime, workspace.id);
   const anchor = layoutSignature(before, "desktop-default");
   const tiledRect = await windowRect(appPage, tasks);
-  const zoomButton = tasks.getByRole("button", { name: "Zoom window" });
+  const zoomButton = tasks.locator('button[data-action="zoom"]');
   await zoomButton.click();
 
   await expect
@@ -342,6 +342,82 @@ test("E2E-003: zoom lifts a window off a shared desktop and unzoom restores the 
   await expect.poll(() => windowRect(appPage, tasks)).toEqual(tiledRect);
   await expect(tasks).toBeVisible();
   await expect(settings).toBeVisible();
+});
+
+// Invariant: real pointer resizing exits internal zoom, persists the new geometry,
+// and subsequent restore cycles leave the other desktop's windows untouched.
+test("Issue 585: internal windows restore and resize across repeated zoom cycles", async ({
+  appPage,
+  runtime,
+}) => {
+  const workspace = await prepareShell(appPage, runtime);
+  const tasks = await openDockApp(appPage, "Tasks", "tasks");
+  const settings = await openDockApp(appPage, "Settings", "settings");
+  await openDockApp(appPage, "Tasks", "tasks");
+  const tasksID = await windowID(tasks);
+  const settingsID = await windowID(settings);
+  const before = await windowManagerSnapshot(runtime, workspace.id);
+  const originalRect = await windowRect(appPage, tasks);
+  const originalFloating = before.windows[tasksID]!.floating_rect;
+
+  for (let cycle = 0; cycle < 2; cycle++) {
+    await tasks.getByRole("button", { name: "Zoom window", exact: true }).click();
+    await expect(windowFrame(tasks)).toHaveAttribute("data-zoomed");
+    await tasks.getByRole("button", { name: "Restore window", exact: true }).click();
+    await expect(windowFrame(tasks)).not.toHaveAttribute("data-zoomed");
+    await expect.poll(() => windowRect(appPage, tasks)).toEqual(originalRect);
+    const restored = await windowManagerSnapshot(runtime, workspace.id);
+    expect(restored.windows[tasksID]!.floating_rect).toEqual(originalFloating);
+    expect(restored.windows[tasksID]!.placement).toBe("floating");
+    expect(restored.windows[settingsID]).toEqual(before.windows[settingsID]);
+  }
+
+  for (const cursor of ["se-resize", "col-resize"]) {
+    await tasks.getByRole("button", { name: "Zoom window", exact: true }).click();
+    await expect(windowFrame(tasks)).toHaveAttribute("data-zoomed");
+    const handle = windowFrame(tasks)
+      .locator("..")
+      .locator(
+        cursor === "col-resize"
+          ? '[style*="cursor: col-resize"][style*="left: -5px"]'
+          : '[style*="cursor: se-resize"]'
+      );
+    await expect(handle).toBeVisible();
+    await handle.hover();
+    const box = await handle.boundingBox();
+    if (!box) throw new Error("Maximized window resize handle must have a layout box");
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    await appPage.mouse.move(x, y);
+    await appPage.mouse.down();
+    await appPage.mouse.move(
+      x + (cursor === "col-resize" ? 160 : -160),
+      y - (cursor === "se-resize" ? 100 : 0),
+      { steps: 12 }
+    );
+    await appPage.mouse.up();
+    await expect(windowFrame(tasks)).not.toHaveAttribute("data-zoomed");
+    const resizedRect = await windowRect(appPage, tasks);
+    const resized = await windowManagerSnapshot(runtime, workspace.id);
+    expect(resized.windows[settingsID]).toEqual(before.windows[settingsID]);
+    const desktopID = resized.windows[tasksID]!.desktop_id;
+    const signature = layoutSignature(resized, desktopID);
+    expect(
+      resized.desktops.find(desktop => desktop.id === desktopID)!.groups[0]!.frame.width
+    ).toBeLessThan(1);
+
+    await tasks.getByRole("button", { name: "Zoom window", exact: true }).click();
+    await expect(windowFrame(tasks)).toHaveAttribute("data-zoomed");
+    await tasks.getByRole("button", { name: "Restore window", exact: true }).click();
+    await expect(windowFrame(tasks)).not.toHaveAttribute("data-zoomed");
+    await expect.poll(() => windowRect(appPage, tasks)).toEqual(resizedRect);
+    await appPage.reload();
+    await expect(tasks).toBeVisible();
+    await expect.poll(() => windowRect(appPage, tasks)).toEqual(resizedRect);
+    const persisted = await windowManagerSnapshot(runtime, workspace.id);
+    expect(layoutSignature(persisted, desktopID)).toEqual(signature);
+    expect(persisted.windows[settingsID]).toEqual(before.windows[settingsID]);
+  }
 });
 
 test("E2E-137: grouping into a zoomed window keeps the frame zoomed and unzoom restores the split", async ({
@@ -390,7 +466,7 @@ test("E2E-137: grouping into a zoomed window keeps the frame zoomed and unzoom r
     ""
   );
 
-  await shell.deck(stackID).getByRole("button", { name: "Zoom window" }).click();
+  await shell.deck(stackID).getByRole("button", { name: "Restore window" }).click();
   await expect
     .poll(async () => {
       const snapshot = await windowManagerSnapshot(runtime, workspace.id);

--- a/web/src/systems/os/components/__tests__/os-window-frame.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-window-frame.test.tsx
@@ -73,7 +73,7 @@ describe("OsWindowFrame", () => {
       </OsWindowFrame>
     );
 
-    expect(screen.getByRole("button", { name: "Zoom window" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Restore window" })).toHaveAttribute(
       "aria-pressed",
       "true"
     );

--- a/web/src/systems/os/components/__tests__/os-window.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-window.test.tsx
@@ -207,7 +207,7 @@ describe("OsWindow", () => {
     const chrome = screen.getByTestId("os-window-frame-window:tasks");
     expect(chrome).toHaveAttribute("data-zoomed", "");
     expect(chrome.parentElement).toHaveStyle({ zIndex: WINDOW_VISUAL_LAYER.zoomed });
-    expect(screen.getByRole("button", { name: "Zoom window" })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Restore window" })).toHaveAttribute(
       "aria-pressed",
       "true"
     );

--- a/web/src/systems/os/components/os-traffic-lights.tsx
+++ b/web/src/systems/os/components/os-traffic-lights.tsx
@@ -1,3 +1,4 @@
+import { Maximize2, Minimize2 } from "lucide-react";
 import { Fragment } from "react";
 
 import { cn } from "@/lib/utils";
@@ -57,6 +58,8 @@ function Light({
   compact: boolean;
   pressed?: boolean;
 }) {
+  const label = action === "zoom" && pressed ? "Restore window" : ACTION_LABEL[action];
+  const ZoomIcon = pressed ? Minimize2 : Maximize2;
   const glyph = cn(
     "rounded-xs border border-line-strong bg-btn-default-fill transition-colors duration-base",
     compact ? "size-traffic-light-compact" : "size-traffic-light"
@@ -68,7 +71,8 @@ function Light({
   return (
     <button
       type="button"
-      aria-label={ACTION_LABEL[action]}
+      aria-label={label}
+      title={label}
       aria-pressed={pressed}
       data-action={action}
       className={cn(
@@ -84,7 +88,12 @@ function Light({
       onMouseDown={event => event.preventDefault()}
       onClick={() => onSelect(action)}
     >
-      <span aria-hidden="true" className={cn(glyph, ACTION_TONE[action])} />
+      <span
+        aria-hidden="true"
+        className={cn(glyph, ACTION_TONE[action], "grid place-items-center")}
+      >
+        {action === "zoom" ? <ZoomIcon className="size-2.5" /> : null}
+      </span>
     </button>
   );
 }

--- a/web/src/systems/os/components/os-window.tsx
+++ b/web/src/systems/os/components/os-window.tsx
@@ -102,9 +102,9 @@ export function OsWindow({ frame }: OsWindowProps) {
       minHeight={compact ? undefined : minimum.height}
       maxWidth={resizeMax?.width}
       maxHeight={resizeMax?.height}
-      // A zoomed frame is pinned to the work area: unzoom it to move or size it.
+      // Resize ends zoom through window.resize; moving still requires restore.
       disableDragging={compact || frame.zoomed}
-      enableResizing={!compact && !frame.zoomed && enableResizing}
+      enableResizing={!compact && enableResizing}
       dragHandleClassName={OS_WINDOW_DRAG_HANDLE_CLASS}
       cancel={OS_WINDOW_DRAG_CANCEL_SELECTOR}
       onDragStart={handleDragStart}

--- a/web/src/systems/os/lib/__tests__/group-projection.test.ts
+++ b/web/src/systems/os/lib/__tests__/group-projection.test.ts
@@ -381,10 +381,10 @@ describe("zoomed frames", () => {
     expect(zoomed?.id).toBe("w-tasks");
     expect(zoomed?.rect).toEqual({ x: 0, y: 0, w: WORK_AREA.w, h: WORK_AREA.h });
     expect(zoomed?.resizableEdges).toEqual({
-      left: false,
-      right: false,
-      top: false,
-      bottom: false,
+      left: true,
+      right: true,
+      top: true,
+      bottom: true,
     });
     const settings = desktopFrames.find(frame => frame.id === "w-settings");
     expect(settings?.zoomed).toBe(false);

--- a/web/src/systems/os/lib/group-projection.ts
+++ b/web/src/systems/os/lib/group-projection.ts
@@ -44,7 +44,7 @@ export interface OsWindowFrameModel {
   /** Real stack identity for stack commands; null for solo frames. */
   stackId: LayoutNodeId | null;
   minimized: boolean;
-  /** The unit fills the desktop work area; drag and resize are off until it unzooms. */
+  /** The unit fills the desktop work area; resizing commits a new zone and ends zoom. */
   zoomed: boolean;
   /** Pane too small for its split — projection degraded it to a stack. */
   adapted: boolean;
@@ -231,9 +231,9 @@ export function buildDesktopFrames(input: {
 }
 
 /**
- * The unit holding a zoomed window takes the whole layout area and gives up
- * its own drag and resize affordances; every other frame keeps its place so
- * unzooming reveals the tree exactly as it was.
+ * The zoomed unit owns a full-frame island. Keep its edges available: the daemon
+ * ends zoom atomically when window.resize commits the new zone. The zoom
+ * control instead restores the saved return anchor.
  */
 function zoomFrames(
   frames: readonly OsWindowFrameModel[],
@@ -248,7 +248,7 @@ function zoomFrames(
         return window !== undefined && window.zoomed && !window.minimized;
       });
     if (!zoomed) return frame;
-    return { ...frame, rect: { ...zoomRect }, zoomed: true, resizableEdges: NO_EDGES_RESIZABLE };
+    return { ...frame, rect: { ...zoomRect }, zoomed: true, resizableEdges: ALL_EDGES_RESIZABLE };
   });
 }
 


### PR DESCRIPTION
## Problem and root cause

Closes #585.

Internal windows became impossible to resize after maximizing. Zoom structurally places the window into its own full-size tiled island, even when it started floating; the saved return anchor is separate from the active resize zone. The daemon already supports ending zoom atomically through `window.resize`, and `window.zoom` already saves/restores the original placement, but the shared frontend disabled access to that behavior twice: `group-projection.ts` replaced every zoomed frame's resizable edges with `false`, and `OsWindow` independently disabled react-rnd resizing whenever `frame.zoomed` was true. The zoom control also kept an empty glyph and the label “Zoom window” when its action was actually restore.

## Resulting behavior

- A maximized internal window exposes its border and corner resize handles. Releasing a resize uses the existing `window.resize` command, ends zoom, and persists the resized tiled zone on the current desktop.
- The zoom button displays maximize/restore icons, a state-specific accessible name, and a native tooltip. “Restore window” invokes the existing zoom toggle and returns the saved floating geometry or tiled slot; resizing deliberately adopts a new zone instead.
- Existing app minimum sizes, tiled obstacle limits, compact presentation, revision checks, and rollback behavior remain in the existing resize path. Title-bar dragging while maximized still requires restoring first.
- Web and Electron use these same frontend components. This concerns internal windows, not native application/browser fullscreen.

## Verification

- Reproduced the disabled-edge regression in the existing projection suite before repairing production code: all four expected resize edges were false.
- Repository-root `bunx turbo run test --filter=./web -- ...` passed the four affected projection/window/frame/zoom-menu suites: **32 tests**.
- Repository-root `bunx turbo run build --filter=./web` passed, including Web typecheck.
- Real daemon-served Chromium E2E, with a binary built from this worktree and isolated homes/ports/sockets:
  - Existing E2E-003: lifted zoom and exact tiled-anchor restoration passed.
  - Existing E2E-137: grouping into a zoomed frame and restoring the split passed.
  - New regression in the existing `os-shell.spec.ts`: two floating maximize/restore cycles; southeast-corner and west-edge resizing during zoom; subsequent maximize/restore/reload cycles; persisted geometry and unchanged peer-window records. **Passed in 5.1s**, including exact normalized x/y/width/height derived from the pointer deltas on Tasks' own tiled group.
- The runtime fixtures completed teardown. The host daemon was not restarted or changed.
- `make gate`: **passed**; Web lane reports **771 files / 7,117 tests passed**, with lint reporting **0 warnings / 0 errors**. `make gate-status` confirms `js-web` is `CURRENT-PASS` after commit.
- Reviewed the complete changed diff and checked formatting/whitespace.

Local E2E commands used the repository's installed Playwright CLI with `--config web/playwright.config.ts os-shell.spec.ts --grep ...`, under the shared machine lock and with `COMPOZY_TEST_DAEMON_BIN` pointing at the worktree binary. The test subprocess omitted the host-inherited `COMPOZY_INTERNAL_RESTART_OPERATION_ID`; otherwise its fresh isolated database cannot resolve that host restart operation. Initial test setup also needed to bring Tasks forward via the dock and wait for desktop animation stability before dragging. No production failures or assertions were suppressed.

## Cross-surface and compatibility impact

Audit follows `docs/_memory/change-impact.md`:

- **Native tools / CLI / HTTP / UDS:** no IDs, schemas, descriptors, capability gates, or commands changed. The Web resize gesture now reaches the already-supported `window.resize`; restoring still uses `window.zoom`.
- **Extensibility / hooks / config:** no extensions, hooks, resources, SDKs, or configuration keys changed. Existing semantic command dispatch and events remain authoritative.
- **Workspace/profile isolation and user state:** no storage/schema changes or migrations. Existing workspace/profile-scoped command transport and daemon persistence own geometry. E2E checks that a peer window is unchanged and that resized geometry survives reload. Existing return anchors and structural zoom semantics remain intact.
- **Official Compozy skill:** its existing window-management contract already documents resizing as ending zoom in place and unzoom as restoring the return anchor; no tool/runtime instruction change is needed.
- **Web / Docs:** updated shared window projection/chrome, the existing E2E and component suites, window-management user documentation, canonical Zoom/Restore wording in `COPY.md`, and both affected QA scenarios. No public compatibility removal or internal consumer was left behind.

## Limits

Linux and Electron were not run locally; local real-run evidence is macOS with Chromium against the shared Web bundle. The Web build emits pre-existing CSS `::highlight` and large-chunk warnings outside this change. React Doctor reports one maintainability warning on the existing `OsWindow` control-flow complexity (93/100); this patch removes one condition from that function and introduces no new branching there. Required PR CI is tracked on this PR; local build/test diagnostic output outside the changed behavior was not suppressed.
