### PR TITLE
fix: recover layout settings saves and expose apply results

### DIFF
--- a/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
+++ b/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
@@ -131,3 +131,12 @@ The review batch passed the existing adapter/MSW/shortcut-table suites (42 tests
 18-test shortcut-table run including late workspace results, and root Web typecheck/build.
 At the user's request, the queued local gate for this batch was canceled; subsequent delivery gates
 run in CI. Earlier local gate results above apply to their recorded inputs, not the final PR head.
+
+The subsequent CodeRabbit review identified a warning-loss case for persisted bindings with
+`applied: false` and `next_action: none`. The shared receipt message now includes those warnings;
+the existing shortcut-table failure test passed both explicit retry and unverified application cases.
+The palette test remains in the canonical root/surface suite, which already owns its registry,
+ranking and action-panel behavior; no separate surface suite exists. Its ownership header and the
+PR delivery requirement explain that placement and the CI-driven palette correction. The CI Go
+lint failure in `c322164` was a 125-character documentation line, now wrapped to the 120-character
+limit. Documentation coverage remediation includes the touched test helpers.

--- a/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
+++ b/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
@@ -72,11 +72,11 @@ preserving the newer draft. A second browser capture, `edit-clears-error.png`, e
 ## Verification and limits
 
 - Root `bunx turbo run test typecheck build --filter=./web` passed: 771 suites / 7,133 tests,
-  typecheck and build. The final gate passed 771 suites / 7,137 tests.
+  typecheck and build. The gate for `1e829ff` passed 771 suites / 7,137 tests.
 - `CGO_ENABLED=1 go test -race ./internal/settings ./internal/api/core` passed; the receipt case also
   passed after extending it to both HTTP and UDS handler shims.
 - Root `bunx turbo run build --filter=./packages/site` passed, including TypeScript and static pages.
-- `make gate` passed on the final production diff: codegen-check, Go lint (zero issues), scoped
+- `make gate` passed on commit `1e829ff` before the subsequent review remediation: codegen-check, Go lint (zero issues), scoped
   Go race tests, and Web lint (zero warnings/errors), typecheck and all tests. Required CI is
   tracked on the current PR head.
 - Laboratory teardown completed with `clean: true`.
@@ -96,3 +96,38 @@ checker produced identical findings on the base and changed test files; there ar
 This targeted walk does not claim Electron global-hotkey registration, Linux, provider-backed agent
 workflows, or the full resilience matrix. The application-rejection test is a unit I/O boundary test;
 the live failure evidence is transport and HTTP write rejection.
+
+
+## Complete review remediation
+
+All inline, review-body and summary comments from Greptile, CodeRabbit and React Doctor were
+inventoried, including the docstring-coverage warning. Immediate shortcut, global-hotkey and alias
+writes now retain apply receipts, cache canonical persisted sections on application failure, and
+show warnings and deferred actions. Late results update only the submitting workspace. The existing
+adapter, shortcut-table and MSW suites cover these boundaries; interactive fixtures retain each
+profile/workspace configuration through subsequent GETs and reset between stories.
+
+The resumed isolated browser walk verified the exact served JavaScript filename against the current
+`web/dist/index.html` before recording `window.tab.new` as `meta+alt+KeyS` and editing the session alias.
+The UI showed “Settings saved and applied.”; reload retained the shortcut, and the public settings
+read retained both the shortcut and alias. Evidence: `keyboard-current.har`,
+`keyboard-current-applied.png`, `keyboard-current-feedback.txt`, `keyboard-current-reloaded.txt`,
+and `keyboard-current-persisted.json` under the artifact root above. An earlier attempt served an
+older bundle and is explicitly excluded from current-build evidence (`keyboard-older-bundle.har`).
+Global OS hotkey registration and injected apply failures remain unit-boundary evidence, not live
+platform claims. The own-lab teardown is retained in the same manifest.
+
+## CI follow-up and validation ownership
+
+CI run `34510838879` failed Herdr E2E-016: the second palette chord lost its action panel.
+The trace showed the automatically selected row changing from `palette.view.sessions` to
+`palette.open` when asynchronous ranking arrived. The palette surface derived its initial fallback
+without retaining that selection, so each reorder could choose another first row. A regression in
+the existing palette hook suite reproduced the failure before the correction and passed afterward (one focused case). The surface now
+retains automatic selection with the same guarded render-time reconciliation used by the view
+shell. The E2E assertion is unchanged.
+
+The review batch passed the existing adapter/MSW/shortcut-table suites (42 tests), an additional
+18-test shortcut-table run including late workspace results, and root Web typecheck/build.
+At the user's request, the queued local gate for this batch was canceled; subsequent delivery gates
+run in CI. Earlier local gate results above apply to their recorded inputs, not the final PR head.

--- a/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
+++ b/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
@@ -1,0 +1,76 @@
+# QA Run Report — 2026-09-10 — Layout settings Save
+
+- Scope: issue #593; recoverable Save, zero spacing, application receipts, and shortcut preservation.
+- Cadence: targeted; owning scenario `MS-configure-window-manager`, shared Save bar slice of `ET-web-ui-resilience`.
+- Baseline: `e76cb83d31598d68f9a5fabdf760e1e168b13496`.
+- Status: targeted real app walk and local delivery gates passed.
+- Local verification verdict: PASS.
+- Persona: Bruno, Studio workspace, Chromium on macOS, English UI.
+- Lab manifest: `/private/tmp/compozy-qa-593/compozy-issue-593-layout-settings-save-20260910-160728-799340-lab/qa-artifacts/qa/bootstrap-manifest.json`.
+- Evidence root: `/private/tmp/compozy-qa-593/` (local artifacts, no production data).
+
+## Session matrix
+
+| Journey | Result | Evidence |
+| --- | --- | --- |
+| Original failure | Reproduced: aborting PATCH disables Save and Discard; another edit retains the error | `before-failed-save.png`, `before-failed-save.har` |
+| Transport recovery | Original draft retry succeeds without editing; subsequent edit clears the error, and discard restores persisted zero | `after-retryable-error.png`, `after-real-saves.har` |
+| Zero spacing | Inner zero with nonzero outer insets; all outer zeros with inner 1; all gaps zero; save and reload each | `outer-zero-applied.png`, `all-zero-applied.png`, `zero-after-reload.png` |
+| Rendered geometry | At zero gap, tiles meet at x=640; inner 1 moves the second tile to x=641. Top inset 1 moves y=44 to y=45. All-zero reload restores x=0/640 and y=44 | `zero-tiled-layout.png`, `zero-after-reload.png`; DOM bounding rectangles |
+| HTTP failure | Temporarily removing write permission on the isolated home produces HTTP 500. Visible error retains draft and offers retry/discard. Permissions restored in `finally`; retry succeeds | `server-write-error.png`, `after-real-saves.har` |
+| Shortcut integrity | Change shortcut/global shortcut maps and alias via public PATCH while spacing draft is open; Save preserves their newer values | `shortcut-live-edit.json`, `all-zero-shortcuts-preserved.json` |
+| Repeated save | Identical public PATCH reports skipped/no changes without advancing generation | `repeated-save.json` |
+
+## Root cause and application evidence
+
+The failed TanStack mutation error outlived the editor error reset and overrode dirty state. The Save
+bar then disabled both recovery actions. The frontend full-config serializer also omitted global
+shortcuts, and replacing the full config could erase them or overwrite separately edited shortcuts.
+
+Both the Layouts adapter and the backend section-echo handler discarded application outcome. The
+fixed real PATCH returns the original section plus `apply`. One captured retry returned HTTP 200,
+`applied: true`, `next_action: none`, and record `cfgapp-f748c8967ffcfc30`. The UI displayed
+“Settings saved and applied.” Zero was valid before the fix; no validator relaxation was required.
+The earlier connection-refused logs do not prove a daemon crash.
+
+The live walk used the real daemon and Web app. Transport abortion and filesystem permission failure
+were deliberate disruptions. No application receipt was mocked in the browser. Partial application
+failure, warnings and restart/new-session result interpretation are verified at the owning adapter
+and handler test boundaries, not claimed as live platform failures.
+
+## Change impact
+
+- Native tools: no IDs, toolsets, permissions or CLI commands changed. HTTP/UDS share the settings
+  handler; PATCH adds an `apply` receipt and optional `preserve_shortcuts` flag. OpenAPI and generated
+  Web contracts co-ship. Existing section response fields remain available.
+- Extensibility/config: no new persisted config keys, hooks or extension contracts. The optional
+  request flag preserves current shortcut maps inside the existing settings mutation lock; explicit
+  top-level maps retain replacement semantics. Omitting the flag preserves legacy full replacement.
+- User state/isolation: no schema migration or data deletion. The existing user-scoped settings
+  boundary remains; workspace layouts and profile routing are unchanged. The lab used its own home,
+  socket, ports and workspace. No host daemon restart or production settings write occurred.
+- Web/Docs: Layouts editor, shared Save bar recovery and settings adapter changed. Existing shortcut
+  consumers retain their section parsing. Site docs, official `skills/compozy` window-management
+  reference, and the two affected QA scenario entries were updated.
+
+## Verification and limits
+
+- Root `bunx turbo run test typecheck build --filter=./web` passed: 771 suites / 7,133 tests,
+  typecheck and build. The final gate passed 771 suites / 7,135 tests.
+- `CGO_ENABLED=1 go test -race ./internal/settings ./internal/api/core` passed; the receipt case also
+  passed after extending it to both HTTP and UDS handler shims.
+- Root `bunx turbo run build --filter=./packages/site` passed, including TypeScript and static pages.
+- `make gate` passed on the final production diff: codegen-check, Go lint (zero issues), scoped
+  Go race tests, and Web lint (zero warnings/errors), typecheck and all tests. Required CI is
+  tracked on the current PR head.
+- Laboratory teardown completed with `clean: true`.
+
+The final `bunx turbo run build --filter=./web` also passed after the pending-action adjustment.
+
+The Web build emitted existing CSS `::highlight` optimizer and bundle-size warnings. The full Web
+suite also emitted unrelated harness warnings. No warning suppression was added. The Go convention
+checker produced identical findings on the base and changed test files; there are no new findings.
+
+This targeted walk does not claim Electron global-hotkey registration, Linux, provider-backed agent
+workflows, or the full resilience matrix. The application-rejection test is a unit I/O boundary test;
+the live failure evidence is transport and HTTP write rejection.

--- a/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
+++ b/docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md
@@ -38,6 +38,22 @@ were deliberate disruptions. No application receipt was mocked in the browser. P
 failure, warnings and restart/new-session result interpretation are verified at the owning adapter
 and handler test boundaries, not claimed as live platform failures.
 
+## Application retry follow-up
+
+The application-recovery regression reproduced another defect: after persistence succeeded and
+runtime application failed, repeating the identical Layouts PATCH returned `applied: true` and
+`skipped: true` without calling the runtime again. For user-scoped window-manager saves, the shared projected-apply recorder requires both the persisted
+mutation and the active projection to be unchanged before skipping. A cold-service
+Save captures the active baseline before writing, so the first failed apply is also retryable. The owning
+`TestConfigApplyServiceRecordsRuntimeReconcileFailures` case fails before the fix and passes after
+it, using real config persistence and a runtime-applier I/O stub. It verifies successful retry,
+unchanged-repeat idempotence, and preservation of an unrelated pending HTTP port change.
+
+The editor adopts the canonical saved baseline from an application-error receipt, so Discard cannot
+restore an obsolete pre-save value. A result arriving during another edit retains its warnings while
+preserving the newer draft. A second browser capture, `edit-clears-error.png`, explicitly records
+“Unsaved changes” after editing a transport-failed Save; the second lab teardown is also clean.
+
 ## Change impact
 
 - Native tools: no IDs, toolsets, permissions or CLI commands changed. HTTP/UDS share the settings
@@ -56,7 +72,7 @@ and handler test boundaries, not claimed as live platform failures.
 ## Verification and limits
 
 - Root `bunx turbo run test typecheck build --filter=./web` passed: 771 suites / 7,133 tests,
-  typecheck and build. The final gate passed 771 suites / 7,135 tests.
+  typecheck and build. The final gate passed 771 suites / 7,137 tests.
 - `CGO_ENABLED=1 go test -race ./internal/settings ./internal/api/core` passed; the receipt case also
   passed after extending it to both HTTP and UDS handler shims.
 - Root `bunx turbo run build --filter=./packages/site` passed, including TypeScript and static pages.
@@ -65,7 +81,13 @@ and handler test boundaries, not claimed as live platform failures.
   tracked on the current PR head.
 - Laboratory teardown completed with `clean: true`.
 
-The final `bunx turbo run build --filter=./web` also passed after the pending-action adjustment.
+The final root `bunx turbo run build --filter=./web --filter=./packages/site` passed after the
+receipt-retention and message-wrapping changes. The settings package also passed a fresh
+`go test -race ./internal/settings` after the cold-service retry correction.
+
+An earlier concurrent gate run timed out in two unchanged terminal rendering tests while their lazy
+component was still behind its null Suspense fallback. The unchanged owning suite then passed all
+30 tests in isolation and again in the final complete gate. No test timeout or assertion was changed.
 
 The Web build emitted existing CSS `::highlight` optimizer and bundle-size warnings. The full Web
 suite also emitted unrelated harness warnings. No warning suppression was added. The Go convention

--- a/docs/qa/scenarios/ET-editable-shell-shortcuts.md
+++ b/docs/qa/scenarios/ET-editable-shell-shortcuts.md
@@ -19,3 +19,11 @@ overlaps: ET-web-command-palette-shortcuts
 Flagged 2026-08-16 for the Herdr parity QA tail after the shell-chord registry migration.
 
 QA 2026-08-16 Herdr parity: The full Web E2E, daemon settings contract suites, and inspected visual bundles covered editable shortcuts, array/range persistence, blocked and shadowed diagnostics, Terminal preset preview/apply/revert, live cheatsheet freshness, and editable-context routing.
+
+## Palette selection continuity
+
+Open the palette from a focused composer while its command catalog is still loading. Open the
+action panel with the palette chord again. When recent or pinned commands reorder the results,
+the selected command and its action panel must remain available. Removing the selected command
+may select its nearest remaining neighbor. The existing Herdr E2E-016 journey owns the real
+keyboard flow; the palette hook suite covers asynchronous catalog and ranking arrival.

--- a/docs/qa/scenarios/ET-web-ui-resilience.md
+++ b/docs/qa/scenarios/ET-web-ui-resilience.md
@@ -18,3 +18,9 @@ overlaps: TA-039; NB-045; ET-web-loop-editor-topbar; ET-web-marketplace-landing-
 
 Added by the 2026-07-21 full frontend systems audit. Flag only: the next QA cycle owns live
 keyboard, filters, loading, mutation-race, error-announcement, reduced-motion, and responsive retesting.
+
+2026-09-10, issue #593: shared settings Save bars retain retry and discard actions for a valid dirty
+draft after failure, while invalid drafts remain unsavable. Verify error announcement, retry after
+network recovery, edit-after-failure, and discard in Layouts; keep saving actions disabled in flight.
+Targeted evidence: `docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md` (does not rerun the
+entire resilience scenario).

--- a/docs/qa/scenarios/MS-configure-window-manager.md
+++ b/docs/qa/scenarios/MS-configure-window-manager.md
@@ -28,6 +28,10 @@ daemon's next action and warnings; HTTP 200 alone is not live-apply evidence. Wh
 succeeds but application fails, retry must reapply the pending layout rather than skip it as an
 unchanged file, and Discard must retain the canonical saved baseline. Edit shortcuts while a
 behavior draft is open and verify saving that draft preserves the latest shortcut maps and aliases.
+For immediate shortcut, global-hotkey and alias edits, verify the saved section remains canonical
+after application failure, no failure is announced as an applied success, and warnings plus
+restart/new-session actions remain visible. Switch workspace during a pending edit and confirm
+the result stays with its original scope.
 The targeted run is tracked in `docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md`.
 
 qa-impact: 2026-07-22 replaced storage-limit settings with validated behavior defaults, shortcuts, bindings, gaps, snap thresholds, and declarative layout editing; 2026-07-24 added `window_manager.swap_modifier` (default `shift`) across config.toml, settings PATCH, Settings UI, and web gesture resolution; 2026-07-24 rebuilt Settings › Layouts as a direct-manipulation surface (canvas + inspector + docked review gate, diagram choice cards, gap box, snap map, repeat-width track, chord recorder, saved-layout cards) and added the `compozy layout-profile` CLI verbs. Flag only; the next QA cycle owns live retesting.

--- a/docs/qa/scenarios/MS-configure-window-manager.md
+++ b/docs/qa/scenarios/MS-configure-window-manager.md
@@ -51,3 +51,7 @@ live window-manager config contract. Reset for the window-tabs targeted cycle.
 the daemon serves defaults and the effective map. Reset for the Herdr parity QA tail.
 
 QA 2026-08-16 Herdr parity: The full Web E2E, daemon settings contract suites, and inspected visual bundles covered editable shortcuts, array/range persistence, blocked and shadowed diagnostics, Terminal preset preview/apply/revert, live cheatsheet freshness, and editable-context routing.
+
+A binding receipt that reports saved settings without confirmed application (`applied: false`,
+`next_action: none`) must show its warnings with the retry error, including when no partial-failure
+diagnostic is supplied.

--- a/docs/qa/scenarios/MS-configure-window-manager.md
+++ b/docs/qa/scenarios/MS-configure-window-manager.md
@@ -24,7 +24,9 @@ story: As a person running agent work, I can tune window behavior and layouts wi
 then reload and inspect tiled layout geometry. Repeat a save, interrupt the settings request, and
 verify the original draft remains retryable without another edit. Editing or discarding after a
 failure must clear the old error. HTTP/application rejection must remain visible, including the
-daemon's next action and warnings; HTTP 200 alone is not live-apply evidence. Edit shortcuts while a
+daemon's next action and warnings; HTTP 200 alone is not live-apply evidence. When persistence
+succeeds but application fails, retry must reapply the pending layout rather than skip it as an
+unchanged file, and Discard must retain the canonical saved baseline. Edit shortcuts while a
 behavior draft is open and verify saving that draft preserves the latest shortcut maps and aliases.
 The targeted run is tracked in `docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md`.
 

--- a/docs/qa/scenarios/MS-configure-window-manager.md
+++ b/docs/qa/scenarios/MS-configure-window-manager.md
@@ -18,6 +18,16 @@ overlaps: ET-window-manager-layout-recovery; ET-window-manager-layout-gestures
 
 story: As a person running agent work, I can tune window behavior and layouts without accepting a partial or internally conflicting runtime configuration.
 
+## Save recovery and application receipts
+
+2026-09-10, issue #593: verify zero inner spacing, zero outer insets, and all-zero gaps independently,
+then reload and inspect tiled layout geometry. Repeat a save, interrupt the settings request, and
+verify the original draft remains retryable without another edit. Editing or discarding after a
+failure must clear the old error. HTTP/application rejection must remain visible, including the
+daemon's next action and warnings; HTTP 200 alone is not live-apply evidence. Edit shortcuts while a
+behavior draft is open and verify saving that draft preserves the latest shortcut maps and aliases.
+The targeted run is tracked in `docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md`.
+
 qa-impact: 2026-07-22 replaced storage-limit settings with validated behavior defaults, shortcuts, bindings, gaps, snap thresholds, and declarative layout editing; 2026-07-24 added `window_manager.swap_modifier` (default `shift`) across config.toml, settings PATCH, Settings UI, and web gesture resolution; 2026-07-24 rebuilt Settings › Layouts as a direct-manipulation surface (canvas + inspector + docked review gate, diagram choice cards, gap box, snap map, repeat-width track, chord recorder, saved-layout cards) and added the `compozy layout-profile` CLI verbs. Flag only; the next QA cycle owns live retesting.
 
 QA impact 2026-07-25 (deep-review remediation): ratio-track controls now keep stable semantic

--- a/internal/api/contract/settings_window_manager.go
+++ b/internal/api/contract/settings_window_manager.go
@@ -98,11 +98,12 @@ type SettingsWindowManagerBindingPayload struct {
 }
 
 type UpdateSettingsWindowManagerRequest struct {
-	Config          *SettingsWindowManagerConfigPayload       `json:"config,omitempty"`
-	Shortcuts       *map[string]windowmanager.ShortcutBinding `json:"shortcuts,omitempty"`
-	Aliases         *map[string]string                        `json:"aliases,omitempty"`
-	GlobalShortcuts *map[string]string                        `json:"global_shortcuts,omitempty"`
-	Overwrite       bool                                      `json:"overwrite,omitempty"`
+	PreserveShortcuts bool                                      `json:"preserve_shortcuts,omitzero"`
+	Config            *SettingsWindowManagerConfigPayload       `json:"config,omitempty"`
+	Shortcuts         *map[string]windowmanager.ShortcutBinding `json:"shortcuts,omitempty"`
+	Aliases           *map[string]string                        `json:"aliases,omitempty"`
+	GlobalShortcuts   *map[string]string                        `json:"global_shortcuts,omitempty"`
+	Overwrite         bool                                      `json:"overwrite,omitempty"`
 }
 
 type SettingsWindowManagerResponse struct {
@@ -160,4 +161,10 @@ type SettingsWindowManagerMutationError struct {
 	Chord   string `json:"chord,omitempty"`
 	Alias   string `json:"alias,omitempty"`
 	Message string `json:"message,omitempty"`
+}
+
+// SettingsWindowManagerMutationResponse preserves the section echo alongside live apply truth.
+type SettingsWindowManagerMutationResponse struct {
+	SettingsWindowManagerResponse
+	Apply SettingsApplyResponse `json:"apply"`
 }

--- a/internal/api/core/settings.go
+++ b/internal/api/core/settings.go
@@ -163,7 +163,24 @@ func (h *BaseHandlers) UpdateSettingsWindowManager(c *gin.Context) {
 		h.respondError(c, StatusForSettingsError(err), err)
 		return
 	}
-	h.updateSettingsSectionEcho(c, req, h.respondWindowManagerMutationError)
+	result, ok := h.applySettingsSection(c, req, h.respondWindowManagerMutationError)
+	if !ok {
+		return
+	}
+	envelope, err := h.Settings.GetSection(c.Request.Context(), req.SectionRequest)
+	if err != nil {
+		h.respondError(c, StatusForSettingsError(err), err)
+		return
+	}
+	section, err := settingsWindowManagerSectionResponse(envelope)
+	if err != nil {
+		h.respondError(c, http.StatusInternalServerError, err)
+		return
+	}
+	c.JSON(http.StatusOK, contract.SettingsWindowManagerMutationResponse{
+		SettingsWindowManagerResponse: section,
+		Apply:                         SettingsApplyResponseFromResult(result),
+	})
 }
 
 // GetSettingsCmdPalette returns the command-palette settings section.

--- a/internal/api/core/settings.go
+++ b/internal/api/core/settings.go
@@ -156,7 +156,7 @@ func (h *BaseHandlers) GetSettingsWindowManager(c *gin.Context) {
 	h.getSettingsSection(c, settingspkg.SectionWindowManager)
 }
 
-// UpdateSettingsWindowManager persists the window-manager settings section.
+// UpdateSettingsWindowManager returns canonical persisted settings and their separate apply receipt.
 func (h *BaseHandlers) UpdateSettingsWindowManager(c *gin.Context) {
 	req, err := parseUpdateSettingsWindowManagerRequest(c)
 	if err != nil {

--- a/internal/api/core/settings_section_requests.go
+++ b/internal/api/core/settings_section_requests.go
@@ -330,12 +330,13 @@ func parseUpdateSettingsWindowManagerRequest(c *gin.Context) (settingspkg.Sectio
 		config = &parsed
 	}
 	return settingspkg.SectionUpdateRequest{
-		SectionRequest:               req,
-		WindowManager:                config,
-		WindowManagerShortcuts:       body.Shortcuts,
-		WindowManagerGlobalShortcuts: body.GlobalShortcuts,
-		WindowManagerAliases:         body.Aliases,
-		Overwrite:                    body.Overwrite,
+		SectionRequest:                 req,
+		WindowManager:                  config,
+		WindowManagerPreserveShortcuts: body.PreserveShortcuts,
+		WindowManagerShortcuts:         body.Shortcuts,
+		WindowManagerGlobalShortcuts:   body.GlobalShortcuts,
+		WindowManagerAliases:           body.Aliases,
+		Overwrite:                      body.Overwrite,
 	}, nil
 }
 

--- a/internal/api/core/settings_section_requests.go
+++ b/internal/api/core/settings_section_requests.go
@@ -305,6 +305,7 @@ func parseUpdateSettingsNetworkRequest(c *gin.Context) (settingspkg.SectionUpdat
 	return settingspkg.SectionUpdateRequest{SectionRequest: req, Network: &config}, nil
 }
 
+// parseUpdateSettingsWindowManagerRequest decodes the scope and preserves the opt-in shortcut merge policy.
 func parseUpdateSettingsWindowManagerRequest(c *gin.Context) (settingspkg.SectionUpdateRequest, error) {
 	var body contract.UpdateSettingsWindowManagerRequest
 	if err := decodeStrictJSONBody(c, &body); err != nil {

--- a/internal/api/core/settings_test.go
+++ b/internal/api/core/settings_test.go
@@ -2653,6 +2653,52 @@ func TestUpdateSettingsMemoryRejectsUnavailableProvider(t *testing.T) {
 func TestUpdateSettingsSectionHandlersDelegateValidPayloads(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should echo the window-manager section with its failed apply receipt", func(t *testing.T) {
+		t.Parallel()
+		service := &stubSettingsService{
+			ApplySectionFn: func(_ context.Context, req settingspkg.SectionUpdateRequest) (settingspkg.ApplyResult, error) {
+				if !req.WindowManagerPreserveShortcuts || req.WindowManager.Gaps.Inner != 0 {
+					t.Fatalf("request lost preservation or zero gap: %#v", req)
+				}
+				return settingspkg.ApplyResult{
+					Section: settingspkg.SectionWindowManager, Scope: settingspkg.ScopeUser,
+					Record:     settingspkg.ApplyRecord{ID: "apply-layout", Generation: 7, Lifecycle: lifecycle.Live},
+					NextAction: lifecycle.NextActionRetry, Warnings: []string{"Runtime unavailable"},
+				}, nil
+			},
+			GetSectionFn: func(_ context.Context, req settingspkg.SectionRequest) (settingspkg.SectionEnvelope, error) {
+				return settingspkg.SectionEnvelope{
+					Section:         req.Section,
+					Scope:           settingspkg.ScopeUser,
+					AvailableScopes: []settingspkg.ScopeKind{settingspkg.ScopeUser, settingspkg.ScopeWorkspace},
+					WindowManager: &settingspkg.WindowManagerSection{
+						Config: compozyconfig.DefaultWindowManagerConfig(),
+					},
+				}, nil
+			},
+		}
+		for _, transport := range []string{"api-core-http", "api-core-uds"} {
+			fixture := newSettingsHandlerFixture(t, transport, service, nil)
+			config := validSettingsWindowManagerConfigPayload()
+			config.Gaps.Inner = 0
+			response := performRequest(t, fixture.Engine, http.MethodPatch, "/api/settings/window-manager",
+				mustJSON(t, contract.UpdateSettingsWindowManagerRequest{Config: &config, PreserveShortcuts: true}))
+			if response.Code != http.StatusOK {
+				t.Fatalf("status = %d: %s", response.Code, response.Body.String())
+			}
+			var result contract.SettingsWindowManagerMutationResponse
+			decodeJSON(t, response.Body.Bytes(), &result)
+			if result.Section != contract.SettingsSectionName(settingspkg.SectionWindowManager) ||
+				result.Config.HistoryLimit == 0 ||
+				result.Apply.Applied ||
+				result.Apply.ApplyRecordID != "apply-layout" ||
+				result.Apply.NextAction != contract.SettingsApplyNextActionRetry ||
+				len(result.Apply.Warnings) != 1 {
+				t.Fatalf("mutation response lost section or receipt: %#v", result)
+			}
+		}
+	})
+
 	memoryPayload := validSettingsMemoryConfigPayload()
 	memoryPayload.GlobalDir = "/tmp/memory"
 	memoryPayload.Dream.MinHours = 1.5

--- a/internal/api/core/settings_test.go
+++ b/internal/api/core/settings_test.go
@@ -2650,6 +2650,7 @@ func TestUpdateSettingsMemoryRejectsUnavailableProvider(t *testing.T) {
 	})
 }
 
+// TestUpdateSettingsSectionHandlersDelegateValidPayloads verifies decoded writes and echoed application outcomes.
 func TestUpdateSettingsSectionHandlersDelegateValidPayloads(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/core/settings_window_manager_payload.go
+++ b/internal/api/core/settings_window_manager_payload.go
@@ -12,6 +12,7 @@ import (
 	"github.com/compozy/compozy/internal/windowmanager"
 )
 
+// settingsWindowManagerSectionResponse projects the canonical section without discarding required zero-valued settings.
 func settingsWindowManagerSectionResponse(
 	envelope settingspkg.SectionEnvelope,
 ) (contract.SettingsWindowManagerResponse, error) {

--- a/internal/api/core/settings_window_manager_payload.go
+++ b/internal/api/core/settings_window_manager_payload.go
@@ -14,9 +14,9 @@ import (
 
 func settingsWindowManagerSectionResponse(
 	envelope settingspkg.SectionEnvelope,
-) (any, error) {
+) (contract.SettingsWindowManagerResponse, error) {
 	if envelope.WindowManager == nil {
-		return nil, errors.New("settings window-manager section is required")
+		return contract.SettingsWindowManagerResponse{}, errors.New("settings window-manager section is required")
 	}
 	effective := envelope.WindowManager.EffectiveShortcuts
 	diagnostics := envelope.WindowManager.Diagnostics
@@ -26,7 +26,10 @@ func settingsWindowManagerSectionResponse(
 			windowmanager.DefaultBindableIDs(),
 		)
 		if err != nil {
-			return nil, fmt.Errorf("settings window-manager shortcuts are invalid: %w", err)
+			return contract.SettingsWindowManagerResponse{}, fmt.Errorf(
+				"settings window-manager shortcuts are invalid: %w",
+				err,
+			)
 		}
 		effective = resolved
 		diagnostics = storedDiagnostics

--- a/internal/api/spec/registry_settings_window_manager.go
+++ b/internal/api/spec/registry_settings_window_manager.go
@@ -37,7 +37,7 @@ func updateSettingsWindowManagerOperationSpec() OperationSpec {
 		},
 		RequestBody: contract.UpdateSettingsWindowManagerRequest{},
 		Responses: []ResponseSpec{
-			{Status: 200, Description: "OK", Body: contract.SettingsWindowManagerResponse{}},
+			{Status: 200, Description: "OK", Body: contract.SettingsWindowManagerMutationResponse{}},
 			{Status: 400, Description: specInvalidSettingsPayloadDescription, Body: contract.ErrorPayload{}},
 			{Status: 403, Description: specForbiddenDescription, Body: contract.ErrorPayload{}},
 			{Status: 404, Description: specWorkspaceNotFoundDescription, Body: contract.ErrorPayload{}},

--- a/internal/api/spec/registry_settings_window_manager.go
+++ b/internal/api/spec/registry_settings_window_manager.go
@@ -23,6 +23,7 @@ func getSettingsWindowManagerOperationSpec() OperationSpec {
 	}
 }
 
+// updateSettingsWindowManagerOperationSpec declares the additive section-and-apply mutation response.
 func updateSettingsWindowManagerOperationSpec() OperationSpec {
 	return OperationSpec{
 		Method:      httpMethodPatch,

--- a/internal/settings/config_apply_service_test.go
+++ b/internal/settings/config_apply_service_test.go
@@ -2316,6 +2316,86 @@ func TestConfigApplyServiceReloadUsesBootedConfigAsActiveState(t *testing.T) {
 func TestConfigApplyServiceRecordsRuntimeReconcileFailures(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should retry a persisted layout without applying unrelated pending config", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		homePaths := testHomePaths(t)
+		writeFile(t, homePaths.ConfigFile, baseSettingsConfig())
+		db, err := globaldb.OpenGlobalDB(ctx, homePaths.DatabaseFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := db.Close(context.Background()); err != nil {
+				t.Error(err)
+			}
+		})
+		applier := &fakeConfigRuntimeApplier{failures: []ApplyFailure{{
+			Subsystem: "window-manager",
+			Diagnostic: diagnostics.NewItem(diagnostics.ItemSpec{
+				ID: "config.apply.layout_failure", Code: diagnosticcontract.CodeConfigPartialFailure,
+				Category: diagnosticcontract.CategoryConfig, Title: "Layout apply failed",
+				Message: "Runtime unavailable", Severity: diagnosticcontract.SeverityError,
+				DataFreshness: diagnosticcontract.FreshnessLive,
+			}),
+		}}}
+		service := testService(t, homePaths, Dependencies{
+			ApplyRecords: NewConfigApplyRecordRepository(db.DB(), nil), RuntimeApplier: applier,
+		})
+		cfg, err := compozyconfig.LoadForHome(homePaths)
+		if err != nil {
+			t.Fatal(err)
+		}
+		desired := cfg.WindowManager
+		desired.Gaps.Inner = 0
+		request := SectionUpdateRequest{SectionRequest: SectionRequest{Section: SectionWindowManager},
+			WindowManager: &desired, WindowManagerPreserveShortcuts: true}
+		failed, err := service.ApplySection(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if failed.Applied || failed.NextAction != lifecycle.NextActionRetry || applier.calls != 1 {
+			t.Fatalf("failed layout apply = %#v, calls = %d", failed, applier.calls)
+		}
+		persisted, err := compozyconfig.LoadForHome(homePaths)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if persisted.WindowManager.Gaps.Inner != 0 {
+			t.Fatal("failed runtime apply lost persisted zero")
+		}
+		general := generalSettingsFromConfig(&persisted)
+		general.HTTP.Port++
+		if _, err := service.UpdateSection(ctx, SectionUpdateRequest{
+			SectionRequest: SectionRequest{Section: SectionGeneral}, General: &general,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		applier.failures = nil
+		retried, err := service.ApplySection(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !retried.Applied || retried.Skipped || applier.calls != 2 {
+			t.Fatalf("retry skipped pending runtime apply: %#v, calls = %d", retried, applier.calls)
+		}
+		active := applier.snapshots[1]
+		if active.WindowManager.Gaps.Inner != 0 || active.HTTP.Port != cfg.HTTP.Port {
+			t.Fatalf(
+				"retry applied the wrong projection: gaps=%#v port=%d",
+				active.WindowManager.Gaps,
+				active.HTTP.Port,
+			)
+		}
+		repeated, err := service.ApplySection(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !repeated.Skipped || applier.calls != 2 || repeated.Record.Generation != retried.Record.Generation {
+			t.Fatalf("unchanged active layout reapplied: %#v, calls = %d", repeated, applier.calls)
+		}
+	})
+
 	t.Run("Should fail apply record without advancing generation when runtime reconcile fails", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/settings/config_apply_service_test.go
+++ b/internal/settings/config_apply_service_test.go
@@ -2313,6 +2313,8 @@ func TestConfigApplyServiceReloadUsesBootedConfigAsActiveState(t *testing.T) {
 	})
 }
 
+// TestConfigApplyServiceRecordsRuntimeReconcileFailures preserves failure receipts
+// and retries only pending projections.
 func TestConfigApplyServiceRecordsRuntimeReconcileFailures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/settings/models.go
+++ b/internal/settings/models.go
@@ -216,6 +216,7 @@ type SectionUpdateRequest struct {
 	Network                        *compozyconfig.NetworkConfig
 	Gateway                        *compozyconfig.GatewayConfig
 	WindowManager                  *compozyconfig.WindowManagerConfig
+	WindowManagerPreserveShortcuts bool
 	WindowManagerShortcuts         *map[string]windowmanager.ShortcutBinding
 	WindowManagerGlobalShortcuts   *map[string]string
 	WindowManagerAliases           *map[string]string

--- a/internal/settings/provider_model_active_config.go
+++ b/internal/settings/provider_model_active_config.go
@@ -41,6 +41,7 @@ func (s *service) recordProviderModelsMutationApply(
 	)
 }
 
+// recordProjectedMutationApply records and applies only the selected active projection, retrying pending layout application.
 func (s *service) recordProjectedMutationApply(
 	ctx context.Context,
 	result MutationResult,

--- a/internal/settings/provider_model_active_config.go
+++ b/internal/settings/provider_model_active_config.go
@@ -41,7 +41,8 @@ func (s *service) recordProviderModelsMutationApply(
 	)
 }
 
-// recordProjectedMutationApply records and applies only the selected active projection, retrying pending layout application.
+// recordProjectedMutationApply records and applies only the selected active projection,
+// retrying pending layout application.
 func (s *service) recordProjectedMutationApply(
 	ctx context.Context,
 	result MutationResult,

--- a/internal/settings/provider_model_active_config.go
+++ b/internal/settings/provider_model_active_config.go
@@ -56,6 +56,10 @@ func (s *service) recordProjectedMutationApply(
 	ctx = correlatedCtx
 	configLifecycle := mutationLifecycle(result)
 	noChanges := mutationResultHasNoChanges(result)
+	// A Layouts retry must compare its scoped active projection, not only the file diff.
+	if result.Section == SectionWindowManager && result.Scope == ScopeUser {
+		noChanges = noChanges && nextActiveHash == state.hash
+	}
 	record, plan, err := s.persistRuntimeApply(
 		ctx,
 		state,

--- a/internal/settings/section_window_manager_update.go
+++ b/internal/settings/section_window_manager_update.go
@@ -56,6 +56,12 @@ func (s *service) updateWindowManagerSection(
 	if err != nil {
 		return MutationResult{}, err
 	}
+	// Capture the active baseline before the first write, including a cold-service Save.
+	if loaded.scope == ScopeUser {
+		if _, err := s.ensureActiveConfigState(ctx); err != nil {
+			return MutationResult{}, err
+		}
+	}
 	result, err := s.updateScopedConfigSection(
 		req.Section,
 		changed,

--- a/internal/settings/section_window_manager_update.go
+++ b/internal/settings/section_window_manager_update.go
@@ -7,6 +7,7 @@ import (
 	compozyconfig "github.com/compozy/compozy/internal/config"
 )
 
+// updateWindowManagerSection validates and persists window-manager settings against the pre-write active baseline.
 func (s *service) updateWindowManagerSection(
 	ctx context.Context,
 	req SectionUpdateRequest,

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -813,6 +813,7 @@ func TestUpdateSectionGeneralReturnsRestartRequired(t *testing.T) {
 	}
 }
 
+// TestUpdateSectionWindowManager verifies scoped persistence, shortcut preservation, and runtime application.
 func TestUpdateSectionWindowManager(t *testing.T) {
 	t.Parallel()
 

--- a/internal/settings/service_test.go
+++ b/internal/settings/service_test.go
@@ -816,6 +816,52 @@ func TestUpdateSectionGeneralReturnsRestartRequired(t *testing.T) {
 func TestUpdateSectionWindowManager(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should preserve current shortcuts when saving stale behavior with zero gaps", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		homePaths := testHomePaths(t)
+		writeFile(t, homePaths.ConfigFile, baseSettingsConfig())
+		service := testService(t, homePaths, Dependencies{})
+		stale := testWindowManagerConfig()
+		shortcuts := map[string]windowmanager.ShortcutBinding{"window.close": {"meta+shift+KeyW"}}
+		globals := map[string]string{windowmanager.DefaultGlobalSummonCommandID: "meta+shift+Space"}
+		aliases := map[string]string{"session.new": "start"}
+		if _, err := service.UpdateSection(ctx, SectionUpdateRequest{
+			SectionRequest:               SectionRequest{Section: SectionWindowManager},
+			WindowManagerShortcuts:       &shortcuts,
+			WindowManagerGlobalShortcuts: &globals,
+			WindowManagerAliases:         &aliases,
+		}); err != nil {
+			t.Fatalf("update shortcuts: %v", err)
+		}
+		stale.Gaps = compozyconfig.WindowManagerGapsConfig{}
+		for range 2 {
+			if _, err := service.UpdateSection(ctx, SectionUpdateRequest{
+				SectionRequest:                 SectionRequest{Section: SectionWindowManager},
+				WindowManager:                  &stale,
+				WindowManagerPreserveShortcuts: true,
+			}); err != nil {
+				t.Fatalf("save behavior: %v", err)
+			}
+		}
+		loaded, err := compozyconfig.LoadForHome(homePaths)
+		if err != nil {
+			t.Fatalf("reload config: %v", err)
+		}
+		if loaded.WindowManager.Gaps != (compozyconfig.WindowManagerGapsConfig{}) {
+			t.Fatalf("gaps = %#v, want all zeros", loaded.WindowManager.Gaps)
+		}
+		if !reflect.DeepEqual(loaded.WindowManager.Shortcuts, shortcuts) ||
+			!reflect.DeepEqual(loaded.WindowManager.GlobalShortcuts, globals) ||
+			!reflect.DeepEqual(loaded.CmdPalette.Aliases, aliases) {
+			t.Fatalf(
+				"behavior save replaced shortcut state: %#v, aliases %#v",
+				loaded.WindowManager,
+				loaded.CmdPalette.Aliases,
+			)
+		}
+	})
+
 	t.Run("Should round-trip the complete validated global config", func(t *testing.T) {
 		t.Parallel()
 
@@ -824,6 +870,8 @@ func TestUpdateSectionWindowManager(t *testing.T) {
 		writeFile(t, homePaths.ConfigFile, baseSettingsConfig())
 		service := testService(t, homePaths, Dependencies{})
 		desired := testWindowManagerConfig()
+		desired.Gaps.Inner = 0
+		desired.GlobalShortcuts = map[string]string{windowmanager.DefaultGlobalSummonCommandID: "meta+shift+Space"}
 
 		result, err := service.UpdateSection(ctx, SectionUpdateRequest{
 			SectionRequest: SectionRequest{Section: SectionWindowManager},

--- a/internal/settings/window_manager_request.go
+++ b/internal/settings/window_manager_request.go
@@ -20,6 +20,10 @@ func mergeWindowManagerRequest(
 	desired := cloneWindowManagerConfig(current)
 	if req.WindowManager != nil {
 		desired = cloneWindowManagerConfig(*req.WindowManager)
+		if req.WindowManagerPreserveShortcuts {
+			desired.Shortcuts = windowmanager.CloneShortcutMap(current.Shortcuts)
+			desired.GlobalShortcuts = windowmanager.CloneGlobalShortcutMap(current.GlobalShortcuts)
+		}
 	}
 	if req.WindowManagerShortcuts != nil {
 		desired.Shortcuts = windowmanager.CloneShortcutMap(*req.WindowManagerShortcuts)

--- a/internal/settings/window_manager_request.go
+++ b/internal/settings/window_manager_request.go
@@ -12,6 +12,7 @@ func hasWindowManagerMutation(req SectionUpdateRequest) bool {
 		req.WindowManagerAliases != nil
 }
 
+// mergeWindowManagerRequest merges behavior with current shortcut maps when preservation is requested.
 func mergeWindowManagerRequest(
 	current compozyconfig.WindowManagerConfig,
 	aliases map[string]string,

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -174796,6 +174796,9 @@
                   "overwrite": {
                     "type": "boolean"
                   },
+                  "preserve_shortcuts": {
+                    "type": "boolean"
+                  },
                   "shortcuts": {
                     "additionalProperties": {
                       "items": {
@@ -174822,12 +174825,187 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": false,
                   "properties": {
                     "aliases": {
                       "additionalProperties": {
                         "type": "string"
                       },
+                      "type": "object"
+                    },
+                    "apply": {
+                      "properties": {
+                        "active_config_hash": {
+                          "type": "string"
+                        },
+                        "active_generation": {
+                          "format": "int64",
+                          "type": "integer"
+                        },
+                        "agent_name": {
+                          "type": "string"
+                        },
+                        "applied": {
+                          "type": "boolean"
+                        },
+                        "apply_record_id": {
+                          "type": "string"
+                        },
+                        "lifecycle": {
+                          "enum": [
+                            "live",
+                            "live-add",
+                            "live-remove-if-unused",
+                            "restart-required",
+                            "session-rebind"
+                          ],
+                          "type": "string"
+                        },
+                        "next_action": {
+                          "enum": [
+                            "none",
+                            "restart-daemon",
+                            "new-session",
+                            "retry"
+                          ],
+                          "type": "string"
+                        },
+                        "partial_failures": {
+                          "items": {
+                            "properties": {
+                              "diagnostic": {
+                                "properties": {
+                                  "category": {
+                                    "type": "string"
+                                  },
+                                  "code": {
+                                    "type": "string"
+                                  },
+                                  "data_freshness": {
+                                    "type": "string"
+                                  },
+                                  "doc_url": {
+                                    "type": "string"
+                                  },
+                                  "evidence": {
+                                    "additionalProperties": {},
+                                    "type": "object"
+                                  },
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "severity": {
+                                    "type": "string"
+                                  },
+                                  "suggested_command": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "category",
+                                  "code",
+                                  "data_freshness",
+                                  "id",
+                                  "message",
+                                  "severity",
+                                  "title"
+                                ],
+                                "type": "object"
+                              },
+                              "subsystem": {
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "diagnostic",
+                              "subsystem"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        "profile": {
+                          "type": "string"
+                        },
+                        "restart_required": {
+                          "type": "boolean"
+                        },
+                        "restart_scope": {
+                          "type": "string"
+                        },
+                        "scope": {
+                          "enum": [
+                            "user",
+                            "profile",
+                            "workspace",
+                            "agent"
+                          ],
+                          "type": "string"
+                        },
+                        "section": {
+                          "enum": [
+                            "general",
+                            "persona",
+                            "memory",
+                            "roles",
+                            "skills",
+                            "automation",
+                            "network",
+                            "window-manager",
+                            "cmd-palette",
+                            "attention",
+                            "shell",
+                            "observability",
+                            "hooks-extensions",
+                            "providers",
+                            "mcp-servers",
+                            "sandboxes",
+                            "hooks"
+                          ],
+                          "type": "string"
+                        },
+                        "skipped": {
+                          "type": "boolean"
+                        },
+                        "skipped_reason": {
+                          "type": "string"
+                        },
+                        "warnings": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "workspace_id": {
+                          "type": "string"
+                        },
+                        "write_target": {
+                          "enum": [
+                            "global-config",
+                            "profile-config",
+                            "workspace-config",
+                            "global-mcp-sidecar",
+                            "profile-mcp-sidecar",
+                            "workspace-mcp-sidecar",
+                            "global-agent-file",
+                            "workspace-agent-file"
+                          ],
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "active_config_hash",
+                        "active_generation",
+                        "applied",
+                        "apply_record_id",
+                        "lifecycle",
+                        "next_action"
+                      ],
                       "type": "object"
                     },
                     "available_scopes": {
@@ -175203,6 +175381,7 @@
                   },
                   "required": [
                     "aliases",
+                    "apply",
                     "available_scopes",
                     "commands",
                     "config",

--- a/packages/site/content/docs/workspaces/window-management.mdx
+++ b/packages/site/content/docs/workspaces/window-management.mdx
@@ -98,7 +98,9 @@ on demand.
 
 Settings → Layouts accepts zero for the gap between tiles and for each outer inset independently.
 A failed Save keeps your draft and offers retry or discard. The save result distinguishes applied
-settings from saved settings that still need an action, and displays application warnings.
+settings from saved settings that still need an action, and displays application warnings. If a save
+reaches disk but application fails, retry applies the pending layout; discard keeps the configuration
+already saved on disk.
 
 `PATCH /api/settings/window-manager` retains the section fields and adds an `apply` receipt with
 `applied`, `next_action`, `warnings`, and `partial_failures`. A successful HTTP response does not by

--- a/packages/site/content/docs/workspaces/window-management.mdx
+++ b/packages/site/content/docs/workspaces/window-management.mdx
@@ -96,6 +96,18 @@ on demand.
 
 ## Declarative layouts and recovery
 
+Settings → Layouts accepts zero for the gap between tiles and for each outer inset independently.
+A failed Save keeps your draft and offers retry or discard. The save result distinguishes applied
+settings from saved settings that still need an action, and displays application warnings.
+
+`PATCH /api/settings/window-manager` retains the section fields and adds an `apply` receipt with
+`applied`, `next_action`, `warnings`, and `partial_failures`. A successful HTTP response does not by
+itself mean the configuration became active. Send `preserve_shortcuts: true` with a behavior-only
+`config` to preserve the current shortcut and global-hotkey maps atomically. Explicit top-level
+`shortcuts` or `global_shortcuts` still replace those maps; omitting the flag retains full-config
+replacement behavior. Settings uses preservation so an open spacing draft cannot overwrite a
+separately edited shortcut.
+
 Semantic commands are the normal control surface. A validated layout document is the raw recovery
 escape hatch:
 

--- a/skills/compozy/references/window-management.md
+++ b/skills/compozy/references/window-management.md
@@ -342,6 +342,13 @@ Use `GET/PATCH /api/settings/window-manager` for the typed Settings surface. Edg
 `zoom`, `reserved`, or `none`; any/landscape/portrait profiles are `window_layout` resources.
 Workspace layout documents may carry typed overrides without changing other workspaces.
 
+The Settings PATCH preserves its section echo and adds `apply`, the daemon's application receipt.
+Inspect `apply.applied`, `next_action`, `warnings`, and `partial_failures`; HTTP success alone does
+not prove live application. For a behavior-only `config` save, pass `preserve_shortcuts: true` to
+retain the current local and global shortcut maps atomically. Explicit top-level shortcut maps still
+replace their respective maps. Omitting the flag retains full-config replacement semantics.
+Zero is valid for every gap: `inner` controls spacing between tiles; the other four values are insets.
+
 Shortcut values are one chord string or an array; `""` and `[]` disable an action. Indexed family
 keys accept ranges: `desktop.switch = "control+Digit1..9"` and
 `window.tab.jump = "control+alt+Digit1..8"`. The daemon expands ranges and validates defaults plus

--- a/skills/compozy/references/window-management.md
+++ b/skills/compozy/references/window-management.md
@@ -344,7 +344,8 @@ Workspace layout documents may carry typed overrides without changing other work
 
 The Settings PATCH preserves its section echo and adds `apply`, the daemon's application receipt.
 Inspect `apply.applied`, `next_action`, `warnings`, and `partial_failures`; HTTP success alone does
-not prove live application. For a behavior-only `config` save, pass `preserve_shortcuts: true` to
+not prove live application. An unchanged file still retries a pending scoped live application;
+a global settings reload is not needed to retry a Layouts PATCH. For a behavior-only `config` save, pass `preserve_shortcuts: true` to
 retain the current local and global shortcut maps atomically. Explicit top-level shortcut maps still
 replace their respective maps. Omitting the flag retains full-config replacement semantics.
 Zero is valid for every gap: `inner` controls spacing between tiles; the other four values are insets.

--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -21,6 +21,7 @@ import { storybookSystemHandlerGroups, storybookSystemHandlers } from "@/storybo
 import { resetSettingsRestartStore } from "@/systems/settings/stores/use-settings-restart-store";
 import { clearActiveWorkspaceSelection } from "@/systems/workspace";
 import { sessionStore } from "@/systems/session/stores/session-store";
+import { resetWindowManagerSettingsMockState } from "@/systems/settings/mocks";
 import { resetAgentMockState } from "@/systems/agent/mocks";
 import { resetWindowManagerMockState } from "@/systems/os/mocks";
 
@@ -256,6 +257,7 @@ export function createStorybookRouter(
 
 export function resetStorybookAppState(initialEntry?: string) {
   resetAgentMockState();
+  resetWindowManagerSettingsMockState();
   resetWindowManagerMockState(initialEntry);
   clearActiveWorkspaceSelection();
   sessionStore.trigger.allDraftsDiscarded();

--- a/web/.storybook/preview.ts
+++ b/web/.storybook/preview.ts
@@ -255,6 +255,7 @@ export function createStorybookRouter(
   return createStubStorybookRouter(Story, options);
 }
 
+/** Reset daemon fixtures and client stores so stories cannot inherit another story’s edits. */
 export function resetStorybookAppState(initialEntry?: string) {
   resetAgentMockState();
   resetWindowManagerSettingsMockState();

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -71458,6 +71458,7 @@ export interface operations {
             [key: string]: string;
           } | null;
           overwrite?: boolean;
+          preserve_shortcuts?: boolean;
           shortcuts?: {
             [key: string]: string[] | string;
           } | null;
@@ -71474,6 +71475,78 @@ export interface operations {
           "application/json": {
             aliases: {
               [key: string]: string;
+            };
+            apply: {
+              active_config_hash: string;
+              /** Format: int64 */
+              active_generation: number;
+              agent_name?: string;
+              applied: boolean;
+              apply_record_id: string;
+              /** @enum {string} */
+              lifecycle:
+                | "live"
+                | "live-add"
+                | "live-remove-if-unused"
+                | "restart-required"
+                | "session-rebind";
+              /** @enum {string} */
+              next_action: "none" | "restart-daemon" | "new-session" | "retry";
+              partial_failures?: {
+                diagnostic: {
+                  category: string;
+                  code: string;
+                  data_freshness: string;
+                  doc_url?: string;
+                  evidence?: {
+                    [key: string]: unknown;
+                  };
+                  id: string;
+                  message: string;
+                  severity: string;
+                  suggested_command?: string;
+                  title: string;
+                };
+                subsystem: string;
+              }[];
+              profile?: string;
+              restart_required?: boolean;
+              restart_scope?: string;
+              /** @enum {string} */
+              scope?: "user" | "profile" | "workspace" | "agent";
+              /** @enum {string} */
+              section?:
+                | "general"
+                | "persona"
+                | "memory"
+                | "roles"
+                | "skills"
+                | "automation"
+                | "network"
+                | "window-manager"
+                | "cmd-palette"
+                | "attention"
+                | "shell"
+                | "observability"
+                | "hooks-extensions"
+                | "providers"
+                | "mcp-servers"
+                | "sandboxes"
+                | "hooks";
+              skipped?: boolean;
+              skipped_reason?: string;
+              warnings?: string[];
+              workspace_id?: string;
+              /** @enum {string} */
+              write_target?:
+                | "global-config"
+                | "profile-config"
+                | "workspace-config"
+                | "global-mcp-sidecar"
+                | "profile-mcp-sidecar"
+                | "workspace-mcp-sidecar"
+                | "global-agent-file"
+                | "workspace-agent-file";
             };
             available_scopes: ("user" | "workspace")[];
             commands: {

--- a/web/src/routes/_app/settings/-layouts-settings-page.tsx
+++ b/web/src/routes/_app/settings/-layouts-settings-page.tsx
@@ -13,6 +13,7 @@ import {
   useLayoutsSettingsData,
   useSettingsSaveBarState,
   useSettingsTopbar,
+  windowManagerApplyMessage,
   useWindowManagerConfigEditor,
   useWindowManagerKeyboardEditors,
   useWindowManagerLayoutEditor,
@@ -186,11 +187,22 @@ function LayoutsSettingsView({
     clientId
   );
   const saveBarState = useSettingsSaveBarState({
-    isDirty: configEditor.dirty,
+    isDirty: configEditor.dirty || configEditor.error !== null,
     isInvalid: configEditor.problems.length > 0,
     isSaving: configEditor.phase === "saving",
     error: configEditor.error instanceof Error ? configEditor.error.message : null,
-    warnings: configEditor.problems.map(problem => problem.message),
+    warnings: [
+      ...configEditor.problems.map(problem => problem.message),
+      ...(configEditor.result?.apply.warnings ?? []),
+      ...(configEditor.result &&
+      (configEditor.result.apply.next_action !== "none" ||
+        (!configEditor.result.apply.applied && !configEditor.result.apply.skipped))
+        ? [windowManagerApplyMessage(configEditor.result.apply)]
+        : []),
+    ],
+    lastAppliedLabel: configEditor.result
+      ? windowManagerApplyMessage(configEditor.result.apply)
+      : null,
   });
 
   return (

--- a/web/src/routes/_app/settings/-layouts-settings-page.tsx
+++ b/web/src/routes/_app/settings/-layouts-settings-page.tsx
@@ -3,7 +3,11 @@ import { useRef, type ReactNode } from "react";
 
 import { Button, Spinner } from "@compozy/ui";
 
-import type { WindowManagerConfig, WindowManagerSettingsSection } from "@/systems/os";
+import {
+  windowManagerApplyMessage,
+  type WindowManagerConfig,
+  type WindowManagerSettingsSection,
+} from "@/systems/os";
 import {
   LayoutProfileGrid,
   LayoutStage,
@@ -13,7 +17,6 @@ import {
   useLayoutsSettingsData,
   useSettingsSaveBarState,
   useSettingsTopbar,
-  windowManagerApplyMessage,
   useWindowManagerConfigEditor,
   useWindowManagerKeyboardEditors,
   useWindowManagerLayoutEditor,
@@ -181,7 +184,7 @@ function LayoutsSettingsView({
   const configEditor = useWindowManagerConfigEditor(config);
   // Keyboard state is daemon-owned and applies live, so it writes through its
   // own path rather than joining the page's draft (US-022.AC-3).
-  const { aliases, globalRecorder, recorder } = useWindowManagerKeyboardEditors(
+  const { aliases, globalRecorder, recorder, bindingApply } = useWindowManagerKeyboardEditors(
     section,
     workspaceId,
     clientId
@@ -237,6 +240,7 @@ function LayoutsSettingsView({
       )}
       <WindowManagerConfigEditor
         aliases={aliases}
+        bindingApply={bindingApply}
         editor={configEditor}
         focusCommandId={focusCommandId}
         globalRecorder={globalRecorder}

--- a/web/src/systems/os/adapters/window-manager-settings-api.ts
+++ b/web/src/systems/os/adapters/window-manager-settings-api.ts
@@ -12,6 +12,12 @@ import {
   parseSettingsWindowManagerSection,
   type WindowManagerSettingsSection,
 } from "../lib/window-manager-settings-section";
+import {
+  parseWindowManagerSettingsApply,
+  windowManagerApplyFailed,
+  windowManagerApplyMessage,
+  type WindowManagerSettingsApply,
+} from "../lib/window-manager-settings-result";
 import type {
   WindowManagerGlobalShortcutMap,
   WindowManagerShortcutMap,
@@ -118,6 +124,20 @@ export async function fetchWindowManagerSettings(
   return parseSettingsWindowManagerSection(requireResponseData(data, response, fallback));
 }
 
+/** Canonical saved bindings and their separate runtime application outcome. */
+export interface WindowManagerBindingsResult {
+  section: WindowManagerSettingsSection;
+  apply: WindowManagerSettingsApply;
+}
+
+/** Preserves the saved section when persistence succeeded but runtime application failed. */
+export class WindowManagerBindingsApplyError extends Error {
+  constructor(public readonly result: WindowManagerBindingsResult) {
+    super(windowManagerApplyMessage(result.apply));
+    this.name = "WindowManagerBindingsApplyError";
+  }
+}
+
 /**
  * Applies a whole desired map — the daemon replaces `shortcuts`/`aliases`
  * wholesale — and returns the section it produced, so callers never have to
@@ -126,7 +146,7 @@ export async function fetchWindowManagerSettings(
 export async function updateWindowManagerBindings(
   update: WindowManagerBindingUpdate,
   signal?: AbortSignal
-): Promise<WindowManagerSettingsSection> {
+): Promise<WindowManagerBindingsResult> {
   const { data, error, response } = await apiClient.PATCH("/api/settings/window-manager", {
     body: {
       shortcuts: shortcutsBody(update.shortcuts),
@@ -142,6 +162,11 @@ export async function updateWindowManagerBindings(
   if (apiRequestFailed(response, error)) {
     throw settingsError(response, error, fallback);
   }
-  const { apply: _apply, ...section } = requireResponseData(data, response, fallback);
-  return parseSettingsWindowManagerSection(section);
+  const { apply, ...section } = requireResponseData(data, response, fallback);
+  const result = {
+    section: parseSettingsWindowManagerSection(section),
+    apply: parseWindowManagerSettingsApply(apply),
+  };
+  if (windowManagerApplyFailed(result.apply)) throw new WindowManagerBindingsApplyError(result);
+  return result;
 }

--- a/web/src/systems/os/adapters/window-manager-settings-api.ts
+++ b/web/src/systems/os/adapters/window-manager-settings-api.ts
@@ -142,5 +142,6 @@ export async function updateWindowManagerBindings(
   if (apiRequestFailed(response, error)) {
     throw settingsError(response, error, fallback);
   }
-  return parseSettingsWindowManagerSection(requireResponseData(data, response, fallback));
+  const { apply: _apply, ...section } = requireResponseData(data, response, fallback);
+  return parseSettingsWindowManagerSection(section);
 }

--- a/web/src/systems/os/adapters/window-manager-settings-api.ts
+++ b/web/src/systems/os/adapters/window-manager-settings-api.ts
@@ -109,6 +109,7 @@ function settingsError(response: Response, error: unknown, fallback: string) {
   );
 }
 
+/** Load and validate canonical settings for the requesting workspace and shell client. */
 export async function fetchWindowManagerSettings(
   scope: WindowManagerSettingsScopeInput,
   signal?: AbortSignal

--- a/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
@@ -1,11 +1,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-// Suite: OS command palette root
+// Suite: OS command palette root and surface
 // Invariant: every row is a projection of the one client registry, entity rows
 // preserve the selected tab's identity, session landing goes through the shared
 // attention jump exactly once (BR-20), destination mode offers only navigable
 // targets, and a pushed view owns the surface completely — its own results, its
 // own filters, and a keyboard selection that survives the catalog moving.
-// Owning layer: palette root view-model and presentation boundary.
+// Owning layer: palette root/surface view-model and presentation boundary.
+// This canonical suite also owns automatic surface selection and action-panel
+// continuity; its shared registry/ranking setup exercises those hooks together.
 // Boundary OUT: the dispatch seam and client-op table (cmd-palette-dispatch),
 // availability evaluation (cmd-palette-availability), overlay lifetime
 // (use-desktop-overlays), stack and filter mechanics (palette-view-stack,

--- a/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
@@ -33,6 +33,7 @@ import type { LayoutDesktop } from "../../lib/window-manager-types";
 import type { OsAppId, OsDesktopRuntimeStore, OsWindow } from "../../lib/os-types";
 import { OsCommandPalette } from "../../components/os-command-palette";
 import type { CmdPaletteRunOptions } from "../use-cmd-palette-dispatch";
+import { useOsPaletteSurface } from "../use-os-palette-surface";
 import { useOsPaletteRoot } from "../use-os-palette-root";
 import {
   cmdPaletteExecutionStore,
@@ -1841,6 +1842,31 @@ describe("palette execution surfaces", () => {
   afterEach(() => {
     resetPaletteExecutionEntry();
     cmdPaletteExecutionStore.trigger.pendingSettled({ commandId: CAPTURE_COMMAND.id });
+  });
+
+  it("Should retain an automatically selected row and its actions when async ranking arrives", () => {
+    let registry: PaletteRegistry = { ...EXECUTION_REGISTRY, commands: [], byId: new Map() };
+    const { result, rerender } = renderHook(
+      () => useOsPaletteSurface({ open: true, onOpenChange: vi.fn(), dispatch: paletteDispatch }),
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <CmdPaletteRegistryProvider registry={registry}>{children}</CmdPaletteRegistryProvider>
+        ),
+      }
+    );
+    expect(result.current.selected).toBe("");
+    registry = EXECUTION_REGISTRY;
+    rerender();
+    const selected = result.current.selected;
+    expect(selected).not.toBe("");
+    expect(selected).not.toBe("settings.layouts");
+    act(() => result.current.execution.setPanelOpen(true));
+    expect(result.current.execution.panel.open).toBe(true);
+    paletteMocks.rankSignals = { ...TEST_RANK_SIGNALS, pins: ["settings.layouts"] };
+    rerender();
+    expect(result.current.values[0]).toBe("settings.layouts");
+    expect(result.current.selected).toBe(selected);
+    expect(result.current.execution.panel.open).toBe(true);
   });
 
   it("Should toggle the action panel on the selected row, filter it, and close it [UT-125]", async () => {

--- a/web/src/systems/os/hooks/use-os-palette-surface.ts
+++ b/web/src/systems/os/hooks/use-os-palette-surface.ts
@@ -64,6 +64,15 @@ export function useOsPaletteSurface({
   // The highlight survives the catalog moving underneath it, falling to the
   // nearest neighbour only when its own row leaves.
   const selected = resolveCommandSelection(selection.previous, values, selection.value);
+  // Remember automatic selection too, so asynchronous ranking cannot move it
+  // again after the catalog first arrives or the selected row disappears.
+  if (
+    selection.value !== selected ||
+    selection.previous.length !== values.length ||
+    selection.previous.some((value, index) => value !== values[index])
+  ) {
+    setSelection({ previous: values, value: selected });
+  }
   const execution = useOsPaletteExecution({
     open,
     registry: root.registry,

--- a/web/src/systems/os/index.ts
+++ b/web/src/systems/os/index.ts
@@ -32,6 +32,8 @@ export {
   fetchWindowManagerSettings,
   updateWindowManagerBindings,
   WindowManagerSettingsError,
+  WindowManagerBindingsApplyError,
+  type WindowManagerBindingsResult,
   type WindowManagerBindingUpdate,
   type WindowManagerMutationCode,
 } from "./adapters/window-manager-settings-api";
@@ -179,3 +181,10 @@ export {
   systemNotificationState,
   type SystemNotificationState,
 } from "./lib/system-notification-channel";
+
+export {
+  parseWindowManagerSettingsApply,
+  windowManagerApplyFailed,
+  windowManagerApplyMessage,
+  type WindowManagerSettingsApply,
+} from "./lib/window-manager-settings-result";

--- a/web/src/systems/os/lib/window-manager-settings-result.ts
+++ b/web/src/systems/os/lib/window-manager-settings-result.ts
@@ -29,10 +29,12 @@ const applySchema = z.object({
 
 export type WindowManagerSettingsApply = z.infer<typeof applySchema>;
 
+/** Validate the daemon receipt before any caller interprets HTTP success as live application. */
 export function parseWindowManagerSettingsApply(value: unknown): WindowManagerSettingsApply {
   return applySchema.parse(value);
 }
 
+/** Describe persisted state separately from application failure or a pending operator action. */
 export function windowManagerApplyMessage(result: WindowManagerSettingsApply): string {
   if (result.partial_failures?.length || result.next_action === "retry") {
     const details = [
@@ -56,6 +58,7 @@ export function windowManagerApplyMessage(result: WindowManagerSettingsApply): s
   return "Settings saved and applied.";
 }
 
+/** Identify failed or unverified live application while allowing explicit deferred actions. */
 export function windowManagerApplyFailed(result: WindowManagerSettingsApply): boolean {
   return (
     Boolean(result.partial_failures?.length) ||

--- a/web/src/systems/os/lib/window-manager-settings-result.ts
+++ b/web/src/systems/os/lib/window-manager-settings-result.ts
@@ -54,7 +54,10 @@ export function windowManagerApplyMessage(result: WindowManagerSettingsApply): s
   }
   if (result.next_action === "new-session") return "Settings saved. New sessions use this config.";
   if (result.skipped) return "No config changes detected.";
-  if (!result.applied) return "Settings saved, but not applied. Retry to apply.";
+  if (!result.applied) {
+    const details = result.warnings?.join(" · ");
+    return `Settings saved, but not applied. ${details ? `${details} ` : ""}Retry to apply.`;
+  }
   return "Settings saved and applied.";
 }
 

--- a/web/src/systems/settings/adapters/__tests__/window-manager-layouts-api.test.ts
+++ b/web/src/systems/settings/adapters/__tests__/window-manager-layouts-api.test.ts
@@ -1,3 +1,4 @@
+import { parseSettingsWindowManagerSection } from "@/systems/os";
 // Suite: window-manager Settings adapter
 // Invariant: the editor reads document + CAS revision from one authoritative snapshot, and
 // resource discovery returns the complete unbounded collection exposed by the daemon.
@@ -6,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { windowManagerSnapshotFixture } from "@/systems/os/mocks";
 import {
+  settingsWindowManagerSectionFixture,
   windowManagerLayoutDocumentFixture,
   windowManagerLayoutResourceFixture,
 } from "../../mocks/window-manager-fixtures";
@@ -15,6 +17,7 @@ import {
 } from "../../lib/window-manager-layout-schema";
 
 import {
+  updateWindowManagerSettings,
   applyWindowManagerLayout,
   deleteWindowManagerLayoutProfile,
   exportWindowManagerLayout,
@@ -46,6 +49,115 @@ afterEach(() => {
 });
 
 describe("window-manager layouts API", () => {
+  const receipt = {
+    applied: true,
+    lifecycle: "live",
+    apply_record_id: "apply-1",
+    active_generation: 2,
+    active_config_hash: "hash",
+    next_action: "none",
+  };
+
+  it("Should preserve zero gaps and global shortcuts and request current shortcut preservation", async () => {
+    const config = parseSettingsWindowManagerSection(settingsWindowManagerSectionFixture).config;
+    config.gaps = { inner: 0, top: 0, right: 0, bottom: 0, left: 0 };
+    config.globalShortcuts = { "palette.summon.global": "meta+shift+Space" };
+    apiMocks.fetch.mockResolvedValueOnce(
+      jsonResponse({ ...settingsWindowManagerSectionFixture, apply: receipt })
+    );
+    const result = await updateWindowManagerSettings(config);
+    const request = JSON.parse(apiMocks.fetch.mock.calls[0]?.[1].body);
+    expect(request).toMatchObject({
+      preserve_shortcuts: true,
+      config: { gaps: config.gaps, global_shortcuts: config.globalShortcuts },
+    });
+    expect(result.apply).toEqual(receipt);
+  });
+
+  it.each([
+    { applied: false, next_action: "retry" },
+    { applied: false, next_action: "none" },
+    {
+      applied: true,
+      partial_failures: [
+        {
+          subsystem: "window-manager",
+          diagnostic: { title: "Apply failed", message: "Layout unavailable" },
+        },
+      ],
+    },
+  ])("Should reject HTTP success when application failed: %j", async outcome => {
+    const config = parseSettingsWindowManagerSection(settingsWindowManagerSectionFixture).config;
+    apiMocks.fetch.mockResolvedValueOnce(
+      jsonResponse({ ...settingsWindowManagerSectionFixture, apply: { ...receipt, ...outcome } })
+    );
+    await expect(updateWindowManagerSettings(config)).rejects.toThrow(/Settings saved, but/);
+  });
+
+  it("Should expose failure diagnostics, warnings, and the daemon's recovery action", async () => {
+    const config = parseSettingsWindowManagerSection(settingsWindowManagerSectionFixture).config;
+    apiMocks.fetch.mockResolvedValueOnce(
+      jsonResponse({
+        ...settingsWindowManagerSectionFixture,
+        apply: {
+          ...receipt,
+          applied: false,
+          next_action: "restart-daemon",
+          warnings: ["A runtime dependency is unavailable"],
+          partial_failures: [
+            {
+              subsystem: "window-manager",
+              diagnostic: {
+                title: "Apply failed",
+                message: "Layout unavailable",
+              },
+            },
+          ],
+        },
+      })
+    );
+    await expect(updateWindowManagerSettings(config)).rejects.toThrow(
+      "Settings saved, but apply failed. Layout unavailable · A runtime dependency is unavailable Restart CompozyOS to apply."
+    );
+  });
+
+  it("Should not claim success for an unverified application receipt", async () => {
+    const config = parseSettingsWindowManagerSection(settingsWindowManagerSectionFixture).config;
+    apiMocks.fetch.mockResolvedValueOnce(jsonResponse(settingsWindowManagerSectionFixture));
+    await expect(updateWindowManagerSettings(config)).rejects.toThrow(
+      "The save result could not be verified"
+    );
+  });
+
+  it.each(["restart-daemon", "new-session"])(
+    "Should retain warnings and pending action %s",
+    async nextAction => {
+      const config = parseSettingsWindowManagerSection(settingsWindowManagerSectionFixture).config;
+      const apply = {
+        ...receipt,
+        applied: nextAction === "new-session",
+        next_action: nextAction,
+        warnings: ["Action required"],
+      };
+      apiMocks.fetch.mockResolvedValueOnce(
+        jsonResponse({ ...settingsWindowManagerSectionFixture, apply })
+      );
+      await expect(updateWindowManagerSettings(config)).resolves.toMatchObject({ apply });
+    }
+  );
+
+  it("Should expose transport and server failures instead of success", async () => {
+    const config = parseSettingsWindowManagerSection(settingsWindowManagerSectionFixture).config;
+    apiMocks.fetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    await expect(updateWindowManagerSettings(config)).rejects.toThrow(
+      "Check the connection and retry"
+    );
+    apiMocks.fetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Config write failed" }), { status: 500 })
+    );
+    await expect(updateWindowManagerSettings(config)).rejects.toThrow("Config write failed");
+  });
+
   it("Should derive the exported document and revision from one snapshot response", async () => {
     apiMocks.fetch.mockResolvedValueOnce(jsonResponse(windowManagerSnapshotFixture));
 

--- a/web/src/systems/settings/adapters/__tests__/window-manager-layouts-api.test.ts
+++ b/web/src/systems/settings/adapters/__tests__/window-manager-layouts-api.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/lib/api-client", () => ({
   runtimeFetch: apiMocks.fetch,
 }));
 
+/** Return a JSON transport response for the adapter’s fetch boundary. */
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,

--- a/web/src/systems/settings/adapters/__tests__/window-manager-settings-api.test.ts
+++ b/web/src/systems/settings/adapters/__tests__/window-manager-settings-api.test.ts
@@ -17,9 +17,11 @@ import {
   parseSettingsWindowManagerSection,
   updateWindowManagerBindings,
   WindowManagerSettingsError,
+  WindowManagerBindingsApplyError,
   type WindowManagerSettingsWire,
 } from "@/systems/os";
 
+import { settingsReloadAppliedFixture } from "../../mocks/fixtures";
 import { settingsWindowManagerSectionFixture } from "../../mocks/window-manager-fixtures";
 
 vi.mock("@/lib/api-client", async importOriginal => {
@@ -174,7 +176,7 @@ describe("window-manager settings API adapter", () => {
   it("Should send complete maps and keep overwrite off the wire until asked [RA0252]", async () => {
     const wire = sectionWire();
     vi.mocked(apiClient.PATCH).mockResolvedValue({
-      data: wire,
+      data: { ...wire, apply: settingsReloadAppliedFixture },
       error: undefined,
       response: new Response(null, { status: 200 }),
     } as never);
@@ -210,5 +212,62 @@ describe("window-manager settings API adapter", () => {
         body: expect.objectContaining({ overwrite: true }),
       })
     );
+  });
+  it.each([
+    { applied: false, next_action: "retry" },
+    {
+      partial_failures: [
+        {
+          subsystem: "window-manager",
+          diagnostic: { title: "Apply failed", message: "Renderer unavailable" },
+        },
+      ],
+    },
+    { applied: false },
+  ])("Should retain canonical saved bindings when application fails: %j", async patch => {
+    const wire = sectionWire();
+    wire.config.shortcuts = { "window.close": ["meta+KeyW"] };
+    const apply = { ...settingsReloadAppliedFixture, ...patch };
+    vi.mocked(apiClient.PATCH).mockResolvedValue({
+      data: { ...wire, apply },
+      response: new Response(null, { status: 200 }),
+    } as never);
+    const failure = await updateWindowManagerBindings({
+      workspaceId: "workspace:alpha",
+      shortcuts: { "window.close": ["meta+KeyW"] },
+    }).catch(error => error);
+    expect(failure).toBeInstanceOf(WindowManagerBindingsApplyError);
+    expect(failure.result).toEqual({ section: parseSettingsWindowManagerSection(wire), apply });
+    expect(failure.message).toMatch(/saved.*(failed|not applied)/);
+  });
+
+  it.each(["restart-daemon", "new-session"])(
+    "Should retain pending %s actions and warnings",
+    async next_action => {
+      const wire = sectionWire();
+      const apply = {
+        ...settingsReloadAppliedFixture,
+        applied: false,
+        next_action,
+        warnings: ["Some shortcuts await application"],
+      };
+      vi.mocked(apiClient.PATCH).mockResolvedValue({
+        data: { ...wire, apply },
+        response: new Response(null, { status: 200 }),
+      } as never);
+      await expect(
+        updateWindowManagerBindings({ workspaceId: null, aliases: {} })
+      ).resolves.toEqual({ section: parseSettingsWindowManagerSection(wire), apply });
+    }
+  );
+
+  it("Should reject a successful HTTP response without a verifiable apply receipt", async () => {
+    vi.mocked(apiClient.PATCH).mockResolvedValue({
+      data: sectionWire(),
+      response: new Response(null, { status: 200 }),
+    } as never);
+    await expect(
+      updateWindowManagerBindings({ workspaceId: null, aliases: {} })
+    ).rejects.toBeInstanceOf(ZodError);
   });
 });

--- a/web/src/systems/settings/adapters/__tests__/window-manager-settings-api.test.ts
+++ b/web/src/systems/settings/adapters/__tests__/window-manager-settings-api.test.ts
@@ -37,6 +37,7 @@ vi.mock("@/lib/api-client", async importOriginal => {
 
 import { apiClient } from "@/lib/api-client";
 
+/** Clone the wire fixture so malformed-response cases cannot leak into another test. */
 function sectionWire(): WindowManagerSettingsWire {
   return structuredClone(settingsWindowManagerSectionFixture) as WindowManagerSettingsWire;
 }

--- a/web/src/systems/settings/adapters/window-manager-layouts-api.ts
+++ b/web/src/systems/settings/adapters/window-manager-layouts-api.ts
@@ -1,3 +1,11 @@
+import { parseSettingsWindowManagerSection } from "@/systems/os";
+import {
+  parseWindowManagerSettingsApply,
+  windowManagerApplyFailed,
+  windowManagerApplyMessage,
+  type WindowManagerSettingsApply,
+} from "../lib/window-manager-settings-result";
+
 import { apiBaseUrl, runtimeFetch } from "@/lib/api-client";
 
 import {
@@ -88,15 +96,66 @@ function jsonRequest(body: unknown, signal?: AbortSignal): RequestInit {
   };
 }
 
+export interface WindowManagerSettingsSaveResult {
+  config: WindowManagerConfig;
+  apply: WindowManagerSettingsApply;
+}
+
+export class WindowManagerSettingsApplyError extends Error {
+  constructor(public readonly result: WindowManagerSettingsSaveResult) {
+    super(windowManagerApplyMessage(result.apply));
+    this.name = "WindowManagerSettingsApplyError";
+  }
+}
+
 export async function updateWindowManagerSettings(
   config: WindowManagerConfig,
   signal?: AbortSignal
-): Promise<void> {
-  const response = await runtimeFetch(`${apiBaseUrl}/api/settings/window-manager`, {
-    ...jsonRequest({ config: windowManagerSettingsConfigToWire(config) }, signal),
-    method: "PATCH",
-  });
-  await requireJson(response, "Unable to save window-manager settings");
+): Promise<WindowManagerSettingsSaveResult> {
+  let response: Response;
+  try {
+    response = await runtimeFetch(`${apiBaseUrl}/api/settings/window-manager`, {
+      ...jsonRequest(
+        { config: windowManagerSettingsConfigToWire(config), preserve_shortcuts: true },
+        signal
+      ),
+      method: "PATCH",
+    });
+  } catch (cause) {
+    if (signal?.aborted) throw cause;
+    throw new WindowManagerLayoutsApiError(
+      "Unable to reach CompozyOS. Check the connection and retry; your changes are kept.",
+      0
+    );
+  }
+  const body = await responseJson(response);
+  if (!response.ok) {
+    throw new WindowManagerLayoutsApiError(
+      `${errorMessage(body, `Unable to save settings (${response.status})`)}. Your changes are kept. Retry when the problem is resolved, or discard your changes.`,
+      response.status
+    );
+  }
+  if (body === null || typeof body !== "object") {
+    throw new WindowManagerLayoutsApiError(
+      "CompozyOS returned an invalid settings result.",
+      response.status
+    );
+  }
+  const { apply, ...section } = body as Record<string, unknown>;
+  let result: WindowManagerSettingsSaveResult;
+  try {
+    result = {
+      config: parseSettingsWindowManagerSection(section).config,
+      apply: parseWindowManagerSettingsApply(apply),
+    };
+  } catch {
+    throw new WindowManagerLayoutsApiError(
+      "The save result could not be verified. Reload settings before retrying; your changes are kept.",
+      response.status
+    );
+  }
+  if (windowManagerApplyFailed(result.apply)) throw new WindowManagerSettingsApplyError(result);
+  return result;
 }
 
 export async function exportWindowManagerLayout(

--- a/web/src/systems/settings/adapters/window-manager-layouts-api.ts
+++ b/web/src/systems/settings/adapters/window-manager-layouts-api.ts
@@ -89,6 +89,7 @@ async function requireJson(response: Response, fallback: string): Promise<unknow
   );
 }
 
+/** Encode a settings mutation as JSON while preserving cancellation at the transport boundary. */
 function jsonRequest(body: unknown, signal?: AbortSignal): RequestInit {
   return {
     body: JSON.stringify(body),

--- a/web/src/systems/settings/adapters/window-manager-layouts-api.ts
+++ b/web/src/systems/settings/adapters/window-manager-layouts-api.ts
@@ -1,10 +1,12 @@
-import { parseSettingsWindowManagerSection } from "@/systems/os";
 import {
   parseWindowManagerSettingsApply,
+  parseSettingsWindowManagerSection,
+  fetchWindowManagerSnapshot,
+  type WindowManagerConfig,
   windowManagerApplyFailed,
   windowManagerApplyMessage,
   type WindowManagerSettingsApply,
-} from "../lib/window-manager-settings-result";
+} from "@/systems/os";
 
 import { apiBaseUrl, runtimeFetch } from "@/lib/api-client";
 
@@ -30,7 +32,6 @@ import type {
   WindowManagerLayoutValidation,
 } from "../lib/window-manager-layout-types";
 import { windowManagerSnapshotToLayoutState } from "../lib/window-manager-layout-projection";
-import { fetchWindowManagerSnapshot, type WindowManagerConfig } from "@/systems/os";
 
 export class WindowManagerLayoutsApiError extends Error {
   constructor(
@@ -101,6 +102,7 @@ export interface WindowManagerSettingsSaveResult {
   apply: WindowManagerSettingsApply;
 }
 
+/** Keeps the canonical saved config available when only runtime application failed. */
 export class WindowManagerSettingsApplyError extends Error {
   constructor(public readonly result: WindowManagerSettingsSaveResult) {
     super(windowManagerApplyMessage(result.apply));
@@ -108,6 +110,7 @@ export class WindowManagerSettingsApplyError extends Error {
   }
 }
 
+/** Persist behavior without replacing live-edited shortcuts and preserve the daemon apply receipt. */
 export async function updateWindowManagerSettings(
   config: WindowManagerConfig,
   signal?: AbortSignal

--- a/web/src/systems/settings/components/__tests__/settings-save-bar.test.tsx
+++ b/web/src/systems/settings/components/__tests__/settings-save-bar.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { SettingsSaveBar } from "../settings-save-bar";
 import type { SettingsSaveBarState } from "../../lib/save-state";
 
+/** Render the shared recovery controls and expose their action spies to behavior assertions. */
 function renderSaveBar(
   state: SettingsSaveBarState,
   overrides: Partial<React.ComponentProps<typeof SettingsSaveBar>> = {}

--- a/web/src/systems/settings/components/__tests__/settings-save-bar.test.tsx
+++ b/web/src/systems/settings/components/__tests__/settings-save-bar.test.tsx
@@ -69,6 +69,25 @@ describe("SettingsSaveBar", () => {
     );
   });
 
+  it("keeps retry and discard available with a recoverable error", () => {
+    const { onSave, onReset } = renderSaveBar({
+      kind: "error",
+      message: "Connection failed",
+      canRetry: true,
+      canDiscard: true,
+    });
+    fireEvent.click(screen.getByTestId("settings-page-general-save"));
+    fireEvent.click(screen.getByTestId("settings-page-general-reset"));
+    expect(onSave).toHaveBeenCalledOnce();
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry an invalid failed draft but permits discard", () => {
+    renderSaveBar({ kind: "error", message: "Save failed", canRetry: false, canDiscard: true });
+    expect(screen.getByTestId("settings-page-general-save")).toBeDisabled();
+    expect(screen.getByTestId("settings-page-general-reset")).not.toBeDisabled();
+  });
+
   it("renders an explicit saved state without implying unsaved changes", () => {
     renderSaveBar({ kind: "saved", message: "Applied 2 fields" });
 

--- a/web/src/systems/settings/components/__tests__/window-manager-shortcut-table.test.tsx
+++ b/web/src/systems/settings/components/__tests__/window-manager-shortcut-table.test.tsx
@@ -14,9 +14,12 @@ import * as os from "@/systems/os";
 import {
   parseSettingsWindowManagerSection,
   WindowManagerSettingsError,
+  WindowManagerBindingsApplyError,
+  windowManagerKeys,
   type WindowManagerSettingsWire,
 } from "@/systems/os";
 
+import { settingsReloadAppliedFixture } from "../../mocks/fixtures";
 import { useWindowManagerAliasEditor } from "../../hooks/use-window-manager-alias-editor";
 import { useWindowManagerBindingMutations } from "../../hooks/use-window-manager-binding-mutations";
 import { useGlobalShortcutRecorder } from "../../hooks/use-global-shortcut-recorder";
@@ -42,10 +45,12 @@ function sectionFrom(mutate: (wire: WindowManagerSettingsWire) => void = () => {
  */
 function ShortcutSurface({
   section = sectionFrom(),
+  workspaceId = "workspace:alpha",
 }: {
   section?: ReturnType<typeof sectionFrom>;
+  workspaceId?: string;
 }) {
-  const mutations = useWindowManagerBindingMutations("workspace:alpha");
+  const mutations = useWindowManagerBindingMutations(workspaceId);
   const recorder = useWindowManagerShortcutRecorder(section, mutations);
   const globalRecorder = useGlobalShortcutRecorder(section, mutations);
   const aliases = useWindowManagerAliasEditor(
@@ -55,7 +60,12 @@ function ShortcutSurface({
   );
   return (
     <>
-      <WindowManagerShortcutTable aliases={aliases} recorder={recorder} section={section} />
+      <WindowManagerShortcutTable
+        apply={mutations.apply}
+        aliases={aliases}
+        recorder={recorder}
+        section={section}
+      />
       <WindowManagerGlobalHotkeys recorder={globalRecorder} section={section} />
     </>
   );
@@ -63,14 +73,16 @@ function ShortcutSurface({
 
 function renderTable(section?: ReturnType<typeof sectionFrom>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const tree = (next?: ReturnType<typeof sectionFrom>) => (
+  const tree = (next?: ReturnType<typeof sectionFrom>, workspaceId?: string) => (
     <QueryClientProvider client={client}>
-      <ShortcutSurface section={next ?? section} />
+      <ShortcutSurface section={next ?? section} workspaceId={workspaceId} />
     </QueryClientProvider>
   );
   const view = render(tree());
   return {
     ...view,
+    client,
+    showScope: (workspaceId: string) => view.rerender(tree(undefined, workspaceId)),
     /** Re-renders with the section a later daemon answer would have served. */
     showSection: (next: ReturnType<typeof sectionFrom>) => view.rerender(tree(next)),
   };
@@ -82,7 +94,10 @@ function updateWindowManagerBindingsMock() {
 
 describe("WindowManagerShortcutTable", () => {
   beforeEach(() => {
-    vi.spyOn(os, "updateWindowManagerBindings").mockResolvedValue(sectionFrom());
+    vi.spyOn(os, "updateWindowManagerBindings").mockResolvedValue({
+      section: sectionFrom(),
+      apply: settingsReloadAppliedFixture,
+    });
   });
 
   afterEach(() => {
@@ -221,7 +236,10 @@ describe("WindowManagerShortcutTable", () => {
         "ext.notes.capture": ["meta+KeyN"],
       };
     });
-    updateWindowManagerBindingsMock().mockResolvedValueOnce(afterOverwrite);
+    updateWindowManagerBindingsMock().mockResolvedValueOnce({
+      section: afterOverwrite,
+      apply: settingsReloadAppliedFixture,
+    });
     const view = renderTable();
 
     await user.click(screen.getByTestId("shortcut-recorder-ext.notes.capture"));
@@ -375,5 +393,72 @@ describe("WindowManagerShortcutTable", () => {
     expect(screen.getByTestId("window-manager-global-hotkeys")).toHaveTextContent(
       "No global hotkeys"
     );
+  });
+  it.each([
+    ["restart-daemon", "Settings saved. Restart CompozyOS to apply."],
+    ["new-session", "Settings saved. New sessions use this config."],
+  ] as const)(
+    "Should visibly preserve the %s action and warnings after a shortcut edit",
+    async (next_action, message) => {
+      updateWindowManagerBindingsMock().mockResolvedValueOnce({
+        section: sectionFrom(),
+        apply: {
+          ...settingsReloadAppliedFixture,
+          applied: false,
+          next_action,
+          warnings: ["A shell still needs the new keymap"],
+        },
+      });
+      const user = userEvent.setup();
+      renderTable();
+      await user.click(screen.getByTestId("shortcut-reset-all"));
+      expect(await screen.findByText(message)).toBeVisible();
+      expect(screen.getByText("A shell still needs the new keymap")).toBeVisible();
+    }
+  );
+
+  it("Should cache persisted bindings and show application failure instead of successful reset", async () => {
+    const saved = sectionFrom(wire => {
+      wire.config.shortcuts = {};
+    });
+    updateWindowManagerBindingsMock().mockRejectedValueOnce(
+      new WindowManagerBindingsApplyError({
+        section: saved,
+        apply: { ...settingsReloadAppliedFixture, applied: false, next_action: "retry" },
+      })
+    );
+    const user = userEvent.setup();
+    const { client } = renderTable();
+    await user.click(screen.getByTestId("shortcut-reset-all"));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Settings saved, but apply failed.");
+    expect(screen.queryByText("Every shortcut restored to its default.")).not.toBeInTheDocument();
+    expect(client.getQueryData(windowManagerKeys.config("workspace:alpha"))).toEqual(saved);
+    await user.click(screen.getByTestId("shortcut-reset-all"));
+    expect(await screen.findByText("Settings saved and applied.")).toBeVisible();
+    expect(updateWindowManagerBindingsMock()).toHaveBeenCalledTimes(2);
+  });
+
+  it("Should reconcile a late binding result only into the workspace that submitted it", async () => {
+    let finish!: (result: os.WindowManagerBindingsResult) => void;
+    updateWindowManagerBindingsMock().mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          finish = resolve;
+        })
+    );
+    const user = userEvent.setup();
+    const { client, showScope } = renderTable();
+    await user.click(screen.getByTestId("shortcut-reset-all"));
+    await waitFor(() => expect(updateWindowManagerBindingsMock()).toHaveBeenCalledTimes(1));
+    showScope("workspace:beta");
+    const saved = sectionFrom(wire => {
+      wire.config.shortcuts = {};
+    });
+    finish({ section: saved, apply: settingsReloadAppliedFixture });
+    await waitFor(() =>
+      expect(client.getQueryData(windowManagerKeys.config("workspace:alpha"))).toEqual(saved)
+    );
+    expect(client.getQueryData(windowManagerKeys.config("workspace:beta"))).toBeUndefined();
+    expect(screen.queryByText("Settings saved and applied.")).not.toBeInTheDocument();
   });
 });

--- a/web/src/systems/settings/components/__tests__/window-manager-shortcut-table.test.tsx
+++ b/web/src/systems/settings/components/__tests__/window-manager-shortcut-table.test.tsx
@@ -71,6 +71,7 @@ function ShortcutSurface({
   );
 }
 
+/** Render binding editors with an isolated cache and explicit server/scope transitions. */
 function renderTable(section?: ReturnType<typeof sectionFrom>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const tree = (next?: ReturnType<typeof sectionFrom>, workspaceId?: string) => (
@@ -88,6 +89,7 @@ function renderTable(section?: ReturnType<typeof sectionFrom>) {
   };
 }
 
+/** Access the adapter I/O seam used to supply canonical sections and application receipts. */
 function updateWindowManagerBindingsMock() {
   return vi.mocked(os.updateWindowManagerBindings);
 }
@@ -417,26 +419,39 @@ describe("WindowManagerShortcutTable", () => {
     }
   );
 
-  it("Should cache persisted bindings and show application failure instead of successful reset", async () => {
-    const saved = sectionFrom(wire => {
-      wire.config.shortcuts = {};
-    });
-    updateWindowManagerBindingsMock().mockRejectedValueOnce(
-      new WindowManagerBindingsApplyError({
-        section: saved,
-        apply: { ...settingsReloadAppliedFixture, applied: false, next_action: "retry" },
-      })
-    );
-    const user = userEvent.setup();
-    const { client } = renderTable();
-    await user.click(screen.getByTestId("shortcut-reset-all"));
-    expect(await screen.findByRole("alert")).toHaveTextContent("Settings saved, but apply failed.");
-    expect(screen.queryByText("Every shortcut restored to its default.")).not.toBeInTheDocument();
-    expect(client.getQueryData(windowManagerKeys.config("workspace:alpha"))).toEqual(saved);
-    await user.click(screen.getByTestId("shortcut-reset-all"));
-    expect(await screen.findByText("Settings saved and applied.")).toBeVisible();
-    expect(updateWindowManagerBindingsMock()).toHaveBeenCalledTimes(2);
-  });
+  it.each(["retry", "none"] as const)(
+    "Should cache persisted bindings and show %s application failure instead of successful reset",
+    async next_action => {
+      const saved = sectionFrom(wire => {
+        wire.config.shortcuts = {};
+      });
+      updateWindowManagerBindingsMock().mockRejectedValueOnce(
+        new WindowManagerBindingsApplyError({
+          section: saved,
+          apply: {
+            ...settingsReloadAppliedFixture,
+            applied: false,
+            skipped: false,
+            restart_required: false,
+            next_action,
+            warnings: ["Renderer unavailable"],
+          },
+        })
+      );
+      const user = userEvent.setup();
+      const { client } = renderTable();
+      await user.click(screen.getByTestId("shortcut-reset-all"));
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /Settings saved, but (apply failed|not applied)\./
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent("Renderer unavailable");
+      expect(screen.queryByText("Every shortcut restored to its default.")).not.toBeInTheDocument();
+      expect(client.getQueryData(windowManagerKeys.config("workspace:alpha"))).toEqual(saved);
+      await user.click(screen.getByTestId("shortcut-reset-all"));
+      expect(await screen.findByText("Settings saved and applied.")).toBeVisible();
+      expect(updateWindowManagerBindingsMock()).toHaveBeenCalledTimes(2);
+    }
+  );
 
   it("Should reconcile a late binding result only into the workspace that submitted it", async () => {
     let finish!: (result: os.WindowManagerBindingsResult) => void;

--- a/web/src/systems/settings/components/layouts/window-manager-shortcut-table.tsx
+++ b/web/src/systems/settings/components/layouts/window-manager-shortcut-table.tsx
@@ -2,8 +2,13 @@ import { useState } from "react";
 
 import { Button, Empty, Table, TableBody, TableHead, TableHeader, TableRow } from "@compozy/ui";
 
-import { orderShortcutSources, shortcutLabel } from "@/systems/os";
-import type { WindowManagerSettingsSection } from "@/systems/os";
+import {
+  orderShortcutSources,
+  shortcutLabel,
+  windowManagerApplyFailed,
+  windowManagerApplyMessage,
+} from "@/systems/os";
+import type { WindowManagerSettingsApply, WindowManagerSettingsSection } from "@/systems/os";
 
 import type { AliasEditorModel } from "../../hooks/use-window-manager-alias-editor";
 import type { ShortcutRecorderModel } from "../../hooks/use-window-manager-shortcut-recorder";
@@ -21,6 +26,7 @@ export interface WindowManagerShortcutTableProps {
   section: WindowManagerSettingsSection;
   recorder: ShortcutRecorderModel;
   aliases: AliasEditorModel;
+  apply?: WindowManagerSettingsApply | null;
   /** Command the operator arrived to bind, from a palette deep link. */
   focusCommandId?: string;
 }
@@ -37,6 +43,7 @@ export function WindowManagerShortcutTable({
   section,
   recorder,
   aliases,
+  apply,
   focusCommandId,
 }: WindowManagerShortcutTableProps) {
   const [source, setSource] = useState<string>(SHORTCUT_SOURCE_ALL);
@@ -83,6 +90,15 @@ export function WindowManagerShortcutTable({
           Reset all
         </Button>
       </div>
+
+      {apply && !windowManagerApplyFailed(apply) ? (
+        <div className="px-4 py-2 text-form-hint text-fg-muted" role="status">
+          <p>{windowManagerApplyMessage(apply)}</p>
+          {apply.warnings?.map((warning, index) => (
+            <p key={`${index}:${warning}`}>{warning}</p>
+          ))}
+        </div>
+      ) : null}
 
       {recorder.error !== null ? (
         <p className="px-4 py-2 text-form-hint text-danger" role="alert">

--- a/web/src/systems/settings/components/settings-save-bar.tsx
+++ b/web/src/systems/settings/components/settings-save-bar.tsx
@@ -66,14 +66,14 @@ function SettingsSaveBar({ slug, state, onSave, onReset, className }: SettingsSa
             <Pill.Dot className="size-settings-save-dot" tone={dotTone} />
           )}
           <span
-            className={cn("truncate", isError && "text-danger")}
+            className={cn("break-words", isError && "text-danger")}
             data-testid={`settings-page-${slug}-save-message`}
           >
             {messageFor(state)}
           </span>
           {warnings.length > 0 ? (
             <span
-              className="truncate text-form-hint text-warning"
+              className="break-words text-form-hint text-warning"
               data-testid={`settings-page-${slug}-save-warnings`}
             >
               {warnings.join(" · ")}
@@ -82,7 +82,7 @@ function SettingsSaveBar({ slug, state, onSave, onReset, className }: SettingsSa
         </span>
         <Button
           data-testid={`settings-page-${slug}-reset`}
-          disabled={!isDirty || isSaving}
+          disabled={!(isDirty || (state.kind === "error" && state.canDiscard)) || isSaving}
           onClick={onReset}
           size="sm"
           type="button"
@@ -92,7 +92,7 @@ function SettingsSaveBar({ slug, state, onSave, onReset, className }: SettingsSa
         </Button>
         <Button
           data-testid={`settings-page-${slug}-save`}
-          disabled={state.kind !== "dirty"}
+          disabled={state.kind !== "dirty" && !(state.kind === "error" && state.canRetry)}
           onClick={onSave}
           size="sm"
           type="button"

--- a/web/src/systems/settings/components/settings-save-bar.tsx
+++ b/web/src/systems/settings/components/settings-save-bar.tsx
@@ -12,12 +12,14 @@ interface SettingsSaveBarProps {
   className?: string;
 }
 
+/** Keep daemon warnings visible in both applied and dirty save states. */
 function warningsFor(state: SettingsSaveBarState): string[] {
   return state.kind === "dirty" || state.kind === "invalid" || state.kind === "warning"
     ? state.warnings
     : [];
 }
 
+/** Choose the status message from the save lifecycle without losing supplied diagnostics. */
 function messageFor(state: Exclude<SettingsSaveBarState, { kind: "idle" }>): string {
   switch (state.kind) {
     case "dirty":
@@ -34,6 +36,7 @@ function messageFor(state: Exclude<SettingsSaveBarState, { kind: "idle" }>): str
 }
 
 /** Pure save-state renderer. Mutation and saved-flash orchestration live in route hooks. */
+/** Render save status and only the recovery actions allowed by the owning editor. */
 function SettingsSaveBar({ slug, state, onSave, onReset, className }: SettingsSaveBarProps) {
   if (state.kind === "idle") return null;
 

--- a/web/src/systems/settings/components/settings-save-bar.tsx
+++ b/web/src/systems/settings/components/settings-save-bar.tsx
@@ -66,14 +66,14 @@ function SettingsSaveBar({ slug, state, onSave, onReset, className }: SettingsSa
             <Pill.Dot className="size-settings-save-dot" tone={dotTone} />
           )}
           <span
-            className={cn("break-words", isError && "text-danger")}
+            className={cn("min-w-0 break-words", isError && "text-danger")}
             data-testid={`settings-page-${slug}-save-message`}
           >
             {messageFor(state)}
           </span>
           {warnings.length > 0 ? (
             <span
-              className="break-words text-form-hint text-warning"
+              className="min-w-0 break-words text-form-hint text-warning"
               data-testid={`settings-page-${slug}-save-warnings`}
             >
               {warnings.join(" · ")}

--- a/web/src/systems/settings/components/window-manager-config-editor.tsx
+++ b/web/src/systems/settings/components/window-manager-config-editor.tsx
@@ -1,6 +1,6 @@
 import { HelpTip, Slider } from "@compozy/ui";
 
-import type { WindowManagerSettingsSection } from "@/systems/os";
+import type { WindowManagerSettingsApply, WindowManagerSettingsSection } from "@/systems/os";
 
 import type { AliasEditorModel } from "../hooks/use-window-manager-alias-editor";
 import type { GlobalShortcutRecorderModel } from "../hooks/use-global-shortcut-recorder";
@@ -22,6 +22,7 @@ import { WindowManagerSnapMap } from "./layouts/window-manager-snap-map";
 
 interface WindowManagerConfigEditorProps {
   editor: WindowManagerConfigEditorModel;
+  bindingApply?: WindowManagerSettingsApply | null;
   /** Daemon truth for the keyboard surface; not part of the draft. */
   section: WindowManagerSettingsSection;
   recorder: ShortcutRecorderModel;
@@ -40,6 +41,7 @@ interface WindowManagerConfigEditorProps {
  */
 export function WindowManagerConfigEditor({
   aliases,
+  bindingApply,
   editor,
   focusCommandId,
   globalRecorder,
@@ -101,6 +103,7 @@ export function WindowManagerConfigEditor({
         <div className="overflow-hidden rounded-lg border border-line bg-canvas-soft">
           <WindowManagerShortcutTable
             aliases={aliases}
+            apply={bindingApply}
             focusCommandId={focusCommandId}
             recorder={recorder}
             section={section}
@@ -150,6 +153,7 @@ export function WindowManagerConfigEditor({
   );
 }
 
+/** Group a behavior control with its explanation and validation error. */
 function WindowManagerConfigCard({
   title,
   help,

--- a/web/src/systems/settings/hooks/__tests__/use-window-manager-config-editor.test.tsx
+++ b/web/src/systems/settings/hooks/__tests__/use-window-manager-config-editor.test.tsx
@@ -95,6 +95,7 @@ const APPLY = {
   next_action: "none" as const,
 };
 
+/** Exercise the draft editor with an isolated query cache and replaceable daemon baseline. */
 function renderEditor(initial = CONFIG) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -110,6 +111,7 @@ function renderEditor(initial = CONFIG) {
   };
 }
 
+/** Project validation diagnostics to the editable fields whose saves must be blocked. */
 function fields(problems: ReadonlyArray<{ field: string }>) {
   return problems.map(problem => problem.field);
 }

--- a/web/src/systems/settings/hooks/__tests__/use-window-manager-config-editor.test.tsx
+++ b/web/src/systems/settings/hooks/__tests__/use-window-manager-config-editor.test.tsx
@@ -85,6 +85,15 @@ const CONFIG: WindowManagerConfig = {
   effectiveShortcuts: SHORTCUT_DEFAULTS,
 };
 
+const APPLY = {
+  applied: true,
+  lifecycle: "live" as const,
+  apply_record_id: "apply-1",
+  active_generation: 2,
+  active_config_hash: "hash",
+  next_action: "none" as const,
+};
+
 function renderEditor(initial = CONFIG) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -107,7 +116,91 @@ function fields(problems: ReadonlyArray<{ field: string }>) {
 describe("useWindowManagerConfigEditor", () => {
   beforeEach(() => {
     updateWindowManagerSettings.mockReset();
-    updateWindowManagerSettings.mockResolvedValue(undefined);
+    updateWindowManagerSettings.mockImplementation(async (config: WindowManagerConfig) => ({
+      config,
+      apply: APPLY,
+    }));
+  });
+
+  it("Should retain the failed draft and retry it without an extra edit", async () => {
+    updateWindowManagerSettings.mockRejectedValueOnce(new Error("Failed to fetch"));
+    const { result } = renderEditor();
+    act(() =>
+      result.current.setDraft(current => ({
+        ...current,
+        gaps: { inner: 0, top: 0, right: 0, bottom: 0, left: 0 },
+      }))
+    );
+    act(() => result.current.save());
+    await waitFor(() => expect(result.current.error?.message).toBe("Failed to fetch"));
+    expect(result.current.draft.gaps.inner).toBe(0);
+    expect(result.current.canSave).toBe(true);
+    act(() => result.current.save());
+    await waitFor(() => expect(result.current.result?.apply.applied).toBe(true));
+    expect(result.current.error).toBeNull();
+    expect(result.current.dirty).toBe(false);
+    expect(result.current.draft.gaps.inner).toBe(0);
+    expect(updateWindowManagerSettings).toHaveBeenCalledTimes(2);
+    expect(updateWindowManagerSettings.mock.calls[0]?.[0]).toEqual(
+      updateWindowManagerSettings.mock.calls[1]?.[0]
+    );
+  });
+
+  it.each(["edit", "discard"])("Should clear a failed save after %s", async action => {
+    updateWindowManagerSettings.mockRejectedValueOnce(new Error("Failed to fetch"));
+    const { result } = renderEditor();
+    act(() => result.current.setDraft(current => ({ ...current, historyLimit: 101 })));
+    act(() => result.current.save());
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    act(() => {
+      if (action === "edit")
+        result.current.setDraft(current => ({ ...current, historyLimit: 102 }));
+      else result.current.reset();
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.dirty).toBe(action === "edit");
+  });
+
+  it("Should keep a newer edit retryable when an in-flight save fails", async () => {
+    let rejectSave!: (error: Error) => void;
+    updateWindowManagerSettings.mockImplementationOnce(
+      () =>
+        new Promise((_, reject) => {
+          rejectSave = reject;
+        })
+    );
+    const { result } = renderEditor();
+    act(() => result.current.setDraft(current => ({ ...current, historyLimit: 101 })));
+    act(() => result.current.save());
+    await waitFor(() => expect(updateWindowManagerSettings).toHaveBeenCalledOnce());
+    act(() => {
+      result.current.setDraft(current => ({ ...current, historyLimit: 102 }));
+      result.current.save();
+    });
+    expect(result.current.canSave).toBe(false);
+    expect(updateWindowManagerSettings).toHaveBeenCalledOnce();
+    await act(async () => rejectSave(new Error("Failed to fetch")));
+    await waitFor(() => expect(result.current.canSave).toBe(true));
+    expect(result.current.draft.historyLimit).toBe(102);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("Should retain the behavior draft when live shortcut state changes", () => {
+    const { result, rerender } = renderEditor();
+    act(() =>
+      result.current.setDraft(current => ({ ...current, gaps: { ...current.gaps, inner: 0 } }))
+    );
+    rerender({
+      baseline: {
+        ...CONFIG,
+        shortcuts: { "window.close": ["meta+shift+KeyW"] },
+        globalShortcuts: { "palette.summon.global": "meta+shift+Space" },
+      },
+    });
+    expect(result.current.draft.gaps.inner).toBe(0);
+    expect(result.current.canSave).toBe(true);
+    act(() => result.current.reset());
+    expect(result.current.dirty).toBe(false);
   });
 
   it("Should preserve every daemon-required limit in the wire config", () => {
@@ -132,14 +225,14 @@ describe("useWindowManagerConfigEditor", () => {
   it("Should ignore a late save result after a newer draft transition", () => {
     const store = windowManagerConfigEditorLogic.createStore({ baseline: CONFIG });
     let snapshot = store.getInitialSnapshot();
-    const revision = JSON.stringify(CONFIG);
+    const revision = snapshot.context.baselineRevision;
     [snapshot] = store.transition(snapshot, {
       type: "draftChanged",
       draft: { ...CONFIG, historyLimit: 101 },
     });
     [snapshot] = store.transition(snapshot, {
       type: "saveRequested",
-      execute: async () => undefined,
+      execute: async () => ({ config: CONFIG, apply: APPLY }),
     });
     [snapshot] = store.transition(snapshot, {
       type: "draftChanged",
@@ -147,6 +240,7 @@ describe("useWindowManagerConfigEditor", () => {
     });
     [snapshot] = store.transition(snapshot, {
       type: "saveSucceeded",
+      result: { config: CONFIG, apply: APPLY },
       operation: 1,
       revision,
       draftRevision: 1,

--- a/web/src/systems/settings/hooks/__tests__/use-window-manager-config-editor.test.tsx
+++ b/web/src/systems/settings/hooks/__tests__/use-window-manager-config-editor.test.tsx
@@ -21,6 +21,7 @@ vi.mock("../../adapters/window-manager-layouts-api", async importOriginal => {
   return { ...actual, updateWindowManagerSettings };
 });
 
+import { WindowManagerSettingsApplyError } from "../../adapters/window-manager-layouts-api";
 import { windowManagerSettingsConfigToWire } from "../../lib/window-manager-layout-schema";
 import {
   applyTerminalShortcutPreset,
@@ -161,29 +162,64 @@ describe("useWindowManagerConfigEditor", () => {
     expect(result.current.dirty).toBe(action === "edit");
   });
 
-  it("Should keep a newer edit retryable when an in-flight save fails", async () => {
-    let rejectSave!: (error: Error) => void;
-    updateWindowManagerSettings.mockImplementationOnce(
-      () =>
-        new Promise((_, reject) => {
-          rejectSave = reject;
-        })
+  it("Should adopt persisted config after apply failure so discard cannot restore an obsolete baseline", async () => {
+    const saved = { ...CONFIG, gaps: { ...CONFIG.gaps, inner: 0 } };
+    updateWindowManagerSettings.mockRejectedValueOnce(
+      new WindowManagerSettingsApplyError({
+        config: saved,
+        apply: { ...APPLY, applied: false, next_action: "retry" },
+      })
     );
     const { result } = renderEditor();
-    act(() => result.current.setDraft(current => ({ ...current, historyLimit: 101 })));
+    act(() => result.current.setDraft(saved));
     act(() => result.current.save());
-    await waitFor(() => expect(updateWindowManagerSettings).toHaveBeenCalledOnce());
-    act(() => {
-      result.current.setDraft(current => ({ ...current, historyLimit: 102 }));
-      result.current.save();
-    });
-    expect(result.current.canSave).toBe(false);
-    expect(updateWindowManagerSettings).toHaveBeenCalledOnce();
-    await act(async () => rejectSave(new Error("Failed to fetch")));
-    await waitFor(() => expect(result.current.canSave).toBe(true));
-    expect(result.current.draft.historyLimit).toBe(102);
+    await waitFor(() =>
+      expect(result.current.error).toBeInstanceOf(WindowManagerSettingsApplyError)
+    );
+    expect(result.current.dirty).toBe(false);
+    expect(result.current.canSave).toBe(true);
+    expect(result.current.result?.apply.applied).toBe(false);
+    act(() => result.current.reset());
+    expect(result.current.draft.gaps.inner).toBe(0);
     expect(result.current.error).toBeNull();
   });
+
+  it.each(["transport", "application"])(
+    "Should keep a newer edit retryable after an in-flight %s failure",
+    async failure => {
+      let rejectSave!: (error: Error) => void;
+      updateWindowManagerSettings.mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            rejectSave = reject;
+          })
+      );
+      const { result } = renderEditor();
+      act(() => result.current.setDraft(current => ({ ...current, historyLimit: 101 })));
+      act(() => result.current.save());
+      await waitFor(() => expect(updateWindowManagerSettings).toHaveBeenCalledOnce());
+      act(() => {
+        result.current.setDraft(current => ({ ...current, historyLimit: 102 }));
+        result.current.save();
+      });
+      expect(result.current.canSave).toBe(false);
+      expect(updateWindowManagerSettings).toHaveBeenCalledOnce();
+      const error =
+        failure === "application"
+          ? new WindowManagerSettingsApplyError({
+              config: { ...CONFIG, historyLimit: 101 },
+              apply: { ...APPLY, applied: false, next_action: "retry" },
+            })
+          : new Error("Failed to fetch");
+      await act(async () => rejectSave(error));
+      await waitFor(() => expect(result.current.canSave).toBe(true));
+      expect(result.current.draft.historyLimit).toBe(102);
+      expect(result.current.error).toBeNull();
+      expect(result.current.result?.apply.next_action).toBe(
+        failure === "application" ? "retry" : undefined
+      );
+    }
+  );
 
   it("Should retain the behavior draft when live shortcut state changes", () => {
     const { result, rerender } = renderEditor();
@@ -240,13 +276,14 @@ describe("useWindowManagerConfigEditor", () => {
     });
     [snapshot] = store.transition(snapshot, {
       type: "saveSucceeded",
-      result: { config: CONFIG, apply: APPLY },
+      result: { config: CONFIG, apply: { ...APPLY, warnings: ["Follow-up required"] } },
       operation: 1,
       revision,
       draftRevision: 1,
     });
 
     expect(snapshot.context.draft.historyLimit).toBe(102);
+    expect(snapshot.context.result?.apply.warnings).toEqual(["Follow-up required"]);
     expect(snapshot.context.phase).toBe("dirty");
   });
 

--- a/web/src/systems/settings/hooks/use-window-manager-binding-mutations.ts
+++ b/web/src/systems/settings/hooks/use-window-manager-binding-mutations.ts
@@ -5,6 +5,10 @@ import {
   cmdPaletteKeys,
   updateWindowManagerBindings,
   windowManagerKeys,
+  WindowManagerBindingsApplyError,
+  type WindowManagerBindingUpdate,
+  type WindowManagerBindingsResult,
+  type WindowManagerSettingsApply,
   type WindowManagerSettingsSection,
 } from "@/systems/os";
 
@@ -18,6 +22,7 @@ export interface WindowManagerBindingCommit {
 export interface WindowManagerBindingMutations {
   commit: (update: WindowManagerBindingCommit) => Promise<WindowManagerSettingsSection>;
   saving: boolean;
+  apply: WindowManagerSettingsApply | null;
 }
 
 /**
@@ -36,32 +41,51 @@ export function useWindowManagerBindingMutations(
   const queryClient = useQueryClient();
   const queue = useRef<Promise<void> | null>(null);
   const [pendingCount, setPendingCount] = useState(0);
+  const [receipt, setReceipt] = useState<{
+    workspaceId: string | null;
+    clientId: string | undefined;
+    apply: WindowManagerSettingsApply;
+  } | null>(null);
+  const reconcile = async (
+    result: WindowManagerBindingsResult,
+    scope: WindowManagerBindingUpdate
+  ) => {
+    queryClient.setQueryData(
+      windowManagerKeys.config(scope.workspaceId, scope.clientId),
+      result.section
+    );
+    setReceipt({ workspaceId: scope.workspaceId, clientId: scope.clientId, apply: result.apply });
+    await queryClient.invalidateQueries({
+      queryKey: cmdPaletteKeys.workspaceCatalogs(scope.workspaceId ?? ""),
+    });
+  };
   const mutation = useMutation({
-    mutationFn: (update: WindowManagerBindingCommit) => {
-      const scope = clientId === undefined ? { workspaceId } : { workspaceId, clientId };
-      return updateWindowManagerBindings({ ...update, ...scope });
-    },
-    onSuccess: async section => {
-      queryClient.setQueryData(windowManagerKeys.config(workspaceId, clientId), section);
-      await queryClient.invalidateQueries({
-        queryKey: cmdPaletteKeys.workspaceCatalogs(workspaceId ?? ""),
-      });
+    mutationFn: (update: WindowManagerBindingUpdate) => updateWindowManagerBindings(update),
+    onMutate: () => setReceipt(null),
+    onSuccess: reconcile,
+    onError: async (error, scope) => {
+      if (error instanceof WindowManagerBindingsApplyError) await reconcile(error.result, scope);
     },
   });
 
   return {
     commit: update => {
       setPendingCount(count => count + 1);
-      const run = () => mutation.mutateAsync(update);
+      const scope = clientId === undefined ? { workspaceId } : { workspaceId, clientId };
+      const run = () => mutation.mutateAsync({ ...update, ...scope });
       const next = (queue.current ?? Promise.resolve()).then(run, run);
       queue.current = next.then(
         () => undefined,
         () => undefined
       );
-      return next.finally(() => {
-        setPendingCount(count => Math.max(0, count - 1));
-      });
+      return next
+        .then(result => result.section)
+        .finally(() => {
+          setPendingCount(count => Math.max(0, count - 1));
+        });
     },
     saving: pendingCount > 0,
+    apply:
+      receipt?.workspaceId === workspaceId && receipt.clientId === clientId ? receipt.apply : null,
   };
 }

--- a/web/src/systems/settings/hooks/use-window-manager-config-editor.ts
+++ b/web/src/systems/settings/hooks/use-window-manager-config-editor.ts
@@ -6,6 +6,7 @@ import { useStoreBinding } from "@/hooks/use-store-binding";
 
 import {
   updateWindowManagerSettings,
+  WindowManagerSettingsApplyError,
   type WindowManagerSettingsSaveResult,
 } from "../adapters/window-manager-layouts-api";
 import { WINDOW_MANAGER_RANGES } from "../lib/window-manager-snap-geometry";
@@ -148,11 +149,21 @@ export const windowManagerConfigEditorLogic = createStoreLogic<
     ) => {
       if (context.operation !== event.operation || !isCurrentConfig(context, event.revision))
         return;
+      const saved =
+        event.error instanceof WindowManagerSettingsApplyError ? event.error.result : null;
+      const nextContext = saved
+        ? {
+            ...context,
+            baseline: structuredClone(saved.config),
+            baselineRevision: configRevision(saved.config),
+            result: saved,
+          }
+        : context;
       if (context.draftRevision !== event.draftRevision) {
-        return { ...context, phase: "dirty" };
+        return { ...nextContext, phase: "dirty" };
       }
       return {
-        ...context,
+        ...nextContext,
         error: event.error,
         phase: isConflictError(event.error) ? "conflict" : "error",
       };
@@ -195,7 +206,7 @@ export const windowManagerConfigEditorLogic = createStoreLogic<
             ? structuredClone(event.result.config)
             : context.draft,
         error: null,
-        result: context.draftRevision === event.draftRevision ? event.result : null,
+        result: event.result,
         phase: context.draftRevision === event.draftRevision ? "baseline" : "dirty",
       };
     },

--- a/web/src/systems/settings/hooks/use-window-manager-config-editor.ts
+++ b/web/src/systems/settings/hooks/use-window-manager-config-editor.ts
@@ -4,7 +4,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useStoreBinding } from "@/hooks/use-store-binding";
 
-import { updateWindowManagerSettings } from "../adapters/window-manager-layouts-api";
+import {
+  updateWindowManagerSettings,
+  type WindowManagerSettingsSaveResult,
+} from "../adapters/window-manager-layouts-api";
 import { WINDOW_MANAGER_RANGES } from "../lib/window-manager-snap-geometry";
 import { type WindowManagerConfig, windowManagerKeys } from "@/systems/os";
 
@@ -25,9 +28,11 @@ export type WindowManagerConfigProblem =
 interface WindowManagerConfigEditorStoreContext {
   baseline: WindowManagerConfig;
   baselineRevision: string;
+  inputRevision: string;
   draft: WindowManagerConfig;
   draftRevision: number;
   error: Error | null;
+  result: WindowManagerSettingsSaveResult | null;
   operation: number;
   phase: WindowManagerConfigEditorPhase;
 }
@@ -41,12 +46,26 @@ type WindowManagerConfigEditorStoreEvents = {
   draftChanged: { draft: WindowManagerConfig };
   resetRequested: {};
   saveFailed: { error: Error; operation: number; revision: string; draftRevision: number };
-  saveRequested: { execute: (draft: WindowManagerConfig) => Promise<void> };
-  saveSucceeded: { operation: number; revision: string; draftRevision: number };
+  saveRequested: {
+    execute: (draft: WindowManagerConfig) => Promise<WindowManagerSettingsSaveResult>;
+  };
+  saveSucceeded: {
+    operation: number;
+    revision: string;
+    draftRevision: number;
+    result: WindowManagerSettingsSaveResult;
+  };
 };
 
 function configRevision(config: WindowManagerConfig): string {
-  return JSON.stringify(config);
+  const {
+    shortcuts: _shortcuts,
+    globalShortcuts: _globalShortcuts,
+    shortcutDefaults: _defaults,
+    effectiveShortcuts: _effective,
+    ...behavior
+  } = config;
+  return JSON.stringify(behavior);
 }
 
 function isCurrentConfig(
@@ -66,9 +85,11 @@ function initialConfigEditorContext(
   return {
     baseline: structuredClone(baseline),
     baselineRevision: configRevision(baseline),
+    inputRevision: configRevision(baseline),
     draft: structuredClone(baseline),
     draftRevision: 0,
     error: null,
+    result: null,
     operation: 0,
     phase: "baseline",
   };
@@ -79,16 +100,17 @@ function reconcileConfigEditorContext(
   baseline: WindowManagerConfig
 ): WindowManagerConfigEditorStoreContext {
   const revision = configRevision(baseline);
-  if (revision === previous.baselineRevision) return previous;
+  if (revision === previous.inputRevision) return previous;
   const clean = configRevision(previous.draft) === previous.baselineRevision;
   const draft = clean ? structuredClone(baseline) : previous.draft;
   return {
     ...previous,
     baseline: structuredClone(baseline),
     baselineRevision: revision,
+    inputRevision: revision,
     draft,
     draftRevision: previous.draftRevision + 1,
-    error: null,
+    error: previous.error,
     phase: configRevision(draft) === revision ? "baseline" : "dirty",
   };
 }
@@ -109,25 +131,26 @@ export const windowManagerConfigEditorLogic = createStoreLogic<
       draft: event.draft,
       draftRevision: context.draftRevision + 1,
       error: null,
-      phase: "dirty",
+      result: null,
+      phase: context.phase === "saving" ? "saving" : "dirty",
     }),
     resetRequested: context => ({
       ...context,
       draft: structuredClone(context.baseline),
       draftRevision: context.draftRevision + 1,
       error: null,
+      result: null,
       phase: "baseline",
     }),
     saveFailed: (
       context,
       event: { error: Error; operation: number; revision: string; draftRevision: number }
     ) => {
-      if (
-        context.operation !== event.operation ||
-        !isCurrentConfig(context, event.revision) ||
-        context.draftRevision !== event.draftRevision
-      )
+      if (context.operation !== event.operation || !isCurrentConfig(context, event.revision))
         return;
+      if (context.draftRevision !== event.draftRevision) {
+        return { ...context, phase: "dirty" };
+      }
       return {
         ...context,
         error: event.error,
@@ -142,27 +165,39 @@ export const windowManagerConfigEditorLogic = createStoreLogic<
       const revision = context.baselineRevision;
       enqueue.effect(async ({ trigger }) => {
         try {
-          await event.execute(draft);
-          trigger.saveSucceeded({ draftRevision, operation, revision });
+          const result = await event.execute(draft);
+          trigger.saveSucceeded({ draftRevision, operation, revision, result });
         } catch (cause) {
           const error =
             cause instanceof Error ? cause : new Error("Unable to save window-manager settings.");
           trigger.saveFailed({ draftRevision, error, operation, revision });
         }
       });
-      return { ...context, error: null, operation, phase: "saving" };
+      return { ...context, error: null, result: null, operation, phase: "saving" };
     },
     saveSucceeded: (
       context,
-      event: { operation: number; revision: string; draftRevision: number }
+      event: {
+        operation: number;
+        revision: string;
+        draftRevision: number;
+        result: WindowManagerSettingsSaveResult;
+      }
     ) => {
-      if (
-        context.operation !== event.operation ||
-        !isCurrentConfig(context, event.revision) ||
-        context.draftRevision !== event.draftRevision
-      )
+      if (context.operation !== event.operation || !isCurrentConfig(context, event.revision))
         return;
-      return { ...context, error: null, phase: "draft" };
+      return {
+        ...context,
+        baseline: structuredClone(event.result.config),
+        baselineRevision: configRevision(event.result.config),
+        draft:
+          context.draftRevision === event.draftRevision
+            ? structuredClone(event.result.config)
+            : context.draft,
+        error: null,
+        result: context.draftRevision === event.draftRevision ? event.result : null,
+        phase: context.draftRevision === event.draftRevision ? "baseline" : "dirty",
+      };
     },
   },
 });
@@ -226,7 +261,7 @@ export function useWindowManagerConfigEditor(baseline: WindowManagerConfig) {
     current => {
       const previousContext = current.store.getSnapshot().context;
       return (
-        previousContext.phase !== "saving" && previousContext.baselineRevision !== baselineRevision
+        previousContext.phase !== "saving" && previousContext.inputRevision !== baselineRevision
       );
     }
   );
@@ -235,8 +270,7 @@ export function useWindowManagerConfigEditor(baseline: WindowManagerConfig) {
 
   const saveMutation = useMutation({
     mutationFn: async (next: WindowManagerConfig) => {
-      await updateWindowManagerSettings(next);
-      return next;
+      return updateWindowManagerSettings(next);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: windowManagerKeys.configs() });
@@ -252,17 +286,19 @@ export function useWindowManagerConfigEditor(baseline: WindowManagerConfig) {
   };
 
   return {
-    canSave: dirty && problems.length === 0 && context.phase !== "saving",
+    canSave:
+      (dirty || context.error !== null) && problems.length === 0 && context.phase !== "saving",
     dirty,
     draft: context.draft,
-    error: context.error ?? saveMutation.error,
+    error: context.error,
+    result: context.result,
     phase: context.phase,
     problems,
     reset: () => store.trigger.resetRequested(),
     save: () =>
       store.trigger.saveRequested({
         execute: async draft => {
-          await saveMutation.mutateAsync(draft);
+          return saveMutation.mutateAsync(draft);
         },
       }),
     setDraft,

--- a/web/src/systems/settings/hooks/use-window-manager-config-editor.ts
+++ b/web/src/systems/settings/hooks/use-window-manager-config-editor.ts
@@ -58,6 +58,7 @@ type WindowManagerConfigEditorStoreEvents = {
   };
 };
 
+/** Track behavior changes independently of separately edited shortcut maps. */
 function configRevision(config: WindowManagerConfig): string {
   const {
     shortcuts: _shortcuts,
@@ -69,6 +70,7 @@ function configRevision(config: WindowManagerConfig): string {
   return JSON.stringify(behavior);
 }
 
+/** Fence asynchronous results against the canonical baseline that started the save. */
 function isCurrentConfig(
   context: WindowManagerConfigEditorStoreContext,
   revision: string
@@ -76,10 +78,12 @@ function isCurrentConfig(
   return context.baselineRevision === revision;
 }
 
+/** Recognize the transport conflict status without replacing the original error. */
 function isConflictError(error: Error): boolean {
   return Reflect.get(error, "status") === 409;
 }
 
+/** Create independent baseline and draft snapshots for a newly loaded configuration. */
 function initialConfigEditorContext(
   baseline: WindowManagerConfig
 ): WindowManagerConfigEditorStoreContext {
@@ -96,6 +100,7 @@ function initialConfigEditorContext(
   };
 }
 
+/** Adopt a new server baseline while preserving an existing behavior draft. */
 function reconcileConfigEditorContext(
   previous: WindowManagerConfigEditorStoreContext,
   baseline: WindowManagerConfig
@@ -213,10 +218,12 @@ export const windowManagerConfigEditorLogic = createStoreLogic<
   },
 });
 
+/** Accept finite values within the inclusive limits, including valid zero spacing. */
 function inRange(value: number, range: { min: number; max: number }): boolean {
   return Number.isInteger(value) && value >= range.min && value <= range.max;
 }
 
+/** Validate editable behavior before submitting a full configuration to the daemon. */
 function collectProblems(config: WindowManagerConfig): WindowManagerConfigProblem[] {
   const problems: WindowManagerConfigProblem[] = [];
   const ranges = WINDOW_MANAGER_RANGES;
@@ -259,6 +266,7 @@ function collectProblems(config: WindowManagerConfig): WindowManagerConfigProble
   return problems;
 }
 
+/** Expose a retryable, single-flight behavior draft with canonical persistence and apply outcomes. */
 export function useWindowManagerConfigEditor(baseline: WindowManagerConfig) {
   const baselineRevision = configRevision(baseline);
   const { store } = useStoreBinding(

--- a/web/src/systems/settings/hooks/use-window-manager-keyboard-editors.ts
+++ b/web/src/systems/settings/hooks/use-window-manager-keyboard-editors.ts
@@ -5,6 +5,7 @@ import { useWindowManagerAliasEditor } from "./use-window-manager-alias-editor";
 import { useWindowManagerBindingMutations } from "./use-window-manager-binding-mutations";
 import { useWindowManagerShortcutRecorder } from "./use-window-manager-shortcut-recorder";
 
+/** Share one scoped write queue and application receipt across shortcut, hotkey and alias editors. */
 export function useWindowManagerKeyboardEditors(
   section: WindowManagerSettingsSection,
   workspaceId: string,
@@ -21,5 +22,5 @@ export function useWindowManagerKeyboardEditors(
     bindings,
     commandId => section.commands.find(command => command.id === commandId)?.title ?? commandId
   );
-  return { aliases, globalRecorder, recorder };
+  return { aliases, globalRecorder, recorder, bindingApply: bindings.apply };
 }

--- a/web/src/systems/settings/index.ts
+++ b/web/src/systems/settings/index.ts
@@ -419,5 +419,3 @@ export { buildRolesViewModel, type RoleViewModel } from "./lib/roles-view-model"
 export { ROLE_ORDER, type RoleRuntimeValue } from "./lib/roles-config";
 export type { RolesDisclosure } from "./hooks/use-roles-disclosure";
 export type { RolesRuntimeOptions } from "./hooks/use-roles-runtime-options";
-
-export { windowManagerApplyMessage } from "./lib/window-manager-settings-result";

--- a/web/src/systems/settings/index.ts
+++ b/web/src/systems/settings/index.ts
@@ -419,3 +419,5 @@ export { buildRolesViewModel, type RoleViewModel } from "./lib/roles-view-model"
 export { ROLE_ORDER, type RoleRuntimeValue } from "./lib/roles-config";
 export type { RolesDisclosure } from "./hooks/use-roles-disclosure";
 export type { RolesRuntimeOptions } from "./hooks/use-roles-runtime-options";
+
+export { windowManagerApplyMessage } from "./lib/window-manager-settings-result";

--- a/web/src/systems/settings/lib/__tests__/save-state.test.ts
+++ b/web/src/systems/settings/lib/__tests__/save-state.test.ts
@@ -7,6 +7,17 @@ import { describe, expect, it } from "vitest";
 import { deriveSettingsSaveBarState } from "../save-state";
 
 describe("deriveSettingsSaveBarState", () => {
+  it.each([false, true])("preserves recovery actions with validation=%s", isInvalid => {
+    expect(
+      deriveSettingsSaveBarState({
+        isDirty: true,
+        isInvalid,
+        isSaving: false,
+        error: "Save failed",
+        showSaved: false,
+      })
+    ).toEqual({ kind: "error", message: "Save failed", canRetry: !isInvalid, canDiscard: true });
+  });
   it("projects invalid input even when the last valid draft is unchanged", () => {
     expect(
       deriveSettingsSaveBarState({

--- a/web/src/systems/settings/lib/save-state.ts
+++ b/web/src/systems/settings/lib/save-state.ts
@@ -17,6 +17,7 @@ export interface SettingsSaveStateInput {
   showSaved: boolean;
 }
 
+/** Derive visible save status and recovery actions without treating an error as an immutable lock. */
 export function deriveSettingsSaveBarState({
   isDirty,
   isInvalid = false,

--- a/web/src/systems/settings/lib/save-state.ts
+++ b/web/src/systems/settings/lib/save-state.ts
@@ -3,7 +3,7 @@ export type SettingsSaveBarState =
   | { kind: "dirty"; warnings: string[] }
   | { kind: "invalid"; warnings: string[] }
   | { kind: "saving" }
-  | { kind: "error"; message: string }
+  | { kind: "error"; message: string; canRetry?: boolean; canDiscard?: boolean }
   | { kind: "saved"; message: string }
   | { kind: "warning"; message: string; warnings: string[] };
 
@@ -27,7 +27,8 @@ export function deriveSettingsSaveBarState({
   showSaved,
 }: SettingsSaveStateInput): SettingsSaveBarState {
   if (isSaving) return { kind: "saving" };
-  if (error) return { kind: "error", message: error };
+  if (error)
+    return { kind: "error", message: error, canRetry: isDirty && !isInvalid, canDiscard: isDirty };
   if (isInvalid) return { kind: "invalid", warnings };
   if (isDirty) return { kind: "dirty", warnings };
   if (warnings.length > 0) {

--- a/web/src/systems/settings/lib/window-manager-layout-schema.ts
+++ b/web/src/systems/settings/lib/window-manager-layout-schema.ts
@@ -413,6 +413,7 @@ export function windowManagerProfileToWire(profile: WindowManagerLayoutProfile) 
   };
 }
 
+/** Serialize the complete behavior configuration, including zero gaps and global shortcuts. */
 export function windowManagerSettingsConfigToWire(config: WindowManagerConfig) {
   return {
     new_window_policy: config.newWindowPolicy,

--- a/web/src/systems/settings/lib/window-manager-layout-schema.ts
+++ b/web/src/systems/settings/lib/window-manager-layout-schema.ts
@@ -440,5 +440,6 @@ export function windowManagerSettingsConfigToWire(config: WindowManagerConfig) {
       bottom_center: config.bindings.bottomCenter,
     },
     shortcuts: config.shortcuts,
+    global_shortcuts: config.globalShortcuts,
   };
 }

--- a/web/src/systems/settings/lib/window-manager-settings-result.ts
+++ b/web/src/systems/settings/lib/window-manager-settings-result.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+
+const applySchema = z.object({
+  applied: z.boolean(),
+  lifecycle: z.enum([
+    "live",
+    "live-add",
+    "live-remove-if-unused",
+    "restart-required",
+    "session-rebind",
+  ]),
+  apply_record_id: z.string(),
+  active_generation: z.number().int(),
+  active_config_hash: z.string(),
+  next_action: z.enum(["none", "restart-daemon", "new-session", "retry"]),
+  restart_required: z.boolean().optional(),
+  warnings: z.array(z.string()).optional(),
+  partial_failures: z
+    .array(
+      z.object({
+        subsystem: z.string(),
+        diagnostic: z.object({ title: z.string(), message: z.string() }),
+      })
+    )
+    .optional(),
+  skipped: z.boolean().optional(),
+  skipped_reason: z.string().optional(),
+});
+
+export type WindowManagerSettingsApply = z.infer<typeof applySchema>;
+
+export function parseWindowManagerSettingsApply(value: unknown): WindowManagerSettingsApply {
+  return applySchema.parse(value);
+}
+
+export function windowManagerApplyMessage(result: WindowManagerSettingsApply): string {
+  if (result.partial_failures?.length || result.next_action === "retry") {
+    const details = [
+      ...(result.partial_failures?.map(failure => failure.diagnostic.message) ?? []),
+      ...(result.warnings ?? []),
+    ].join(" · ");
+    const action =
+      result.next_action === "restart-daemon" || result.restart_required
+        ? "Restart CompozyOS to apply."
+        : result.next_action === "new-session"
+          ? "Start a new session to apply."
+          : "Resolve the problem and retry.";
+    return `Settings saved, but apply failed. ${details ? `${details} ` : ""}${action}`;
+  }
+  if (result.restart_required || result.next_action === "restart-daemon") {
+    return "Settings saved. Restart CompozyOS to apply.";
+  }
+  if (result.next_action === "new-session") return "Settings saved. New sessions use this config.";
+  if (result.skipped) return "No config changes detected.";
+  if (!result.applied) return "Settings saved, but not applied. Retry to apply.";
+  return "Settings saved and applied.";
+}
+
+export function windowManagerApplyFailed(result: WindowManagerSettingsApply): boolean {
+  return (
+    Boolean(result.partial_failures?.length) ||
+    result.next_action === "retry" ||
+    (!result.applied &&
+      !result.skipped &&
+      !result.restart_required &&
+      result.next_action === "none")
+  );
+}

--- a/web/src/systems/settings/mocks/__tests__/handlers.test.ts
+++ b/web/src/systems/settings/mocks/__tests__/handlers.test.ts
@@ -1,6 +1,8 @@
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
+import { resetWindowManagerSettingsMockState } from "../window-manager-settings-handlers";
+import { settingsWindowManagerSectionFixture } from "../window-manager-fixtures";
 import { handlers } from "../handlers";
 
 const server = setupServer(...handlers);
@@ -12,6 +14,7 @@ beforeAll(() => {
 
 afterEach(() => {
   server.resetHandlers();
+  resetWindowManagerSettingsMockState();
 });
 
 afterAll(() => {
@@ -42,6 +45,60 @@ describe("settings shell MSW handlers", () => {
           document: { workspace_id: "workspace-custom" },
         },
       },
+    });
+  });
+
+  it("Should persist a full layout Save through reload without crossing profile or workspace boundaries", async () => {
+    const url = `${API}/api/settings/window-manager?scope=workspace&workspace_id=ws-save&profile=alpha`;
+    const config = {
+      ...structuredClone(settingsWindowManagerSectionFixture.config),
+      gaps: { inner: 0, top: 0, right: 0, bottom: 0, left: 0 },
+    };
+    const write = await fetch(url, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ config }),
+    });
+    expect(write.status).toBe(200);
+    await expect(write.json()).resolves.toMatchObject({ config, apply: { applied: true } });
+    await expect((await fetch(url)).json()).resolves.toMatchObject({ config });
+    for (const query of [
+      "scope=workspace&workspace_id=ws-other&profile=alpha",
+      "scope=workspace&workspace_id=ws-save&profile=beta",
+      "scope=user&profile=alpha",
+    ]) {
+      await expect(
+        (await fetch(`${API}/api/settings/window-manager?${query}`)).json()
+      ).resolves.toMatchObject({ config: settingsWindowManagerSectionFixture.config });
+    }
+    resetWindowManagerSettingsMockState();
+    await expect((await fetch(url)).json()).resolves.toMatchObject({
+      config: settingsWindowManagerSectionFixture.config,
+    });
+  });
+
+  it("Should preserve separately edited shortcuts when a behavior draft is saved", async () => {
+    const url = `${API}/api/settings/window-manager?scope=user`;
+    const shortcuts = { "window.close": ["meta+KeyW"] };
+    const global_shortcuts = { "palette.summon.global": "meta+alt+Space" };
+    const aliases = { "session.new": "start" };
+    const write = (body: unknown) =>
+      fetch(url, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    await write({ shortcuts, global_shortcuts, aliases });
+    await write({
+      config: {
+        ...settingsWindowManagerSectionFixture.config,
+        gaps: { inner: 0, top: 0, right: 0, bottom: 0, left: 0 },
+      },
+      preserve_shortcuts: true,
+    });
+    await expect((await fetch(url)).json()).resolves.toMatchObject({
+      config: { shortcuts, global_shortcuts, gaps: { inner: 0 } },
+      aliases,
     });
   });
 

--- a/web/src/systems/settings/mocks/handlers.ts
+++ b/web/src/systems/settings/mocks/handlers.ts
@@ -27,6 +27,7 @@ import {
   settingsProvidersCollectionFixture,
   settingsProviderFixtures,
   settingsReloadBlockedFixture,
+  settingsReloadAppliedFixture,
   settingsRestartRequiredMutationFixture,
   settingsRestartResponseFixture,
   settingsRestartStatusFixture,
@@ -218,10 +219,12 @@ export const handlers: HttpHandler[] = [
   compozyApiMock.get("/api/settings/window-manager", () =>
     HttpResponse.json(settingsWindowManagerSectionFixture)
   ),
-  // Bindings echo the section the daemon produced, never a write receipt: the
-  // caller has to see the keymap that actually resulted (ADR-006).
+  // Mutations preserve the section echo and expose the daemon apply receipt.
   compozyApiMock.patch("/api/settings/window-manager", () =>
-    HttpResponse.json(settingsWindowManagerSectionFixture)
+    HttpResponse.json({
+      ...settingsWindowManagerSectionFixture,
+      apply: settingsReloadAppliedFixture,
+    })
   ),
 
   compozyApiMock.get("/api/workspaces/{workspace_id}/window-manager/layout", ({ params }) =>

--- a/web/src/systems/settings/mocks/handlers.ts
+++ b/web/src/systems/settings/mocks/handlers.ts
@@ -27,7 +27,6 @@ import {
   settingsProvidersCollectionFixture,
   settingsProviderFixtures,
   settingsReloadBlockedFixture,
-  settingsReloadAppliedFixture,
   settingsRestartRequiredMutationFixture,
   settingsRestartResponseFixture,
   settingsRestartStatusFixture,
@@ -39,11 +38,11 @@ import {
 } from "./layered-fixtures";
 import {
   settingsWindowManagerDesktopIds,
-  settingsWindowManagerSectionFixture,
   settingsWindowManagerSnapshotFixture,
   windowManagerLayoutDocumentFixture,
   windowManagerLayoutResourceFixture,
 } from "./window-manager-fixtures";
+import { windowManagerSettingsHandlers } from "./window-manager-settings-handlers";
 import { rolesStatusFixture, settingsRolesSectionFixture } from "./roles-fixtures";
 import { settingsUpdateStatusFixture } from "./settings-update-fixture";
 
@@ -216,16 +215,7 @@ export const handlers: HttpHandler[] = [
     HttpResponse.json(settingsCmdPaletteSectionFixture)
   ),
 
-  compozyApiMock.get("/api/settings/window-manager", () =>
-    HttpResponse.json(settingsWindowManagerSectionFixture)
-  ),
-  // Mutations preserve the section echo and expose the daemon apply receipt.
-  compozyApiMock.patch("/api/settings/window-manager", () =>
-    HttpResponse.json({
-      ...settingsWindowManagerSectionFixture,
-      apply: settingsReloadAppliedFixture,
-    })
-  ),
+  ...windowManagerSettingsHandlers,
 
   compozyApiMock.get("/api/workspaces/{workspace_id}/window-manager/layout", ({ params }) =>
     HttpResponse.json(layoutDocumentForWorkspace(String(params.workspace_id)))

--- a/web/src/systems/settings/mocks/index.ts
+++ b/web/src/systems/settings/mocks/index.ts
@@ -55,3 +55,5 @@ export {
   windowManagerLayoutDocumentFixture,
   windowManagerLayoutResourceFixture,
 } from "./window-manager-fixtures";
+
+export { resetWindowManagerSettingsMockState } from "./window-manager-settings-handlers";

--- a/web/src/systems/settings/mocks/window-manager-settings-handlers.ts
+++ b/web/src/systems/settings/mocks/window-manager-settings-handlers.ts
@@ -1,0 +1,53 @@
+import { HttpResponse, type HttpHandler } from "msw";
+
+import { compozyApiMock } from "@/storybook/openapi-msw";
+import type { SettingsWindowManagerSection } from "../types";
+import { settingsReloadAppliedFixture } from "./fixtures";
+import { settingsWindowManagerSectionFixture } from "./window-manager-fixtures";
+
+const sections = new Map<string, SettingsWindowManagerSection>();
+
+/** Starts each story or test with an independent window-manager settings fixture. */
+export function resetWindowManagerSettingsMockState(): void {
+  sections.clear();
+}
+
+/** Persisted settings belong to the profile and workspace, not the requesting shell client. */
+function scopedSection(request: Request) {
+  const query = new URL(request.url).searchParams;
+  const scope = query.get("scope") === "workspace" ? "workspace" : "user";
+  const workspaceId = scope === "workspace" ? (query.get("workspace_id") ?? "") : "";
+  const key = JSON.stringify([query.get("profile") ?? "default", scope, workspaceId]);
+  const section = sections.get(key) ?? {
+    ...structuredClone(settingsWindowManagerSectionFixture),
+    scope,
+    workspace_id: workspaceId,
+  };
+  return { key, section };
+}
+
+/** Echoes writes and subsequent reads from the same scoped state for interactive stories. */
+export const windowManagerSettingsHandlers: HttpHandler[] = [
+  compozyApiMock.get("/api/settings/window-manager", ({ request }) =>
+    HttpResponse.json(scopedSection(request).section)
+  ),
+  compozyApiMock.patch("/api/settings/window-manager", async ({ request }) => {
+    const { key, section } = scopedSection(request);
+    const body = await request.json();
+    const config = { ...section.config, ...body.config };
+    if (body.preserve_shortcuts) {
+      config.shortcuts = section.config.shortcuts;
+      config.global_shortcuts = section.config.global_shortcuts;
+    }
+    if (body.shortcuts != null) config.shortcuts = body.shortcuts;
+    if (body.global_shortcuts != null) config.global_shortcuts = body.global_shortcuts;
+    const saved: SettingsWindowManagerSection = {
+      ...section,
+      config,
+      aliases: body.aliases ?? section.aliases,
+      effective_shortcuts: { ...section.defaults, ...config.shortcuts },
+    };
+    sections.set(key, saved);
+    return HttpResponse.json({ ...saved, apply: settingsReloadAppliedFixture });
+  }),
+];


### PR DESCRIPTION
## Problem and root cause

Closes #593.

A failed Save in **Settings → Layouts** could disable both Save and Discard indefinitely. The editor cleared its store error after an edit/reset, but continued exposing the previous TanStack mutation error. Error state took precedence over dirty state and the shared Save bar disabled its recovery actions.

The same path had two data/result defects: the full-config serializer omitted `global_shortcuts`, and a stale behavior draft could overwrite shortcut changes made separately. Both the frontend adapter and the backend section-echo handler also discarded the daemon's application receipt, making HTTP success indistinguishable from completed live application.

Zero gaps were already valid. The original connection-refused logs do not establish a settings-triggered daemon crash. This PR fixes the evidenced recovery, preservation and result-reporting defects without changing gap validation.

## Resulting behavior and implementation

- Failed saves keep the draft and enable retry/discard. Editing or resetting clears the old error; in-flight saves remain single-flight, and late results cannot overwrite newer edits.
- Successful saves adopt the canonical returned config and display the daemon's apply outcome. Application failures remain errors; warnings and pending restart/new-session actions remain visible. Malformed/unverified receipts cannot become a success message.
- A save that reached disk but failed runtime application adopts the persisted baseline. For user-scoped Layouts saves, the projected-apply recorder compares the active hash before skipping an unchanged write, so retry re-applies only the pending layout. The first Save captures its pre-write active baseline as well. A regression verifies this from a cold service and keeps an unrelated pending HTTP port change inactive.
- The Settings PATCH retains all section-echo fields and adds `apply`. Its optional `preserve_shortcuts` flag preserves the latest local/global shortcut maps inside the existing mutation boundary. Layouts sends this flag; explicit top-level shortcut maps retain their replacement semantics.
- Full serialization includes global shortcuts. Behavior draft revisions exclude separately owned shortcut state, so a live shortcut edit does not reset a spacing draft.
- Existing settings editor, Save bar, state derivation, adapter, service and HTTP/UDS handler suites cover the regressions. OpenAPI/generated Web contracts, the official Compozy reference, site documentation and affected QA scenarios co-ship.

- Immediate shortcut, global-hotkey and alias edits also retain the application receipt. Failed application caches the canonical saved section while preserving an error; warnings and pending actions remain visible. Late responses reconcile only into their originating workspace. Interactive Storybook fixtures persist submitted settings per profile/workspace and reset between stories.

## Validation

- Real isolated macOS Chromium + daemon flow: reproduced the original disabled recovery buttons by aborting PATCH; verified original-draft retry, edit-after-failure, discard, successful save and reload after the fix.
- Saved zero inner spacing, zero outer insets and all-zero gaps independently. DOM measurement confirmed adjacent tiles meet at x=640 with zero gap; a 1 px gap moves the second tile to x=641. A top inset of 1 px moves y=44 to y=45. All-zero reload restores the original coordinates.
- A real HTTP 500 caused by temporary write denial in the isolated home retained the draft and allowed retry after permissions were restored in `finally`.
- Changed shortcuts/global shortcuts and an alias while a spacing draft was open; the later Save preserved the newer values. An identical repeated PATCH returned `skipped: true` without advancing the generation. A separate browser capture confirms that editing a failed Save displays “Unsaved changes”.
- Root Turborepo Web tests, typecheck and build passed. The gate for `1e829ff` included 771 suites / 7,137 tests, lint and typecheck.
- `CGO_ENABLED=1 go test -race ./internal/settings ./internal/api/core` passed. The receipt case also passed through both HTTP and UDS handler shims.
- `make gate` on `1e829ff` before the final review batch: passed — codegen-check, Go lint (zero issues), affected Go race suites, Web lint (zero warnings/errors), typecheck and all tests.
- Documentation build: `bunx turbo run build --filter=./packages/site` passed, including TypeScript and 2,509 static pages.

See [the targeted QA report](docs/qa/reports/2026-09-10-issue-593-layout-settings-save.md) for the scenario matrix, receipt evidence and cross-surface audit. Lab teardown returned `clean: true`.

## Compatibility, isolation and limits

The response and request changes are additive. Existing clients retain the section echo and full-config replacement semantics when the new flag is omitted. There are no persisted schema changes, migrations, native tool ID changes, hook changes or workspace/profile routing changes. The existing user-scoped config authority remains with the daemon.

No production settings or host daemon were changed. Live evidence covers transport and HTTP write rejection; partial-application/restart receipt cases are verified at unit I/O boundaries, not presented as real platform failures. Electron global-hotkey registration, Linux and provider-backed workflows were not exercised. The Web build succeeds with pre-existing CSS `::highlight` optimizer and bundle-size warnings; unrelated test harness warnings are recorded without suppressing them.


The CI follow-up also fixes palette selection continuity: asynchronously arriving ranking could
replace an automatically selected row and close its action panel. A hook regression failed before
the correction and passed afterward; the existing Herdr E2E-016 assertion remains unchanged. The final review batch
passed targeted settings suites and root Web typecheck/build. Per the user's updated instruction,
subsequent delivery gates run in CI; the queued local gate was canceled. Current-head CI results
will be recorded after completion.

## Delivery requirement: existing palette E2E must pass

The user explicitly requires every current-head CI check to pass, including the existing Herdr
E2E-016 keyboard journey. [Run 34510838879, shard 2](https://github.com/compozy/compozy/actions/runs/34510838879/job/102984422218)
failed that journey. Its trace showed a rank refresh replacing the selected row and closing its
actions. The small palette correction is required to satisfy that delivery requirement; it leaves
the E2E assertions intact and adds the deterministic regression to the existing root/surface suite.
There is no separate `use-os-palette-surface` suite in this repository; the canonical root suite
already owns surface presentation and selection continuity. Its ownership header now makes this
explicit, avoiding duplicate registry/ranking harnesses.

The final review also covers unverified binding application: `applied: false` with
`next_action: none` retains receipt warnings in the visible retry error. The existing shortcut-table
suite covers this alongside explicit retry receipts. The Go lint documentation-line finding is
fixed without changing lint policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window-manager settings can preserve existing shortcuts and global shortcuts when saving layout changes.
  * Save responses now report whether changes were applied, including warnings and required follow-up actions.
  * Window-manager shortcut and layout editors display apply status and warnings.
* **Bug Fixes**
  * Improved recovery after failed or partial settings application, with options to retry or discard valid changes.
  * Preserved pending edits and saved settings more reliably during concurrent updates.
  * Command-palette selection remains stable while results load asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->