### PR TITLE
fix: bound session summaries and preserve complete details

### DIFF
--- a/docs/qa/reports/2026-09-10-session-summary-truncation.md
+++ b/docs/qa/reports/2026-09-10-session-summary-truncation.md
@@ -1,0 +1,84 @@
+# Session summary presentation — issue #598
+
+## Problem and policy
+
+The Working activity was an unconstrained nested inline span. Unknown provider
+strings were incorporated wholesale into the action, and other summaries only
+ellipsized at their container's far edge. The Web transcript adapter also dropped
+`title` while retaining the canonical tool identity supplied in the part type.
+
+Summary text now uses one-line ellipsis and the existing Tailwind readable measures:
+24 rem (`max-w-sm`) for combined tool text, live activity, reasoning, and Goal text;
+20 rem (`max-w-xs`) for headings/window titles. Every limit shrinks with the parent.
+The existing 264 px session rail and 96–180 px deck slots already constrain titles
+more tightly and keep their layouts. Display normalization collapses whitespace and
+limits previews to 80 graphemes (existing non-command input summaries stay at 60),
+without slicing Unicode clusters. Free-form titles use the truthful generic tool
+label; known identities retain their action. No shell identity is inferred from prose.
+
+The full original title follows the existing projection into detail and copy flows.
+Live and Working summaries have keyboard/pointer popups. Tool titles and Goal
+objectives appear in disclosures. Find opens title/name matches as well as payloads,
+including currently running calls. Expanded content and ordinary message bodies
+retain their existing rendering.
+
+## Rendered evidence
+
+The production thread was exercised through the existing Storybook runtime and MSW
+fixture boundary, using sanitized synthetic heredocs and Unicode text. The
+`SessionsStability/Working/LongSummaries` interaction story owns the layout and
+keyboard regression checks.
+
+- Before: Working measured 75.25 px at 1600 px; reasoning/live summaries crossed
+  almost the full window. The baseline screenshot captures these original layout
+  constraints (the settled tool's generic wording had already been normalized).
+- After: Working measured 22 px at 360, 860, and 1600 px, with document widths equal
+  to viewport widths. The composer and stop control remained reachable.
+- Keyboard live/Working disclosure, Escape focus restoration, and exact multiline
+  activity copy passed at all three widths.
+- At 200% CSS zoom with reduced motion, Working measured 44 px (22 CSS px).
+  Full-payload search found a tail absent from the summaries and opened its detail.
+- Three concurrent calls, including a long agent prompt, retained independent
+  keyboard details and the agent counter at 360 and 1600 px without page overflow.
+- Shared window headings retain the route's programmatic focus target and use a
+  native button for pointer/keyboard disclosure of the full title.
+
+Sanitized captures are retained locally under `docs/qa/evidence/issue-598/` (the
+repository excludes generated evidence). Reproduce them with the named story;
+no private commands, host paths, or runtime identifiers appear in fixtures.
+
+## Change impact
+
+This record applies the checklist in `docs/_memory/change-impact.md` once for #598.
+
+- **Web/shared UI:** session presentation, transient tool-title projection, find
+  disclosure, shared tool rows and window headings. Existing unit suites and the
+  production composition story own verification. Site imports receive only the
+  generic heading/tool-row width behavior; no site content changes are required.
+- **Native/public contracts:** no tool IDs, schemas, descriptors, HTTP/UDS/CLI
+  contracts, or event formats change. The existing transcript `title` field is
+  consumed rather than discarded.
+- **Extensibility/hooks/config:** no changes to registries, extensions, hooks,
+  MCP metadata, provider configuration, or authentication.
+- **Workspace isolation/user state:** no database, file, persisted transcript,
+  layout, query key, authorization, or workspace/profile boundary changes. Only
+  transient Web view models carry the additional existing title. No migration or
+  compatibility shim is needed under the internal-code regime.
+- **Official skill:** `skills/compozy/` is unaffected; runtime operations and native
+  tool contracts are unchanged. UI QA guidance is updated in the owning scenario.
+
+## Validation and limits
+
+The changed diff was reviewed and the production composition was exercised in
+Chromium through the existing Storybook/MSW fixture boundary. Canonical unit suites
+were extended for original-title projection, truthful tool identity, Unicode-safe
+summaries, detail/copy preservation, and title/name find disclosure. The two long
+summary stories also run browser interaction checks.
+
+At the user's request, delivery gates (including typecheck/build, tests, and
+`make gate`) are delegated to CI. Local gate tasks already in flight were stopped;
+their interrupted results are not claimed as passing evidence. CI on the PR's
+current head is the delivery authority. The local rendered walkthrough is a real
+production-component browser run with fixture I/O, not a live-provider claim.
+Linux, Electron, and live Codex provider behavior are not established by this local
+walkthrough. No host daemon was restarted or changed.

--- a/docs/qa/reports/2026-09-10-session-summary-truncation.md
+++ b/docs/qa/reports/2026-09-10-session-summary-truncation.md
@@ -14,7 +14,9 @@ The existing 264 px session rail and 96–180 px deck slots already constrain ti
 more tightly and keep their layouts. Display normalization collapses whitespace and
 limits previews to 80 graphemes (existing non-command input summaries stay at 60),
 without slicing Unicode clusters. Free-form titles use the truthful generic tool
-label; known identities retain their action. No shell identity is inferred from prose.
+label; exact identities and documented hosted-MCP identities retain their action.
+A description beginning with a known name (for example, `Bash investigation`)
+stays a description. No tool identity is inferred from prose.
 
 The full original title follows the existing projection into detail and copy flows.
 Live and Working summaries have keyboard/pointer popups. Tool titles and Goal

--- a/docs/qa/reports/2026-09-10-session-summary-truncation.md
+++ b/docs/qa/reports/2026-09-10-session-summary-truncation.md
@@ -38,6 +38,7 @@ keyboard regression checks.
   activity copy passed at all three widths.
 - At 200% CSS zoom with reduced motion, Working measured 44 px (22 CSS px).
   Full-payload search found a tail absent from the summaries and opened its detail.
+  A separate live-title query also opened the original title during execution.
 - Three concurrent calls, including a long agent prompt, retained independent
   keyboard details and the agent counter at 360 and 1600 px without page overflow.
 - Shared window headings retain the route's programmatic focus target and use a

--- a/docs/qa/scenarios/ET-web-session-transcript-calm-grammar.md
+++ b/docs/qa/scenarios/ET-web-session-transcript-calm-grammar.md
@@ -63,3 +63,26 @@ is pending task10 and must follow the task07/task08 normative artboards.
 QA 2026-09-06 integrated verdict: Selected new grammar and navigation branches passed: all task07/08 visual rows and substates, actual3,023-message history, unloaded Unicode input and all text/title/output/error/filename fields, exact nested landing, focus/trail/no-match/bottom ownership, full260-line browser download, and generation1→2 archive invalidation while Find remained focused. The report retains each repair/re-walk and the distinction between controlled runtime and deterministic visual fixtures.
 
 QA impact 2026-09-10: the thinking indicator now re-arms an early timer callback until its existing flicker-guard deadline, preventing an indefinitely hidden pending state. The canonical thread-status timing tests and full conversation/runtime suites passed. Evidence and browser verification are owned by `docs/qa/reports/2026-09-10-release-integration-repair.md`.
+
+## Bounded summaries (issue #598)
+
+Use the sanitized `SessionsStability/Working/LongSummaries` story, then repeat the
+relevant transcript flow against the isolated browser runtime. At 360, 860, and
+1600 px, summaries stay on one line: tool/reasoning/live/activity/Goal text uses a
+maximum 24 rem readable measure; headings use at most 20 rem. Smaller containers
+shrink these bounds. Session sidebar and deck tabs retain their existing tighter
+constraints. Full message bodies and intentionally expanded content remain readable.
+
+- Inspect a multiline heredoc, an unbroken path, Unicode graphemes, a provider title
+  separate from tool identity, concurrent tools, and running/settled/error states.
+- Confirm the Working row remains 22 px high, elapsed time and stop/composer controls
+  stay visible, and no horizontal page overflow appears. Repeat at 200% zoom and
+  with reduced motion; opening a summary popup must not shift the transcript.
+- Use Tab and Enter to inspect live tool/activity details, Escape to return focus,
+  and the tool/reasoning/Goal disclosure to inspect complete originals. Window head
+  titles reveal their full label on pointer activation or Enter from keyboard focus.
+- Copy a full tool payload and compare its title/input/output with the fixture.
+  Find a unique tail omitted from a summary; the matching title/name/input body
+  must open in both running and settled tools. Closing the reveal remains reader-owned.
+
+Verification record: [issue #598 report](../reports/2026-09-10-session-summary-truncation.md).

--- a/packages/ui/src/components/custom/__tests__/topbar.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/topbar.test.tsx
@@ -410,3 +410,21 @@ describe("Topbar", () => {
     expect(screen.getByTestId("probe")).toHaveTextContent("ok");
   });
 });
+
+// Invariant: bounded window titles expose the complete label on keyboard focus.
+// Owner: shared window head; canonical suite: topbar.
+it("Should disclose the full title while preserving the route focus target", () => {
+  const title = "Inspect session summaries — ação ".repeat(12);
+  render(
+    <TopbarSlotProvider>
+      <Topbar title={title} />
+    </TopbarSlotProvider>
+  );
+  const heading = screen.getByRole("heading", { name: title.trim() });
+  expect(heading).toHaveAttribute("tabindex", "-1");
+  const trigger = screen.getByRole("button", { name: title.trim() });
+  trigger.focus();
+  expect(trigger).toHaveFocus();
+  fireEvent.click(trigger);
+  expect(screen.getByRole("dialog", { name: "Full title" }).textContent).toBe(title);
+});

--- a/packages/ui/src/components/custom/stories/topbar.stories.tsx
+++ b/packages/ui/src/components/custom/stories/topbar.stories.tsx
@@ -212,3 +212,12 @@ export const SessionDocument: Story = {
     </TopbarSlotProvider>
   ),
 };
+
+/** Long session/window names stay readable at wide widths and expose the full label through keyboard/pointer disclosure. */
+export const LongTitle: Story = {
+  render: () => (
+    <TopbarSlotProvider>
+      <Topbar title={"Inspect session summary layout — ação 👩🏽‍💻 ".repeat(12)} />
+    </TopbarSlotProvider>
+  ),
+};

--- a/packages/ui/src/components/custom/stories/topbar.stories.tsx
+++ b/packages/ui/src/components/custom/stories/topbar.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { LayoutDashboard, ListChecks } from "lucide-react";
 
 import { Button } from "../../button";
@@ -215,9 +216,26 @@ export const SessionDocument: Story = {
 
 /** Long session/window names stay readable at wide widths and expose the full label through keyboard/pointer disclosure. */
 export const LongTitle: Story = {
+  tags: ["play-fn"],
+  play: async ({ canvasElement }) => {
+    const heading = within(canvasElement).getByRole("heading", { level: 1 });
+    await expect(heading.getBoundingClientRect().width).toBeLessThanOrEqual(320);
+    const trigger = within(heading).getByRole("button");
+    trigger.focus();
+    await userEvent.keyboard("{Enter}");
+    const detail = await within(canvasElement.ownerDocument.body).findByRole("dialog", {
+      name: "Full title",
+    });
+    await expect(detail.textContent).toBe(trigger.textContent);
+    await expect(detail.getBoundingClientRect().height).toBeLessThanOrEqual(256);
+    await expect(detail.scrollHeight).toBeGreaterThan(detail.clientHeight);
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(trigger).toHaveFocus());
+    canvasElement.dataset.titleChecks = "passed";
+  },
   render: () => (
     <TopbarSlotProvider>
-      <Topbar title={"Inspect session summary layout — ação 👩🏽‍💻 ".repeat(12)} />
+      <Topbar title={"Inspect session summary layout — ação 👩🏽‍💻 ".repeat(40)} />
     </TopbarSlotProvider>
   ),
 };

--- a/packages/ui/src/components/custom/tool-call-row.tsx
+++ b/packages/ui/src/components/custom/tool-call-row.tsx
@@ -144,11 +144,11 @@ function ToolCallRowInner({
       >
         {iconContent}
       </span>
-      <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+      <span className="flex min-w-0 max-w-sm flex-1 items-baseline gap-1.5">
         <span
           id={toolNameId}
           data-slot="tool-call-row-tool"
-          className="min-w-0 shrink truncate font-medium text-muted transition-colors group-hover/tool-row:text-fg"
+          className="min-w-0 max-w-xs shrink truncate font-medium text-muted transition-colors group-hover/tool-row:text-fg"
           title={nativeTitle(toolName)}
         >
           {toolName}

--- a/packages/ui/src/components/custom/topbar.tsx
+++ b/packages/ui/src/components/custom/topbar.tsx
@@ -3,6 +3,8 @@
 import { ChevronLeft, MoreHorizontal } from "lucide-react";
 import * as React from "react";
 
+import { Popover, PopoverContent, PopoverTrigger } from "../popover";
+
 import { cn } from "../../lib/utils";
 import {
   DropdownMenu,
@@ -156,15 +158,9 @@ function TopbarIdentity({
               /
             </span>
           ) : null}
-          <h1
-            ref={titleRef}
-            tabIndex={-1}
-            data-slot="topbar-title"
-            data-testid="topbar-title-text"
-            className="min-w-0 truncate pl-0.5 text-ws-name font-semibold tracking-tight text-fg-strong outline-none focus-visible:shadow-focus-ring"
-          >
+          <TopbarTitle titleRef={titleRef} className="pl-0.5">
             {leaf}
-          </h1>
+          </TopbarTitle>
         </nav>
       </div>
     );
@@ -187,21 +183,49 @@ function TopbarIdentity({
           {mark}
         </span>
       ) : null}
-      <h1
-        ref={titleRef}
-        tabIndex={-1}
-        data-slot="topbar-title"
-        data-testid="topbar-title-text"
-        className="min-w-0 truncate text-ws-name font-semibold tracking-tight text-fg-strong outline-none focus-visible:shadow-focus-ring"
-      >
-        {leaf}
-      </h1>
+      <TopbarTitle titleRef={titleRef}>{leaf}</TopbarTitle>
       {slot?.count !== undefined && slot.count !== null ? (
         <span data-slot="topbar-count" className="font-mono text-mono-id tabular-nums text-faint">
           {slot.count}
         </span>
       ) : null}
     </div>
+  );
+}
+
+function TopbarTitle({
+  children,
+  titleRef,
+  className,
+}: {
+  children: React.ReactNode;
+  titleRef?: React.Ref<HTMLHeadingElement>;
+  className?: string;
+}) {
+  return (
+    <h1
+      ref={titleRef}
+      tabIndex={-1}
+      data-slot="topbar-title"
+      data-testid="topbar-title-text"
+      className={cn(
+        "min-w-0 max-w-xs text-ws-name font-semibold tracking-tight text-fg-strong outline-none",
+        className
+      )}
+    >
+      <Popover>
+        <PopoverTrigger className="block max-w-full truncate rounded-sm text-left focus-visible:outline-none focus-visible:shadow-focus-ring">
+          {children}
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          aria-label="Full title"
+          className="max-w-[calc(100vw-2rem)] whitespace-pre-wrap select-text [overflow-wrap:anywhere]"
+        >
+          {children}
+        </PopoverContent>
+      </Popover>
+    </h1>
   );
 }
 

--- a/packages/ui/src/components/custom/topbar.tsx
+++ b/packages/ui/src/components/custom/topbar.tsx
@@ -220,7 +220,7 @@ function TopbarTitle({
         <PopoverContent
           align="start"
           aria-label="Full title"
-          className="max-w-[calc(100vw-2rem)] whitespace-pre-wrap select-text [overflow-wrap:anywhere]"
+          className="max-h-64 max-w-[calc(100vw-2rem)] overflow-auto whitespace-pre-wrap select-text [overflow-wrap:anywhere]"
         >
           {children}
         </PopoverContent>

--- a/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
+++ b/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
@@ -5627,3 +5627,52 @@ describe("SessionThread thinking guard", () => {
     }
   });
 });
+
+// Invariant: runtime projection retains canonical identity plus exact provider title,
+// and live/working summaries offer keyboard disclosure without losing the timer.
+// Owner: session thread composition; canonical suite: session-thread.
+it("Should preserve provider titles through the runtime and disclose live and Working details", async () => {
+  const user = userEvent.setup();
+  const title = "Inspect layout\n" + "ação 👩🏽‍💻 ".repeat(100) + "provider-title-tail";
+  const transcript = [
+    {
+      id: "long-title",
+      role: "assistant",
+      status: { type: "running" },
+      parts: [
+        {
+          type: "tool-Bash",
+          title,
+          toolCallId: "long-call",
+          state: "input-available",
+          turnId: "long-turn",
+          input: { command: "printf 'input-tail'" },
+        },
+      ],
+    },
+  ] as unknown as SessionMessage[];
+  renderThreadState({
+    status: "success",
+    messages: toReadonlyThreadMessages(transcript),
+    isSessionRunning: true,
+    statusSession: runningStatusSession("2026-09-06T12:00:00Z", title),
+  });
+  const live = await screen.findByTestId("live-tool-label");
+  expect(live).toHaveTextContent("Running shell");
+  expect(live).not.toHaveTextContent("provider-title-tail");
+  const trigger = within(live).getByRole("button", { name: "Tool details" });
+  trigger.focus();
+  await user.keyboard("{Enter}");
+  const details = await screen.findByRole("dialog", { name: "Tool details" });
+  expect(details.textContent).toContain(title);
+  expect(details).toHaveTextContent("input-tail");
+  await user.keyboard("{Escape}");
+  expect(trigger).toHaveFocus();
+  const activity = screen.getByRole("button", { name: "Activity details" });
+  activity.focus();
+  await user.keyboard("{Enter}");
+  expect((await screen.findByRole("dialog", { name: "Activity details" })).textContent).toContain(
+    title
+  );
+  expect(screen.getByTestId("session-working-timer")).toBeInTheDocument();
+});

--- a/web/src/components/assistant-ui/session-live-tool-row.tsx
+++ b/web/src/components/assistant-ui/session-live-tool-row.tsx
@@ -1,16 +1,18 @@
 import { ChevronRight, Layers } from "lucide-react";
 import { createElement } from "react";
 
-import { SessionToolCallRow } from "@/systems/session/components/tool-call-card";
+import {
+  SessionToolCallRow,
+  SessionSummaryDisclosure,
+  liveToolLabel,
+  parallelToolLabel,
+} from "@/systems/session";
 import type { SessionNavigationReveal } from "./hooks/session-navigation-target-context";
 import { toolMessageFromPart } from "./session-timeline-tool-message";
-
-import { SessionSummaryDisclosure } from "@/systems/session/components/session-summary-disclosure";
 
 import { cn } from "@/lib/utils";
 import { useSessionThreadLiveData } from "./hooks/use-session-thread-live-data";
 import { getToolIcon, resolveRegisteredToolName } from "@/systems/session/lib/tool-labels";
-import { liveToolLabel, parallelToolLabel } from "@/systems/session/lib/session-tool-visual-state";
 
 import type { SessionLiveToolRow, SessionTimelineToolPart } from "./session-timeline.logic";
 

--- a/web/src/components/assistant-ui/session-live-tool-row.tsx
+++ b/web/src/components/assistant-ui/session-live-tool-row.tsx
@@ -1,6 +1,12 @@
 import { ChevronRight, Layers } from "lucide-react";
 import { createElement } from "react";
 
+import { SessionToolCallRow } from "@/systems/session/components/tool-call-card";
+import type { SessionNavigationReveal } from "./hooks/session-navigation-target-context";
+import { toolMessageFromPart } from "./session-timeline-tool-message";
+
+import { SessionSummaryDisclosure } from "@/systems/session/components/session-summary-disclosure";
+
 import { cn } from "@/lib/utils";
 import { useSessionThreadLiveData } from "./hooks/use-session-thread-live-data";
 import { getToolIcon, resolveRegisteredToolName } from "@/systems/session/lib/tool-labels";
@@ -20,7 +26,7 @@ function LiveToolGlyph({ part }: { part: SessionTimelineToolPart }) {
 // (plain subtle text when still — under reduced motion, or while the window
 // is paused — the word "Running" carries the state), nothing on the right.
 function LiveToolLine({ part, still }: { part: SessionTimelineToolPart; still: boolean }) {
-  const label = liveToolLabel(part.toolName, part.args);
+  const label = liveToolLabel(part.toolName, part.args, part.toolTitle);
   return (
     <div
       className="flex min-h-transcript-line min-w-0 items-center gap-transcript-inline-gap px-1 text-small-body"
@@ -32,13 +38,17 @@ function LiveToolLine({ part, still }: { part: SessionTimelineToolPart; still: b
       </span>
       <span
         className={cn(
-          "min-w-0 flex-1 truncate font-medium",
+          "min-w-0 max-w-sm flex-1 truncate font-medium",
           still ? "text-subtle" : "session-shimmer"
         )}
         data-testid="live-tool-label"
-        title={label.text}
       >
-        {label.text}
+        <SessionSummaryDisclosure
+          summary={label.text}
+          label="Tool details"
+          detail={`${part.toolTitle ?? part.toolName}\n\n${JSON.stringify({ tool: part.toolName, ...(part.toolTitle ? { title: part.toolTitle } : {}), input: part.args }, null, 2)}`}
+          className="max-w-full font-medium"
+        />
       </span>
     </div>
   );
@@ -48,6 +58,7 @@ export interface SessionLiveToolRowViewProps {
   row: SessionLiveToolRow;
   reducedMotion: boolean;
   onToggle: () => void;
+  reveal?: SessionNavigationReveal | null;
 }
 
 /**
@@ -63,6 +74,7 @@ export function SessionLiveToolRowView({
   row,
   reducedMotion,
   onToggle,
+  reveal,
 }: SessionLiveToolRowViewProps) {
   const liveData = useSessionThreadLiveData();
   const still = reducedMotion || !liveData;
@@ -77,6 +89,15 @@ export function SessionLiveToolRowView({
         className="flex min-w-0 flex-col"
       >
         <LiveToolLine part={first} still={still} />
+        {reveal ? (
+          <SessionToolCallRow
+            message={toolMessageFromPart(first)}
+            partIndex={first.partIndex}
+            revealOpen
+            revealField={reveal.field ?? undefined}
+            onRevealRelease={onToggle}
+          />
+        ) : null}
       </div>
     );
   }
@@ -104,7 +125,7 @@ export function SessionLiveToolRowView({
         </span>
         <span
           className={cn(
-            "min-w-0 flex-1 truncate font-medium",
+            "min-w-0 max-w-sm flex-1 truncate font-medium",
             still ? "text-subtle" : "session-shimmer"
           )}
           data-testid="live-tool-label"
@@ -133,7 +154,20 @@ export function SessionLiveToolRowView({
         }
       >
         {row.expanded
-          ? row.entries.map(part => <LiveToolLine key={part.id} part={part} still={still} />)
+          ? row.entries.map(part => (
+              <div key={part.id} className="min-w-0">
+                <LiveToolLine part={part} still={still} />
+                {reveal && reveal.partIndex === part.partIndex ? (
+                  <SessionToolCallRow
+                    message={toolMessageFromPart(part)}
+                    partIndex={part.partIndex}
+                    revealOpen
+                    revealField={reveal.field ?? undefined}
+                    onRevealRelease={onToggle}
+                  />
+                ) : null}
+              </div>
+            ))
           : null}
       </div>
     </div>

--- a/web/src/components/assistant-ui/session-row-equality.ts
+++ b/web/src/components/assistant-ui/session-row-equality.ts
@@ -146,6 +146,7 @@ function toolEntriesEqual(
       tool.id === other.id &&
       tool.toolCallId === other.toolCallId &&
       tool.toolName === other.toolName &&
+      tool.toolTitle === other.toolTitle &&
       tool.status === other.status &&
       tool.state === other.state &&
       tool.isError === other.isError &&

--- a/web/src/components/assistant-ui/session-timeline-render.tsx
+++ b/web/src/components/assistant-ui/session-timeline-render.tsx
@@ -169,6 +169,7 @@ function SessionWorkRowView({ row }: { row: SessionWorkRow }) {
 }
 
 function SessionLiveToolRowContent({ row }: { row: SessionLiveToolRow }) {
+  const navigation = useOptionalSessionNavigationTarget();
   const store = useTimelineRowContext();
   const scrollStore = useOptionalThreadScrollStore();
   const reducedMotion = usePrefersReducedMotion();
@@ -180,6 +181,7 @@ function SessionLiveToolRowContent({ row }: { row: SessionLiveToolRow }) {
     <SessionLiveToolRowView
       row={hold.held && !row.expanded ? { ...row, expanded: true } : row}
       reducedMotion={reducedMotion}
+      reveal={hold.held ? navigation?.reveal : null}
       onToggle={() => {
         notifyDisclosureToggled(scrollStore);
         if (hold.held) {

--- a/web/src/components/assistant-ui/session-timeline-tool-message.ts
+++ b/web/src/components/assistant-ui/session-timeline-tool-message.ts
@@ -9,6 +9,7 @@ export function toolMessageFromPart(part: SessionTimelineToolPart): UIMessage {
     role: part.result !== undefined || part.isError ? "tool_result" : "tool_call",
     content: "",
     toolName: part.toolName,
+    toolTitle: part.toolTitle,
     toolInput: part.args,
     toolResult: resolveToolResult(part.result),
     toolError: part.isError,

--- a/web/src/components/assistant-ui/session-timeline.logic.ts
+++ b/web/src/components/assistant-ui/session-timeline.logic.ts
@@ -77,6 +77,7 @@ export interface SessionTimelineToolPart extends SessionTimelineBasePart {
   kind: "tool";
   toolCallId: string;
   toolName: string;
+  toolTitle?: string;
   args: Record<string, unknown>;
   result?: unknown;
   isError?: boolean;

--- a/web/src/components/assistant-ui/timeline-message-parts.ts
+++ b/web/src/components/assistant-ui/timeline-message-parts.ts
@@ -107,6 +107,7 @@ export function toTimelineParts(message: {
           id,
           toolCallId: stringField(part, "toolCallId") ?? id,
           toolName: stringField(part, "toolName") ?? "tool",
+          toolTitle: stringField(part, "toolTitle"),
           args: recordField(part, "args"),
           result,
           isError,

--- a/web/src/systems/session/components/__tests__/session-goal-strip.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-goal-strip.test.tsx
@@ -183,13 +183,14 @@ describe("SessionGoalStrip", () => {
     expect(body).toHaveTextContent("Approved · 2 blocking issues");
     expect(body).toHaveTextContent("verdict_007");
   });
-});
 
-// Invariant: the full objective remains in the keyboard-accessible disclosure, independent of the contract summary.
-it("Should disclose the exact multiline Goal objective", () => {
-  const objective = "Inspect summary layout\n" + "unbroken_path_".repeat(80) + "objective-tail";
-  render(<SessionGoalStrip snapshot={snapshot({ objective })} />);
-  fireEvent.click(screen.getByTestId("goal-strip-line"));
-  const body = screen.getByTestId("goal-strip-body");
-  expect(body.textContent).toContain(objective);
+  // Invariant: the full objective remains in the keyboard-accessible disclosure, independent of the contract summary.
+  // Owner: session Goal disclosure; canonical suite: session-goal-strip.
+  it("Should disclose the exact multiline Goal objective", () => {
+    const objective = "Inspect summary layout\n" + "unbroken_path_".repeat(80) + "objective-tail";
+    render(<SessionGoalStrip snapshot={snapshot({ objective })} />);
+    fireEvent.click(screen.getByTestId("goal-strip-line"));
+    const body = screen.getByTestId("goal-strip-body");
+    expect(body.textContent).toContain(objective);
+  });
 });

--- a/web/src/systems/session/components/__tests__/session-goal-strip.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-goal-strip.test.tsx
@@ -184,3 +184,12 @@ describe("SessionGoalStrip", () => {
     expect(body).toHaveTextContent("verdict_007");
   });
 });
+
+// Invariant: the full objective remains in the keyboard-accessible disclosure, independent of the contract summary.
+it("Should disclose the exact multiline Goal objective", () => {
+  const objective = "Inspect summary layout\n" + "unbroken_path_".repeat(80) + "objective-tail";
+  render(<SessionGoalStrip snapshot={snapshot({ objective })} />);
+  fireEvent.click(screen.getByTestId("goal-strip-line"));
+  const body = screen.getByTestId("goal-strip-body");
+  expect(body.textContent).toContain(objective);
+});

--- a/web/src/systems/session/components/__tests__/thinking-block.test.tsx
+++ b/web/src/systems/session/components/__tests__/thinking-block.test.tsx
@@ -108,3 +108,15 @@ describe("ThinkingBlock", () => {
     expect(trigger).not.toHaveTextContent("updates");
   });
 });
+
+// Invariant: only the collapsed preview is bounded; keyboard disclosure preserves reasoning.
+it("Should expose the full long reasoning after keyboard expansion", async () => {
+  const user = userEvent.setup();
+  const thinking = "Reviewing " + "ação 👩🏽‍💻 ".repeat(90) + "reasoning-tail";
+  render(<ThinkingBlock thinking={thinking} thinkingComplete />);
+  const trigger = screen.getByTestId("thinking-trigger");
+  expect(trigger).not.toHaveTextContent("reasoning-tail");
+  trigger.focus();
+  await user.keyboard("{Enter}");
+  expect(screen.getByRole("region", { name: "Reasoning" })).toHaveTextContent(thinking);
+});

--- a/web/src/systems/session/components/__tests__/thinking-block.test.tsx
+++ b/web/src/systems/session/components/__tests__/thinking-block.test.tsx
@@ -107,16 +107,17 @@ describe("ThinkingBlock", () => {
     // The "N updates" eyebrow is gone — grouping stays a derivation concern.
     expect(trigger).not.toHaveTextContent("updates");
   });
-});
 
-// Invariant: only the collapsed preview is bounded; keyboard disclosure preserves reasoning.
-it("Should expose the full long reasoning after keyboard expansion", async () => {
-  const user = userEvent.setup();
-  const thinking = "Reviewing " + "ação 👩🏽‍💻 ".repeat(90) + "reasoning-tail";
-  render(<ThinkingBlock thinking={thinking} thinkingComplete />);
-  const trigger = screen.getByTestId("thinking-trigger");
-  expect(trigger).not.toHaveTextContent("reasoning-tail");
-  trigger.focus();
-  await user.keyboard("{Enter}");
-  expect(screen.getByRole("region", { name: "Reasoning" })).toHaveTextContent(thinking);
+  // Invariant: only the collapsed preview is bounded; keyboard disclosure preserves reasoning.
+  // Owner: reasoning disclosure; canonical suite: thinking-block.
+  it("Should expose the full long reasoning after keyboard expansion", async () => {
+    const user = userEvent.setup();
+    const thinking = "Reviewing " + "ação 👩🏽‍💻 ".repeat(90) + "reasoning-tail";
+    render(<ThinkingBlock thinking={thinking} thinkingComplete />);
+    const trigger = screen.getByTestId("thinking-trigger");
+    expect(trigger).not.toHaveTextContent("reasoning-tail");
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("region", { name: "Reasoning" })).toHaveTextContent(thinking);
+  });
 });

--- a/web/src/systems/session/components/__tests__/tool-call-card.test.tsx
+++ b/web/src/systems/session/components/__tests__/tool-call-card.test.tsx
@@ -654,3 +654,46 @@ describe("Session SessionToolCallRow — wraps <SessionToolCallRow> from @compoz
     expect(screen.getAllByTestId("tool-matched-field")).toHaveLength(1);
   });
 });
+
+// Invariant: title summaries leave the exact title, input, and output available for keyboard disclosure/copy/find.
+// Owner: session tool card; canonical suite: tool-call-card.
+it("Should disclose a long provider title and copy its exact original payload", async () => {
+  const user = userEvent.setup();
+  const title = "Inspect fixture\n" + "ação 👩🏽‍💻 ".repeat(80) + "title-tail";
+  const message = makeToolMessage({
+    toolName: "Bash",
+    toolTitle: title,
+    toolInput: { command: "printf 'input-tail'" },
+    toolResult: { stdout: "output-tail" },
+  });
+  render(<SessionToolCallRow message={message} turnSettled />);
+  expect(queryToolName()).toHaveTextContent("Ran command");
+  expect(queryPreview()).not.toHaveTextContent("title-tail");
+  const trigger = screen.getByRole("button", { name: /Ran command.*Toggle tool call/ });
+  trigger.focus();
+  await user.keyboard("{Enter}");
+  expect(screen.getByLabelText("Tool title").textContent).toBe(title);
+  const writeText = vi.spyOn(navigator.clipboard, "writeText");
+  await user.click(screen.getByRole("button", { name: "Copy tool payload" }));
+  await waitFor(() => expect(writeText).toHaveBeenCalled());
+  expect(JSON.parse(writeText.mock.calls[0]![0])).toMatchObject({
+    tool: "Bash",
+    title,
+    input: message.toolInput,
+    output: message.toolResult,
+  });
+});
+
+it("Should show a title-only unknown tool in full when find reveals its title", () => {
+  const title = "provider description ".repeat(80) + "title-only-tail";
+  render(
+    <SessionToolCallRow
+      message={makeToolMessage({ toolName: title, toolInput: undefined })}
+      turnSettled
+      revealOpen
+      revealField="title"
+    />
+  );
+  expect(screen.getByLabelText("Tool title").textContent).toBe(title);
+  expect(queryToolName()).toHaveTextContent("Used tool");
+});

--- a/web/src/systems/session/components/goal/session-goal-strip.tsx
+++ b/web/src/systems/session/components/goal/session-goal-strip.tsx
@@ -70,7 +70,9 @@ function StripRow({ label, children }: { label: string; children: React.ReactNod
   return (
     <div className="flex gap-2.5 text-transcript-body leading-normal">
       <span className="w-[76px] shrink-0 pt-px text-transcript-caption text-faint">{label}</span>
-      <span className="min-w-0 text-muted">{children}</span>
+      <span className="min-w-0 whitespace-pre-wrap text-muted [overflow-wrap:anywhere]">
+        {children}
+      </span>
     </div>
   );
 }
@@ -142,7 +144,7 @@ export function SessionGoalStrip({
           className={cn("size-1.5 shrink-0 rounded-full", STATE_DOT[state])}
         />
         <Eyebrow className="shrink-0 text-subtle">Goal</Eyebrow>
-        <span className="min-w-0 flex-1 truncate text-small-body text-fg">
+        <span className="min-w-0 max-w-sm flex-1 truncate text-small-body text-fg">
           {snapshot.objective}
         </span>
         <span
@@ -164,6 +166,7 @@ export function SessionGoalStrip({
       </button>
       {open ? (
         <div data-testid="goal-strip-body" className="flex flex-col gap-[5px] px-1 pt-1.5 pb-0.5">
+          <StripRow label="Objective">{snapshot.objective}</StripRow>
           {snapshot.contract_summary ? (
             <StripRow label="Contract">{snapshot.contract_summary}</StripRow>
           ) : null}

--- a/web/src/systems/session/components/session-summary-disclosure.tsx
+++ b/web/src/systems/session/components/session-summary-disclosure.tsx
@@ -1,0 +1,54 @@
+import { useId } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  CopyIconButton,
+  Popover,
+  PopoverContent,
+  PopoverTitle,
+  PopoverTrigger,
+  cn,
+} from "@compozy/ui";
+
+/** Compact chrome with a keyboard/pointer detail surface that does not move the transcript. */
+export function SessionSummaryDisclosure({
+  summary,
+  detail,
+  label,
+  className,
+}: {
+  summary: string;
+  detail: string;
+  label: string;
+  className?: string;
+}) {
+  const summaryId = useId();
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label={label}
+        aria-describedby={summaryId}
+        className={cn(
+          "inline-flex min-w-0 max-w-sm items-center gap-1 rounded-sm text-left hover:bg-hover focus-visible:shadow-focus-inset focus-visible:outline-none",
+          className
+        )}
+      >
+        <span id={summaryId} className="min-w-0 truncate">
+          {summary}
+        </span>
+        <ChevronDown aria-hidden="true" className="size-3 shrink-0 text-faint" />
+      </PopoverTrigger>
+      <PopoverContent align="start" side="top" className="w-sm max-w-[calc(100vw-2rem)]">
+        <div className="flex items-center justify-between gap-2">
+          <PopoverTitle>{label}</PopoverTitle>
+          <CopyIconButton value={detail} copyLabel={`Copy ${label.toLowerCase()}`} />
+        </div>
+        <pre
+          tabIndex={0}
+          className="max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono text-transcript-body select-text [overflow-wrap:anywhere]"
+        >
+          {detail}
+        </pre>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/systems/session/components/session-thinking-row.tsx
+++ b/web/src/systems/session/components/session-thinking-row.tsx
@@ -1,5 +1,7 @@
 import { CircleAlert, CircleStop, LoaderCircle } from "lucide-react";
 
+import { SessionSummaryDisclosure } from "./session-summary-disclosure";
+
 import { TypingDots } from "@compozy/ui";
 
 import { cn } from "@/lib/utils";
@@ -39,7 +41,7 @@ export interface SessionThinkingRowProps {
 }
 
 const ROW_CLASS =
-  "flex min-h-transcript-row items-center gap-2 px-1 py-0.5 text-transcript-meta text-subtle tabular-nums";
+  "flex min-h-transcript-row min-w-0 items-center gap-2 px-1 py-0.5 text-transcript-meta text-subtle tabular-nums";
 
 function SessionStatusSeparator() {
   return (
@@ -76,11 +78,13 @@ function WorkingStatusLine({
   liveDataEnabled,
   pausedAtMs,
   reducedMotion,
+  activityDetail,
 }: {
   status: Extract<SessionWorkingStatus, { kind: "working" }>;
   liveDataEnabled: boolean;
   pausedAtMs: number | null;
   reducedMotion: boolean;
+  activityDetail?: string;
 }) {
   const asOf = !liveDataEnabled && pausedAtMs !== null ? formatMessageTimestamp(pausedAtMs) : null;
   return (
@@ -93,35 +97,48 @@ function WorkingStatusLine({
       className={ROW_CLASS}
     >
       <Dots reducedMotion={reducedMotion || !liveDataEnabled} />
-      <span>
-        {status.startedAtMs !== null ? (
-          <>
-            Working for{" "}
-            <WorkingTimer
-              startedAtMs={status.startedAtMs}
-              enabled={liveDataEnabled}
-              fallback={status.elapsed}
-            />
-          </>
-        ) : (
-          "Working…"
-        )}
+      <span className="flex min-w-0 flex-1 items-center">
+        <span className="shrink-0 whitespace-nowrap">
+          {status.startedAtMs !== null ? (
+            <>
+              Working for{" "}
+              <WorkingTimer
+                startedAtMs={status.startedAtMs}
+                enabled={liveDataEnabled}
+                fallback={status.elapsed}
+              />
+            </>
+          ) : (
+            "Working…"
+          )}
+        </span>
         {status.activity ? (
           <>
             <SessionStatusSeparator />
-            <span data-testid="session-working-activity">{status.activity}</span>
+            <span data-testid="session-working-activity" className="min-w-0 max-w-sm">
+              <SessionSummaryDisclosure
+                label="Activity details"
+                summary={status.activity}
+                detail={activityDetail ?? status.activity}
+                className="max-w-full"
+              />
+            </span>
           </>
         ) : null}
         {status.agentCount > 0 ? (
           <>
             <SessionStatusSeparator />
-            <span data-testid="session-working-agents">{agentCountLabel(status.agentCount)}</span>
+            <span data-testid="session-working-agents" className="shrink-0 whitespace-nowrap">
+              {agentCountLabel(status.agentCount)}
+            </span>
           </>
         ) : null}
         {asOf ? (
           <>
             <SessionStatusSeparator />
-            <span data-testid="session-working-as-of">as of {asOf}</span>
+            <span data-testid="session-working-as-of" className="shrink-0 whitespace-nowrap">
+              as of {asOf}
+            </span>
           </>
         ) : null}
       </span>
@@ -134,11 +151,13 @@ function SessionStatusLine({
   liveDataEnabled,
   pausedAtMs,
   reducedMotion,
+  activityDetail,
 }: {
   status: SessionWorkingStatus;
   liveDataEnabled: boolean;
   pausedAtMs: number | null;
   reducedMotion: boolean;
+  activityDetail?: string;
 }) {
   switch (status.kind) {
     case "thinking": {
@@ -166,6 +185,7 @@ function SessionStatusLine({
           liveDataEnabled={liveDataEnabled}
           pausedAtMs={pausedAtMs}
           reducedMotion={reducedMotion}
+          activityDetail={activityDetail}
         />
       );
     case "stopped":
@@ -271,6 +291,13 @@ export function SessionThinkingRow({
       liveDataEnabled={liveDataEnabled}
       pausedAtMs={pausedAtMs}
       reducedMotion={reducedMotion}
+      activityDetail={
+        session.pending_interactions.length === 0 &&
+        (session.supervision?.work_signals.filter(signal => signal.kind === "tool_running")
+          .length ?? 0) <= 1
+          ? session.activity?.current_tool
+          : undefined
+      }
     />
   );
 }

--- a/web/src/systems/session/components/stories/sessions-stability-story-routes.ts
+++ b/web/src/systems/session/components/stories/sessions-stability-story-routes.ts
@@ -54,9 +54,15 @@ function searchableFields(
   const type = readString(source, "type") ?? "";
   if (type === "text") return [{ field: "text", text: readString(source, "text") ?? "", role: "" }];
   if (!type.startsWith("tool-")) return [];
-  return Object.entries(asRecord(source.input))
+  const inputs = Object.entries(asRecord(source.input))
     .filter((entry): entry is [string, string] => typeof entry[1] === "string")
     .map(([, text]) => ({ field: "input", text, role: "tool" }));
+  const title = readString(source, "title");
+  return [
+    ...inputs,
+    ...(title ? [{ field: "title", text: title, role: "tool" }] : []),
+    { field: "tool_name", text: type.slice("tool-".length), role: "tool" },
+  ];
 }
 
 function snippetAround(text: string, at: number, length: number): string {

--- a/web/src/systems/session/components/stories/sessions-stability-working.stories.tsx
+++ b/web/src/systems/session/components/stories/sessions-stability-working.stories.tsx
@@ -1,3 +1,7 @@
+import { HttpResponse } from "msw";
+import { compozyApiMock } from "@/storybook/openapi-msw";
+import type { SessionGoalSnapshot } from "@/systems/session/types";
+
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 import { SessionBusyInputRefusalError, type SessionSendOutcome } from "@/systems/session";
@@ -21,6 +25,83 @@ import {
 } from "./sessions-stability-story-fixtures";
 import { stabilityHandlers, discardStabilityDraft } from "./sessions-stability-story-routes";
 import { StabilityThreadHost } from "./sessions-stability-story-host";
+
+import {
+  part,
+  textPart,
+  userMessage,
+  TURN,
+} from "../assistant-ui/stories/session-thread-story-quiet-parts";
+
+// Sanitized provider-style payload; the tail is intentionally outside every summary.
+const longToolTitle = `python3 - <<'PY'
+${"print('Inspecting summary layout — ação 👩🏽‍💻')\n".repeat(24)}print('summary-preservation-tail')
+PY`;
+const longSummaryTranscript = [
+  userMessage("summary-user", "Inspect the summary layout and preserve the complete tool payload."),
+  {
+    id: "summary-assistant",
+    role: "assistant" as const,
+    status: { type: "running" as const },
+    parts: [
+      part({
+        type: "reasoning",
+        text: "Reviewing " + "a very long reasoning preview — ação 👩🏽‍💻 ".repeat(30),
+        state: "done",
+        turnId: TURN,
+      }),
+      part({
+        type: `tool-${longToolTitle}`,
+        toolCallId: "summary-settled",
+        state: "output-available",
+        turnId: TURN,
+        input: { command: longToolTitle },
+        output: { type: "tool_result", raw: { stdout: "Inspection complete." } },
+      }),
+      textPart(
+        "The full command remains available for inspection and copying.",
+        "2026-07-07T12:06:00Z"
+      ),
+      part({
+        type: `tool-${longToolTitle}`,
+        toolCallId: "summary-live",
+        state: "input-available",
+        turnId: TURN,
+        input: { command: longToolTitle },
+      }),
+    ],
+  },
+];
+
+const longObjective =
+  "Verify compact session summaries — " + "/fixtures/".repeat(90) + "objective-tail";
+const summaryGoal: SessionGoalSnapshot = {
+  bound_session_id: "summary-session",
+  origin_session_id: "summary-session",
+  run_id: "summary-run",
+  node_id: "goal",
+  objective: longObjective,
+  cause: null,
+  status: "active",
+  run_status: "running",
+  live: false,
+  turns_used: 3,
+  turn_limit: 20,
+  contract_summary: "Complete payloads stay inspectable and searchable.",
+  last_verdict: null,
+  context: {
+    nudge_ratio: 0.8,
+    ratio: null,
+    reported_at: null,
+    size: null,
+    state: "unknown",
+    used: null,
+  },
+};
+const summaryGoalHandler = compozyApiMock.get(
+  "/api/workspaces/{workspace_id}/sessions/{session_id}/goal",
+  () => HttpResponse.json({ goal: summaryGoal })
+);
 
 const MINUTE = 60_000;
 
@@ -189,4 +270,117 @@ export const ComposerStopping: Story = {
 };
 export const ComposerStopped: Story = {
   parameters: storybookMswParameters({ session: stabilityHandlers(escalatedStopTranscript) }),
+};
+
+export const LongSummaries: Story = {
+  tags: ["play-fn"],
+  parameters: {
+    layout: "fullscreen",
+    ...storybookMswParameters({
+      session: [summaryGoalHandler, ...stabilityHandlers(longSummaryTranscript)],
+    }),
+  },
+  render: () => (
+    <StabilityThreadHost
+      width={1600}
+      height={760}
+      isSessionRunning
+      statusSession={{
+        ...runningSession({ turnId: TURN }),
+        activity: { ...runningSession({ turnId: TURN }).activity!, current_tool: longToolTitle },
+      }}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const working = await canvas.findByTestId("session-working-row");
+    await expect(working.getBoundingClientRect().height).toBeLessThanOrEqual(26);
+    const live = await canvas.findByTestId("live-tool-label");
+    await expect(live.getBoundingClientRect().width).toBeLessThanOrEqual(384);
+    await expect(working).not.toHaveTextContent("summary-preservation-tail");
+    const activity = canvas.getByRole("button", { name: "Activity details" });
+    activity.focus();
+    await userEvent.keyboard("{Enter}");
+    const document = within(canvasElement.ownerDocument.body);
+    await expect(
+      await document.findByRole("dialog", { name: "Activity details" })
+    ).toHaveTextContent("summary-preservation-tail");
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(activity).toHaveFocus());
+    const goal = canvas.getByTestId("goal-strip-line");
+    goal.focus();
+    await userEvent.keyboard("{Enter}");
+    await expect(canvas.getByTestId("goal-strip-body").textContent).toContain(longObjective);
+    await userEvent.keyboard("{Enter}");
+    canvasElement.dataset.summaryChecks = "passed";
+  },
+};
+
+/** Concurrent provider calls and a long agent prompt keep their own inspectable originals. */
+export const LongSummariesParallel: Story = {
+  ...LongSummaries,
+  tags: ["play-fn"],
+  render: () => (
+    <StabilityThreadHost
+      width={1600}
+      height={760}
+      isSessionRunning
+      statusSession={runningSession({ agents: 1, currentTool: longToolTitle, turnId: TURN })}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const group = await canvas.findByTestId("live-tool-parallel");
+    group.focus();
+    await userEvent.keyboard("{Enter}");
+    const details = await canvas.findAllByRole("button", { name: "Tool details" });
+    await expect(details).toHaveLength(3);
+    for (const trigger of details) {
+      trigger.focus();
+      await userEvent.keyboard("{Enter}");
+      await expect(
+        await within(canvasElement.ownerDocument.body).findByRole("dialog", {
+          name: "Tool details",
+        })
+      ).toBeVisible();
+      await userEvent.keyboard("{Escape}");
+      await waitFor(() => expect(trigger).toHaveFocus());
+    }
+    await expect(
+      canvas.getByTestId("session-working-row").getBoundingClientRect().height
+    ).toBeLessThanOrEqual(26);
+    canvasElement.dataset.parallelChecks = "passed";
+  },
+  parameters: {
+    layout: "fullscreen",
+    ...storybookMswParameters({
+      session: [
+        summaryGoalHandler,
+        ...stabilityHandlers([
+          ...longSummaryTranscript.slice(0, -1),
+          {
+            ...longSummaryTranscript.at(-1)!,
+            parts: [
+              ...longSummaryTranscript.at(-1)!.parts,
+              part({
+                type: "tool-Read",
+                title: "Inspect " + "/fixtures/".repeat(100),
+                toolCallId: "summary-parallel",
+                state: "input-available",
+                turnId: TURN,
+                input: { file_path: "/fixtures/".repeat(100) },
+              }),
+              part({
+                type: "tool-Agent",
+                toolCallId: "summary-agent",
+                state: "input-available",
+                turnId: TURN,
+                input: { prompt: "Review " + "ação 👩🏽‍💻 ".repeat(100) + "agent-tail" },
+              }),
+            ],
+          },
+        ]),
+      ],
+    }),
+  },
 };

--- a/web/src/systems/session/components/stories/sessions-stability-working.stories.tsx
+++ b/web/src/systems/session/components/stories/sessions-stability-working.stories.tsx
@@ -64,6 +64,7 @@ const longSummaryTranscript = [
       ),
       part({
         type: `tool-${longToolTitle}`,
+        title: longToolTitle + "\nlive-title-tail",
         toolCallId: "summary-live",
         state: "input-available",
         turnId: TURN,

--- a/web/src/systems/session/components/thinking-block.tsx
+++ b/web/src/systems/session/components/thinking-block.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Brain, ChevronDown } from "lucide-react";
 
+import { compactSessionSummary } from "../lib/session-summary";
+
 import { cn } from "@/lib/utils";
 import { MessageMarkdown } from "@/systems/session/components/message-markdown";
 
@@ -42,7 +44,7 @@ export function ThinkingBlock({
   const live = !thinkingComplete;
   const ownOpen = userOpen ?? live;
   const open = ownOpen || revealOpen;
-  const preview = firstThinkingLine(thinking);
+  const preview = compactSessionSummary(firstThinkingLine(thinking));
 
   return (
     <div
@@ -81,7 +83,7 @@ export function ThinkingBlock({
                 Thought
               </span>
               {preview ? (
-                <span className="min-w-0 flex-1 truncate text-subtle">{preview}</span>
+                <span className="min-w-0 max-w-sm flex-1 truncate text-subtle">{preview}</span>
               ) : null}
             </span>
             <ChevronDown

--- a/web/src/systems/session/components/tool-call-card.tsx
+++ b/web/src/systems/session/components/tool-call-card.tsx
@@ -1,6 +1,9 @@
 import { CopyIconButton, ToolCallRow, type ToolCallStatus } from "@compozy/ui";
 import { Suspense, useState, lazy } from "react";
 
+import { compactSessionSummary } from "../lib/session-summary";
+import { DetailPayload } from "./tool-renderers/detail-payload";
+
 import { deriveToolRowStatus, hasToolInput, toolResultIsEmpty } from "../lib/message-parts";
 import { isDeliberateTerminalTool, readSupervisedTerminalId } from "../lib/session-terminal-tools";
 import { fileDiffStatForTool } from "../lib/tool-diff-stat";
@@ -9,6 +12,7 @@ import {
   getToolIcon,
   getToolLabel,
   resolveRegisteredToolName,
+  toolHeadingName,
 } from "../lib/tool-labels";
 import type { UIMessage } from "../types";
 import { isToolBodyField } from "../lib/tool-matched-field";
@@ -56,6 +60,7 @@ function formatToolPayload(message: UIMessage): string {
     return JSON.stringify(
       {
         tool: message.toolName,
+        ...(message.toolTitle ? { title: message.toolTitle } : {}),
         input: message.toolInput ?? {},
         output: message.toolResult ?? null,
         error: message.toolError === true,
@@ -113,9 +118,17 @@ function previewFor(
   status: ToolCallStatus
 ): string | undefined {
   if (status === "failed") {
-    return failurePreview(message, registryTool);
+    return compactSessionSummary(failurePreview(message, registryTool));
   }
-  const summary = getToolCompactSummary(registryTool, message.toolInput);
+  const description =
+    message.toolTitle && message.toolTitle !== registryTool
+      ? message.toolTitle
+      : message.toolName !== toolHeadingName(registryTool)
+        ? message.toolName
+        : undefined;
+  const summary = description
+    ? compactSessionSummary(description)
+    : getToolCompactSummary(registryTool, message.toolInput);
   if (registryTool === "Read" && status === "success" && summary) {
     const body = message.toolResult?.stdout ?? message.toolResult?.content;
     if (typeof body === "string" && body.length > 0) {
@@ -174,9 +187,17 @@ function toolCallPresentation({
   const showArtifactResult = message.toolResult?.truncated === true;
   // A find jump names the field it matched: that payload renders in full beside
   // the tool's own display, so the searched text is on screen (not only the
-  // specialized summary of it). Header fields (title, tool name, file) already show.
+  // specialized summary of it). Title/name matches open the original title below.
   const matchedField = revealOpen && isToolBodyField(revealField) ? revealField : null;
+  const titleDetail =
+    revealField === "tool_name" ? message.toolName : (message.toolTitle ?? message.toolName);
+  const showTitleDetail = Boolean(
+    titleDetail &&
+    (titleDetail !== toolHeadingName(registryTool) ||
+      (revealOpen && (revealField === "title" || revealField === "tool_name")))
+  );
   const showExpandedBody =
+    showTitleDetail ||
     showArtifactResult ||
     isSpecialized ||
     hasOutput ||
@@ -195,6 +216,8 @@ function toolCallPresentation({
     matchedField,
     showArtifactResult,
     showExpandedBody,
+    showTitleDetail,
+    titleDetail,
   };
 }
 
@@ -238,6 +261,8 @@ export function SessionToolCallRow({
     matchedField,
     showArtifactResult,
     showExpandedBody,
+    showTitleDetail,
+    titleDetail,
   } = toolCallPresentation({
     message,
     turnSettled,
@@ -289,6 +314,14 @@ export function SessionToolCallRow({
       >
         {showExpandedBody ? (
           <ToolCallRow.Output>
+            {showTitleDetail && titleDetail ? (
+              <DetailPayload
+                aria-label="Tool title"
+                text={titleDetail}
+                defaultExpanded
+                downloadName="tool-title.txt"
+              />
+            ) : null}
             {matchedField ? (
               <MatchedToolFieldContent message={message} field={matchedField} />
             ) : null}

--- a/web/src/systems/session/index.ts
+++ b/web/src/systems/session/index.ts
@@ -432,6 +432,7 @@ export {
   type SessionWorkspaceSwitchDialogProps,
 } from "./components/session-workspace-switch-dialog";
 export { SessionToolCallRow, type SessionToolCallRowProps } from "./components/tool-call-card";
+export { SessionSummaryDisclosure } from "./components/session-summary-disclosure";
 export {
   SessionChatRuntimeProvider,
   type SessionChatRuntimeProviderProps,

--- a/web/src/systems/session/lib/__tests__/session-navigation.test.ts
+++ b/web/src/systems/session/lib/__tests__/session-navigation.test.ts
@@ -295,7 +295,7 @@ describe("navigation host derivations", () => {
     });
     expect(findMatchSource({ field: "tool_name", part_index: 1 }, agent)).toMatchObject({
       insideFold: true,
-      opensBody: false,
+      opensBody: true,
     });
     expect(findMatchSource({ field: "text", part_index: 0 }, agent)).toMatchObject({
       insideFold: true,

--- a/web/src/systems/session/lib/__tests__/session-tool-visual-state.test.ts
+++ b/web/src/systems/session/lib/__tests__/session-tool-visual-state.test.ts
@@ -70,3 +70,15 @@ describe("tool visual state", () => {
     expect(parallelToolLabel(3)).toBe("Running 3 tools…");
   });
 });
+
+// Invariant: provider descriptions and agent prompts cannot become unbounded action headings.
+it("Should keep identity separate from long descriptive titles and bound agent previews", () => {
+  const title = "Inspect\n" + "ação 👩🏽‍💻 ".repeat(100);
+  expect(liveToolLabel("Bash", { command: "ls" }, title)).toMatchObject({ verb: "Running shell" });
+  expect(liveToolLabel(title).verb).toBe("Running tool");
+  expect(liveToolLabel(title).preview).not.toContain("\n");
+  const label = liveToolLabel("Agent", { prompt: title });
+  expect(label.verb).toBe("Running agent");
+  expect(label.preview).toMatch(/…$/);
+  expect(label.preview!.length).toBeLessThan(title.length);
+});

--- a/web/src/systems/session/lib/__tests__/session-tool-visual-state.test.ts
+++ b/web/src/systems/session/lib/__tests__/session-tool-visual-state.test.ts
@@ -76,6 +76,11 @@ it("Should keep identity separate from long descriptive titles and bound agent p
   const title = "Inspect\n" + "ação 👩🏽‍💻 ".repeat(100);
   expect(liveToolLabel("Bash", { command: "ls" }, title)).toMatchObject({ verb: "Running shell" });
   expect(liveToolLabel(title).verb).toBe("Running tool");
+  expect(liveToolLabel("Bash dependency investigation")).toMatchObject({
+    verb: "Running tool",
+    preview: "Bash dependency investigation",
+  });
+  expect(liveToolLabel("Bash", {}, "Bash dependency investigation").verb).toBe("Running shell");
   expect(liveToolLabel(title).preview).not.toContain("\n");
   const label = liveToolLabel("Agent", { prompt: title });
   expect(label.verb).toBe("Running agent");

--- a/web/src/systems/session/lib/__tests__/tool-labels.test.ts
+++ b/web/src/systems/session/lib/__tests__/tool-labels.test.ts
@@ -163,3 +163,22 @@ describe("getToolCompactSummary", () => {
     expect(getToolCompactSummary("Bash")).toBeUndefined();
   });
 });
+
+// Invariant: display-only normalization is one line, grapheme-safe, and never invents tool identity.
+// Owner: session presentation; canonical suite: tool-labels.
+describe("provider summary presentation", () => {
+  it("Should treat a script title as an unknown tool and preserve canonical prefix resolution", () => {
+    const title = "python3 - <<'PY'\n" + "print('hello')\n".repeat(30) + "PY";
+    expect(getToolLabel(title, "active")).toBe("Running tool...");
+    expect(getToolLabel(title, "past")).toBe("Used tool");
+    expect(resolveRegisteredToolName(title)).toBe(title);
+    expect(resolveRegisteredToolName("Read /fixtures/a.txt")).toBe("Read");
+  });
+  it("Should normalize multiline input and truncate between complete graphemes", () => {
+    const emoji = "👩🏽‍💻";
+    const command = emoji.repeat(90) + "\nraw-tail";
+    expect(getToolCompactSummary("Bash", { command })).toBe(emoji.repeat(79) + "…");
+    expect(getToolCompactSummary("Bash", { command: "first\n\tsecond" })).toBe("first second");
+    expect(command).toContain("\nraw-tail");
+  });
+});

--- a/web/src/systems/session/lib/__tests__/tool-labels.test.ts
+++ b/web/src/systems/session/lib/__tests__/tool-labels.test.ts
@@ -102,9 +102,9 @@ describe("getToolLabel", () => {
 });
 
 describe("resolveRegisteredToolName", () => {
-  it("returns the registry id for exact and ACP-style titles", () => {
+  it("resolves exact identities while preserving free-form titles", () => {
     expect(resolveRegisteredToolName("Read")).toBe("Read");
-    expect(resolveRegisteredToolName("Read routes.go")).toBe("Read");
+    expect(resolveRegisteredToolName("Read routes.go")).toBe("Read routes.go");
     expect(resolveRegisteredToolName("Bash")).toBe("Bash");
   });
 
@@ -167,12 +167,15 @@ describe("getToolCompactSummary", () => {
 // Invariant: display-only normalization is one line, grapheme-safe, and never invents tool identity.
 // Owner: session presentation; canonical suite: tool-labels.
 describe("provider summary presentation", () => {
-  it("Should treat a script title as an unknown tool and preserve canonical prefix resolution", () => {
+  it("Should treat a script title as an unknown tool and preserve explicit native identity", () => {
     const title = "python3 - <<'PY'\n" + "print('hello')\n".repeat(30) + "PY";
     expect(getToolLabel(title, "active")).toBe("Running tool...");
     expect(getToolLabel(title, "past")).toBe("Used tool");
     expect(resolveRegisteredToolName(title)).toBe(title);
-    expect(resolveRegisteredToolName("Read /fixtures/a.txt")).toBe("Read");
+    expect(resolveRegisteredToolName("mcp__host__compozy__terminal_exec")).toBe(
+      "compozy__terminal_exec"
+    );
+    expect(getToolLabel("Bash dependency investigation", "past")).toBe("Used tool");
   });
   it("Should normalize multiline input and truncate between complete graphemes", () => {
     const emoji = "👩🏽‍💻";

--- a/web/src/systems/session/lib/session-navigation-transcript.ts
+++ b/web/src/systems/session/lib/session-navigation-transcript.ts
@@ -145,7 +145,12 @@ export function findMatchSource(
     kind,
     opensBody:
       kind === "reasoning" ||
-      (kind === "tool" && (field === "input" || field === "output" || field === "error")),
+      (kind === "tool" &&
+        (field === "input" ||
+          field === "output" ||
+          field === "error" ||
+          field === "title" ||
+          field === "tool_name")),
     partIndex,
     toolCallId: kind === "tool" ? (readString(part, "toolCallId") ?? null) : null,
   };

--- a/web/src/systems/session/lib/session-summary.ts
+++ b/web/src/systems/session/lib/session-summary.ts
@@ -1,0 +1,12 @@
+/** Display-only summaries. Callers retain the original for detail, copy, and find. */
+const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export function compactSessionSummary(text: string, limit = 80): string {
+  const line = text.replace(/\s+/gu, " ").trim();
+  const result: string[] = [];
+  for (const { segment } of graphemes.segment(line)) {
+    if (result.length === limit) return result.slice(0, limit - 1).join("") + "…";
+    result.push(segment);
+  }
+  return result.join("");
+}

--- a/web/src/systems/session/lib/session-thread-repository.ts
+++ b/web/src/systems/session/lib/session-thread-repository.ts
@@ -122,6 +122,7 @@ function toToolPart(
     type: "tool-call" as const,
     toolCallId,
     toolName,
+    toolTitle: stringField(record, "title"),
     args: toJSONObject(input),
     argsText: jsonText(input),
     result: toolPartResult(record, isError),

--- a/web/src/systems/session/lib/session-tool-visual-state.ts
+++ b/web/src/systems/session/lib/session-tool-visual-state.ts
@@ -7,7 +7,9 @@
 // module owns the mapping and the accessible words; palette fidelity is owned
 // by the artboards and Storybook capture, never by a unit test.
 
-import { getToolCompactSummary, resolveRegisteredToolName } from "./tool-labels";
+import { compactSessionSummary } from "./session-summary";
+
+import { getToolCompactSummary, resolveRegisteredToolName, toolHeadingName } from "./tool-labels";
 
 export type SessionToolVisualStatus =
   | "live"
@@ -104,7 +106,7 @@ const LIVE_VERB: Record<SessionToolKind, string> = {
 function liveVerb(kind: SessionToolKind, registryTool: string): string {
   if (kind === "search") return registryTool === "Glob" ? "Finding files" : "Searching content";
   if (kind === "web") return registryTool === "WebSearch" ? "Searching the web" : "Fetching";
-  if (kind === "other") return `Running ${registryTool}`;
+  if (kind === "other") return `Running ${toolHeadingName(registryTool)}`;
   return LIVE_VERB[kind];
 }
 
@@ -115,7 +117,9 @@ function livePreview(
 ): string | null {
   if (kind === "agent") {
     const description = args.description ?? args.prompt;
-    return typeof description === "string" && description.trim() ? description.trim() : null;
+    return typeof description === "string" && description.trim()
+      ? compactSessionSummary(description)
+      : null;
   }
   const summary = getToolCompactSummary(registryTool, args);
   return summary && summary.trim().length > 0 ? summary : null;
@@ -123,12 +127,21 @@ function livePreview(
 
 export function liveToolLabel(
   toolName: string,
-  args: Record<string, unknown> = {}
+  args: Record<string, unknown> = {},
+  title?: string
 ): SessionLiveToolLabel {
   const registryTool = resolveRegisteredToolName(toolName);
   const kind = toolVisualKind(toolName);
   const verb = liveVerb(kind, registryTool);
-  const preview = livePreview(kind, registryTool, args);
+  const description =
+    title && title !== registryTool
+      ? title
+      : toolHeadingName(toolName) === "tool" && toolName !== "tool"
+        ? toolName
+        : null;
+  const preview = description
+    ? compactSessionSummary(description)
+    : livePreview(kind, registryTool, args);
   if (preview === null) return { verb, preview, text: verb };
   // Paths read as the object of the verb ("Editing a/b.ts"); everything else is
   // set off with a dash ("Running shell — go test").

--- a/web/src/systems/session/lib/session-working-status.ts
+++ b/web/src/systems/session/lib/session-working-status.ts
@@ -129,7 +129,7 @@ function currentActivity(session: SessionWorkingStatusInput["session"]): string 
   if (runningTools > 1) return `Running ${runningTools} tools`;
   const tool = session.activity?.current_tool?.trim();
   if (!tool) return null;
-  return liveToolLabel(tool).verb;
+  return liveToolLabel(tool).text;
 }
 
 export function agentCountLabel(count: number): string {

--- a/web/src/systems/session/lib/tool-labels.ts
+++ b/web/src/systems/session/lib/tool-labels.ts
@@ -210,7 +210,7 @@ const REGISTERED_TOOL_NAMES = new Set(Object.keys(TOOL_LABELS));
 
 /**
  * Resolve a canonical registry tool id from a streamed or persisted tool name.
- * Accepts exact ids ("Read") and ACP-style titles ("Read routes.go").
+ * Accepts exact ids and the documented hosted-MCP projection; prose remains a title.
  */
 export function resolveRegisteredToolName(toolName: string): string {
   const trimmed = toolName.trim();
@@ -223,11 +223,6 @@ export function resolveRegisteredToolName(toolName: string): string {
   const canonical = canonicalCompozyToolName(trimmed);
   if (REGISTERED_TOOL_NAMES.has(canonical)) {
     return canonical;
-  }
-  for (const registered of REGISTERED_TOOL_NAMES) {
-    if (trimmed.startsWith(`${registered} `)) {
-      return registered;
-    }
   }
   return trimmed;
 }

--- a/web/src/systems/session/lib/tool-labels.ts
+++ b/web/src/systems/session/lib/tool-labels.ts
@@ -28,6 +28,8 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
+import { compactSessionSummary } from "./session-summary";
+
 import { canonicalCompozyToolName } from "./session-terminal-tools";
 
 // --- Tool Icons ---
@@ -230,10 +232,19 @@ export function resolveRegisteredToolName(toolName: string): string {
   return trimmed;
 }
 
+/** Free-form provider titles are descriptions, not canonical tool identities. */
+export function toolHeadingName(toolName: string): string {
+  const resolved = resolveRegisteredToolName(toolName);
+  return REGISTERED_TOOL_NAMES.has(resolved) || /^[\p{L}\p{N}_:.-]{1,80}$/u.test(resolved)
+    ? resolved
+    : "tool";
+}
+
 export function getToolLabel(toolName: string, tense: ToolLabelTense): string {
   const labels = TOOL_LABELS[toolName];
   if (labels) return labels[tense];
 
+  toolName = toolHeadingName(toolName);
   // Fallback for unknown tools
   switch (tense) {
     case "active":
@@ -258,13 +269,7 @@ export function getToolCompactSummary(
   const fullSummary = getToolFullSummary(toolName, toolInput);
   if (fullSummary === undefined) return undefined;
 
-  return truncate(fullSummary, getToolSummaryMaxLength(toolName));
-}
-
-function truncate(str: string, maxLen: number): string {
-  if (!str) return "";
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen - 1) + "\u2026";
+  return compactSessionSummary(fullSummary, getToolSummaryMaxLength(toolName));
 }
 
 function getToolFullSummary(

--- a/web/src/systems/session/types.ts
+++ b/web/src/systems/session/types.ts
@@ -332,6 +332,7 @@ export interface UIMessage {
   role: UIMessageRole;
   content: string;
   toolName?: string;
+  toolTitle?: string;
   toolInput?: Record<string, unknown>;
   toolResult?: ToolUseResult;
   toolError?: boolean;


### PR DESCRIPTION
Closes #598.

## Problem and evidenced root cause

Long Codex/provider descriptions could include an entire multiline command in the Working activity. That activity had no width or line constraint. Unknown tool titles also became the complete action label, while existing tool, reasoning, and Goal ellipses only took effect at the far edge of the window. The transcript projection discarded the provider's separate `title` even when canonical tool identity was available.

## Resulting behavior

- One-line summaries shrink with their container and stop at an intentional readable measure: 24 rem for combined tool/live/activity/reasoning/Goal summaries and 20 rem for tool/window headings. Existing narrower session rail and deck constraints remain intact.
- Display-only previews collapse whitespace and stop at 80 grapheme clusters (existing non-command input summaries retain their 60-cluster limit). Unicode clusters remain intact. Exact tool names and documented hosted-MCP identities keep their action; free-form unknown descriptions use a truthful generic tool identity, even when the description starts with a known name such as `Bash investigation`. Identity is never inferred from a prose prefix.
- Working keeps its elapsed time and agent indicators. Live/Working summaries and window titles provide keyboard/pointer disclosures. Tool titles and Goal objectives have complete detail views.
- The original provider title passes through the transient transcript projection. Detail, copy, and find consume originals, including title/name matches in running tools. Expanded payloads and ordinary assistant messages are unchanged.

## Verification

The production session composition was exercised in Chromium using existing Storybook/MSW fixtures containing sanitized heredocs, Unicode, unbroken paths, long objectives, and concurrent tools. No private command payloads are used.

- Working measured **75.25 px before** at a 1600 px viewport and **22 px after** at 360, 860, and 1600 px. Document width equaled viewport width; the composer and stop control remained reachable. The baseline screenshot captures original layout behavior after the settled tool's generic wording had already been normalized.
- At 200% CSS zoom with reduced motion, Working measured 44 rendered pixels. Keyboard disclosure, Escape focus restoration, and exact multiline activity copy passed at all three widths.
- Three concurrent calls, including a long agent prompt, passed narrow/wide disclosure and overflow checks. Shared window titles passed keyboard disclosure at 360 and 1600 px.
- Full-payload find opened a tail omitted from the collapsed summary; a distinct live-title query opened the complete title while its tool was still running.
- Extended the canonical tool-label, visual-state, thread, tool-card, reasoning, Goal, navigation, and shared Topbar tests. The two long-summary stories and the long window-title story include browser interaction assertions, rather than CSS-string assertions. The domain disclosure is covered by the existing thread composition test and these production-composition stories; no duplicate isolated suite was introduced.

**Per the user's instruction, delivery gates run in CI.** Local gate tasks already in flight were stopped; interrupted typecheck/build/test results are not presented as passing evidence. Required checks must pass on this PR's current head before delivery. Squash merge is authorized after the current-head checks pass.

Sanitized before/after captures are retained in the repository's ignored QA evidence directory. Reproduce the rendered contract with `SessionsStability/Working/LongSummaries`, `LongSummariesParallel`, and shared `Topbar/LongTitle`.

## Impact and limits

The [QA report and change-impact record](docs/qa/reports/2026-09-10-session-summary-truncation.md) and [owning scenario](docs/qa/scenarios/ET-web-session-transcript-calm-grammar.md) document the policy and walkthrough.

This changes Web presentation and shared UI components only. No native tool IDs, CLI/HTTP/UDS schemas, configuration, hooks, extensions, database state, persisted transcripts, or workspace/profile isolation contracts change. The existing public `title` field is consumed without a wire change. No migration or compatibility shim is needed. The official `skills/compozy/` runtime guidance is unaffected.

The local browser evidence uses fixture I/O and does not establish live Codex, Linux, or Electron behavior. No active host daemon was restarted or modified.
