### PR TITLE
fix: load knowledge memories without enabling automation

### DIFF
--- a/docs/qa/scenarios/MS-001.md
+++ b/docs/qa/scenarios/MS-001.md
@@ -5,7 +5,7 @@ title: List memory/knowledge by scope
 persona: Rafa
 journey: J-25
 expected: `GET /api/memory` returns identity-scoped `{memories,page{total,limit,has_more,next_cursor}}` with `scope/workspace_id/agent_name/agent_tier/type/sort/cursor/limit/include_system`; filtering/order occur before the cut, entries beyond 200 remain reachable, system-managed files stay hidden by default, and the Knowledge route preserves backend order with exact total and Load more; semantic recall remains a separate query.
-entry_points: Web `/knowledge`; `GET /api/memory`; UDS parity
+entry_points: Command Palette Knowledge; Web `/knowledge`; `GET /api/memory`; UDS parity
 qa_status: untested
 bug_ids:
 fix_status:
@@ -35,3 +35,21 @@ vocabulary is now `profile | workspace | agent`; the home-level tier is no longe
 and is owned per profile. Re-walk the `scope` filter with the new values, confirm the retired value
 is rejected rather than silently accepted, and confirm the listing never returns another profile's
 profile-tier entries. Profile-tier isolation itself is owned by `MS-profile-memory-tier-scope`.
+
+2026-09-10 qa-impact (#586): Knowledge listing remains available with `memory.enabled=false`,
+including when session compaction is disabled. Automatic prompt injection, extraction, and dreaming
+remain off. A failed list has no automatic retries and displays a readable service-error message.
+
+Regression walk:
+
+1. Start an isolated daemon with memory automation and session compaction disabled. Open a workspace
+   containing an existing `.compozy/memory` document, open the Command Palette, and select Knowledge.
+   Confirm the document loads and its scope/workspace identity matches; verify the same list over HTTP
+   and UDS. Check the source bytes are unchanged.
+2. Repeat with a workspace without memory files. Expect HTTP/UDS 200 with `memories: []`, total zero,
+   and no continuation; the palette must show its empty state.
+3. Make only the disposable workspace's memory source inaccessible. Expect a server error, preserved
+   source data, and a visible Knowledge error. Count one list attempt per fetch, with no automatic
+   retries; restore the source and explicitly retry to confirm recovery.
+4. Switch workspaces and profiles. Confirm workspace memories stay in their workspace and profile-tier
+   memories do not leak across profiles. Recheck automatic memory opt-out on an ordinary session turn.

--- a/internal/daemon/boot.go
+++ b/internal/daemon/boot.go
@@ -70,7 +70,7 @@ type bootState struct {
 	memoryExtractor        *daemonMemoryExtractor
 	runtimeWorkers         daemonRuntimeWorkers
 	checkpointRuntime      *checkpointSummaryRuntime
-	checkpointStore        *memory.Store
+	memoryCatalogStore     *memory.Store
 	ledgerMaterializer     session.LedgerMaterializer
 	skillsRegistry         *skills.Registry
 	mcpResolver            *skills.MCPResolver

--- a/internal/daemon/boot_checkpoint.go
+++ b/internal/daemon/boot_checkpoint.go
@@ -23,7 +23,7 @@ func (d *Daemon) bootCheckpointSummaryRuntime(
 	}
 	checkpointStore := state.memoryStore
 	if checkpointStore == nil {
-		checkpointStore = state.checkpointStore
+		checkpointStore = state.memoryCatalogStore
 		if checkpointStore == nil {
 			return errors.New("daemon: compaction checkpoint store is unavailable")
 		}

--- a/internal/daemon/boot_memory_catalog.go
+++ b/internal/daemon/boot_memory_catalog.go
@@ -7,14 +7,14 @@ import (
 	"github.com/compozy/compozy/internal/memory"
 )
 
-// bootMemoryCatalog applies the shared memory stream on every boot while
-// retaining private checkpoint storage when session compaction needs it.
+// bootMemoryCatalog keeps operator access independent of automatic memory processing.
 func (d *Daemon) bootMemoryCatalog(
 	ctx context.Context,
 	state *bootState,
 	cleanup *bootCleanup,
 ) error {
 	if state.memoryStore != nil {
+		state.memoryCatalogStore = state.memoryStore
 		if err := state.memoryStore.OpenCatalog(ctx); err != nil {
 			return fmt.Errorf("daemon: open memory catalog database %q: %w", d.homePaths.DatabaseFile, err)
 		}
@@ -24,21 +24,15 @@ func (d *Daemon) bootMemoryCatalog(
 		return nil
 	}
 
-	migrationStore := memory.NewStore(
+	catalogStore := memory.NewStore(
 		firstNonEmptyString(state.cfg.Memory.GlobalDir, d.homePaths.MemoryDir),
 		memory.WithCatalogDatabasePath(d.homePaths.DatabaseFile),
 		memory.WithFileLimits(state.cfg.Memory.File),
 	)
-	if err := migrationStore.OpenCatalog(ctx); err != nil {
+	if err := catalogStore.OpenCatalog(ctx); err != nil {
 		return fmt.Errorf("daemon: migrate disabled memory catalog database %q: %w", d.homePaths.DatabaseFile, err)
 	}
-	if state.cfg.Session.Compaction.Enabled {
-		state.checkpointStore = migrationStore
-		cleanup.add(migrationStore.CloseCatalog)
-		return nil
-	}
-	if err := migrationStore.CloseCatalog(ctx); err != nil {
-		return fmt.Errorf("daemon: close disabled memory catalog database %q: %w", d.homePaths.DatabaseFile, err)
-	}
+	state.memoryCatalogStore = catalogStore
+	cleanup.add(catalogStore.CloseCatalog)
 	return nil
 }

--- a/internal/daemon/boot_publish.go
+++ b/internal/daemon/boot_publish.go
@@ -14,7 +14,7 @@ func (d *Daemon) publishBootState(state *bootState) {
 		registry:               state.registry,
 		profiles:               state.profiles,
 		memoryStore:            state.memoryStore,
-		checkpointStore:        state.checkpointStore,
+		memoryCatalogStore:     state.memoryCatalogStore,
 		memoryProviderRegistry: state.memoryProviderRegistry,
 		memoryExtractor:        state.memoryExtractor,
 		runtimeWorkers:         state.runtimeWorkers,

--- a/internal/daemon/daemon_memory_e2e_integration_test.go
+++ b/internal/daemon/daemon_memory_e2e_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"github.com/compozy/compozy/internal/testutil/acpmock"
 	e2etest "github.com/compozy/compozy/internal/testutil/e2e"
 	toolspkg "github.com/compozy/compozy/internal/tools"
+	workspacepkg "github.com/compozy/compozy/internal/workspace"
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 	_ "modernc.org/sqlite"
 )
@@ -32,6 +34,98 @@ const (
 	roleDreamProviderName = "role-dream"
 	roleDreamModel        = "routed-dream-model"
 )
+
+func TestDaemonE2EKnowledgeWithoutMemoryAutomation(t *testing.T) {
+	t.Parallel()
+	const filename = ".compozy/memory/project.md"
+	content := memoryDocument(
+		"Existing project",
+		"Preserved workspace memory",
+		memcontract.TypeProject,
+		"Keep this memory.",
+	)
+	for _, tc := range []struct {
+		name       string
+		files      map[string]string
+		wantStatus int
+		wantCount  int
+	}{
+		{name: "Should list existing workspace memories", files: map[string]string{filename: content}, wantStatus: http.StatusOK, wantCount: 1},
+		{name: "Should return an empty workspace catalog", wantStatus: http.StatusOK},
+		{name: "Should preserve an inaccessible memory source as a server error", files: map[string]string{".compozy/memory": "unavailable source"}, wantStatus: http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			harness := e2etest.StartRuntimeHarness(t, &e2etest.RuntimeHarnessOptions{
+				Workspace: e2etest.WorkspaceSeedOptions{Files: tc.files},
+				ConfigSeed: e2etest.ConfigSeedOptions{Mutate: func(cfg *compozyconfig.Config) {
+					cfg.Memory.Enabled = false
+					cfg.Session.Compaction.Enabled = false
+				}},
+			})
+			identity, err := workspacepkg.EnsureIdentity(t.Context(), harness.WorkspaceRoot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := "/api/memory?profile=default&scope=workspace&workspace_id=" + url.QueryEscape(harness.WorkspaceID)
+			for _, transport := range []struct {
+				name   string
+				base   string
+				client *http.Client
+			}{
+				{name: "HTTP", base: harness.HTTPBaseURL, client: harness.HTTPClient},
+				{name: "UDS", base: harness.UDSBaseURL, client: harness.UDSClient},
+			} {
+				request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, transport.base+path, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				response, err := transport.client.Do(request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				body, readErr := io.ReadAll(response.Body)
+				closeErr := response.Body.Close()
+				if readErr != nil || closeErr != nil {
+					t.Fatalf("read=%v close=%v", readErr, closeErr)
+				}
+				if response.StatusCode != tc.wantStatus {
+					t.Fatalf("%s status=%d body=%s, want %d", transport.name, response.StatusCode, body, tc.wantStatus)
+				}
+				if tc.wantStatus != http.StatusOK {
+					var failure struct {
+						Code    string `json:"code"`
+						Message string `json:"message"`
+					}
+					if err := json.Unmarshal(body, &failure); err != nil {
+						t.Fatal(err)
+					}
+					if failure.Code != "memory.internal" || failure.Message == "" {
+						t.Fatalf("%s missing error body: %s", transport.name, body)
+					}
+					continue
+				}
+				var page compozycontract.MemoryListResponse
+				if err := json.Unmarshal(body, &page); err != nil {
+					t.Fatal(err)
+				}
+				if len(page.Memories) != tc.wantCount || page.Page.Total != tc.wantCount || page.Page.HasMore {
+					t.Fatalf("%s catalog=%#v, want %d memories", transport.name, page, tc.wantCount)
+				}
+				if tc.wantCount > 0 &&
+					(page.Memories[0].Name != "Existing project" || page.Memories[0].WorkspaceID != identity.WorkspaceID) {
+					t.Fatalf("%s lost memory identity: %#v", transport.name, page.Memories)
+				}
+			}
+			for path, original := range tc.files {
+				preserved, err := os.ReadFile(filepath.Join(harness.WorkspaceRoot, path))
+				if err != nil || string(preserved) != original {
+					t.Fatalf("source %s changed: %v", path, err)
+				}
+			}
+		})
+	}
+}
 
 func TestDaemonE2EMemoryOptInAndExtractorOutput(t *testing.T) {
 	t.Parallel()

--- a/internal/daemon/daemon_runtime_state.go
+++ b/internal/daemon/daemon_runtime_state.go
@@ -31,7 +31,7 @@ type daemonRuntimeState struct {
 	registry               Registry
 	profiles               *profile.Manager
 	memoryStore            *memory.Store
-	checkpointStore        *memory.Store
+	memoryCatalogStore     *memory.Store
 	memoryProviderRegistry *extensionpkg.MemoryProviderRegistry
 	memoryExtractor        *daemonMemoryExtractor
 	runtimeWorkers         daemonRuntimeWorkers

--- a/internal/daemon/daemon_shutdown_resources.go
+++ b/internal/daemon/daemon_shutdown_resources.go
@@ -21,15 +21,12 @@ func (d *Daemon) shutdownPersistentResources(ctx context.Context, targets *shutd
 	if err := RemoveInfo(targets.infoPath); err != nil {
 		*errs = append(*errs, err)
 	}
-	if targets.checkpointStore != nil {
+	if targets.memoryCatalogStore != nil {
 		appendWrappedError(
 			errs,
-			"daemon: close compaction checkpoint catalog",
-			targets.checkpointStore.CloseCatalog(ctx),
+			"daemon: close memory catalog database",
+			targets.memoryCatalogStore.CloseCatalog(ctx),
 		)
-	}
-	if targets.memoryStore != nil {
-		appendWrappedError(errs, "daemon: close memory catalog database", targets.memoryStore.CloseCatalog(ctx))
 	}
 	if targets.registry != nil {
 		appendWrappedError(errs, "daemon: close global database", targets.registry.Close(ctx))

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5391,6 +5391,7 @@ func TestBootInjectsComposedAssemblerForFeatureFlagCombinations(t *testing.T) {
 			d := newTestDaemon(t, homePaths, &cfg)
 
 			var capturedDeps SessionManagerDeps
+			var publicDeps RuntimeDeps
 			d.newSessionManager = func(_ context.Context, deps SessionManagerDeps) (SessionManager, error) {
 				capturedDeps = deps
 				return &fakeSessionManager{}, nil
@@ -5398,7 +5399,8 @@ func TestBootInjectsComposedAssemblerForFeatureFlagCombinations(t *testing.T) {
 			d.newObserver = func(context.Context, RuntimeDeps) (Observer, error) {
 				return &fakeObserver{}, nil
 			}
-			d.httpFactory = func(context.Context, RuntimeDeps) (Server, error) {
+			d.httpFactory = func(_ context.Context, deps RuntimeDeps) (Server, error) {
+				publicDeps = deps
 				return &fakeServer{name: "http"}, nil
 			}
 			d.udsFactory = func(context.Context, RuntimeDeps) (Server, error) {
@@ -5441,6 +5443,17 @@ func TestBootInjectsComposedAssemblerForFeatureFlagCombinations(t *testing.T) {
 
 			workspace := filepath.Join(t.TempDir(), "workspace")
 			writeDaemonMemoryIndex(t, cfg.Memory.GlobalDir, workspace)
+			if publicDeps.MemoryStore == nil {
+				t.Fatal("public memory store is unavailable with memory automation disabled")
+			}
+			headers, err := publicDeps.MemoryStore.ForWorkspace(workspace).
+				CatalogHeaders(t.Context(), memcontract.ScopeWorkspace)
+			if err != nil {
+				t.Fatalf("public workspace memory catalog: %v", err)
+			}
+			if len(headers) == 0 {
+				t.Fatal("public workspace memory catalog lost existing memories")
+			}
 
 			workspaceRef := workspacepkg.ResolvedWorkspace{
 				Workspace: workspacepkg.Workspace{RootDir: workspace},

--- a/internal/daemon/runtime_dependencies.go
+++ b/internal/daemon/runtime_dependencies.go
@@ -43,7 +43,7 @@ func (d *Daemon) runtimeDeps(
 		Registry:              state.registry,
 		Profiles:              state.profiles,
 		SchemaStreams:         newDaemonSchemaStreamStatusReader(state.registry),
-		MemoryStore:           state.memoryStore,
+		MemoryStore:           state.memoryCatalogStore,
 		MemoryExtractor:       state.memoryExtractor,
 		MemoryProviders:       memoryProviders,
 		MemorySessionLedger:   newDaemonMemorySessionLedgerService(state, d.now),

--- a/packages/site/content/docs/memory/index.mdx
+++ b/packages/site/content/docs/memory/index.mdx
@@ -8,6 +8,10 @@ consolidation are explicit choices. To enable memory, set `memory.enabled = true
 `config.toml` and restart. Dreaming remains off until `roles.dream.enabled = true` is also set.
 Existing explicit settings and stored memory are preserved.
 
+You can browse existing memories in Knowledge, the Command Palette, or the memory API/CLI while
+automatic memory is disabled. An empty workspace shows an empty catalog. If storage is unavailable,
+Knowledge displays an error and does not automatically retry the failed list request.
+
 Memory is the durable layer that survives a session. CompozyOS stores curated facts as Markdown files
 behind typed indexes so agents can rediscover knowledge without replaying past transcripts. The
 runtime keeps three scopes — profile, workspace, and agent — and a dreaming loop that promotes

--- a/skills/compozy/references/memory.md
+++ b/skills/compozy/references/memory.md
@@ -13,6 +13,10 @@ them implicitly. To opt in, set `memory.enabled = true` in the daemon configurat
 Set `roles.dream.enabled = true` separately for dreaming; profile/workspace role overrides apply
 when the daemon memory runtime is enabled. Existing explicit settings and memory files are preserved.
 
+Knowledge and the operator memory API/CLI remain available while `memory.enabled = false`.
+They can list existing memories and return an empty catalog for an empty workspace without enabling
+prompt injection, extraction, or dreaming. Storage failures remain errors, not empty catalogs.
+
 ## What Memory Stores
 
 CompozyOS memory is durable Markdown outside transient session prompts. Use it for facts that should survive across sessions: project context, user preferences, durable decisions, and reusable references.

--- a/web/src/systems/knowledge/adapters/__tests__/knowledge-api.test.ts
+++ b/web/src/systems/knowledge/adapters/__tests__/knowledge-api.test.ts
@@ -102,7 +102,10 @@ describe("listMemories", () => {
     vi.mocked(globalThis.fetch).mockResolvedValue(new Response(null, { status: 500 }));
 
     await expect(listMemories()).rejects.toThrow(KnowledgeApiError);
-    await expect(listMemories()).rejects.toThrow("Failed to fetch memories: 500");
+    await expect(listMemories()).rejects.toMatchObject({
+      message: "Memories are unavailable right now. Try again later.",
+      status: 500,
+    });
   });
 });
 

--- a/web/src/systems/knowledge/adapters/knowledge-api.ts
+++ b/web/src/systems/knowledge/adapters/knowledge-api.ts
@@ -89,7 +89,9 @@ export async function listMemories(
   });
   if (apiRequestFailed(response, error)) {
     throw new KnowledgeApiError(
-      defaultApiErrorMessage("Failed to fetch memories", response, error),
+      response.status >= 500
+        ? "Memories are unavailable right now. Try again later."
+        : defaultApiErrorMessage("Failed to fetch memories", response, error),
       response.status
     );
   }

--- a/web/src/systems/knowledge/hooks/__tests__/use-knowledge.test.tsx
+++ b/web/src/systems/knowledge/hooks/__tests__/use-knowledge.test.tsx
@@ -50,6 +50,34 @@ const validHeader: MemoryHeader = {
 };
 
 describe("useMemories", () => {
+  it("Should expose a failed list after one attempt and allow an explicit retry", async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: 3, retryDelay: 0 } },
+    });
+    const failure = new Error("Memories are unavailable right now. Try again later.");
+    vi.mocked(listMemories).mockRejectedValue(failure);
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+    const { result, unmount } = renderHook(
+      () => useMemories({ profile: "default", scope: "workspace", workspaceId: "ws" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBe(failure);
+    expect(listMemories).toHaveBeenCalledTimes(1);
+    vi.mocked(listMemories).mockResolvedValue({
+      memories: [],
+      page: { has_more: false, limit: 50, total: 0 },
+    });
+    await result.current.refetch();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+    expect(listMemories).toHaveBeenCalledTimes(2);
+    unmount();
+    client.clear();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/web/src/systems/knowledge/lib/query-options.ts
+++ b/web/src/systems/knowledge/lib/query-options.ts
@@ -28,6 +28,7 @@ export function memoriesListOptions(filters?: KnowledgeListFilter) {
     initialPageParam: INITIAL_CURSOR,
     getNextPageParam: lastPage => (lastPage.page.has_more ? lastPage.page.next_cursor : undefined),
     staleTime: 30_000,
+    retry: false,
   });
 }
 


### PR DESCRIPTION
## Problem and root cause

Closes #586.

With the shipped `memory.enabled = false` default, opening Command Palette → Knowledge requests `GET /api/memory?profile=default&scope=workspace&workspace_id=...` and receives HTTP 500, including for an empty workspace.

Tracing the palette's `useMemories` → `memoriesListOptions` → `listMemories` → `BaseHandlers.ListMemory` → scoped `Store.CatalogHeaders` exposed a boot dependency error: the daemon created `state.memoryStore` only when automatic memory was enabled. Disabled-memory boot migrated the catalog and either retained it privately for compaction or closed it. Public HTTP/UDS handlers therefore received a nil store and returned `memory.internal`. The existing boot feature-flag suite reproduced the failure in both memory-off combinations before the fix; memory-on combinations passed. The issue does not include the reporter's configuration, so this identifies a reproduced shipped-default cause rather than claiming inspection of their machine.

The list query also inherited TanStack Query's automatic retry behavior, multiplying the failing request, while the adapter displayed a technical status message.

## Resulting behavior and implementation

- Retain the already-created catalog as `memoryCatalogStore` for operator API/CLI access regardless of automatic-memory enablement. Reuse it for compaction, publish it with the daemon generation, and close it once through the existing shutdown/failed-boot ownership paths.
- Keep the automation-bound `memoryStore` and its existing enablement checks intact. Listing Knowledge does not opt the user into prompt injection, extraction, background dreaming, or native agent memory writes.
- Preserve existing scope resolution, durable workspace identity, profile binding, filtering, pagination, and catalog-read error handling. Existing documents load; an empty workspace returns the normal counted empty page. Invalid storage still returns 500, with HTTP redaction and UDS diagnostics preserved.
- Disable automatic list retries in the shared query factory. Server failures remain `KnowledgeApiError` with their original status and a readable message; an explicit refetch can recover normally.
- Update the official memory reference, public memory documentation, and MS-001 regression walk.

## Validation

- Before-fix reproduction: `TestBootInjectsComposedAssemblerForFeatureFlagCombinations` failed in the two memory-off cases because the public memory store was absent. After the fix, all four combinations pass with `-race`, preserving the existing prompt inclusion/exclusion assertions.
- `CGO_ENABLED=1 go test -race ./internal/api/core -run '^TestMemoryHandlersAndHelpers$' -count=1` — passed; includes existing workspace/profile isolation coverage.
- `CGO_ENABLED=1 go test -race -tags integration ./internal/daemon -run '^TestDaemonE2EKnowledgeWithoutMemoryAutomation$' -count=1` — passed. Real CLI-started daemons, real SQLite, unique temporary homes/workspaces/ports/sockets, HTTP and UDS requests, populated/empty/invalid-storage cases, source-byte preservation, and harness-owned process teardown. Both memory automation and compaction are disabled in these cases.
- `bunx turbo run test --filter=./web -- src/systems/knowledge/hooks/__tests__/use-knowledge.test.tsx src/systems/knowledge/adapters/__tests__/knowledge-api.test.ts` — 37 tests passed. The retry regression uses an actual QueryClient with three retries configured globally and proves one failed list attempt followed by successful explicit recovery.
- `bunx turbo run build --filter=./web` — passed, including the dependent web typecheck and codegen check.
- Final diff reviewed; `git diff --check` passed. The integration test passes the test-convention helper; that helper reports existing violations in untouched portions of the older `daemon_test.go` file.
- `env -u COMPOZY_INTERNAL_RESTART_OPERATION_ID make gate` — passed: Go lint (0 issues), race-enabled daemon/skills suites, web lint (0 warnings/errors), typecheck, and all 7,118 web tests across 771 files. Gate evidence is recorded under `.cache/gate/`.

- Published-head CI: [CI run 34497282148](https://github.com/compozy/compozy/actions/runs/34497282148) passed for `9526f110aaa57d5059a8990b6197ce30b147d55c`, including Go race shards, static/build/platform checks, frontend lint/typecheck/tests/build, runtime E2E, desktop E2E, and all four web E2E shards. React Doctor and Vercel also passed; CodeRabbit approved and Greptile reported no actionable findings.

Local daemon tests remove the inherited `COMPOZY_INTERNAL_RESTART_OPERATION_ID` only from their own process environment. No active host daemon was restarted or modified.

## Cross-surface and compatibility impact

Audit owner: this PR, following `docs/_memory/change-impact.md`.

- **Native tools:** no IDs, schemas, capabilities, risk flags, or registry descriptors change. Native agent memory dependencies remain tied to the existing automatic-memory enablement; the repaired dependency is the operator HTTP/UDS/CLI store.
- **Extensibility/hooks/config:** no new config or default changes. Provider registration, extension memory dependencies, extraction, dreaming, and prompt assembly retain their existing opt-in gates. Pressure compaction reuses the retained catalog under its existing independent switch.
- **Workspace/profile isolation:** the API still resolves the requested workspace before binding the store and uses the existing per-profile owner. No query keys, selector semantics, storage paths, or authorization checks change. The catalog returns the existing durable workspace ULID, distinct from the registration `ws_...` reference accepted on ingress.
- **User state:** no schema changes, migration changes, resets, file deletion, or new compatibility shim. Existing Markdown and database data remain intact.
- **Public/internal compatibility:** HTTP/UDS routes and response DTOs remain unchanged; failed-storage responses remain errors. The private checkpoint-store field is renamed with every consumer updated. The official skill and site docs explain listing availability without opting into automation.
- **Web/QA:** the shared Knowledge query affects the Command Palette and Knowledge window; MS-001 documents the three outcomes and recovery/isolation checks.

## Limits

Local execution was on macOS. No local Linux or Electron run, live ACP-provider validation, or manual browser walkthrough is claimed. Required PR CI is the delivery gate for the published head. The successful web build emitted existing warnings for `::highlight` rules in unchanged session-search CSS, large chunks, and plugin timings; this change does not suppress them. The full web test suite also emits React `act(...)` and timer warnings from unchanged tests; scoped Knowledge tests pass without those warnings.
