### PR TITLE
fix: confirm terminal termination when closing windows

### DIFF
--- a/docs/qa/journeys/J-operate-integrated-terminal.md
+++ b/docs/qa/journeys/J-operate-integrated-terminal.md
@@ -17,7 +17,9 @@ flowchart TD
   G -->|yes| D
   G -->|exited| H[Read the final output and exit state]
   H --> Z[True end: terminal state, journal, window list, and session transcript agree on what was supervised]
-  B -.->|operator closes before typing| X1[Abandon: the terminal remains available until its configured lifecycle closes it]
+  B -.->|operator closes| X1{Confirm termination?}
+  X1 -->|cancel| D
+  X1 -->|confirm| Z
   E -.->|operator does not return| X2[Abandon: detached lifetime policy remains authoritative]
 ```
 
@@ -53,7 +55,7 @@ journey:
     natural: "The operator closes the finished terminal or continues work in the resumed one."
   abandonment:
     - at_step: 2
-      how: "Close the window while the command is still running."
+      how: "Minimize the window or detach the viewer while the command is still running."
       resume: "Reopen the Terminal app and attach to the same terminal from the current stream cursor."
   crosses: [terminal-runtime, session-transcript, journal, recordings, profile-scope, WebSocket-stream]
 ```

--- a/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
+++ b/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
@@ -48,15 +48,15 @@ layout/scope checks precede termination; the final close is revision-fenced.
 
 ## Verification
 
-- Focused Turbo unit run: 105 tests passed across four existing suites.
+- Focused Turbo unit run: 105 tests passed across four existing suites before the final workspace-switch regression. The final revision extends that existing suite to cover a different workspace and an unscoped destination; full current-head CI validates those cases.
 - First typecheck found a missing timestamp in the new exit fixture; corrected before final checks.
-- Repository-root Turbo typecheck and production build passed.
-- Final real E2E run: E2E-002, E2E-020 and E2E-019 passed (3 tests), using isolated launch runtimes and the production bundle.
+- Repository-root Turbo typecheck and production build passed before the final workspace-key refinement; current-head CI repeats both.
+- Local real E2E run before the final workspace-key refinement: E2E-002, E2E-020 and E2E-019 passed (3 tests), using isolated launch runtimes and the production bundle. Current-head CI repeats the full suite.
 - E2E-002 proves both terminal IDs survive reload/cancel, both exit after group confirmation, their windows remain closed after reload, and retained output is readable through CLI quote.
 - E2E-020 disconnects the actual browser transport before confirmation; visible failure preserves the window and running process. Reconnect/reload restores the same terminal; Stop preserves its window; exited close is direct.
 - Manual browser QA: Cancel receives initial focus; keyboard and window-menu close use the same dialog; two viewers observe a shared exit; Tasks closes normally. A mixed Tasks/alpha/beta group lists only running terminals. Close others cancellation preserves the group, Close right ends beta only, and final group close ends alpha/removes Tasks while an external terminal remains running.
 - Native compatibility probe: CLI window close removes the managed view; a subsequent terminal get still reports running with zero viewers.
-- React Doctor on all 16 changed-source files: 100/100, no issues. Confirmed independent terminations run concurrently behind an all-settled barrier; partial failure retains all windows until every request completes.
+- React Doctor before the final workspace-key refinement: all 16 changed-source files, 100/100, no issues. Its workflow rechecks the current head. Confirmed independent terminations run concurrently behind an all-settled barrier; partial failure retains all windows until every request completes.
 - Global-scope regression: close resolves the retained desktop's owning project even while the data destination is unscoped; E2E-002 and E2E-020 passed with Global enabled before running/exited close.
 - QA teardown reported `clean: true`, with no surviving registered processes.
 - The initial implementation passed `make gate`. After review remediation, the operator explicitly moved full gates to CI; the queued local rerun was canceled before acquiring capacity. Current-head CI owns final full-gate verification, with outcomes recorded in the pull request.
@@ -64,7 +64,7 @@ layout/scope checks precede termination; the final close is revision-fenced.
 ## Review remediation
 
 - React Doctor: replaced sequential termination with a fully validated concurrent batch. The existing controller suite covers partial-failure settlement, retrying only surviving processes, and rejecting unconfirmed owner changes before any termination.
-- CodeRabbit: launcher creation is keyed by workspace/window, so changing the destination profile cannot hide an in-flight creation. The existing controller suite retains the launcher across guard rebinding and allows close after failed creation.
+- CodeRabbit: launcher creation is keyed by stable window identity, so changing the workspace or destination profile cannot hide an in-flight creation. The existing controller suite retains the launcher across workspace rebinding, including an unscoped destination, allows unrelated windows to close, and permits launcher close after failed creation.
 - CodeRabbit: scope tests now assert one guard call with the exact ordered target IDs, excluding additional or unrelated terminals.
 - CodeRabbit documentation check: documented the lifecycle contracts of the touched controller, guard, dialog, and mutation-key functions.
 - CodeRabbit excluded-path check: manually reviewed all seven excluded documentation, official-skill, and E2E files against issue #594. The scenario matrix and real-run evidence above cover the changed operator contract; native view-only close and retained history remain explicit.

--- a/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
+++ b/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
@@ -1,0 +1,68 @@
+# Terminal close UX — issue #594
+
+- Scope: targeted branch validation of terminal/window close behavior.
+- Environment: isolated local macOS runtime and production Web bundle; no host-daemon changes.
+- Persona: Marina, an operator running shell work and managing terminal tabs.
+- Status: behavioral QA PASS. Delivery gate and current-head CI are recorded in the pull request.
+
+## Session matrix
+
+| Journey | Observable | Status |
+| --- | --- | --- |
+| Running close | Cancel preserves work; confirm stops it and closes the window | PASS |
+| Group close | Exactly the affected terminals are confirmed; unrelated work survives | PASS |
+| Stop and exited close | Stop keeps the window; exited close needs no running warning | PASS |
+| Reconnect and failure | Failure retains a retryable window; reconnect permits a fresh attempt | PASS |
+| Adjacent windows | Ordinary app close and native view-only close retain their contracts | PASS |
+
+## Charter
+
+From the Terminal dock, run ordinary shell work, reload, manage two terminal tabs, and close through
+window chrome and keyboard/menu. Try canceling, stopping first, and disconnecting the browser.
+Use public CLI/API terminal and window reads to verify persisted state. Capture the confirmation,
+failure, and final state. A running process without a visible, retryable window is a failure.
+
+## Implementation and root cause
+
+The former header action called terminal DELETE without closing the managed window. Window chrome,
+keyboard/menu and tab close called only the window manager, so they detached a view while work
+continued. The browser runtime now runs terminal lifecycle preparation before its existing window
+close command. One confirmation covers the selected running terminals. A fresh daemon read and
+layout/scope checks precede termination; the final close is revision-fenced.
+
+## Cross-surface impact
+
+- Native tools: `compozy__window_close` and `compozy__terminal_close` keep their separate contracts,
+  schemas, policy gates, and CLI/HTTP/UDS fallbacks. Browser `window.close` client operations now use
+  the same confirmation as chrome. No native close becomes implicitly process-destructive.
+- Extensibility/hooks/config: no new hooks, settings, capabilities, or SDK contracts. Existing
+  terminal close and window close events remain daemon-owned; the Web composes their public APIs.
+- Workspace/profile isolation: the browser captures the owning desktop workspace and resolves terminal
+  owners from the labeled catalog, submits exact-profile deletes, and abandons stale shell bindings.
+- User state: no database/config/layout shape changes or migrations. Journals, recordings, and
+  retention policies are unchanged. Shared viewers observe the same authoritative process exit.
+- Internal compatibility: redundant header Close props/actions are removed together with their
+  consumers. The terminal-limit dialog retains its separate slot-recovery action.
+- Web/Docs: terminal header, shell close admission/dialog, browser E2E and controller/runtime suites;
+  official Terminal skill, terminal safety docs and affected QA journeys/scenarios updated.
+
+## Verification
+
+- Focused Turbo unit run: 103 tests passed across four existing suites.
+- First typecheck found a missing timestamp in the new exit fixture; corrected before final checks.
+- Repository-root Turbo typecheck and production build passed.
+- Final real E2E run: E2E-002, E2E-020 and E2E-019 passed (3 tests), using isolated launch runtimes and the production bundle.
+- E2E-002 proves both terminal IDs survive reload/cancel, both exit after group confirmation, their windows remain closed after reload, and retained output is readable through CLI quote.
+- E2E-020 disconnects the actual browser transport before confirmation; visible failure preserves the window and running process. Reconnect/reload restores the same terminal; Stop preserves its window; exited close is direct.
+- Manual browser QA: Cancel receives initial focus; keyboard and window-menu close use the same dialog; two viewers observe a shared exit; Tasks closes normally. A mixed Tasks/alpha/beta group lists only running terminals. Close others cancellation preserves the group, Close right ends beta only, and final group close ends alpha/removes Tasks while an external terminal remains running.
+- Native compatibility probe: CLI window close removes the managed view; a subsequent terminal get still reports running with zero viewers.
+- React Doctor changed-source scan: 100/100, no issues.
+- Global-scope regression: close resolves the retained desktop's owning project even while the data destination is unscoped; E2E-002 and E2E-020 passed with Global enabled before running/exited close.
+- QA teardown reported `clean: true`, with no surviving registered processes.
+- Delivery commands: `make gate` and current-head required PR checks; their final outcomes are recorded in the pull request.
+
+## Runtime limitations
+
+Goal activation and a structured read returned active/running with zero turns used. This does not
+prove automatic Goal execution. The completion-report tool is unavailable to this ordinary prompt (`goal_not_active`). Host runtime repair is outside this change. Linux and packaged
+Electron behavior have not been verified in this local pass.

--- a/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
+++ b/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
@@ -56,7 +56,7 @@ layout/scope checks precede termination; the final close is revision-fenced.
 - E2E-020 disconnects the actual browser transport before confirmation; visible failure preserves the window and running process. Reconnect/reload restores the same terminal; Stop preserves its window; exited close is direct.
 - Manual browser QA: Cancel receives initial focus; keyboard and window-menu close use the same dialog; two viewers observe a shared exit; Tasks closes normally. A mixed Tasks/alpha/beta group lists only running terminals. Close others cancellation preserves the group, Close right ends beta only, and final group close ends alpha/removes Tasks while an external terminal remains running.
 - Native compatibility probe: CLI window close removes the managed view; a subsequent terminal get still reports running with zero viewers.
-- React Doctor changed-source scan: 100/100, no issues.
+- React Doctor on all 16 committed changed-source files: 93/100; one `async-await-in-loop` advisory. Termination is deliberately sequential so each target is fenced again and the first failure stops further termination. The earlier 100/100 scan included only the 13 already tracked files.
 - Global-scope regression: close resolves the retained desktop's owning project even while the data destination is unscoped; E2E-002 and E2E-020 passed with Global enabled before running/exited close.
 - QA teardown reported `clean: true`, with no surviving registered processes.
 - Delivery commands: `make gate` and current-head required PR checks; their final outcomes are recorded in the pull request.

--- a/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
+++ b/docs/qa/reports/2026-09-10-issue-594-terminal-close.md
@@ -48,7 +48,7 @@ layout/scope checks precede termination; the final close is revision-fenced.
 
 ## Verification
 
-- Focused Turbo unit run: 103 tests passed across four existing suites.
+- Focused Turbo unit run: 105 tests passed across four existing suites.
 - First typecheck found a missing timestamp in the new exit fixture; corrected before final checks.
 - Repository-root Turbo typecheck and production build passed.
 - Final real E2E run: E2E-002, E2E-020 and E2E-019 passed (3 tests), using isolated launch runtimes and the production bundle.
@@ -56,10 +56,19 @@ layout/scope checks precede termination; the final close is revision-fenced.
 - E2E-020 disconnects the actual browser transport before confirmation; visible failure preserves the window and running process. Reconnect/reload restores the same terminal; Stop preserves its window; exited close is direct.
 - Manual browser QA: Cancel receives initial focus; keyboard and window-menu close use the same dialog; two viewers observe a shared exit; Tasks closes normally. A mixed Tasks/alpha/beta group lists only running terminals. Close others cancellation preserves the group, Close right ends beta only, and final group close ends alpha/removes Tasks while an external terminal remains running.
 - Native compatibility probe: CLI window close removes the managed view; a subsequent terminal get still reports running with zero viewers.
-- React Doctor on all 16 committed changed-source files: 93/100; one `async-await-in-loop` advisory. Termination is deliberately sequential so each target is fenced again and the first failure stops further termination. The earlier 100/100 scan included only the 13 already tracked files.
+- React Doctor on all 16 changed-source files: 100/100, no issues. Confirmed independent terminations run concurrently behind an all-settled barrier; partial failure retains all windows until every request completes.
 - Global-scope regression: close resolves the retained desktop's owning project even while the data destination is unscoped; E2E-002 and E2E-020 passed with Global enabled before running/exited close.
 - QA teardown reported `clean: true`, with no surviving registered processes.
-- Delivery commands: `make gate` and current-head required PR checks; their final outcomes are recorded in the pull request.
+- The initial implementation passed `make gate`. After review remediation, the operator explicitly moved full gates to CI; the queued local rerun was canceled before acquiring capacity. Current-head CI owns final full-gate verification, with outcomes recorded in the pull request.
+
+## Review remediation
+
+- React Doctor: replaced sequential termination with a fully validated concurrent batch. The existing controller suite covers partial-failure settlement, retrying only surviving processes, and rejecting unconfirmed owner changes before any termination.
+- CodeRabbit: launcher creation is keyed by workspace/window, so changing the destination profile cannot hide an in-flight creation. The existing controller suite retains the launcher across guard rebinding and allows close after failed creation.
+- CodeRabbit: scope tests now assert one guard call with the exact ordered target IDs, excluding additional or unrelated terminals.
+- CodeRabbit documentation check: documented the lifecycle contracts of the touched controller, guard, dialog, and mutation-key functions.
+- CodeRabbit excluded-path check: manually reviewed all seven excluded documentation, official-skill, and E2E files against issue #594. The scenario matrix and real-run evidence above cover the changed operator contract; native view-only close and retained history remain explicit.
+- Greptile's initial and documentation-follow-up reviews reported 5/5 with no actionable findings. Current-head review and CI outcomes are tracked in the pull request.
 
 ## Runtime limitations
 

--- a/docs/qa/scenarios/ET-terminal-browser-lifecycle.md
+++ b/docs/qa/scenarios/ET-terminal-browser-lifecycle.md
@@ -4,7 +4,7 @@ area: ET
 title: Use persistent terminals from the browser
 persona: Marina
 journey: J-operate-integrated-terminal
-expected: Clicking the Terminal dock item lands in a working terminal directly; New terminal opens a second one as an OS window tab; reloading preserves both; closing the window never ends a running terminal, and reopening adopts the newest running one; closing an already-ended terminal is a quiet no-op, never an error toast.
+expected: Reload preserves terminal tabs and their processes. Window Close confirms running terminal termination before removing the window; Cancel preserves both; Stop leaves the window open; exited or missing terminals close directly; failures retain retryable windows. Group close confirms exactly its affected terminals and normal history remains retained.
 entry_points: Web dock Terminal app; /terminal; /terminal/{terminal_id}
 qa_status: pass
 bug_ids: BUG-20260906-hidden-terminal-pane-minimum-vote
@@ -35,10 +35,18 @@ Walk:
 
 1. Click the Terminal dock item in a project with no terminals; a working terminal opens with no launcher or empty-state click in between.
 2. Use the head's New terminal; a second terminal joins the frame as an OS window tab; switch between both deck tabs and reload the browser.
-3. Close the Terminal window while one command is still running; confirm via `compozy terminal list` both sessions keep running; click the dock item and confirm it reattaches to the newest running session.
-4. Let a terminal end, then close it again from the head's overflow; confirm the recorded exit is reported with no error toast, and the exit bar owns the story with no "Reconnecting…" line.
-5. Confirm the route, window title, and dock badge remain truthful throughout.
+3. Close a running Terminal window. Cancel the accessible confirmation and verify its process and window remain intact through CLI and refresh.
+4. Confirm Close; verify the process exits before the managed window disappears. Reopen the browser and confirm it stays closed; inspect retained journal/recording history through the normal surfaces.
+5. Stop a running terminal from its header; verify the window remains on its exit state, then close it without another running warning.
+6. Close a group containing two terminals and an unrelated app; verify one confirmation lists only the affected running terminals. Cancel preserves the group; confirm closes the group without terminating terminals outside it.
+7. Exercise the keyboard/window menu and close-other/right gestures. Pinned tabs remain protected by their existing scope rules.
+8. Lose the connection while closing; verify visible failure feedback, a retained window, and a successful fresh retry after reconnect.
+9. Confirm the route, title, dock badge, and another attached viewer remain truthful throughout.
+
+QA impact 2026-09-10: issue #594 intentionally replaces the old operator view-only close behavior. Historical passes below describe the previous contract; this round is tracked in `docs/qa/reports/2026-09-10-issue-594-terminal-close.md`.
 
 2026-09-04 targeted re-walk: passed. The Terminal app opened a second terminal, switched between OS
 window tabs, survived minimize and reload with both instances restored, and closed one window without
 ending the original terminal. A new browser session reattached to the running terminal with shared input.
+
+QA re-walk 2026-09-10: PASS for the changed close contract. Production-bundle E2Es cover running cancel/confirm, grouped reload/history, disconnect feedback, Stop, and exited close. Manual isolated-browser checks cover keyboard/window-menu close, mixed-app groups, close-other/right targeting, shared viewers, and unchanged native view-only close. Scope and evidence: `docs/qa/reports/2026-09-10-issue-594-terminal-close.md`. Unchanged steps retain their earlier evidence.

--- a/docs/qa/scenarios/ET-terminal-window-native-flow.md
+++ b/docs/qa/scenarios/ET-terminal-window-native-flow.md
@@ -27,10 +27,12 @@ Walk:
 2. From the head, open the Journal; confirm the head shows the Journal crumb with a back affordance, and back returns to the same terminal with its scroll intact.
 3. Use the head's New terminal; confirm a second terminal joins the frame as an OS window tab and the deck is the only tab strip visible.
 4. Use the dock's right-click Open in new window; confirm another terminal opens without touching the existing ones.
-5. End a session from the head's overflow Close terminal; confirm the window stays put on the exit bar until you close it yourself.
+5. Use Stop and confirm the window stays on the exit bar. Close it with the traffic-light control without a running warning. A running terminal instead asks for confirmation; there is no redundant Close terminal header action.
 
 QA re-walk 2026-09-06: the terminal grid now fills a flex column whose height follows the window. A targeted rendered probe measured the host at 395px inside a 417px container; hidden panes cast no minimum-size vote. All 12 terminal journeys passed, including live watcher-size agreement after reflow. Evidence: `.cache/sessions-terminal-artifacts-probe2b/` and `.cache/sessions-terminal-e2e002-fixed2-all2-results.json`; BUG-20260906-hidden-terminal-pane-minimum-vote.
 
 QA re-walk 2026-09-06: the packaged macOS Terminal E2E-013 journey passes input, clipboard, accelerators, zoom/refit and IME in 14.5s. Its watcher compares the current RESIZED grid with the visible size vote, accounting for the viewers footer. Evidence: `.cache/sessions-final-desktop-terminal-e2e-run2.log`; web/dist restored byte-for-byte.
 
 Final selection-layout re-walk 2026-09-06: the packaged macOS Terminal E2E-013 passes again in12.8s with selection actions over the grid. Clipboard selection, accelerators, zoom/refit and IME remain functional; `.cache/sessions-final-desktop-selection-e2e.log`, with web/dist restored byte-for-byte.
+
+QA re-walk 2026-09-10: PASS for the changed close contract. Production-bundle E2Es cover running cancel/confirm, grouped reload/history, disconnect feedback, Stop, and exited close. Manual isolated-browser checks cover keyboard/window-menu close, mixed-app groups, close-other/right targeting, shared viewers, and unchanged native view-only close. Scope and evidence: `docs/qa/reports/2026-09-10-issue-594-terminal-close.md`. Unchanged steps retain their earlier evidence.

--- a/packages/site/content/docs/terminal/agents-and-safety.mdx
+++ b/packages/site/content/docs/terminal/agents-and-safety.mdx
@@ -19,8 +19,15 @@ shared operator access, durable command history, or recording.
 
 Every interactive terminal an agent opens — `compozy__terminal_open`, or `compozy__terminal_exec`
 with `visible: true` — appears as a Terminal window on the desktop without moving focus, so the
-operator can watch and interact with the work immediately while the agent stays attached. Closing that window never signals the process, and a
-window the operator closed does not reopen for the same terminal. Pipe terminals (yielded
+operator can watch and interact with the work immediately while the agent stays attached. The window's Close action asks before terminating a running terminal and its work, then closes the
+managed window. Cancel preserves the process and window. An exited terminal closes directly; Stop
+ends the terminal while keeping its window open. Closing a tab group confirms all affected running
+terminals together. Failures keep the windows available for retry; saved history follows normal
+retention. Other attached viewers observe the same terminal exit.
+
+Keyboard and window-menu close use the same confirmation. Native `compozy__window_close` and
+CLI/API window close remain view-only; detaching a stream or closing the browser also leaves work
+running. A closed managed window does not reopen automatically for the same terminal. Pipe terminals (yielded
 executions) stay in the catalog as read-only log panes instead.
 
 ## Terminal toolset

--- a/skills/compozy/references/terminal.md
+++ b/skills/compozy/references/terminal.md
@@ -23,9 +23,15 @@ true:
 
 Every interactive terminal you open (`terminal_open`, or `terminal_exec` with `visible: true`)
 appears as a Terminal window on the operator's CompozyOS desktop without stealing their focus. The
-operator and authorized agents in the same profile can interact with it concurrently. The operator
-closing that window never kills the process, and a window they closed does not reopen for the same
-terminal.
+operator and authorized agents in the same profile can interact with it concurrently. The operator's window Close asks for confirmation before terminating a running terminal and its work,
+then removes the managed window. Cancel preserves both. An exited terminal closes without the running
+warning; Stop ends the terminal without closing its window. Shared viewers observe the same exit.
+Closing a group confirms its affected running terminals together; a failure retains the windows for
+retry, including any terminals already stopped. Normal journal and recording retention is unchanged.
+
+Native `compozy__window_close` and CLI/API window close remain view-only. Detaching a stream or
+closing the browser does not terminate the process. A closed managed window does not reopen
+automatically for the same terminal.
 
 For routine internal commands, keep using the provider's normal command tool. Provider-internal
 commands render in session activity as plain command output; they do not create a CompozyOS

--- a/web/e2e/__tests__/terminal.spec.ts
+++ b/web/e2e/__tests__/terminal.spec.ts
@@ -16,6 +16,7 @@ import { reloadDaemonServedPage } from "../fixtures/navigation";
 import {
   focusWindowThroughPalette,
   openAppWindow,
+  setGlobalScope,
   switchWorkspace,
   windowFrame,
 } from "../fixtures/os-navigation";
@@ -369,7 +370,7 @@ test("E2E-001: CLI golden path opens, runs, lists, and journals a terminal", asy
     });
 });
 
-test("E2E-002: browser keeps two terminal windows across reload and reattaches after close", async ({
+test("E2E-002: browser restores terminal tabs and confirms group termination", async ({
   appPage,
   runtime,
 }) => {
@@ -463,12 +464,17 @@ test("E2E-002: browser keeps two terminal windows across reload and reattaches a
     ])
   );
 
-  // Closing the window is a window gesture: both sessions keep running. In a
-  // stacked frame the traffic lights live on the deck row and close the group.
+  // Cancel preserves every process and the complete group. Confirm terminates
+  // exactly these two terminals before the daemon removes their windows.
   const restored = focusedTerminalWindow(appPage);
   await focusWindowThroughPalette(appPage, restored);
+  // Global retains this project's desktop; close must still use its owner.
+  await setGlobalScope(appPage, true);
   await windowFrame(restored).getByRole("button", { name: "Close window" }).click();
-  await expect(restored).toBeHidden();
+  const confirmation = appPage.getByTestId("terminal-close-dialog");
+  await expect(confirmation).toBeVisible();
+  await confirmation.getByRole("button", { name: "Cancel", exact: true }).click();
+  await expect(restored).toBeVisible();
   const survivors = await runTerminalCLI<TerminalListEnvelope>(runtime.paths, [
     "list",
     "--workspace",
@@ -481,11 +487,28 @@ test("E2E-002: browser keeps two terminal windows across reload and reattaches a
       terminal => [firstID, secondID].includes(terminal.id) && terminal.state === "running"
     )
   ).toHaveLength(2);
+  await windowFrame(restored).getByRole("button", { name: "Close window" }).click();
+  await confirmation.getByRole("button", { name: "Terminate and close" }).click();
+  await expect(restored).toBeHidden();
+  await expect
+    .poll(async () => {
+      const result = await runTerminalCLI<TerminalListEnvelope>(runtime.paths, [
+        "list",
+        "--workspace",
+        workspace.id,
+        "-o",
+        "json",
+      ]);
+      return result.terminals.filter(
+        terminal => [firstID, secondID].includes(terminal.id) && terminal.state === "running"
+      ).length;
+    })
+    .toBe(0);
+  await appPage.reload({ waitUntil: "domcontentloaded" });
+  await expect(appPage.locator('[data-slot="os-window-surface"][data-app="terminal"]')).toHaveCount(
+    0
+  );
 
-  // Reopening from the dock adopts the newest running session instead of
-  // opening a launcher: the screen is the same one, still intact.
-  const reopened = await openAppWindow(appPage, "Terminal", "terminal");
-  expect(await visibleTerminalPaneID(reopened)).toBe(secondID);
   const firstQuote = await runTerminalCLI<{ quote: string }>(runtime.paths, [
     "quote",
     firstID,
@@ -497,6 +520,70 @@ test("E2E-002: browser keeps two terminal windows across reload and reattaches a
     "json",
   ]);
   expect(firstQuote.quote).toContain("first-screen-intact");
+});
+
+test("E2E-020: terminal window close preserves Stop and retries after disconnect", async ({
+  appPage,
+  runtime,
+}) => {
+  assertLaunchRuntime(runtime);
+  const workspace = await runtimeWorkspace(runtime);
+  await ensureProjectWorkspace(appPage, runtime);
+  const terminal = await openAppWindow(appPage, "Terminal", "terminal");
+  const terminalID = await visibleTerminalPaneID(terminal);
+  const log = await interactiveTerminalLog(terminal);
+  await log.click();
+  await appPage.keyboard.type("printf 'work-before-stop\\n'");
+  await appPage.keyboard.press("Enter");
+  await expect
+    .poll(async () => (await terminalScreen(runtime, workspace.id, terminalID)).content)
+    .toContain("work-before-stop");
+  await expect(terminal.getByTestId("terminal-close")).toHaveCount(0);
+
+  await windowFrame(terminal).getByRole("button", { name: "Close window" }).click();
+  const confirmation = appPage.getByTestId("terminal-close-dialog");
+  await expect(confirmation).toBeVisible();
+  await appPage.context().setOffline(true);
+  try {
+    await confirmation.getByRole("button", { name: "Terminate and close" }).click();
+    await expect(appPage.getByText("Could not close terminal", { exact: true })).toBeVisible();
+    await expect(terminal).toBeVisible();
+  } finally {
+    await appPage.context().setOffline(false);
+  }
+  const stillRunning = await runTerminalCLI<TerminalEnvelope>(runtime.paths, [
+    "get",
+    terminalID,
+    "--workspace",
+    workspace.id,
+    "-o",
+    "json",
+  ]);
+  expect(stillRunning.terminal.state).toBe("running");
+  await appPage.reload({ waitUntil: "domcontentloaded" });
+  const restored = focusedTerminalWindow(appPage);
+  expect(await visibleTerminalPaneID(restored)).toBe(terminalID);
+  await restored.getByTestId("terminal-stop").click();
+  await expect
+    .poll(
+      async () =>
+        (
+          await runTerminalCLI<TerminalEnvelope>(runtime.paths, [
+            "get",
+            terminalID,
+            "--workspace",
+            workspace.id,
+            "-o",
+            "json",
+          ])
+        ).terminal.state
+    )
+    .toBe("exited");
+  await expect(restored).toBeVisible();
+  await setGlobalScope(appPage, true);
+  await windowFrame(restored).getByRole("button", { name: "Close window" }).click();
+  await expect(restored).toBeHidden();
+  await expect(confirmation).not.toBeVisible();
 });
 
 test("E2E-007: journal filters update the real browser query", async ({ appPage, runtime }) => {

--- a/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
+++ b/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
@@ -3,10 +3,55 @@
 // unlock survives window remounts without crossing workspaces.
 // Boundary IN: journal enable gate used by the host.
 // Boundary OUT: recording stop reconcile and elapsed timer, owned by
-// terminal-recording-state / use-terminal-recordings. Closing a terminal keeps
-// the window in place by construction — there is no host decision to test.
+// terminal-recording-state / use-terminal-recordings.
+// Close invariant: only confirmed running targets terminate; cancellation,
+// stale scope, or failed termination keeps the managed window retryable.
 
-import { describe, expect, it } from "vitest";
+import { QueryClient } from "@tanstack/react-query";
+import { waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "@compozy/ui";
+import { closeTerminal, fetchTerminals, TerminalApiError } from "@/systems/terminal";
+import { DEV_SERVER_TERMINAL } from "@/systems/terminal/mocks/terminal-fixtures";
+import { TerminalWindowClose, terminalWindowCreateKey } from "../../../lib/terminal-window-close";
+import type { OsWindow } from "../../../lib/os-types";
+
+vi.mock("@/systems/terminal/adapters/terminal-api", async importOriginal => {
+  const actual = await importOriginal<typeof import("@/systems/terminal/adapters/terminal-api")>();
+  return { ...actual, fetchTerminals: vi.fn(), closeTerminal: vi.fn() };
+});
+
+const terminalWindow: OsWindow = {
+  id: "window:terminal",
+  app: "terminal",
+  instanceKey: DEV_SERVER_TERMINAL.id,
+  route: { pathname: `/terminal/${DEV_SERVER_TERMINAL.id}`, search: {} },
+  navStack: [],
+  pinned: false,
+  desktopId: "desktop:one",
+  placement: "floating",
+  rect: { x: 0, y: 0, w: 600, h: 400 },
+  layer: 1,
+  minimized: false,
+  zoomed: false,
+  groupId: null,
+  nodeId: null,
+  stackId: null,
+  stackActive: true,
+  parentAxis: null,
+};
+const terminalExit = {
+  at: "2026-09-10T17:00:00Z",
+  cause: "signaled" as const,
+  code: null,
+  signal: "HUP" as const,
+};
+
+beforeEach(() => {
+  vi.mocked(fetchTerminals).mockReset().mockResolvedValue([DEV_SERVER_TERMINAL]);
+  vi.mocked(closeTerminal).mockReset().mockResolvedValue(terminalExit);
+  vi.spyOn(toast, "error").mockImplementation(() => "toast");
+});
 
 import { terminalJournalQueryEnabled } from "../lib/terminal-window-journal";
 import { terminalJournalUnlockLogic } from "@/systems/terminal/stores/terminal-journal-unlock-store";
@@ -25,5 +70,138 @@ describe("useTerminalWindowControllerState journal and recording host gates", ()
 
     expect(store.getSnapshot().context.unlockedWorkspaces).toEqual({ "ws-atlas": true });
     expect(store.getSnapshot().context.unlockedWorkspaces["ws-other"]).toBeUndefined();
+  });
+});
+
+describe("terminal window close lifecycle", () => {
+  function setup() {
+    const controller = new TerminalWindowClose();
+    const guard = controller.guard("ws-close", new QueryClient(), "default");
+    return { controller, guard };
+  }
+
+  it("Should leave process and window intact when confirmation is canceled", async () => {
+    const { controller, guard } = setup();
+    const result = guard([terminalWindow], () => true);
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    controller.cancel();
+    await expect(result).resolves.toBe(false);
+    expect(closeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("Should close only selected running terminals using their exact workspace and profile", async () => {
+    const other = { ...DEV_SERVER_TERMINAL, id: "unrelated" };
+    vi.mocked(fetchTerminals).mockResolvedValue([DEV_SERVER_TERMINAL, other]);
+    const { controller, guard } = setup();
+    const result = guard([terminalWindow], () => true);
+    await waitFor(() =>
+      expect(controller.confirmation.get()?.terminals).toEqual([DEV_SERVER_TERMINAL])
+    );
+    controller.confirmation.get()?.answer(true);
+    await expect(result).resolves.toBe(true);
+    expect(closeTerminal).toHaveBeenCalledExactlyOnceWith(
+      "ws-close",
+      DEV_SERVER_TERMINAL.id,
+      { profile: DEV_SERVER_TERMINAL.profile_name },
+      "HUP",
+      expect.any(AbortSignal)
+    );
+  });
+
+  it("Should retain a pending launcher and allow closing it after creation fails", async () => {
+    const client = new QueryClient();
+    const controller = new TerminalWindowClose();
+    let fail!: (error: Error) => void;
+    const mutation = client.getMutationCache().build(client, {
+      mutationKey: terminalWindowCreateKey("ws-close", "default", terminalWindow.id),
+      mutationFn: () =>
+        new Promise((_resolve, reject) => {
+          fail = reject;
+        }),
+    });
+    const creation = mutation.execute(undefined).catch(() => undefined);
+    await waitFor(() => expect(fail).toBeDefined());
+    const guard = controller.guard("ws-close", client, "default");
+    const launcher = { ...terminalWindow, instanceKey: null };
+    await expect(guard([launcher], () => true)).resolves.toBe(false);
+    fail(new Error("create unavailable"));
+    await creation;
+    await expect(guard([launcher], () => true)).resolves.toBe(true);
+    expect(closeTerminal).not.toHaveBeenCalled();
+  });
+
+  it.each(["exited", "missing"])(
+    "Should close an %s terminal window without warning",
+    async state => {
+      vi.mocked(fetchTerminals).mockResolvedValue(
+        state === "missing" ? [] : [{ ...DEV_SERVER_TERMINAL, state: "exited" }]
+      );
+      const { controller, guard } = setup();
+      await expect(guard([terminalWindow], () => true)).resolves.toBe(true);
+      expect(controller.confirmation.get()).toBeNull();
+      expect(closeTerminal).not.toHaveBeenCalled();
+    }
+  );
+
+  it("Should re-read a terminal that exits while the dialog is open", async () => {
+    const { controller, guard } = setup();
+    const result = guard([terminalWindow], () => true);
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    vi.mocked(fetchTerminals).mockResolvedValue([{ ...DEV_SERVER_TERMINAL, state: "exited" }]);
+    controller.confirmation.get()?.answer(true);
+    await expect(result).resolves.toBe(true);
+    expect(closeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("Should abandon termination after the window or workspace changes", async () => {
+    let current = true;
+    const { controller, guard } = setup();
+    const result = guard([terminalWindow], () => current);
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    current = false;
+    controller.confirmation.get()?.answer(true);
+    await expect(result).resolves.toBe(false);
+    expect(closeTerminal).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new Error("close refused"),
+    new TerminalApiError("unavailable", 503, "service_unavailable"),
+  ])("Should surface termination failure and allow a fresh retry", async error => {
+    const { controller, guard } = setup();
+    vi.mocked(closeTerminal).mockRejectedValueOnce(error);
+    const result = guard([terminalWindow], () => true);
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    controller.confirmation.get()?.answer(true);
+    await expect(result).resolves.toBe(false);
+    expect(toast.error).toHaveBeenCalledWith("Could not close terminal", expect.any(Object));
+    const retry = guard([terminalWindow], () => true);
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    controller.confirmation.get()?.answer(true);
+    await expect(retry).resolves.toBe(true);
+  });
+
+  it("Should tolerate a terminal removed between the final read and close", async () => {
+    vi.mocked(closeTerminal).mockRejectedValue(
+      new TerminalApiError("missing", 404, "terminal_not_found")
+    );
+    const { controller, guard } = setup();
+    const result = guard([terminalWindow], () => true);
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    controller.confirmation.get()?.answer(true);
+    await expect(result).resolves.toBe(true);
+  });
+
+  it("Should preserve a window when the daemon cannot prove its terminal state", async () => {
+    vi.mocked(fetchTerminals).mockRejectedValue(new Error("offline"));
+    const { guard } = setup();
+    await expect(guard([terminalWindow], () => true)).resolves.toBe(false);
+    expect(closeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("Should close other apps without touching the terminal API", async () => {
+    const { guard } = setup();
+    await expect(guard([{ ...terminalWindow, app: "tasks" }], () => true)).resolves.toBe(true);
+    expect(fetchTerminals).not.toHaveBeenCalled();
   });
 });

--- a/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
+++ b/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
@@ -8,7 +8,7 @@
 // stale scope, or failed termination keeps the managed window retryable.
 
 import { QueryClient } from "@tanstack/react-query";
-import { waitFor } from "@testing-library/react";
+import { act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "@compozy/ui";
 import { closeTerminal, fetchTerminals, TerminalApiError } from "@/systems/terminal";
@@ -50,7 +50,9 @@ const terminalExit = {
 beforeEach(() => {
   vi.mocked(fetchTerminals).mockReset().mockResolvedValue([DEV_SERVER_TERMINAL]);
   vi.mocked(closeTerminal).mockReset().mockResolvedValue(terminalExit);
-  vi.spyOn(toast, "error").mockImplementation(() => "toast");
+  vi.spyOn(toast, "error")
+    .mockClear()
+    .mockImplementation(() => "toast");
 });
 
 import { terminalJournalQueryEnabled } from "../lib/terminal-window-journal";
@@ -76,7 +78,7 @@ describe("useTerminalWindowControllerState journal and recording host gates", ()
 describe("terminal window close lifecycle", () => {
   function setup() {
     const controller = new TerminalWindowClose();
-    const guard = controller.guard("ws-close", new QueryClient(), "default");
+    const guard = controller.guard("ws-close", new QueryClient());
     return { controller, guard };
   }
 
@@ -108,12 +110,12 @@ describe("terminal window close lifecycle", () => {
     );
   });
 
-  it("Should retain a pending launcher and allow closing it after creation fails", async () => {
+  it("Should retain pending creation across a shell rebind and allow closing after failure", async () => {
     const client = new QueryClient();
     const controller = new TerminalWindowClose();
     let fail!: (error: Error) => void;
     const mutation = client.getMutationCache().build(client, {
-      mutationKey: terminalWindowCreateKey("ws-close", "default", terminalWindow.id),
+      mutationKey: terminalWindowCreateKey("ws-close", terminalWindow.id),
       mutationFn: () =>
         new Promise((_resolve, reject) => {
           fail = reject;
@@ -121,12 +123,93 @@ describe("terminal window close lifecycle", () => {
     });
     const creation = mutation.execute(undefined).catch(() => undefined);
     await waitFor(() => expect(fail).toBeDefined());
-    const guard = controller.guard("ws-close", client, "default");
+    const guard = controller.guard("ws-close", client);
     const launcher = { ...terminalWindow, instanceKey: null };
     await expect(guard([launcher], () => true)).resolves.toBe(false);
+    // Profile switches replace the shell guard, but creation still belongs to
+    // the same workspace/window even while its destination profile changes.
+    controller.cancel();
+    const rebound = controller.guard("ws-close", client);
+    await expect(rebound([launcher], () => true)).resolves.toBe(false);
     fail(new Error("create unavailable"));
     await creation;
-    await expect(guard([launcher], () => true)).resolves.toBe(true);
+    await expect(rebound([launcher], () => true)).resolves.toBe(true);
+    expect(closeTerminal).not.toHaveBeenCalled();
+  });
+
+  it("Should await all concurrent closes after partial failure before allowing a fresh retry", async () => {
+    const second = { ...DEV_SERVER_TERMINAL, id: "second", profile_name: "second-profile" };
+    vi.mocked(fetchTerminals).mockResolvedValue([DEV_SERVER_TERMINAL, second]);
+    let rejectFirst!: (error: Error) => void;
+    let resolveSecond!: (exit: typeof terminalExit) => void;
+    vi.mocked(closeTerminal)
+      .mockReturnValueOnce(
+        new Promise((_resolve, reject) => {
+          rejectFirst = reject;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveSecond = resolve;
+        })
+      );
+    const { controller, guard } = setup();
+    const windows = [
+      terminalWindow,
+      { ...terminalWindow, id: "window:second", instanceKey: second.id },
+    ];
+    const settled = vi.fn();
+    const result = guard(windows, () => true).then(settled);
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    controller.confirmation.get()?.answer(true);
+    await waitFor(() => expect(closeTerminal).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      rejectFirst(new Error("first close refused"));
+    });
+    expect(settled).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
+    resolveSecond(terminalExit);
+    await result;
+    expect(settled).toHaveBeenCalledExactlyOnceWith(false);
+    expect(toast.error).toHaveBeenCalledWith("Could not close terminal", {
+      description: "first close refused",
+    });
+
+    vi.mocked(fetchTerminals).mockResolvedValue([
+      DEV_SERVER_TERMINAL,
+      { ...second, state: "exited" },
+    ]);
+    const retry = guard(windows, () => true);
+    await waitFor(() =>
+      expect(controller.confirmation.get()?.terminals).toEqual([DEV_SERVER_TERMINAL])
+    );
+    controller.confirmation.get()?.answer(true);
+    await expect(retry).resolves.toBe(true);
+    expect(closeTerminal).toHaveBeenCalledTimes(3);
+    expect(closeTerminal).toHaveBeenLastCalledWith(
+      "ws-close",
+      DEV_SERVER_TERMINAL.id,
+      { profile: DEV_SERVER_TERMINAL.profile_name },
+      "HUP",
+      expect.any(AbortSignal)
+    );
+  });
+
+  it("Should reject the complete batch before terminating any unconfirmed profile", async () => {
+    const second = { ...DEV_SERVER_TERMINAL, id: "second" };
+    vi.mocked(fetchTerminals).mockResolvedValue([DEV_SERVER_TERMINAL, second]);
+    const { controller, guard } = setup();
+    const result = guard(
+      [terminalWindow, { ...terminalWindow, id: "window:second", instanceKey: second.id }],
+      () => true
+    );
+    await waitFor(() => expect(controller.confirmation.get()).not.toBeNull());
+    vi.mocked(fetchTerminals).mockResolvedValue([
+      DEV_SERVER_TERMINAL,
+      { ...second, profile_name: "changed" },
+    ]);
+    controller.confirmation.get()?.answer(true);
+    await expect(result).resolves.toBe(false);
     expect(closeTerminal).not.toHaveBeenCalled();
   });
 

--- a/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
+++ b/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
@@ -110,32 +110,38 @@ describe("terminal window close lifecycle", () => {
     );
   });
 
-  it("Should retain pending creation across a shell rebind and allow closing after failure", async () => {
-    const client = new QueryClient();
-    const controller = new TerminalWindowClose();
-    let fail!: (error: Error) => void;
-    const mutation = client.getMutationCache().build(client, {
-      mutationKey: terminalWindowCreateKey("ws-close", terminalWindow.id),
-      mutationFn: () =>
-        new Promise((_resolve, reject) => {
-          fail = reject;
-        }),
-    });
-    const creation = mutation.execute(undefined).catch(() => undefined);
-    await waitFor(() => expect(fail).toBeDefined());
-    const guard = controller.guard("ws-close", client);
-    const launcher = { ...terminalWindow, instanceKey: null };
-    await expect(guard([launcher], () => true)).resolves.toBe(false);
-    // Profile switches replace the shell guard, but creation still belongs to
-    // the same workspace/window even while its destination profile changes.
-    controller.cancel();
-    const rebound = controller.guard("ws-close", client);
-    await expect(rebound([launcher], () => true)).resolves.toBe(false);
-    fail(new Error("create unavailable"));
-    await creation;
-    await expect(rebound([launcher], () => true)).resolves.toBe(true);
-    expect(closeTerminal).not.toHaveBeenCalled();
-  });
+  it.each(["ws-other", null])(
+    "Should retain pending creation when rebinding to workspace %s",
+    async workspaceId => {
+      const client = new QueryClient();
+      const controller = new TerminalWindowClose();
+      let fail!: (error: Error) => void;
+      const mutation = client.getMutationCache().build(client, {
+        mutationKey: terminalWindowCreateKey(terminalWindow.id),
+        mutationFn: () =>
+          new Promise((_resolve, reject) => {
+            fail = reject;
+          }),
+      });
+      const creation = mutation.execute(undefined).catch(() => undefined);
+      await waitFor(() => expect(fail).toBeDefined());
+      const guard = controller.guard("ws-close", client);
+      const launcher = { ...terminalWindow, instanceKey: null };
+      await expect(guard([launcher], () => true)).resolves.toBe(false);
+      // The launcher keeps its identity while workspace/profile selection changes.
+      // Its initiating mutation must remain visible to the new shell guard.
+      controller.cancel();
+      const rebound = controller.guard(workspaceId, client);
+      await expect(rebound([launcher], () => true)).resolves.toBe(false);
+      await expect(rebound([{ ...launcher, id: "another-window" }], () => true)).resolves.toBe(
+        true
+      );
+      fail(new Error("create unavailable"));
+      await creation;
+      await expect(rebound([launcher], () => true)).resolves.toBe(true);
+      expect(closeTerminal).not.toHaveBeenCalled();
+    }
+  );
 
   it("Should await all concurrent closes after partial failure before allowing a fresh retry", async () => {
     const second = { ...DEV_SERVER_TERMINAL, id: "second", profile_name: "second-profile" };

--- a/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
+++ b/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
@@ -149,7 +149,7 @@ export function useTerminalWindowControllerState(windowId: string) {
   };
 
   const create = useMutation({
-    mutationKey: terminalWindowCreateKey(workspaceId, windowId),
+    mutationKey: terminalWindowCreateKey(windowId),
     mutationFn: (identity: TerminalViewerIdentity) =>
       createTerminal(workspaceId, {}, destinationScope.params, identity),
     onSuccess: async terminal => {

--- a/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
+++ b/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
@@ -62,6 +62,7 @@ function windowedTerminalKeys(state: TerminalWindowRouteState, currentWindowId: 
   return keys.sort().join("\n");
 }
 
+/** Owns terminal creation, process controls, and retained journal state for one managed window. */
 export function useTerminalWindowControllerState(windowId: string) {
   // Chips are the interaction state; the query reads their projection, so a
   // chip still being typed filters nothing until it carries a value.
@@ -148,7 +149,7 @@ export function useTerminalWindowControllerState(windowId: string) {
   };
 
   const create = useMutation({
-    mutationKey: terminalWindowCreateKey(workspaceId, profile.destination, windowId),
+    mutationKey: terminalWindowCreateKey(workspaceId, windowId),
     mutationFn: (identity: TerminalViewerIdentity) =>
       createTerminal(workspaceId, {}, destinationScope.params, identity),
     onSuccess: async terminal => {

--- a/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
+++ b/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
@@ -33,6 +33,7 @@ import { useActiveWorkspace } from "@/systems/workspace";
 
 import { useDesktop } from "../../../hooks/use-desktop";
 import { useOsShell } from "../../../hooks/use-os-shell";
+import { terminalWindowCreateKey } from "../../../lib/terminal-window-close";
 import { terminalJournalQueryEnabled } from "../lib/terminal-window-journal";
 
 const DEFAULT_ROUTE = "/terminal";
@@ -147,6 +148,7 @@ export function useTerminalWindowControllerState(windowId: string) {
   };
 
   const create = useMutation({
+    mutationKey: terminalWindowCreateKey(workspaceId, profile.destination, windowId),
     mutationFn: (identity: TerminalViewerIdentity) =>
       createTerminal(workspaceId, {}, destinationScope.params, identity),
     onSuccess: async terminal => {
@@ -163,8 +165,8 @@ export function useTerminalWindowControllerState(windowId: string) {
   const close = useMutation({
     mutationFn: (terminalId: string) =>
       closeTerminal(workspaceId, terminalId, terminalSelector(terminalId), "HUP"),
-    // The window stays put: the exit bar reads the outcome, and closing the OS
-    // window is the person's own gesture. Nothing retargets or closes for them.
+    // The terminal-limit dialog frees a slot without closing its launcher.
+    // Normal window close is owned by the shell's terminal close guard.
     onSuccess: invalidateTerminalReads,
     onError: error =>
       toast.error(error instanceof Error ? error.message : "Failed to close terminal"),

--- a/web/src/systems/os/components/desktop-shell.tsx
+++ b/web/src/systems/os/components/desktop-shell.tsx
@@ -76,6 +76,7 @@ export function DesktopShell() {
   );
 }
 
+/** Mounts the shell context and its lifecycle confirmation before rendering desktop content. */
 function DesktopChrome({
   firstRun,
   updateAvailable,

--- a/web/src/systems/os/components/desktop-shell.tsx
+++ b/web/src/systems/os/components/desktop-shell.tsx
@@ -26,6 +26,7 @@ import { OsCommandPalette } from "./os-command-palette";
 import { OsShortcutsDialog } from "./os-shortcuts-dialog";
 import { OsWorkspacesOverview } from "./os-workspaces-overview";
 import { OsWallpaper } from "./os-wallpaper";
+import { TerminalCloseDialog } from "./terminal-close-dialog";
 import { OsWinLayer } from "./os-win-layer";
 import { OsSessionsModal } from "./sessions-modal";
 import { AgentCreateDialog, AgentCreateHostProvider } from "@/systems/agent";
@@ -90,6 +91,7 @@ function DesktopChrome({
   return (
     <WorktreeDialogActionsContext.Provider value={controller.worktreeDialogs}>
       <OsShellContext.Provider value={controller.chrome.shell}>
+        <TerminalCloseDialog controller={controller.chrome.terminalClose} />
         <DesktopChromeContent
           client={controller.chrome.client}
           firstRun={firstRun}

--- a/web/src/systems/os/components/terminal-close-dialog.tsx
+++ b/web/src/systems/os/components/terminal-close-dialog.tsx
@@ -1,0 +1,52 @@
+import { useAtom } from "@xstate/store-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@compozy/ui";
+import type { TerminalWindowClose } from "../lib/terminal-window-close";
+
+export function TerminalCloseDialog({ controller }: { controller: TerminalWindowClose }) {
+  const confirmation = useAtom(controller.confirmation);
+  return (
+    <Dialog
+      open={confirmation !== null}
+      onOpenChange={open => {
+        if (!open) controller.cancel();
+      }}
+    >
+      <DialogContent showCloseButton={false} data-testid="terminal-close-dialog">
+        <DialogHeader>
+          <DialogTitle>
+            {confirmation?.terminals.length === 1
+              ? "Close running terminal?"
+              : "Close running terminals?"}
+          </DialogTitle>
+          <DialogDescription>
+            Closing terminates these terminals and their running work, including work visible in
+            other views. Saved history is kept.
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="space-y-1">
+          {confirmation?.terminals.map(terminal => (
+            <li key={terminal.id}>
+              {terminal.title} · {terminal.profile_name}
+            </li>
+          ))}
+        </ul>
+        <DialogFooter>
+          <Button autoFocus variant="outline" onClick={() => controller.cancel()}>
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={() => confirmation?.answer(true)}>
+            Terminate and close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/systems/os/components/terminal-close-dialog.tsx
+++ b/web/src/systems/os/components/terminal-close-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@compozy/ui";
 import type { TerminalWindowClose } from "../lib/terminal-window-close";
 
+/** Confirms process termination for the captured close scope, with Cancel focused first. */
 export function TerminalCloseDialog({ controller }: { controller: TerminalWindowClose }) {
   const confirmation = useAtom(controller.confirmation);
   return (

--- a/web/src/systems/os/hooks/__tests__/window-manager-runtime.test.ts
+++ b/web/src/systems/os/hooks/__tests__/window-manager-runtime.test.ts
@@ -13,6 +13,7 @@ import {
   fetchWindowManagerSnapshot,
   WindowManagerApiError,
 } from "../../adapters/window-manager-api";
+import type { WindowCloseGuard } from "../../lib/window-close-targets";
 import type { OsWindowRoute } from "../../lib/os-types";
 import { createTileSnapTarget } from "../../lib/snap-targets";
 import { windowManagerKeys } from "../../lib/window-manager-query";
@@ -2320,13 +2321,13 @@ describe("WindowManagerRuntime guarded close", () => {
     ["right", ["app:agents"]],
   ] as const)("Should confirm only targets in the %s scope", async (scope, ids) => {
     const { runtime } = setup();
-    const guard = vi.fn(async () => false);
+    const guard = vi.fn<WindowCloseGuard>(async () => false);
     runtime.setCloseGuard(guard);
     await expect(runtime.closeWindowScoped("app:tasks", scope)).resolves.toBe(false);
-    expect(guard).toHaveBeenCalledWith(
-      expect.arrayContaining(ids.map(id => expect.objectContaining({ id }))),
-      expect.any(Function)
-    );
+    expect(guard).toHaveBeenCalledTimes(1);
+    const [targets, isCurrent] = guard.mock.calls[0]!;
+    expect(targets.map(target => target.id)).toEqual(ids);
+    expect(isCurrent).toEqual(expect.any(Function));
     expect(executeWindowManagerCommand).not.toHaveBeenCalled();
     runtime.stop();
   });

--- a/web/src/systems/os/hooks/__tests__/window-manager-runtime.test.ts
+++ b/web/src/systems/os/hooks/__tests__/window-manager-runtime.test.ts
@@ -2287,3 +2287,119 @@ describe("WindowManagerRuntime", () => {
     }
   });
 });
+
+// Invariant: operator close admission freezes exactly the daemon close scope,
+// never duplicating termination or expanding to newly joined tabs.
+describe("WindowManagerRuntime guarded close", () => {
+  function setup() {
+    const queryClient = new QueryClient();
+    const snapshot = snapshotWithFloatingStack();
+    const key = windowManagerKeys.snapshot("workspace:test", "marketing");
+    queryClient.setQueryData(key, snapshot);
+    queryClient.setQueryData(TEST_CONFIG_KEY, SETTINGS_SECTION);
+    const runtime = new WindowManagerRuntime(queryClient);
+    runtime.start();
+    runtime.bind({ workspaceId: "workspace:test", profileId: "marketing", clientId: "client:web" });
+    runtime.setClient({
+      ...CLIENT_VIEW_DEFAULTS,
+      workspaceId: "workspace:test",
+      clientId: "client:web",
+      presentationRevision: 1,
+      activeDesktopId: "desktop:one",
+      focusedWindowId: "app:agents",
+      focusOrder: ["app:agents", "app:tasks"],
+      connectedAt: "2026-07-22T00:00:00Z",
+    });
+    return { runtime, queryClient, key, snapshot };
+  }
+
+  it.each([
+    ["tab", ["app:tasks"]],
+    ["group", ["app:tasks", "app:agents"]],
+    ["others", ["app:agents"]],
+    ["right", ["app:agents"]],
+  ] as const)("Should confirm only targets in the %s scope", async (scope, ids) => {
+    const { runtime } = setup();
+    const guard = vi.fn(async () => false);
+    runtime.setCloseGuard(guard);
+    await expect(runtime.closeWindowScoped("app:tasks", scope)).resolves.toBe(false);
+    expect(guard).toHaveBeenCalledWith(
+      expect.arrayContaining(ids.map(id => expect.objectContaining({ id }))),
+      expect.any(Function)
+    );
+    expect(executeWindowManagerCommand).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it("Should not terminate pinned tabs through Close others", async () => {
+    const { runtime, queryClient, key, snapshot } = setup();
+    queryClient.setQueryData(key, {
+      ...snapshot,
+      windows: {
+        ...snapshot.windows,
+        "app:agents": { ...snapshot.windows["app:agents"], pinned: true },
+      },
+    });
+    const guard = vi.fn(async () => true);
+    runtime.setCloseGuard(guard);
+    await expect(runtime.closeWindowScoped("app:tasks", "others")).resolves.toBe(false);
+    expect(guard).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it("Should suppress double clicks and refuse a close after the target changes", async () => {
+    const { runtime, queryClient, key, snapshot } = setup();
+    let finish!: (allowed: boolean) => void;
+    const guard = vi.fn(
+      () =>
+        new Promise<boolean>(resolve => {
+          finish = resolve;
+        })
+    );
+    runtime.setCloseGuard(guard);
+    const pending = runtime.closeWindow("app:tasks");
+    await expect(runtime.closeWindow("app:tasks")).resolves.toBe(false);
+    queryClient.setQueryData(key, {
+      ...snapshot,
+      revision: snapshot.revision + 1,
+      windows: {
+        ...snapshot.windows,
+        "app:tasks": { ...snapshot.windows["app:tasks"], instanceKey: "changed" },
+      },
+    });
+    finish(true);
+    await expect(pending).resolves.toBe(false);
+    expect(guard).toHaveBeenCalledTimes(1);
+    expect(executeWindowManagerCommand).not.toHaveBeenCalled();
+    runtime.stop();
+  });
+
+  it("Should fence the confirmed close to the inspected layout revision", async () => {
+    const { runtime, snapshot } = setup();
+    runtime.setCloseGuard(async () => true);
+    vi.mocked(executeWindowManagerCommand).mockResolvedValue({
+      snapshot,
+      applied: true,
+      changes: EMPTY_CHANGES,
+      diagnostics: [],
+      client: null,
+      rebasedFrom: null,
+    });
+    await expect(runtime.closeWindowScoped("app:tasks", "group")).resolves.toBe(true);
+    expect(executeWindowManagerCommand).toHaveBeenCalledWith(
+      "workspace:test",
+      "marketing",
+      "client:web",
+      snapshot.revision,
+      expect.objectContaining({
+        expectedRevision: snapshot.revision,
+        payload: {
+          window_id: "app:tasks",
+          minimize: false,
+          scope: "group",
+        },
+      })
+    );
+    runtime.stop();
+  });
+});

--- a/web/src/systems/os/hooks/use-desktop-chrome-controller.ts
+++ b/web/src/systems/os/hooks/use-desktop-chrome-controller.ts
@@ -13,7 +13,12 @@ import { useActiveWorkspace } from "@/systems/workspace";
 /** Owns the state and supporting models required to mount the desktop chrome. */
 export function useDesktopChromeController() {
   const activeWorkspace = useActiveWorkspace();
-  const chrome = useDesktopChrome(activeWorkspace.desktopWorkspaceId);
+  const chrome = useDesktopChrome(
+    activeWorkspace.desktopWorkspaceId,
+    // Global keeps the project's desktop visible. Its windows still belong
+    // to that project even while the data destination is unscoped.
+    activeWorkspace.desktopWorkspace?.id ?? null
+  );
   const backgroundStreamsEnabled = useAtom(
     chrome.shell.projection,
     backgroundStreamsWithinConnectionBudget

--- a/web/src/systems/os/hooks/use-desktop-chrome.ts
+++ b/web/src/systems/os/hooks/use-desktop-chrome.ts
@@ -89,7 +89,7 @@ export function useDesktopChrome(
   const [manager] = useState(() => new WindowManagerRuntime(queryClient));
   const [terminalClose] = useState(() => new TerminalWindowClose());
   useEffect(() => {
-    manager.setCloseGuard(terminalClose.guard(terminalWorkspaceId, queryClient, profileId));
+    manager.setCloseGuard(terminalClose.guard(terminalWorkspaceId, queryClient));
     return () => {
       terminalClose.cancel();
       manager.setCloseGuard(null);

--- a/web/src/systems/os/hooks/use-desktop-chrome.ts
+++ b/web/src/systems/os/hooks/use-desktop-chrome.ts
@@ -9,6 +9,7 @@ import { GLOBAL_DESKTOP_WORKSPACE_ID, useWorkspaceScopeMode } from "@/systems/wo
 
 import type { OsShellHandle } from "../contexts/os-shell-context";
 import { ClientCommandChannel } from "../lib/client-command-channel";
+import { TerminalWindowClose } from "../lib/terminal-window-close";
 import {
   resolveLivePaletteClientContext,
   selectPaletteDestinationRoute,
@@ -33,6 +34,7 @@ import { useWindowManagerStream } from "./use-window-manager-stream";
 import { useWindowPaletteIntent } from "./use-window-manager-store";
 
 export interface DesktopChromeModel {
+  terminalClose: TerminalWindowClose;
   shell: OsShellHandle;
   query: UseQueryResult<WindowManagerSnapshot, Error>;
   /** The attachment this shell speaks for; the palette projection needs its context. */
@@ -63,7 +65,10 @@ function streamError(error: Error | WindowManagerErrorPayload): Error {
  * that projection atom directly — useDesktop/useOsShell require the provider
  * this hook feeds (BUG-20260813).
  */
-export function useDesktopChrome(activeWorkspaceId: string | null): DesktopChromeModel {
+export function useDesktopChrome(
+  activeWorkspaceId: string | null,
+  terminalWorkspaceId: string | null = activeWorkspaceId
+): DesktopChromeModel {
   const router = useRouter();
   const queryClient = useQueryClient();
   const scope = useWorkspaceScopeMode();
@@ -82,6 +87,14 @@ export function useDesktopChrome(activeWorkspaceId: string | null): DesktopChrom
   const configQuery = useQuery(windowManagerConfigOptions(configWorkspaceId, client.clientId));
   const globalShortcuts = useGlobalShortcutReconciliation(configQuery.data?.globalShortcuts);
   const [manager] = useState(() => new WindowManagerRuntime(queryClient));
+  const [terminalClose] = useState(() => new TerminalWindowClose());
+  useEffect(() => {
+    manager.setCloseGuard(terminalClose.guard(terminalWorkspaceId, queryClient, profileId));
+    return () => {
+      terminalClose.cancel();
+      manager.setCloseGuard(null);
+    };
+  }, [manager, terminalClose, terminalWorkspaceId, profileId, queryClient]);
   // The seam is built deeper in the tree (it needs the shell's own handlers), so
   // the stream reaches it through a ref rather than the shell reaching upward.
   const [clientCommandChannel] = useState(() => new ClientCommandChannel());
@@ -178,6 +191,7 @@ export function useDesktopChrome(activeWorkspaceId: string | null): DesktopChrom
   });
 
   return {
+    terminalClose,
     shell,
     query,
     client: client.client,

--- a/web/src/systems/os/lib/terminal-window-close.ts
+++ b/web/src/systems/os/lib/terminal-window-close.ts
@@ -9,18 +9,21 @@ interface CloseConfirmation {
   answer: (confirmed: boolean) => void;
 }
 
-export const terminalWindowCreateKey = (workspaceId: string, profile: string, windowId: string) =>
-  ["terminal-window-create", workspaceId, profile, windowId] as const;
+/** Tracks launcher creation across destination-profile changes. */
+export const terminalWindowCreateKey = (workspaceId: string, windowId: string) =>
+  ["terminal-window-create", workspaceId, windowId] as const;
 
 /** Operator-only orchestration; native window close remains view-only. */
 export class TerminalWindowClose {
   readonly confirmation = createAtom<CloseConfirmation | null>(null);
 
+  /** Rejects a pending confirmation when its shell binding is replaced. */
   cancel(): void {
     this.confirmation.get()?.answer(false);
   }
 
-  guard(workspaceId: string | null, queryClient: QueryClient, profile: string): WindowCloseGuard {
+  /** Admits window removal only after every confirmed terminal close has settled successfully. */
+  guard(workspaceId: string | null, queryClient: QueryClient): WindowCloseGuard {
     return async (targets, isCurrent) => {
       const windows = targets.filter(window => window.app === "terminal");
       if (windows.length === 0) return true;
@@ -32,7 +35,7 @@ export class TerminalWindowClose {
             window =>
               !window.instanceKey &&
               queryClient.isMutating({
-                mutationKey: terminalWindowCreateKey(workspaceId, profile, window.id),
+                mutationKey: terminalWindowCreateKey(workspaceId, window.id),
                 exact: true,
               }) > 0
           )
@@ -69,37 +72,48 @@ export class TerminalWindowClose {
         // treating the dialog's captured status as daemon truth.
         const current = await readTargets();
         if (!isCurrent()) return false;
-        for (const terminal of current) {
-          if (!isCurrent()) return false;
-          if (terminal.state === "exited") continue;
-          if (
-            !running.some(
-              item => item.id === terminal.id && item.profile_name === terminal.profile_name
-            )
-          ) {
-            throw new Error("The terminal changed while closing. Try again.");
-          }
-          try {
-            const exit = await api.closeTerminal(
-              workspaceId,
-              terminal.id,
-              { profile: terminal.profile_name },
-              "HUP",
-              AbortSignal.timeout(15000)
-            );
-            if (exit === null)
-              throw new Error("Terminal termination was not confirmed. Try again.");
-          } catch (error) {
-            if (
-              !(error instanceof api.TerminalApiError && error.domainCode === "terminal_not_found")
-            ) {
-              throw error;
-            }
-          }
+        const toClose = current.filter(terminal => terminal.state !== "exited");
+        // Validate the complete batch before starting any destructive request.
+        if (
+          toClose.some(
+            terminal =>
+              !running.some(
+                item => item.id === terminal.id && item.profile_name === terminal.profile_name
+              )
+          )
+        ) {
+          throw new Error("The terminal changed while closing. Try again.");
         }
+        // Keep close admission locked until every independent request settles,
+        // including after a partial failure, so a retry cannot overlap this batch.
+        const results = await Promise.allSettled(
+          toClose.map(async terminal => {
+            try {
+              const exit = await api.closeTerminal(
+                workspaceId,
+                terminal.id,
+                { profile: terminal.profile_name },
+                "HUP",
+                AbortSignal.timeout(15000)
+              );
+              if (exit === null)
+                throw new Error("Terminal termination was not confirmed. Try again.");
+            } catch (error) {
+              if (
+                !(
+                  error instanceof api.TerminalApiError && error.domainCode === "terminal_not_found"
+                )
+              ) {
+                throw error;
+              }
+            }
+          })
+        );
         await queryClient.invalidateQueries({
           predicate: query => query.queryKey[0] === "terminal" && query.queryKey[2] === workspaceId,
         });
+        const failure = results.find(result => result.status === "rejected");
+        if (failure) throw failure.reason;
         return isCurrent();
       } catch (error) {
         toast.error("Could not close terminal", {

--- a/web/src/systems/os/lib/terminal-window-close.ts
+++ b/web/src/systems/os/lib/terminal-window-close.ts
@@ -1,0 +1,112 @@
+import { createAtom } from "@xstate/store";
+import { toast } from "@compozy/ui";
+import type { QueryClient } from "@tanstack/react-query";
+import type { TerminalInfo } from "@/systems/terminal";
+import type { WindowCloseGuard } from "./window-close-targets";
+
+interface CloseConfirmation {
+  terminals: readonly TerminalInfo[];
+  answer: (confirmed: boolean) => void;
+}
+
+export const terminalWindowCreateKey = (workspaceId: string, profile: string, windowId: string) =>
+  ["terminal-window-create", workspaceId, profile, windowId] as const;
+
+/** Operator-only orchestration; native window close remains view-only. */
+export class TerminalWindowClose {
+  readonly confirmation = createAtom<CloseConfirmation | null>(null);
+
+  cancel(): void {
+    this.confirmation.get()?.answer(false);
+  }
+
+  guard(workspaceId: string | null, queryClient: QueryClient, profile: string): WindowCloseGuard {
+    return async (targets, isCurrent) => {
+      const windows = targets.filter(window => window.app === "terminal");
+      if (windows.length === 0) return true;
+      if (!workspaceId && windows.every(window => !window.instanceKey)) return true;
+      try {
+        if (!workspaceId) throw new Error("Select the terminal's workspace before closing it.");
+        if (
+          windows.some(
+            window =>
+              !window.instanceKey &&
+              queryClient.isMutating({
+                mutationKey: terminalWindowCreateKey(workspaceId, profile, window.id),
+                exact: true,
+              }) > 0
+          )
+        ) {
+          throw new Error("The terminal is still opening. Try closing it again when it is ready.");
+        }
+        // Keep the terminal bundle lazy until an operator actually closes one.
+        const api = await import("@/systems/terminal");
+        const ids = new Set(windows.map(window => window.instanceKey));
+        const readTargets = async () =>
+          (
+            await api.fetchTerminals(
+              workspaceId,
+              { all_profiles: true },
+              AbortSignal.timeout(15000)
+            )
+          ).filter(terminal => ids.has(terminal.id));
+        const terminals = await readTargets();
+        if (!isCurrent()) return false;
+        const running = terminals.filter(terminal => terminal.state === "running");
+        if (running.length > 0) {
+          const confirmed = await new Promise<boolean>(resolve => {
+            this.confirmation.set({
+              terminals: running,
+              answer: value => {
+                this.confirmation.set(null);
+                resolve(value);
+              },
+            });
+          });
+          if (!confirmed || !isCurrent()) return false;
+        }
+        // A terminal may exit while the question is open. Re-read rather than
+        // treating the dialog's captured status as daemon truth.
+        const current = await readTargets();
+        if (!isCurrent()) return false;
+        for (const terminal of current) {
+          if (!isCurrent()) return false;
+          if (terminal.state === "exited") continue;
+          if (
+            !running.some(
+              item => item.id === terminal.id && item.profile_name === terminal.profile_name
+            )
+          ) {
+            throw new Error("The terminal changed while closing. Try again.");
+          }
+          try {
+            const exit = await api.closeTerminal(
+              workspaceId,
+              terminal.id,
+              { profile: terminal.profile_name },
+              "HUP",
+              AbortSignal.timeout(15000)
+            );
+            if (exit === null)
+              throw new Error("Terminal termination was not confirmed. Try again.");
+          } catch (error) {
+            if (
+              !(error instanceof api.TerminalApiError && error.domainCode === "terminal_not_found")
+            ) {
+              throw error;
+            }
+          }
+        }
+        await queryClient.invalidateQueries({
+          predicate: query => query.queryKey[0] === "terminal" && query.queryKey[2] === workspaceId,
+        });
+        return isCurrent();
+      } catch (error) {
+        toast.error("Could not close terminal", {
+          description: error instanceof Error ? error.message : "Try closing the window again.",
+        });
+        return false;
+      }
+    };
+  }
+}

--- a/web/src/systems/os/lib/terminal-window-close.ts
+++ b/web/src/systems/os/lib/terminal-window-close.ts
@@ -9,9 +9,9 @@ interface CloseConfirmation {
   answer: (confirmed: boolean) => void;
 }
 
-/** Tracks launcher creation across destination-profile changes. */
-export const terminalWindowCreateKey = (workspaceId: string, windowId: string) =>
-  ["terminal-window-create", workspaceId, windowId] as const;
+/** Tracks one launcher across workspace and destination-profile changes. */
+export const terminalWindowCreateKey = (windowId: string) =>
+  ["terminal-window-create", windowId] as const;
 
 /** Operator-only orchestration; native window close remains view-only. */
 export class TerminalWindowClose {
@@ -27,20 +27,22 @@ export class TerminalWindowClose {
     return async (targets, isCurrent) => {
       const windows = targets.filter(window => window.app === "terminal");
       if (windows.length === 0) return true;
-      if (!workspaceId && windows.every(window => !window.instanceKey)) return true;
       try {
-        if (!workspaceId) throw new Error("Select the terminal's workspace before closing it.");
         if (
           windows.some(
             window =>
               !window.instanceKey &&
               queryClient.isMutating({
-                mutationKey: terminalWindowCreateKey(workspaceId, window.id),
+                mutationKey: terminalWindowCreateKey(window.id),
                 exact: true,
               }) > 0
           )
         ) {
           throw new Error("The terminal is still opening. Try closing it again when it is ready.");
+        }
+        if (!workspaceId) {
+          if (windows.every(window => !window.instanceKey)) return true;
+          throw new Error("Select the terminal's workspace before closing it.");
         }
         // Keep the terminal bundle lazy until an operator actually closes one.
         const api = await import("@/systems/terminal");

--- a/web/src/systems/os/lib/window-close-targets.ts
+++ b/web/src/systems/os/lib/window-close-targets.ts
@@ -1,0 +1,29 @@
+import { frameForWindow } from "./group-projection";
+import type { OsCloseScope, OsDesktopRuntimeStore, OsWindow } from "./os-types";
+
+/** Mirrors the daemon's close scopes, including the pinned-tab boundary. */
+export function windowCloseTargets(
+  state: OsDesktopRuntimeStore,
+  windowId: string,
+  scope: OsCloseScope
+): readonly OsWindow[] {
+  const window = state.windows[windowId];
+  if (!window) return [];
+  if (scope === "tab") return window.pinned ? [] : [window];
+  const frame = frameForWindow(state.frames, windowId);
+  if (!frame?.stackId) return scope === "group" ? [window] : [];
+  const selectedIndex = frame.members.indexOf(windowId);
+  return frame.members.flatMap((id, index) => {
+    const member = state.windows[id];
+    if (!member) return [];
+    if (scope === "group") return [member];
+    return id === windowId || member.pinned || (scope === "right" && index <= selectedIndex)
+      ? []
+      : [member];
+  });
+}
+
+export type WindowCloseGuard = (
+  targets: readonly OsWindow[],
+  isCurrent: () => boolean
+) => Promise<boolean>;

--- a/web/src/systems/os/runtime/window-manager-tab-commands.ts
+++ b/web/src/systems/os/runtime/window-manager-tab-commands.ts
@@ -14,6 +14,8 @@ import type { WindowManagerCommandInput } from "../lib/window-manager-types";
 import { windowManagerStore } from "../stores/window-manager-store";
 import { WindowManagerRuntimeCore } from "./window-manager-runtime-core";
 import { randomWindowManagerId } from "./window-manager-runtime-helpers";
+import { windowCloseTargets, type WindowCloseGuard } from "../lib/window-close-targets";
+import { windowManagerCommandsAvailable } from "../lib/window-manager-command-availability";
 
 /**
  * Builders for the tab half of the command surface. They live apart from
@@ -144,6 +146,12 @@ export function retargetWindowCommand(
  * geometry runtime so neither of those files carries the tab surface.
  */
 export abstract class WindowManagerTabRuntime extends WindowManagerRuntimeCore {
+  private closeGuard: WindowCloseGuard | null = null;
+  private closePending = false;
+
+  setCloseGuard(guard: WindowCloseGuard | null): void {
+    this.closeGuard = guard;
+  }
   navigateWindow = (
     id: string,
     route: OsWindowRoute,
@@ -222,6 +230,33 @@ export abstract class WindowManagerTabRuntime extends WindowManagerRuntimeCore {
 
   reopenWindow = (): WindowManagerCommandOutcome => this.dispatch(reopenWindowCommand());
 
-  closeWindowScoped = (windowId: string, scope: OsCloseScope): Promise<boolean> =>
-    this.dispatch(closeWindowCommand(windowId, scope)).completion;
+  closeWindowScoped = async (windowId: string, scope: OsCloseScope): Promise<boolean> => {
+    if (!this.closeGuard) return this.dispatch(closeWindowCommand(windowId, scope)).completion;
+    if (this.closePending || !windowManagerCommandsAvailable(this.view)) return false;
+    const binding = this.binding;
+    const guard = this.closeGuard;
+    const targets = windowCloseTargets(this.view, windowId, scope);
+    if (targets.length === 0) return false;
+    const identity = (windows: typeof targets) =>
+      JSON.stringify(
+        windows.map(window => [window.id, window.app, window.instanceKey, window.route])
+      );
+    const captured = identity(targets);
+    const isCurrent = () =>
+      this.binding === binding &&
+      this.closeGuard === guard &&
+      windowManagerCommandsAvailable(this.view) &&
+      identity(windowCloseTargets(this.view, windowId, scope)) === captured;
+    this.closePending = true;
+    try {
+      if (!(await guard(targets, isCurrent)) || !isCurrent()) return false;
+      // Never let a queued group close expand to newly joined, unconfirmed tabs.
+      return await this.dispatch({
+        ...closeWindowCommand(windowId, scope),
+        expectedRevision: this.view.snapshot?.revision,
+      }).completion;
+    } finally {
+      this.closePending = false;
+    }
+  };
 }

--- a/web/src/systems/os/runtime/window-manager-tab-commands.ts
+++ b/web/src/systems/os/runtime/window-manager-tab-commands.ts
@@ -149,6 +149,7 @@ export abstract class WindowManagerTabRuntime extends WindowManagerRuntimeCore {
   private closeGuard: WindowCloseGuard | null = null;
   private closePending = false;
 
+  /** Installs operator lifecycle admission; replacing it invalidates pending close requests. */
   setCloseGuard(guard: WindowCloseGuard | null): void {
     this.closeGuard = guard;
   }
@@ -230,6 +231,7 @@ export abstract class WindowManagerTabRuntime extends WindowManagerRuntimeCore {
 
   reopenWindow = (): WindowManagerCommandOutcome => this.dispatch(reopenWindowCommand());
 
+  /** Serializes close admission and fences the final command to the inspected targets and revision. */
   closeWindowScoped = async (windowId: string, scope: OsCloseScope): Promise<boolean> => {
     if (!this.closeGuard) return this.dispatch(closeWindowCommand(windowId, scope)).completion;
     if (this.closePending || !windowManagerCommandsAvailable(this.view)) return false;

--- a/web/src/systems/terminal/components/__tests__/terminal-window-app.test.tsx
+++ b/web/src/systems/terminal/components/__tests__/terminal-window-app.test.tsx
@@ -132,9 +132,9 @@ describe("TerminalWindowApp — S1 states", () => {
     expect(screen.getByTestId(`terminal-pipe-pane-${MAKE_GATE_TERMINAL.id}`)).toBeInTheDocument();
     expect(screen.getByText("412")).toBeInTheDocument();
     expect(screen.getByTestId("terminal-pipe-chip")).toHaveTextContent("read-only log");
-    // Wait and Close are the pipe head verbs; Signal lives in overflow.
+    // Wait and Signal remain available; close belongs to the OS window.
     expect(screen.getByTestId("terminal-wait")).toBeInTheDocument();
-    expect(screen.getByTestId("terminal-close")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-close")).not.toBeInTheDocument();
     expect(screen.queryByTestId("terminal-signal")).not.toBeInTheDocument();
     await userEvent.click(screen.getByTestId("terminal-pipe-overflow"));
     expect(await screen.findByTestId("terminal-signal")).toBeInTheDocument();
@@ -890,18 +890,15 @@ describe("TerminalWindowApp — id-less route resolver and close", () => {
     expect(actions.onOpenTerminal).not.toHaveBeenCalled();
   });
 
-  it("Should close the terminal from the head overflow, disabled while pending", async () => {
+  it("Should keep Stop available without a redundant terminal close action", async () => {
     const actions = stubWindowActions();
     renderWindow({ actions, terminals: [DEV_SERVER_TERMINAL] });
 
-    await userEvent.click(screen.getByTestId("terminal-overflow"));
-    await userEvent.click(await screen.findByTestId("terminal-close"));
-    expect(actions.onCloseTerminal).toHaveBeenCalledExactlyOnceWith(DEV_SERVER_TERMINAL.id);
-
-    const pending = stubWindowActions({ closePending: true });
-    renderWindow({ actions: pending, terminals: [DEV_SERVER_TERMINAL] });
-    const overflows = screen.getAllByTestId("terminal-overflow");
-    await userEvent.click(overflows[overflows.length - 1]);
-    expect(await screen.findByTestId("terminal-close")).toHaveAttribute("aria-disabled", "true");
+    expect(screen.queryByTestId("terminal-overflow")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-close")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("terminal-stop"));
+    expect(actions.onStop).toHaveBeenCalledExactlyOnceWith(DEV_SERVER_TERMINAL.id);
+    expect(actions.onCloseTerminal).not.toHaveBeenCalled();
+    expect(screen.getByTestId(`terminal-pane-${DEV_SERVER_TERMINAL.id}`)).toBeInTheDocument();
   });
 });

--- a/web/src/systems/terminal/components/terminal-header-actions.tsx
+++ b/web/src/systems/terminal/components/terminal-header-actions.tsx
@@ -17,28 +17,18 @@ import type { TerminalHeaderProps } from "./terminal-header";
 /**
  * At most two trailing actions, set off from the chips by a hairline.
  *
- * Wait and Close stay on a pipe terminal's head; Signal moves to overflow so
- * the head never grows a third verb.
+ * Stop and Wait stay available; closing belongs to the OS window chrome.
  */
 export function TerminalHeaderActions({
   isPipe,
   recording,
-  closePending,
   onStop,
-  onClose,
   onSignal,
   onWait,
   onStopRecording,
 }: TerminalHeaderActionsProps) {
   if (isPipe) {
-    return (
-      <TerminalPipeHeaderActions
-        closePending={closePending}
-        onClose={onClose}
-        onSignal={onSignal}
-        onWait={onWait}
-      />
-    );
+    return <TerminalPipeHeaderActions onSignal={onSignal} onWait={onWait} />;
   }
   // Stopping the recording is ghost text; danger stays on the rec dot.
   const quietAction =
@@ -71,40 +61,11 @@ export function TerminalHeaderActions({
         <TooltipContent side="bottom">Stop</TooltipContent>
       </Tooltip>
     ) : null;
-  // Ending the session is deliberate, so it lives one step away.
-  const overflow = onClose ? (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button
-            aria-label="More actions"
-            data-testid="terminal-overflow"
-            size="icon-sm"
-            type="button"
-            variant="ghost"
-          />
-        }
-      >
-        <Ellipsis aria-hidden="true" className="size-3.5" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          data-testid="terminal-close"
-          disabled={closePending}
-          onClick={onClose}
-          variant="destructive"
-        >
-          Close terminal
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  ) : null;
-  if (!quietAction && !overflow) return null;
+  if (!quietAction) return null;
   return (
     <>
       <TerminalHeaderRule />
       {quietAction}
-      {overflow}
     </>
   );
 }
@@ -164,26 +125,12 @@ export function TerminalWindowVerbs({
 }
 
 function TerminalPipeHeaderActions({
-  onClose,
   onSignal,
   onWait,
-  closePending,
-}: Pick<TerminalHeaderActionsProps, "onClose" | "onSignal" | "onWait" | "closePending">) {
+}: Pick<TerminalHeaderActionsProps, "onSignal" | "onWait">) {
   const wait = onWait ? (
     <Button data-testid="terminal-wait" onClick={onWait} size="sm" type="button" variant="ghost">
       Wait
-    </Button>
-  ) : null;
-  const close = onClose ? (
-    <Button
-      data-testid="terminal-close"
-      disabled={closePending}
-      onClick={onClose}
-      size="sm"
-      type="button"
-      variant="ghost"
-    >
-      Close
     </Button>
   ) : null;
   const overflow = onSignal ? (
@@ -208,12 +155,11 @@ function TerminalPipeHeaderActions({
       </DropdownMenuContent>
     </DropdownMenu>
   ) : null;
-  if (!wait && !close && !overflow) return null;
+  if (!wait && !overflow) return null;
   return (
     <>
       <TerminalHeaderRule />
       {wait}
-      {close}
       {overflow}
     </>
   );
@@ -225,5 +171,5 @@ function TerminalHeaderRule() {
 
 type TerminalHeaderActionsProps = Pick<
   TerminalHeaderProps,
-  "recording" | "closePending" | "onStop" | "onClose" | "onSignal" | "onWait" | "onStopRecording"
+  "recording" | "onStop" | "onSignal" | "onWait" | "onStopRecording"
 > & { isPipe: boolean };

--- a/web/src/systems/terminal/components/terminal-header-actions.tsx
+++ b/web/src/systems/terminal/components/terminal-header-actions.tsx
@@ -124,6 +124,7 @@ export function TerminalWindowVerbs({
   );
 }
 
+/** Keeps pipe supervision actions available while window chrome owns close confirmation. */
 function TerminalPipeHeaderActions({
   onSignal,
   onWait,

--- a/web/src/systems/terminal/components/terminal-header.tsx
+++ b/web/src/systems/terminal/components/terminal-header.tsx
@@ -18,7 +18,6 @@ export interface TerminalHeaderProps {
   /** The per-project cap, from `[terminal].max_per_workspace`. */
   limit?: number;
   onStop?: () => void;
-  onClose?: () => void;
   onSignal?: () => void;
   onWait?: () => void;
   onStopRecording?: () => void;
@@ -26,8 +25,6 @@ export interface TerminalHeaderProps {
   onNewTerminal?: () => void;
   /** Reveals the journal overlay. */
   onViewJournal?: () => void;
-  /** True while a close is already on its way to the daemon. */
-  closePending?: boolean;
   /**
    * When true, identity and ≤2 actions publish into the OS window head
    * instead of drawing a second identity row under the deck.
@@ -58,13 +55,11 @@ export function TerminalHeader({
   terminalCount,
   limit,
   onStop,
-  onClose,
   onSignal,
   onWait,
   onStopRecording,
   onNewTerminal,
   onViewJournal,
-  closePending = false,
   hostChrome = false,
 }: TerminalHeaderProps) {
   const isPipe = terminal.mode === "pipe";
@@ -73,9 +68,7 @@ export function TerminalHeader({
   const actions = (
     <>
       <TerminalHeaderActions
-        closePending={closePending}
         isPipe={isPipe}
-        onClose={onClose}
         onSignal={onSignal}
         onStop={onStop}
         onStopRecording={onStopRecording}

--- a/web/src/systems/terminal/components/terminal-window-body.tsx
+++ b/web/src/systems/terminal/components/terminal-window-body.tsx
@@ -125,10 +125,8 @@ function TerminalInteractiveWindowBody({
   return (
     <>
       <TerminalHeader
-        closePending={actions.closePending}
         hostChrome={hostChrome}
         limit={limit}
-        onClose={readOnly ? undefined : () => actions.onCloseTerminal(terminal.id)}
         onNewTerminal={newTerminal}
         onStop={controller.stop}
         onStopRecording={controller.stopRecording}
@@ -188,10 +186,8 @@ function TerminalPipeWindowBody({
   return (
     <>
       <TerminalHeader
-        closePending={actions.closePending}
         hostChrome={hostChrome}
         limit={limit}
-        onClose={readOnly ? undefined : () => actions.onCloseTerminal(terminal.id)}
         onNewTerminal={newTerminal}
         onSignal={
           readOnly || terminal.state !== "running" ? undefined : () => actions.onStop(terminal.id)

--- a/web/src/systems/terminal/components/terminal-window-body.tsx
+++ b/web/src/systems/terminal/components/terminal-window-body.tsx
@@ -62,6 +62,7 @@ export function TerminalWindowBody(props: TerminalWindowBodyProps) {
   );
 }
 
+/** Renders the interactive attachment and process controls without owning managed-window closure. */
 function TerminalInteractiveWindowBody({
   terminal,
   viewerId,
@@ -169,6 +170,7 @@ function TerminalInteractiveWindowBody({
   );
 }
 
+/** Renders retained pipe output with Wait and Signal controls under the shared window-close flow. */
 function TerminalPipeWindowBody({
   terminal,
   workspaceId,

--- a/web/src/systems/terminal/index.ts
+++ b/web/src/systems/terminal/index.ts
@@ -7,6 +7,7 @@ export {
   closeTerminal,
   controlTerminalRecording,
   createTerminal,
+  fetchTerminals,
   fetchTerminalInputRequestProjection,
   rejectTerminalInputRequest,
   signalTerminal,


### PR DESCRIPTION
## Problem and root cause

Closes #594.

The header's **Close terminal** called terminal DELETE but never closed the managed window. The traffic light, keyboard, and window menu only closed the window, detaching its viewer while shell work continued. Stop followed by header Close therefore also left the window visible.

## Resulting behavior

- Window Close is the canonical operator gesture. Running terminals show an accessible confirmation naming the affected terminals and warning that their work, including work seen by other viewers, will end. Cancel receives initial focus and preserves both process and window.
- Confirm re-reads daemon state, terminates the selected running terminals, and then closes their managed windows. Already exited or missing terminals close without the running warning. Stop remains available and keeps its window open.
- The redundant header/menu Close terminal action is removed. The terminal-limit dialog keeps its separate slot-recovery action.
- Chrome, keyboard/window-menu, tab close, Close others, and Close right share the same preparation. Group close confirms only affected running terminals; unrelated terminals are untouched. Existing pinned-tab scope rules are preserved.
- Failed state reads or termination show a visible error and keep retryable windows. Repeated clicks are serialized; binding/target changes invalidate stale attempts. Pending terminal creation keeps its launcher until the result is known; failed creation does not trap the launcher.

## Implementation

The Web window runtime admits operator closes through a terminal lifecycle guard. It resolves exact terminal IDs and owning profiles from the workspace catalog, validates the complete captured close scope before starting destructive requests, and supplies the inspected layout revision to the final window command. One shell-owned dialog handles running terminal confirmation. No daemon lifecycle implementation or wire schema changes are required.

Confirmed independent terminal closes run concurrently. An all-settled barrier keeps window-close admission locked until every request finishes, even after partial failure. A group is not a cross-service transaction: if any termination fails, all its windows remain available, including any already stopped terminals. Retrying uses fresh daemon state and asks only about terminals still running. Creation admission is keyed by stable window identity, so changing the workspace or destination profile cannot hide an in-flight launcher mutation, including when no workspace is selected.

## Verification

- Before the final workspace-key refinement, repository-root Turbo focused checks passed **105 tests** across the existing terminal controller, window runtime, terminal app, and desktop chrome suites. The final revision adds different-workspace and unscoped-destination cases to that same controller suite; full current-head CI validates them.
- Repository-root Turbo **typecheck and production build passed** before the final workspace-key refinement; the current head repeats these checks in CI.
- Real daemon-served Playwright **E2E-002, E2E-020, E2E-019: 3 passed** with the reviewed production bundle before the final workspace-key refinement; current-head CI repeats the full E2E suite. They cover grouped reload/reattach, cancellation, confirmed termination, retained CLI output, browser disconnection/failure feedback, Stop/exited close, Global scope with the retained project desktop, and lazy Terminal activation/CSP.
- Manual isolated macOS browser QA: keyboard and window-menu confirmation, initial Cancel focus, two shared viewers, normal Tasks close, mixed-app group cancellation/termination, and Close others/right targeting. Public reads proved the external terminal kept running after group close.
- Native compatibility probe: CLI window close removed the view; a subsequent terminal get still reported running with zero viewers.
- React Doctor on all **16 changed-source files: 100/100, no issues** before the final workspace-key refinement, without diagnostic suppressions; its workflow rechecks the current head.
- The registered QA daemon and both QA browsers were closed; teardown reported **clean: true**. No active host runtime was restarted or modified.
- The initial implementation passed **`make gate`** (7,137 Web tests in 771 files, affected skills Go race tests, lint and code generation). After review remediation, the operator explicitly requested full gates in CI; the queued local rerun was canceled before acquiring capacity. The current PR head must pass full CI. The local review changes passed the focused checks, build and real E2Es listed above. The isolated behavioral QA evidence audit passed.

The detailed scenario record is `docs/qa/reports/2026-09-10-issue-594-terminal-close.md`.

## Review remediation

- **React Doctor:** removed the sequential-await warning with concurrent independent closes and an all-settled barrier. Regression coverage proves partial failure does not release admission while another close is pending, retries only surviving terminals, and rejects unconfirmed owner changes before starting the batch.
- **CodeRabbit:** removed mutable workspace/profile selection from pending-creation identity; retained launcher protection across different-workspace and unscoped shell rebinding; strengthened all close-scope assertions to one invocation with the exact target IDs. Added lifecycle docstrings for all touched controller and rendering functions.
- **CodeRabbit linked-issue check:** manually reviewed the seven files excluded by the repository's review filters: the QA journey/report, both terminal QA scenarios, site safety documentation, official Terminal skill reference, and terminal E2E suite. Their changes implement and verify the issue's acceptance criteria, including running confirm/cancel, Stop, direct exited close, failure feedback, group targeting, retained history, and native API compatibility. The tests and real-run evidence above cover these files' behavioral changes.
- **Greptile:** reviews through the concurrent-close remediation reported 5/5 with no actionable findings. Final review status is checked against the current PR head.

## Cross-surface and compatibility impact

Native `compozy__window_close`, `compozy__terminal_close`, and CLI/HTTP/UDS window/terminal operations keep their separate contracts and policy gates. A direct native window close, viewer detach, or browser shutdown remains view-only. The intentional behavior change is the in-app operator close gesture.

The guard captures the owning desktop workspace and shell profile binding (including a retained project desktop in Global scope), and sends terminal termination to each resolved owner profile. Daemon-owned events, shared viewers, normal journal/recording retention, persisted layouts, config, hooks, extensions, and SDK schemas are unchanged; no migration is needed. Official Compozy skill guidance, terminal safety documentation, and affected QA journeys/scenarios are updated. The report records the cross-surface audit.

## Limits

Local real-run evidence is from macOS and a browser. Packaged Electron and Linux interactive-terminal behavior were not exercised locally. Production bundling emits the existing chunk-size/plugin-timing advisories. Goal activation and a structured status read were performed; an active flag with zero automatic turns is not proof of automatic Goal execution.

## Handoff

All scoped changes are committed and pushed at `449e3b12754e1b5152f5489c498298caf367211e`; the working tree is clean. The operator is taking over merging and any remaining follow-up work. No merge was performed by this session.

The latest CodeRabbit review added one new follow-up after the previous findings were fixed: [capture the initiating scope for pending terminal creation completion](https://github.com/compozy/compozy/pull/597#discussion_r3982537005). This finding is not implemented in this head. React Doctor reports 100/100 with zero errors/warnings; Greptile reports 5/5 on this head. At handoff, two Web E2E shards were still pending and no checks had failed. See the live checks for their final result.
