### PR TITLE
fix: delegate bounded native tools to orchestrated workers

### DIFF
--- a/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
+++ b/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
@@ -100,3 +100,12 @@ Evidence: `.cache/issue-565/e2e-per-run-green.log`; targeted teardown reported `
 no survivors at `2026-09-09T17:12:37Z`. The broader terminal-path limitation above remains separate.
 
 QA 2026-09-10: Initial ACP process registration now retains the startup context instead of applying the separate process-finalization deadline. The existing orchestrated Profile extension Agent journey passed three race-enabled repetitions, including its local skill, worker settlement, and selected-profile assertions. See [release integration recovery](../reports/2026-09-10-release-integration-repair.md).
+
+Worker-tool regression (#588): inspect the conductor's spawn request and persisted child lineage.
+Require the root system conductor to have a concrete Agent-derived delegation budget and an explicit
+bootstrap tool subset within that budget. Agents without an allowlist use the native universe minus
+Agent denies; explicit overrides remain narrow. Provenance-linked system children remain unseeded.
+During the worker turn, invoke
+native `compozy__skill_view` for required guidance; an injected skill summary alone is not proof of
+callable tools. Confirm a nondelegated tool is still denied and omission still means zero tools.
+Then verify task completion, the selected Agent/Profile/runtime and stopped worker cleanup as above.

--- a/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
+++ b/docs/qa/scenarios/LP-implement-tasks-orchestrated-mode.md
@@ -104,7 +104,8 @@ QA 2026-09-10: Initial ACP process registration now retains the startup context 
 Worker-tool regression (#588): inspect the conductor's spawn request and persisted child lineage.
 Require the root system conductor to have a concrete Agent-derived delegation budget and an explicit
 bootstrap tool subset within that budget. Agents without an allowlist use the native universe minus
-Agent denies; explicit overrides remain narrow. Provenance-linked system children remain unseeded.
+Agent denies; explicit overrides remain narrow. Provenance-linked system children, verdict-only
+runtimes, and providers without session MCP remain unseeded.
 During the worker turn, invoke
 native `compozy__skill_view` for required guidance; an injected skill summary alone is not proof of
 callable tools. Confirm a nondelegated tool is still denied and omission still means zero tools.

--- a/extensions/spec-cycle/skills/cy-orchestrate-tasks/SKILL.md
+++ b/extensions/spec-cycle/skills/cy-orchestrate-tasks/SKILL.md
@@ -36,13 +36,29 @@ uses `frontend_runtime`, and every other value uses `default_runtime`. Merge the
 frontmatter `runtime` over that category object field by field before building spawn flags. Create
 one bounded `spawned` session bound to this conductor. Bind the exact `implementer` value from the
 Goal once, then pass it as one quoted argument. TTL and parent-stop are the containment contract;
-`--ttl-seconds` is mandatory:
+`--ttl-seconds` is mandatory.
+
+The child starts with no delegated tools when permission atoms are omitted. Before spawning,
+inspect this conductor's session lineage permission policy and the worker's required operations.
+Pass an explicit subset of the parent's concrete tool IDs: the bootstrap set below supports
+native discovery, descriptor reads, skill lookup, and retained-reference reads. Add only task-required
+tools the parent can delegate. If a required tool is absent from the parent budget, block with that
+missing ID; do not retry without permissions, grant wildcards, or bypass a denial through files/CLI.
+Other permission categories remain empty unless the task needs an explicit parent-authorized subset.
+
+For native `compozy__session_spawn`, put these same IDs in `tools`; use the live descriptor for
+any additional fields. The equivalent CLI recipe is:
 
 ```bash
 IMPLEMENTER="<exact implementer identifier from the Goal>"
 compozy spawn --agent "$IMPLEMENTER" \
   --name "orchestrate-<slug>-<task_id>" \
   --role worker \
+  --tool compozy__tool_search \
+  --tool compozy__tool_info \
+  --tool compozy__tool_artifact_read \
+  --tool compozy__skill_search \
+  --tool compozy__skill_view \
   --ttl-seconds 3600 \
   --auto-stop-on-parent=true \
   --idempotency-key "orchestrate-<slug>-<task_id>" \

--- a/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
+++ b/internal/daemon/daemon_implement_tasks_e2e_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/compozy/compozy/internal/speed"
 	"github.com/compozy/compozy/internal/testutil/acpmock"
 	e2etest "github.com/compozy/compozy/internal/testutil/e2e"
+	toolspkg "github.com/compozy/compozy/internal/tools"
 	worktreepkg "github.com/compozy/compozy/internal/worktree"
 )
 
@@ -847,6 +848,29 @@ func assertImplementTasksSpawnedWorkerRuntimes(
 		}
 		if worker.AgentName != wantAgent {
 			t.Fatalf("spawned worker %q agent = %q, want %q", worker.Name, worker.AgentName, wantAgent)
+		}
+		for _, check := range []struct {
+			id       toolspkg.ToolID
+			callable bool
+		}{
+			{toolspkg.ToolIDSkillView, true},
+			{toolspkg.ToolIDTaskList, false},
+		} {
+			var result contract.ToolResponse
+			if err := harness.CLI.RunJSONInDir(ctx, harness.WorkspaceRoot, &result,
+				"tool", "info", check.id.String(), "--session", worker.ID, "-o", "json",
+			); err != nil {
+				t.Fatal(err)
+			}
+			if result.Tool.Decision.Callable != check.callable {
+				t.Fatalf(
+					"worker %q tool %q callable=%t, want %t",
+					worker.ID,
+					check.id,
+					result.Tool.Decision.Callable,
+					check.callable,
+				)
+			}
 		}
 		got := *worker.Runtime.Effective
 		got.SpeedResolution = nil

--- a/internal/session/manager_allowed_tools.go
+++ b/internal/session/manager_allowed_tools.go
@@ -61,7 +61,12 @@ func (s *sessionStartSpec) materializeRootDelegationTools(
 	catalog toolspkg.ToolsetCatalog,
 	universe []toolspkg.ToolID,
 ) error {
-	if s == nil || normalizeSessionType(s.sessionType) != SessionTypeUser {
+	if s == nil {
+		return nil
+	}
+	switch normalizeSessionType(s.sessionType) {
+	case SessionTypeUser, SessionTypeSystem:
+	default:
 		return nil
 	}
 	lineage := store.NormalizeSessionLineage(s.sessionID, s.lineage)
@@ -94,6 +99,12 @@ func concreteDelegationTools(
 		return nil, fmt.Errorf("%w: agent deny_tools policy is invalid: %w", ErrValidation, err)
 	}
 	candidates := make(map[toolspkg.ToolID]struct{})
+	// An Agent without an allowlist can use the native universe; preserve its denies below.
+	if len(resolved.Tools) == 0 && len(resolved.Toolsets) == 0 {
+		for _, id := range universe {
+			candidates[id] = struct{}{}
+		}
+	}
 	for idx, raw := range resolved.Tools {
 		pattern, parseErr := toolspkg.ParseToolPattern(raw)
 		if parseErr != nil {

--- a/internal/session/manager_allowed_tools.go
+++ b/internal/session/manager_allowed_tools.go
@@ -61,7 +61,7 @@ func (s *sessionStartSpec) materializeRootDelegationTools(
 	catalog toolspkg.ToolsetCatalog,
 	universe []toolspkg.ToolID,
 ) error {
-	if s == nil {
+	if s == nil || !resolved.SessionMCP || strings.EqualFold(s.runtimeMode, RuntimeModeVerdictOnly) {
 		return nil
 	}
 	switch normalizeSessionType(s.sessionType) {

--- a/internal/session/manager_lineage_test.go
+++ b/internal/session/manager_lineage_test.go
@@ -129,29 +129,66 @@ func TestCreateAllowedToolsOverrideNarrowsAgentProfile(t *testing.T) {
 		t.Parallel()
 
 		tests := []struct {
-			name     string
-			override []string
+			name         string
+			override     []string
+			sessionType  Type
+			denyTools    []string
+			unrestricted bool
 		}{
 			{name: "Should leave nil override unchanged"},
 			{name: "Should leave empty override unchanged", override: []string{}},
+			{name: "Should materialize default native tools for a root user session", unrestricted: true},
+			{
+				name:         "Should materialize default native tools for a root system session",
+				sessionType:  SessionTypeSystem,
+				unrestricted: true,
+			},
+			{
+				name:         "Should honor denies with default native tools",
+				sessionType:  SessionTypeSystem,
+				unrestricted: true,
+				denyTools:    []string{toolspkg.ToolIDTaskUpdate.String()},
+			},
+			{
+				name:         "Should preserve a narrower explicit root system override",
+				sessionType:  SessionTypeSystem,
+				unrestricted: true,
+				override:     []string{toolspkg.ToolIDTaskRead.String()},
+			},
+			{name: "Should materialize a root system session budget", sessionType: SessionTypeSystem},
+			{
+				name:        "Should materialize a root system session budget with an empty override",
+				sessionType: SessionTypeSystem,
+				override:    []string{},
+			},
+			{
+				name:        "Should exclude denied tools from a root system session budget",
+				sessionType: SessionTypeSystem,
+				denyTools:   []string{toolspkg.ToolIDTaskUpdate.String()},
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				h := newHostedMCPHarness(t)
+				h := newHostedMCPHarness(t, WithToolUniverse([]toolspkg.ToolID{
+					toolspkg.ToolIDTaskRead, toolspkg.ToolIDTaskUpdate,
+				}))
+				agentTools := []string{toolspkg.ToolIDTaskRead.String(), toolspkg.ToolIDTaskUpdate.String()}
+				if tt.unrestricted {
+					agentTools = nil
+				}
 				addHarnessAgent(t, h, compozyconfig.AgentDef{
-					Name:     "unchanged-coder",
-					Provider: "claude",
-					Prompt:   "Use the default tool profile.",
-					Tools: []string{
-						toolspkg.ToolIDTaskRead.String(),
-						toolspkg.ToolIDTaskUpdate.String(),
-					},
+					Name:      "unchanged-coder",
+					DenyTools: tt.denyTools,
+					Provider:  "claude",
+					Prompt:    "Use the default tool profile.",
+					Tools:     agentTools,
 				})
 
 				sess, err := h.manager.Create(testutil.Context(t), CreateOpts{
 					AgentName:            "unchanged-coder",
+					Type:                 tt.sessionType,
 					Workspace:            h.workspaceID,
 					AllowedToolsOverride: tt.override,
 				})
@@ -171,6 +208,9 @@ func TestCreateAllowedToolsOverrideNarrowsAgentProfile(t *testing.T) {
 				wantTools := []string{
 					toolspkg.ToolIDTaskRead.String(),
 					toolspkg.ToolIDTaskUpdate.String(),
+				}
+				if len(tt.denyTools) > 0 || len(tt.override) > 0 {
+					wantTools = []string{toolspkg.ToolIDTaskRead.String()}
 				}
 				if got := info.Lineage.PermissionPolicy.Tools; !testutil.EqualStringSlices(got, wantTools) {
 					t.Fatalf("lineage tools = %#v, want concrete delegation policy %#v", got, wantTools)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1846,7 +1846,12 @@ func TestCreateOmitsMCPServersForVerdictOnlyRuntime(t *testing.T) {
 				Command:   "/bin/compozy",
 			},
 		}
-		h.manager = newManagerWithHarness(t, h, WithHostedMCPLauncher(hosted))
+		h.manager = newManagerWithHarness(
+			t,
+			h,
+			WithHostedMCPLauncher(hosted),
+			WithToolUniverse([]toolspkg.ToolID{toolspkg.ToolIDSkillView}),
+		)
 
 		session, err := h.manager.Create(testutil.Context(t), CreateOpts{
 			AgentName:   "coder",
@@ -1864,6 +1869,9 @@ func TestCreateOmitsMCPServersForVerdictOnlyRuntime(t *testing.T) {
 			}
 		})
 
+		if got := session.Info().Lineage.PermissionPolicy.Tools; len(got) != 0 {
+			t.Fatalf("verdict-only delegation tools = %#v, want none", got)
+		}
 		if got := h.driver.startCalls[0].MCPServers; len(got) != 0 {
 			t.Fatalf("start MCPServers = %#v, want none for verdict-only runtime", got)
 		}
@@ -1876,58 +1884,71 @@ func TestCreateOmitsMCPServersForVerdictOnlyRuntime(t *testing.T) {
 func TestCreateSkipsHostedMCPWhenProviderDisablesSessionMCP(t *testing.T) {
 	t.Parallel()
 
-	logs := newCaptureLogHandler()
-	h := newHarness(t, WithLogger(slog.New(logs)))
-	h.resolver.upsert(&workspacepkg.ResolvedWorkspace{
-		Workspace: workspacepkg.Workspace{
-			ID:      h.workspaceID,
-			RootDir: h.workspace,
-			Name:    h.workspaceName,
-		},
-		Config: h.cfg,
-		Agents: []compozyconfig.AgentDef{{
-			Name:     "coder",
-			Provider: "openclaw",
-			Prompt:   "You are helpful.",
-		}},
+	t.Run("Should withhold delegation tools when the provider disables session MCP", func(t *testing.T) {
+		t.Parallel()
+
+		logs := newCaptureLogHandler()
+		h := newHarness(t, WithLogger(slog.New(logs)))
+		h.resolver.upsert(&workspacepkg.ResolvedWorkspace{
+			Workspace: workspacepkg.Workspace{
+				ID:      h.workspaceID,
+				RootDir: h.workspace,
+				Name:    h.workspaceName,
+			},
+			Config: h.cfg,
+			Agents: []compozyconfig.AgentDef{{
+				Name:     "coder",
+				Provider: "openclaw",
+				Prompt:   "You are helpful.",
+			}},
+		})
+		hosted := &recordingHostedMCPLauncher{
+			server: compozyconfig.MCPServer{
+				Name:      "compozy-hosted-tools",
+				Transport: compozyconfig.MCPServerTransportStdio,
+				Command:   "/bin/compozy",
+			},
+		}
+		h.manager = newManagerWithHarness(
+			t,
+			h,
+			WithHostedMCPLauncher(hosted),
+			WithLogger(slog.New(logs)),
+			WithToolUniverse([]toolspkg.ToolID{toolspkg.ToolIDSkillView}),
+		)
+
+		session := createSession(t, h)
+		if err := h.manager.Stop(testutil.Context(t), session.ID); err != nil {
+			t.Fatalf("Stop() error = %v", err)
+		}
+
+		if got := session.Info().Lineage.PermissionPolicy.Tools; len(got) != 0 {
+			t.Fatalf("MCP-disabled delegation tools = %#v, want none", got)
+		}
+		got := h.driver.startCalls[0]
+		if got.Command != "openclaw acp" {
+			t.Fatalf("start command = %q, want openclaw acp", got.Command)
+		}
+		if len(got.MCPServers) != 0 {
+			t.Fatalf("start MCPServers = %#v, want none for provider without session MCP support", got.MCPServers)
+		}
+		if requests := hosted.launchRequests(); len(requests) != 0 {
+			t.Fatalf("hosted launch requests = %#v, want none", requests)
+		}
+		record, ok := logs.FindByMessage("session.mcp.skipped")
+		if !ok {
+			t.Fatalf("logs = %#v, want session MCP skipped diagnostic", logs.Records())
+		}
+		if record.Level != slog.LevelInfo {
+			t.Fatalf("session MCP skipped log level = %s, want INFO", record.Level)
+		}
+		if got, want := record.Attrs["reason"], "provider_session_mcp_disabled"; got != want {
+			t.Fatalf("session MCP skipped reason = %q, want %q", got, want)
+		}
+		if got, want := record.Attrs["resolved_provider"], "openclaw"; got != want {
+			t.Fatalf("session MCP skipped provider = %q, want %q", got, want)
+		}
 	})
-	hosted := &recordingHostedMCPLauncher{
-		server: compozyconfig.MCPServer{
-			Name:      "compozy-hosted-tools",
-			Transport: compozyconfig.MCPServerTransportStdio,
-			Command:   "/bin/compozy",
-		},
-	}
-	h.manager = newManagerWithHarness(t, h, WithHostedMCPLauncher(hosted), WithLogger(slog.New(logs)))
-
-	session := createSession(t, h)
-	if err := h.manager.Stop(testutil.Context(t), session.ID); err != nil {
-		t.Fatalf("Stop() error = %v", err)
-	}
-
-	got := h.driver.startCalls[0]
-	if got.Command != "openclaw acp" {
-		t.Fatalf("start command = %q, want openclaw acp", got.Command)
-	}
-	if len(got.MCPServers) != 0 {
-		t.Fatalf("start MCPServers = %#v, want none for provider without session MCP support", got.MCPServers)
-	}
-	if requests := hosted.launchRequests(); len(requests) != 0 {
-		t.Fatalf("hosted launch requests = %#v, want none", requests)
-	}
-	record, ok := logs.FindByMessage("session.mcp.skipped")
-	if !ok {
-		t.Fatalf("logs = %#v, want session MCP skipped diagnostic", logs.Records())
-	}
-	if record.Level != slog.LevelInfo {
-		t.Fatalf("session MCP skipped log level = %s, want INFO", record.Level)
-	}
-	if got, want := record.Attrs["reason"], "provider_session_mcp_disabled"; got != want {
-		t.Fatalf("session MCP skipped reason = %q, want %q", got, want)
-	}
-	if got, want := record.Attrs["resolved_provider"], "openclaw"; got != want {
-		t.Fatalf("session MCP skipped provider = %q, want %q", got, want)
-	}
 }
 
 func TestCreateBlocksMarketplaceSkillMCPServersWithoutConsent(t *testing.T) {

--- a/internal/testutil/acpmock/testdata/implement_tasks_fixture.json
+++ b/internal/testutil/acpmock/testdata/implement_tasks_fixture.json
@@ -35,6 +35,19 @@
                     "match": { "turn_source": "user" },
                     "steps": [
                         {
+                            "kind": "sandbox_exec",
+                            "tool_call_id": "worker-native-skill",
+                            "title": "Read required guidance through native tool policy",
+                            "command": "/bin/sh",
+                            "args": [
+                                "-c",
+                                "exec \"$1\" tool invoke compozy__skill_view --session \"$COMPOZY_SESSION_ID\" --input '{\"name\":\"compozy\"}' -o json",
+                                "worker",
+                                "__COMPOZY_BINARY__"
+                            ],
+                            "expect_exit_code": 0
+                        },
+                        {
                             "kind": "assistant",
                             "text": "{\"status\":\"completed\",\"summary\":\"Task implementation completed.\",\"files_changed\":[]}"
                         }
@@ -84,7 +97,7 @@
                             "command": "/bin/sh",
                             "args": [
                                 "-c",
-                                "set -eu; compozy_bin=$1; profile=$2; printf 'boundary=conductor session=%s agent=%s profile=%s workspace=%s\\n' \"${COMPOZY_SESSION_ID:-}\" \"${COMPOZY_AGENT:-}\" \"$profile\" \"$PWD\"; me_output=$(\"$compozy_bin\" me -o json 2>&1) || { rc=$?; printf 'boundary=me exit=%s output=%s\\n' \"$rc\" \"$me_output\"; exit \"$rc\"; }; printf 'boundary=me exit=0 output=%s\\n' \"$me_output\"; mkdir -p .compozy/tasks/implement-tasks/logs; for task in .compozy/tasks/implement-tasks/task_*.md; do task_id=$(basename \"$task\" .md); task_type=$(awk '/^type:/ { print $2; exit }' \"$task\"); set -- spawn --agent __IMPLEMENTER__ --name \"orchestrate-implement-tasks-$task_id\" --role worker --ttl-seconds 3600 --auto-stop-on-parent=true --no-notify-creator --idempotency-key \"orchestrate-implement-tasks-$task_id\"; case \"$task_type\" in frontend) set -- \"$@\" --provider claude --model opus --reasoning-effort high --speed normal ;; backend) set -- \"$@\" --provider acpmock --model base-model --reasoning-effort high --speed fast ;; *) set -- \"$@\" --provider acpmock --model docs-model --reasoning-effort high --speed normal ;; esac; spawn_json=$(\"$compozy_bin\" \"$@\" -o json 2>&1) || { rc=$?; printf 'boundary=spawn exit=%s output=%s\\n' \"$rc\" \"$spawn_json\"; exit \"$rc\"; }; printf 'boundary=spawn exit=0 output=%s\\n' \"$spawn_json\"; session_id=$(printf '%s\\n' \"$spawn_json\" | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p' | head -n 1); test -n \"$session_id\"; \"$compozy_bin\" session status \"$session_id\" -o json >/dev/null; if ! \"$compozy_bin\" session prompt \"$session_id\" \"Implement $task_id from .compozy/tasks/implement-tasks/.\" -o jsonl > \".compozy/tasks/implement-tasks/logs/$task_id.jsonl\" 2>&1; then cat \".compozy/tasks/implement-tasks/logs/$task_id.jsonl\"; exit 1; fi; sed 's/^status: pending$/status: completed/' \"$task\" > \"$task.tmp\"; mv \"$task.tmp\" \"$task\"; grep -q '^status: completed$' \"$task\"; \"$compozy_bin\" session stop \"$session_id\" -o json >/dev/null; done",
+                                "set -eu; compozy_bin=$1; profile=$2; printf 'boundary=conductor session=%s agent=%s profile=%s workspace=%s\\n' \"${COMPOZY_SESSION_ID:-}\" \"${COMPOZY_AGENT:-}\" \"$profile\" \"$PWD\"; me_output=$(\"$compozy_bin\" me -o json 2>&1) || { rc=$?; printf 'boundary=me exit=%s output=%s\\n' \"$rc\" \"$me_output\"; exit \"$rc\"; }; printf 'boundary=me exit=0 output=%s\\n' \"$me_output\"; mkdir -p .compozy/tasks/implement-tasks/logs; for task in .compozy/tasks/implement-tasks/task_*.md; do task_id=$(basename \"$task\" .md); task_type=$(awk '/^type:/ { print $2; exit }' \"$task\"); set -- spawn --agent __IMPLEMENTER__ --name \"orchestrate-implement-tasks-$task_id\" --role worker --tool compozy__tool_search --tool compozy__tool_info --tool compozy__tool_artifact_read --tool compozy__skill_search --tool compozy__skill_view --ttl-seconds 3600 --auto-stop-on-parent=true --no-notify-creator --idempotency-key \"orchestrate-implement-tasks-$task_id\"; case \"$task_type\" in frontend) set -- \"$@\" --provider claude --model opus --reasoning-effort high --speed normal ;; backend) set -- \"$@\" --provider acpmock --model base-model --reasoning-effort high --speed fast ;; *) set -- \"$@\" --provider acpmock --model docs-model --reasoning-effort high --speed normal ;; esac; spawn_json=$(\"$compozy_bin\" \"$@\" -o json 2>&1) || { rc=$?; printf 'boundary=spawn exit=%s output=%s\\n' \"$rc\" \"$spawn_json\"; exit \"$rc\"; }; printf 'boundary=spawn exit=0 output=%s\\n' \"$spawn_json\"; session_id=$(printf '%s\\n' \"$spawn_json\" | sed -n 's/.*\"id\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\".*/\\1/p' | head -n 1); test -n \"$session_id\"; \"$compozy_bin\" session status \"$session_id\" -o json >/dev/null; if ! \"$compozy_bin\" session prompt \"$session_id\" \"Implement $task_id from .compozy/tasks/implement-tasks/.\" -o jsonl > \".compozy/tasks/implement-tasks/logs/$task_id.jsonl\" 2>&1; then cat \".compozy/tasks/implement-tasks/logs/$task_id.jsonl\"; exit 1; fi; sed 's/^status: pending$/status: completed/' \"$task\" > \"$task.tmp\"; mv \"$task.tmp\" \"$task\"; grep -q '^status: completed$' \"$task\"; \"$compozy_bin\" session stop \"$session_id\" -o json >/dev/null; done",
                                 "conductor",
                                 "__COMPOZY_BINARY__",
                                 "__PROFILE__"

--- a/skills/compozy/references/tasks-and-orchestration.md
+++ b/skills/compozy/references/tasks-and-orchestration.md
@@ -3,6 +3,7 @@
 ## Contents
 
 - Authority model, catalog, inbox, and inspection
+- Bounded worker tools
 - Pause, resume, recovery, blocks, and escalation
 - Scheduler controls
 - Coordinator, worker, and reviewer loops
@@ -17,6 +18,15 @@ Do not infer task ownership from a message. Do not mutate task state outside Com
 Task inspect, pause/resume, and forced run release/fail/retry plus scheduler pause/resume/drain and
 backlog are CLI or HTTP/UDS management surfaces. Native tools do expose task block/list/unblock and
 task-level `needs_attention` recovery; use those only for their narrower daemon-owned contracts.
+
+## Bounded worker tools
+
+`compozy__session_spawn` requires an explicit `tools` subset for a worker that uses native tools.
+Omitted or empty permissions do not inherit the parent's access. Inspect the parent's lineage
+permission budget and grant only required concrete IDs; bootstrap commonly needs `compozy__tool_search`,
+`compozy__tool_info`, `compozy__tool_artifact_read`, `compozy__skill_search`, and `compozy__skill_view`.
+The CLI equivalent repeats `compozy spawn --tool <id>`. Agent policy and parent-subset validation
+still apply. A missing required grant blocks the task rather than authorizing a filesystem/CLI bypass.
 
 ## Catalog And Inbox Reads
 

--- a/web/e2e/__tests__/network.spec.ts
+++ b/web/e2e/__tests__/network.spec.ts
@@ -36,8 +36,9 @@ const createdChannelPurpose = "Coordinate browser e2e work";
 const openWorkId = "browser_work_needs_input_17";
 const openWorkRequestMessageId = "browser_msg_needs_input_request_01";
 const openWorkMessageId = "browser_msg_needs_input_01";
+// Public native ToolIDs such as compozy__mcp_auth_status are not credential markers.
 const sensitivePattern =
-  /compozy_claim_|claim_token["':\s]|mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]|proof["':\s]|signature["':\s]/i;
+  /compozy_claim_|claim_token["':\s]|(?<!compozy__)mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]|proof["':\s]|signature["':\s]/i;
 
 test.use({
   runtimeOptions: {

--- a/web/e2e/__tests__/sandbox.spec.ts
+++ b/web/e2e/__tests__/sandbox.spec.ts
@@ -34,8 +34,9 @@ const sandboxFixture = path.resolve(
 const allowedAgent = "browser-sandbox-allowed";
 const blockedAgent = "browser-sandbox-blocked";
 const sandboxProfileName = "browser-local-sandbox";
+// Public native ToolIDs such as compozy__mcp_auth_status are not credential markers.
 const sensitivePattern =
-  /compozy_claim_|["']claim_token["']\s*:|mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]|DAYTONA_API_KEY|sandbox-secret/i;
+  /compozy_claim_|["']claim_token["']\s*:|(?<!compozy__)mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]|DAYTONA_API_KEY|sandbox-secret/i;
 
 interface SettingsSandboxProfile {
   backend: string;

--- a/web/e2e/__tests__/session-hardening.spec.ts
+++ b/web/e2e/__tests__/session-hardening.spec.ts
@@ -46,8 +46,9 @@ const toolArtifactAgent = "tool-artifact-agent";
 const costProvenancePrompt = "Summarize the cost provenance run";
 const toolArtifactDigest = "c82d7447711d610d6c0d8fd52b8c8ee99f051a81e62f51bf052eaad467fca444";
 const toolArtifactTail = "E2E-009 tool artifact tail";
+// Public native ToolIDs such as compozy__mcp_auth_status are not credential markers.
 const sensitivePattern =
-  /compozy_claim_|claim_token["':\s]|mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]/i;
+  /compozy_claim_|claim_token["':\s]|(?<!compozy__)mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]/i;
 
 interface SessionPayload {
   id: string;

--- a/web/e2e/__tests__/tasks-hardening.spec.ts
+++ b/web/e2e/__tests__/tasks-hardening.spec.ts
@@ -35,8 +35,9 @@ const tasksSessionAgentName = "browser-lifecycle-agent";
 // wake indicator gates on (truthful UI).
 const compozySessionHeader = "X-Compozy-Session-ID";
 const compozyAgentHeader = "X-Compozy-Agent";
+// Public native ToolIDs such as compozy__mcp_auth_status are not credential markers.
 const sensitivePattern =
-  /compozy_claim_|["']claim_token["']\s*:|mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]/i;
+  /compozy_claim_|["']claim_token["']\s*:|(?<!compozy__)mcp[_-]?auth|telegram-bot-token|pkce|oauth|webhook_secret|provider[_-]?credentials?["'\s]*[:=]/i;
 
 test.use({
   runtimeOptions: {

--- a/web/src/systems/onboarding/components/__tests__/onboarding-setup-frame.test.tsx
+++ b/web/src/systems/onboarding/components/__tests__/onboarding-setup-frame.test.tsx
@@ -143,7 +143,7 @@ describe("OnboardingSetupFrame", () => {
     expect(screen.getByTestId("onboarding-summary-value")).toHaveTextContent("None yet");
 
     await user.click(screen.getByRole("button", { name: "About workspace" }));
-    expect(screen.getByText(/Skip starts in Global/)).toBeInTheDocument();
-    expect(screen.getByText(/does not enable Network/)).toBeInTheDocument();
+    expect(await screen.findByText(/Skip starts in Global/)).toBeInTheDocument();
+    expect(await screen.findByText(/does not enable Network/)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## What & why

Fixes #588.

Tool-capable root system Sessions now materialize a concrete delegation budget from their resolved Agent policy, matching root user Sessions. For Agents without an allowlist, both root types now materialize the native universe minus Agent denies, matching the existing effective tool policy. Loop conductors previously had an empty budget even when native tools were available, so an explicit child grant was rejected.

The stock task conductor now explicitly delegates the native discovery and skill-reading tools its workers need. Previously its spawn recipe omitted permissions, so the worker correctly received zero tools and could not load required guidance.

The recipe requires a concrete subset of the parent's budget and blocks when a required grant is unavailable. Omitted permissions still deny all delegated tools; there is no implicit child inheritance. Verdict-only and MCP-disabled runtimes remain without a default delegation budget. Sessions with a parent retain their existing budget; Agent denies and explicit overrides still bound root authority.

Implementation assistance: Richard's agent. The diff was reviewed and its results verified locally.

## How you verified it

- `TestCreateAllowedToolsOverrideNarrowsAgentProfile` and `TestCreateSystemSessionRecordsInternalProvenance` passed with `-race`, covering default/explicit budgets, denies, narrower overrides and unseeded provenance-linked system children. Default-budget cases failed before the fix.
- The implementation journey, loop feedback/convergence, and goal control/restart integration suites passed together with `-race` (368.476s). The strengthened fixture invokes native skill lookup; it also checks a nondelegated tool remains uncallable and workers settle under the selected Agent/Profile/runtime.
- Verdict-only and provider-disabled session tests passed with a populated native universe; explicit tool requirements still fail closed when hosted MCP is unavailable.
- All 13 sandbox and session-hardening browser cases passed. Privacy matchers now distinguish public native tool identifiers from credential markers. An existing onboarding test awaits its asynchronous help portal before asserting its text.
- Live orchestrated execution completed the authored task with unchanged tests passing 3/3. The child received six explicit grants; native skill lookup was callable and an undelegated task tool returned `session_denied`.
- The live Loop settled `done`, its worker stopped, and the disposable lab teardown reported `clean: true`. `make gate` passed on the final diff: lint reported zero issues, all affected race-test packages passed, and frontend validation passed with 7,117 tests across 771 files under Node 22.

## Impact

- Native tools/CLI/API: existing `session_spawn.tools` and repeated `spawn --tool` fields are unchanged. Root delegation budgets and the shipped conductor's use of those fields change.
- Extensibility/hooks/config: bundled conductor guidance changes; subset validation, Agent policy, TTL, parent-stop and cleanup remain authoritative. No new config or SDK contract.
- Workspace data isolation: the child remains bound to its parent Workspace and Profile; extra tools require an explicit parent-authorized subset.
- Official skill and Web/Docs: orchestration reference and QA scenario updated. No web UI or generated CLI-doc change.
- Risk/rollback: workers need additional task-specific grants for operations beyond bootstrap; missing authority stays an explicit blocker. Reverting restores the missing system budget and failing zero-tool recipe.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Root-level tool delegation budgets now apply consistently to both user and system sessions.
  - Sessions without an explicit tool allowlist now receive available native tools by default, while deny rules remain enforced.
  - Explicitly narrower tool selections continue to restrict access as configured.
  - Session tools are no longer delegated when session MCP is disabled or runtime uses verdict-only mode.
  - Spawned worker tool capabilities are now reported correctly, distinguishing callable and non-callable tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->