### PR TITLE
fix: emit profile scope from memory extraction

### DIFF
--- a/docs/qa/scenarios/MS-profile-memory-tier-scope.md
+++ b/docs/qa/scenarios/MS-profile-memory-tier-scope.md
@@ -54,3 +54,11 @@ each of two Profiles. Verify queued turns, extractor role resolution, profile-ti
 diagnostic events retain the source Profile. A missing Profile must refuse extraction/storage;
 it must not resolve the other Profile's Agent or write into default memory. Keep Workspace memory
 shared as specified above. Repeat after replaying the durable extractor inbox.
+
+Extractor vocabulary regression (#587): with memory explicitly enabled, complete a root turn asking
+to remember a personal preference across Workspaces, without an explicit memory-write call. The
+rendered extractor prompt must advertise `profile | workspace | agent`. Confirm its emitted
+Profile candidate is accepted and persists only under the source Profile; the default Profile must
+not return it. Keep `agent_tier: global` valid only for Agent scope, and keep `scope: global` rejected.
+A Workspace fact should still persist into shared Workspace memory. Separate provider-startup
+failures from prompt/parser failures when recording the result.

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -263,6 +264,46 @@ func TestCollectMemoryExtractorOutput(t *testing.T) {
 
 func TestMemoryExtractorOutputContract(t *testing.T) {
 	t.Parallel()
+	t.Run("Should parse every scope advertised by the rendered extractor prompt", func(t *testing.T) {
+		t.Parallel()
+		turn := memcontract.TurnRecord{SessionID: "parent", WorkspaceID: "workspace", AgentID: "engineer"}
+		prompt, err := renderMemoryExtractorPrompt(turn)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, schema, found := strings.Cut(prompt, "```json\n")
+		if !found {
+			t.Fatal("extractor prompt has no candidate JSON schema")
+		}
+		schema, _, found = strings.Cut(schema, "\n```")
+		if !found {
+			t.Fatal("extractor candidate schema is not terminated")
+		}
+		var example extractedMemoryLine
+		if err := json.Unmarshal([]byte(schema), &example); err != nil {
+			t.Fatal(err)
+		}
+		for scope := range strings.SplitSeq(example.Scope, "|") {
+			example.Scope = scope
+			example.Type = "user"
+			example.Content = "The user prefers compact daily summaries."
+			example.AgentTier = ""
+			if scope == string(memcontract.ScopeAgent) {
+				example.AgentTier = string(memcontract.AgentTierGlobal)
+			}
+			output, err := json.Marshal(example)
+			if err != nil {
+				t.Fatal(err)
+			}
+			candidates, err := parseMemoryExtractorCandidates(string(output), turn, "", time.Time{})
+			if err != nil || len(candidates) != 1 {
+				t.Fatalf("advertised scope %q: candidates=%#v, error=%v", scope, candidates, err)
+			}
+			if candidates[0].Scope != memcontract.Scope(scope) {
+				t.Fatalf("candidate scope=%q, want %q", candidates[0].Scope, scope)
+			}
+		}
+	})
 	candidate := `{"type":"user","content":"Pedro prefers concise updates."}`
 	for _, tc := range []struct {
 		name, output string
@@ -278,6 +319,7 @@ func TestMemoryExtractorOutputContract(t *testing.T) {
 		{name: "Should preserve candidates around unknown prose", output: "Here are the candidates:\n" + candidate, count: 1, failure: true},
 		{name: "Should reject unknown prose alone", output: "Unable to determine memories", failure: true},
 		{name: "Should reject invalid candidate fields", output: `{"type":"user","content":""}`, failure: true},
+		{name: "Should reject retired global scope", output: `{"type":"user","scope":"global","content":"Personal preference"}`, failure: true},
 		{name: "Should reject null", output: `null`, failure: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/daemon/memory_runtime_test.go
+++ b/internal/daemon/memory_runtime_test.go
@@ -284,29 +284,34 @@ func TestMemoryExtractorOutputContract(t *testing.T) {
 			t.Fatal(err)
 		}
 		for scope := range strings.SplitSeq(example.Scope, "|") {
-			example.Scope = scope
-			example.Type = "user"
-			example.Content = "The user prefers compact daily summaries."
-			example.AgentTier = ""
-			if scope == string(memcontract.ScopeAgent) {
-				example.AgentTier = string(memcontract.AgentTierGlobal)
-			}
-			output, err := json.Marshal(example)
-			if err != nil {
-				t.Fatal(err)
-			}
-			candidates, err := parseMemoryExtractorCandidates(string(output), turn, "", time.Time{})
-			if err != nil || len(candidates) != 1 {
-				t.Fatalf("advertised scope %q: candidates=%#v, error=%v", scope, candidates, err)
-			}
-			if candidates[0].Scope != memcontract.Scope(scope) {
-				t.Fatalf("candidate scope=%q, want %q", candidates[0].Scope, scope)
-			}
+			t.Run("Should parse "+scope+" scope", func(t *testing.T) {
+				t.Parallel()
+				candidateExample := example
+				candidateExample.Scope = scope
+				candidateExample.Type = "user"
+				candidateExample.Content = "The user prefers compact daily summaries."
+				candidateExample.AgentTier = ""
+				if scope == string(memcontract.ScopeAgent) {
+					candidateExample.AgentTier = string(memcontract.AgentTierGlobal)
+				}
+				output, err := json.Marshal(candidateExample)
+				if err != nil {
+					t.Fatal(err)
+				}
+				candidates, err := parseMemoryExtractorCandidates(string(output), turn, "", time.Time{})
+				if err != nil || len(candidates) != 1 {
+					t.Fatalf("advertised scope %q: candidates=%#v, error=%v", scope, candidates, err)
+				}
+				if candidates[0].Scope != memcontract.Scope(scope) {
+					t.Fatalf("candidate scope=%q, want %q", candidates[0].Scope, scope)
+				}
+			})
 		}
 	})
 	candidate := `{"type":"user","content":"Pedro prefers concise updates."}`
 	for _, tc := range []struct {
 		name, output string
+		wantError    string
 		count        int
 		failure      bool
 	}{
@@ -319,7 +324,7 @@ func TestMemoryExtractorOutputContract(t *testing.T) {
 		{name: "Should preserve candidates around unknown prose", output: "Here are the candidates:\n" + candidate, count: 1, failure: true},
 		{name: "Should reject unknown prose alone", output: "Unable to determine memories", failure: true},
 		{name: "Should reject invalid candidate fields", output: `{"type":"user","content":""}`, failure: true},
-		{name: "Should reject retired global scope", output: `{"type":"user","scope":"global","content":"Personal preference"}`, failure: true},
+		{name: "Should reject retired global scope", output: `{"type":"user","scope":"global","content":"Personal preference"}`, failure: true, wantError: `unsupported scope "global"`},
 		{name: "Should reject null", output: `null`, failure: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -330,6 +335,9 @@ func TestMemoryExtractorOutputContract(t *testing.T) {
 				"",
 				time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC),
 			)
+			if tc.wantError != "" && (err == nil || !strings.Contains(err.Error(), tc.wantError)) {
+				t.Fatalf("parse error = %v, want %q", err, tc.wantError)
+			}
 			if len(candidates) != tc.count || (err != nil) != tc.failure {
 				t.Fatalf(
 					"parse = %d candidates, %v; want %d candidates, failure=%t",

--- a/internal/memory/prompts/extract.v1.tmpl
+++ b/internal/memory/prompts/extract.v1.tmpl
@@ -6,7 +6,7 @@ Return JSONL. If there are no durable candidates, return exactly `{"no_candidate
 Do not describe the empty result in prose. Each candidate line has:
 
 ```json
-{"type":"user|feedback|project|reference","scope":"global|workspace|agent","agent_tier":"","content":"","evidence":"","entity":"","attribute":""}
+{"type":"user|feedback|project|reference","scope":"profile|workspace|agent","agent_tier":"","content":"","evidence":"","entity":"","attribute":""}
 ```
 
 Hard rules:
@@ -16,6 +16,7 @@ Hard rules:
 - Do not emit candidates when the same turn already made an explicit memory write.
 - Keep every candidate lexical-only. Do not include embeddings, vectors, or similarity scores.
 - Include concise evidence tied to the provided message sequence range.
+- Use `profile` for personal facts reusable across Workspaces and `workspace` for repository-specific facts. `global` is not a memory scope.
 - Set `agent_tier` to `workspace` or `global` only when `scope` is `agent`; otherwise leave it empty.
 - Apply the WHAT_NOT_TO_SAVE policy below before emitting any line.
 


### PR DESCRIPTION
## What & why

Fixes #587.

Background extraction now asks for `profile` when a durable preference applies across Workspaces. Previously the prompt requested retired `global` scope, which the real candidate parser rejected. Workspace scope and the separate `agent_tier: global` value remain intact; no validation or ownership boundary is relaxed.

Implementation assistance: Richard's agent. The diff was reviewed and its results verified locally.

## How you verified it

- The new rendered-prompt/parser contract test failed on the old `global` example and passed after the correction. Named subtests cover each advertised scope, and retired scope rejection asserts its specific validation error. The owning extractor/output and Profile-targeted persistence suites passed with `-race`.
- A live background extraction accepted a personal preference as `scope: profile`, persisted it under the source `work` Profile, and returned no entry under `default` for the same Workspace. No explicit memory write was used; extractor settled idle with zero failures.
- The disposable lab teardown reported `clean: true`.
- `make gate` passed: lint reported zero issues and all affected race-test packages passed. An initial run hit a daemon boot timing timeout; the isolated boot test and the complete gate both passed on recheck.

## Impact

- Native tools, CLI and HTTP/UDS contracts: unchanged; the internal prompt now matches their existing closed taxonomy.
- Extensibility/hooks/config: no schema, role setting or lifecycle changes. Memory remains opt-in.
- Workspace data isolation: Profile candidates retain the existing source-Profile persistence path; Workspace memory remains shared. No migration or fallback is added.
- Official skill and Web/Docs: existing scope guidance is already correct. The affected memory QA scenario adds the prompt/parser regression walk; no UI change.
- Risk/rollback: limited to candidate scope selection. Reverting the prompt reintroduces rejected Profile candidates but does not alter stored data.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests, or I explained above why not
- [x] If an agent wrote or co-wrote this, I named it above and verified the result myself
