### PR TITLE
fix: reconcile Goal context and session lifecycle

### DIFF
--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -9,3 +9,13 @@ Use for changed runtime behavior, public contracts, config, or feature documenta
 - **Web/Docs impact:** name affected `web/` routes/components/hooks and `packages/site` docs, plus their verification owner. Backend changes carry this analysis with the feature.
 
 For an unaffected entry, name the checked surfaces and why the change cannot affect them. Do not create separate artifacts or re-audit unchanged surfaces for every checkpoint. Breaking changes also name delete targets and the user-state/public/internal compatibility regime; apply SD-013 before deletion.
+
+## Issue 595 — Goal lifecycle and attention
+
+Owning delivery: [PR #601](https://github.com/compozy/compozy/pull/601). Detailed regression and runtime evidence: [focused QA report](../qa/reports/2026-09-10-issue-595-goal-lifecycle.md).
+
+- **Native tools:** Existing Goal control/read, session stop/removal, and Loop cancellation surfaces keep their IDs, schemas, and authorization. Run terminal state and quarantine govern Goal status. Stopping a session cancels its session-origin Goals; failed cancellation remains retryable in the existing stop settlement receipt.
+- **Extensibility and hooks:** No hook, SDK, configuration, or registry shape changes. Cancellation uses the existing aggregate and durable cleanup outbox. Catalog Loop lineage and window dismissal retain their semantics.
+- **Workspace data isolation:** Binding adoption validates workspace, task, control, phase, session, handle, and epoch. Session Goal cancellation reads immutable profile/workspace scope. Existing receipts preserve session/runtime identity across restart. No schema migration or historical record deletion.
+- **Official Compozy skill:** `skills/compozy/references/loops.md` documents cancellation, orphan recovery, context ownership, and bounded supervision freshness.
+- **Web/Docs:** Session badges, Goal strip, Tasks, and Loop detail consume corrected backend projections; no client-side badge clearing. The Goals guide and GL/LP/RT QA slices accompany the change. Canonical lifecycle suites and focused CLI/API/Web runtime walks own validation; remaining delivery gates run in CI.

--- a/docs/qa/reports/2026-09-10-issue-595-goal-lifecycle.md
+++ b/docs/qa/reports/2026-09-10-issue-595-goal-lifecycle.md
@@ -31,7 +31,7 @@ The first live walk exposed a second defect: a known-context read combined `Afte
 
 Loop supervision previously inferred freshness only from completed coordinator tasks. Initial in-flight action leases and admitted wait deadlines now contribute bounded evidence. Reads do not extend deadlines. Quarantine, approval, and intervention carry explicit attention even when agent progress is fresh; real expired evidence still becomes stale. Goal projections follow terminal Run state and quarantine rather than a stale active checkpoint.
 
-Explicit operator stop/removal now uses canonical Loop cancellation for session-origin Goals. Its existing durable outbox handles session cleanup. Catalog Loop origin lineage remains informational, and daemon shutdown or window-only dismissal does not acquire cancellation semantics. The existing adapter regression suite exposed an early missing-session return that could suppress stop failures; production was corrected without weakening the assertions.
+Explicit operator stop/removal now uses canonical Loop cancellation for session-origin Goals. A cancellation failure retains the existing durable stop receipt and pending settlement; retry and daemon boot recovery repeat cancellation before releasing that receipt. Its existing durable outbox handles session cleanup. Catalog Loop origin lineage remains informational, and daemon shutdown or window-only dismissal does not acquire cancellation semantics. The existing adapter regression suite exposed an early missing-session return that could suppress stop failures; production was corrected without weakening the assertions.
 
 ## Verification
 
@@ -44,6 +44,8 @@ Explicit operator stop/removal now uses canonical Loop cancellation for session-
 - Local gate attempts passed codegen and lint and exposed the adapter regression described above. After correction, the canonical adapter suite and full daemon race suite passed. At the author’s request, remaining delivery gates run in CI; the local global database race suite was interrupted and is not claimed as passed. Current-head CI results are recorded in the PR.
 
 ## Cross-surface impact
+
+Owning audit: [Issue 595 change-impact record](../../_memory/change-impact.md#issue-595--goal-lifecycle-and-attention).
 
 - **Native tools:** Existing `compozy__goal_control`, Goal reads, session stop, and `compozy__loop_cancel` retain their schemas and authorization. Goal status follows terminal Run truth and exposes quarantine as a blocked state.
 - **Extensibility/hooks/config:** No configuration, hook, extension SDK, or tool ID change. Session-origin Goals use canonical cancellation and its durable cleanup outbox. Catalog Loop origin lineage remains informational.

--- a/docs/qa/reports/2026-09-10-issue-595-goal-lifecycle.md
+++ b/docs/qa/reports/2026-09-10-issue-595-goal-lifecycle.md
@@ -1,0 +1,56 @@
+# QA Run Report — 2026-09-10 — Issue 595 Goal lifecycle
+
+- **Scope:** Initial Goal context ownership, supervision freshness, and explicit session stop/removal.
+- **Cadence:** Focused runtime and public API/CLI/Web journeys with real Codex / gpt-6-astra / high.
+- **Build:** `fix/issue-595-goal-lifecycle`, based on `470c7c8f`.
+- **Status:** in-progress; the explicit clarification-answer step is blocked by the execution approval boundary.
+- **Persona:** Ada, a developer using self-directed Goals for a small billing utility; Bruno, an operator stopping unfinished work.
+
+## Session matrix
+
+| Scenario slice | Result | Evidence |
+| --- | --- | --- |
+| Self-activation during an ordinary prompt | Pass | Two real Codex sessions activated their own Goals; the corrected flow had known context, current Loop work, and no stale attention while ordinary work continued. |
+| Known-context public reads | Fail, repaired, re-walk passed | The first live walk exposed incompatible event-query cursors. A canonical real-store regression failed before the fix and passed after it; the persisted Goal became readable after the isolated daemon upgrade. |
+| Goal completion | Pass | Billing utility completed in two turns; a later session reused it to add exact JSON totals, passed twelve real CLI tests, and received an approved one-turn Goal verdict. |
+| Genuine attention | Pass | A structured refund-scope question produced `waiting-for-input` while Loop supervision remained current. Web showed one waiting item. |
+| Answer and continue | Blocked | Execution approval review rejected the operator's synthetic answer. No answer was injected through another surface. The agent did not choose a refund scope or implement it; it paused its Goal after the question expired. |
+| Explicit stop | Pass | A real running Goal reached a stopped session and canceled Run before manual cancellation. Session supervision emptied and all associated task records were canceled. Repeated Run cancellation succeeded. |
+| Session removal | Pass | Removing a separate real running Goal canceled the Run and its Tasks. The session returned 404; Run history remained readable, and cancellation by Run still succeeded with original daemon cancellation provenance. |
+| Window-only dismissal | Pass | Closing the refund session window left its paused Goal live. No session stop or Goal cancellation occurred. |
+| Browser Goal projection | Pass | The expanded Goal strip showed `Done`, `settled`, known context, and the approved verdict with zero blocking issues. |
+| Final restart/reconnect | Pass | After restarting the isolated daemon with the final binary, stopped/removed Runs remained canceled, the approved Run remained done, and the paused Run remained paused. The browser reloaded the retained Goal and transcript. |
+
+Raw lab evidence is retained locally. This report deliberately omits private runtime identities and paths.
+
+## Root causes and regression evidence
+
+The real SQLite/managed binding regression rejected the initial context observation with `BindingEpoch=0`. The active binding already existed; checkpoint adoption previously occurred only during prompt preparation, after the initial context observation. The fixed store adopts the exact active binding under the checkpoint's control/phase/task fence before observing context. Re-adoption preserves the usage sequence floor; stale owners, wrong bindings, and cross-workspace requests remain rejected.
+
+The first live walk exposed a second defect: a known-context read combined `AfterSequence` and `BeforeSequence`, which the session event store rejects. The read now uses one forward cursor and one result, while retaining the exact-sequence check. Missing or non-usage events remain unknown.
+
+Loop supervision previously inferred freshness only from completed coordinator tasks. Initial in-flight action leases and admitted wait deadlines now contribute bounded evidence. Reads do not extend deadlines. Quarantine, approval, and intervention carry explicit attention even when agent progress is fresh; real expired evidence still becomes stale. Goal projections follow terminal Run state and quarantine rather than a stale active checkpoint.
+
+Explicit operator stop/removal now uses canonical Loop cancellation for session-origin Goals. Its existing durable outbox handles session cleanup. Catalog Loop origin lineage remains informational, and daemon shutdown or window-only dismissal does not acquire cancellation semantics. The existing adapter regression suite exposed an early missing-session return that could suppress stop failures; production was corrected without weakening the assertions.
+
+## Verification
+
+- Canonical Goal executor tests and context/compaction telemetry tests passed.
+- Real SQLite checkpoint ownership, Goal projection, Loop work, quarantine/parking, and requeue suites passed.
+- Canonical session work-signal and Goal command tests passed.
+- Existing public daemon subprocess E2E passed controls, disconnect/restart, and new stop/removal followed by repeated Run cancellation.
+- `bunx turbo run typecheck build --filter=@compozy/site` passed all seven tasks.
+- React Doctor changed-source scan found no changed React source files. Its PR check and all bot findings remain part of delivery.
+- Local gate attempts passed codegen and lint and exposed the adapter regression described above. After correction, the canonical adapter suite and full daemon race suite passed. At the author’s request, remaining delivery gates run in CI; the local global database race suite was interrupted and is not claimed as passed. Current-head CI results are recorded in the PR.
+
+## Cross-surface impact
+
+- **Native tools:** Existing `compozy__goal_control`, Goal reads, session stop, and `compozy__loop_cancel` retain their schemas and authorization. Goal status follows terminal Run truth and exposes quarantine as a blocked state.
+- **Extensibility/hooks/config:** No configuration, hook, extension SDK, or tool ID change. Session-origin Goals use canonical cancellation and its durable cleanup outbox. Catalog Loop origin lineage remains informational.
+- **Isolation/data:** Internal queries remain scoped by immutable profile and workspace. Checkpoint adoption validates task/control/binding/phase identity in one transaction. No schema change or destructive migration. Historical failed generations remain available.
+- **Official skill:** Loop guidance documents stop/removal, window-only dismissal, context ownership, bounded freshness, and cancellation by Run for a missing session.
+- **Web/Docs:** Existing session badges, Goal strip, Tasks, and Loop detail consume backend state. No client-side badge clearing. The operator guide and affected scenario slices accompany the fix.
+
+## Limits
+
+The explicit clarification-answer step remains unverified because of the execution approval boundary. Teardown completed with `clean: true`. The PR records final delivery-gate, current-head CI, and complete bot-review remediation status. No live-provider Linux or Electron dogfooding is claimed. This focused issue walk does not claim a full release or multi-agent Network scenario sweep.

--- a/docs/qa/reports/2026-09-10-issue-595-goal-lifecycle.md
+++ b/docs/qa/reports/2026-09-10-issue-595-goal-lifecycle.md
@@ -38,6 +38,8 @@ Explicit operator stop/removal now uses canonical Loop cancellation for session-
 - Canonical Goal executor tests and context/compaction telemetry tests passed.
 - Real SQLite checkpoint ownership, Goal projection, Loop work, quarantine/parking, and requeue suites passed.
 - Canonical session work-signal and Goal command tests passed.
+- Review remediation added pre-commit adoption fault injection: retry reuses the exact durable binding and completes; canonical cancellation closes an unadopted binding and stops its real managed session. The deletion rollback case preserves stopped execution and history. These focused regressions passed.
+- Same-process and restarted stop settlement both retain and retry failed Goal cancellation; focused recovery and boot suites passed.
 - Existing public daemon subprocess E2E passed controls, disconnect/restart, and new stop/removal followed by repeated Run cancellation.
 - `bunx turbo run typecheck build --filter=@compozy/site` passed all seven tasks.
 - React Doctor changed-source scan found no changed React source files. Its PR check and all bot findings remain part of delivery.

--- a/docs/qa/scenarios/GL-agent-session-control.md
+++ b/docs/qa/scenarios/GL-agent-session-control.md
@@ -20,3 +20,7 @@ ENG-148 flag: new typed agent-manageability behavior. Walk the same lifecycle fr
 session to itself and to a descendant, compare direct HTTP/UDS/CLI/native output, then attempt a
 foreign target. Include a runtime override and verify the target's Goal origin/network provenance
 does not change. Record failed binding evidence rather than treating it as an empty projection.
+
+Issue #595 acceptance: activate the session's own Goal during an ordinary Codex prompt after context usage arrives. Read Goal, session supervision, Loop nodes, and task states through CLI and HTTP, then refresh/reconnect. The first context observation must not fail ownership validation; known context reads must resolve their pinned event. Pause/resume and real approval or quarantine retain actionable attention, and recovery clears derived attention. Stop and remove separate live Goal sessions, cancel again by Run, and confirm terminal state with retained audit and unaffected foreign sessions.
+
+Targeted #595 retest evidence and limits: [Goal lifecycle report](../reports/2026-09-10-issue-595-goal-lifecycle.md). This slice does not replace earlier evidence or claim an unrun full-scenario sweep.

--- a/docs/qa/scenarios/LP-forced-cancel-owned-sessions.md
+++ b/docs/qa/scenarios/LP-forced-cancel-owned-sessions.md
@@ -22,3 +22,7 @@ Confirm terminal canceled truth and the work fence appear before cleanup, every 
 the borrowed and foreign-workspace sessions remain active, repeated Cancel is idempotent, failed stops
 retry after daemon restart, every Kill surface is absent, Resume is unavailable, and Rerun starts a new
 generation with new sessions.
+
+Issue #595 acceptance: explicitly stop and remove separate session-origin Goals, including one before its first work turn. Confirm cancellation before removal, no active/queued work after cancellation, and idempotent Run cancellation when the session no longer exists. Distinguish window-only dismissal and daemon reconnect from actual session stop. Retain historical attempts and verify that catalog Loop informational origins still have independent lifecycles.
+
+Targeted #595 retest evidence and limits: [Goal lifecycle report](../reports/2026-09-10-issue-595-goal-lifecycle.md). This slice does not replace earlier evidence or claim an unrun full-scenario sweep.

--- a/docs/qa/scenarios/RT-session-attention-catalog.md
+++ b/docs/qa/scenarios/RT-session-attention-catalog.md
@@ -38,3 +38,7 @@ profiles and confirm the counts an operator sees belong to the acting profile, t
 compose rather than replace one another, and that an agent's identity stays confined to
 same-workspace interaction discovery regardless of profile. Cross-profile totals are only available
 through the explicit labeled aggregate, which `ET-profile-aggregate-owner-labels` owns.
+
+Issue #595 acceptance: a self-directed Goal with a current action lease must not gain stale `loop_run` attention solely because no coordinator has completed yet. Expired leases and overdue waits still surface staleness; real quarantine, intervention, and approval remain attention even with fresh agent progress. Reread after recovery and terminal cancellation to confirm derived attention clears without editing stored badges.
+
+Targeted #595 retest evidence and limits: [Goal lifecycle report](../reports/2026-09-10-issue-595-goal-lifecycle.md). This slice does not replace earlier evidence or claim an unrun full-scenario sweep.

--- a/internal/daemon/boot_session_repair.go
+++ b/internal/daemon/boot_session_repair.go
@@ -33,6 +33,11 @@ func (d *Daemon) bootSessionRepair(ctx context.Context, state *bootState) error 
 	if state.sessions == nil {
 		return errors.New("daemon: boot session repair requires session manager")
 	}
+	// Stop receipts may still own Goal cancellation. Install its handler before
+	// recovery; server preparation refreshes late-bound runtime dependencies later.
+	if err := d.prepareServerDependencies(ctx, state); err != nil {
+		return err
+	}
 	if recoverer, ok := state.sessions.(sessionPendingStopRecoverer); ok {
 		if err := recoverer.RecoverPendingStops(ctx); err != nil {
 			return fmt.Errorf("daemon: recover pending session stops: %w", err)

--- a/internal/daemon/loop_api_goal_snapshot_mapping.go
+++ b/internal/daemon/loop_api_goal_snapshot_mapping.go
@@ -83,13 +83,20 @@ func composeSessionGoalSnapshot(
 		if strings.TrimSpace(checkpoint.SessionID) != "" {
 			boundSessionID = checkpoint.SessionID
 		}
-		status = checkpoint.Status
+		if projection.RunStatus.Live() && projection.RunStatus != looppkg.StatusPaused {
+			status = checkpoint.Status
+		}
 		turnsUsed = checkpoint.TurnsUsed
 		turnLimit = checkpoint.TurnLimit
 		if checkpoint.ControlCause != "" {
 			value := session.GoalReasonCode(checkpoint.ControlCause)
 			cause = &value
 		}
+	}
+	if projection.RunStatus.Live() && projection.Quarantined {
+		status = goalSnapshotStatusBlocked
+		value := session.GoalReasonCode("node_quarantined")
+		cause = &value
 	}
 	return &session.GoalSnapshot{
 		RunID: string(projection.RunID), NodeID: nodeID, Objective: params.Objective,
@@ -121,7 +128,7 @@ func goalVerdictSummary(turn *goalpkg.Turn) *session.GoalVerdictSummary {
 
 func goalStatusFromRun(status looppkg.Status) string {
 	switch status {
-	case looppkg.StatusPaused:
+	case looppkg.StatusPaused, looppkg.StatusCanceled:
 		return "paused"
 	case looppkg.StatusDone, looppkg.StatusNoOp:
 		return goalSnapshotStatusComplete

--- a/internal/daemon/loop_goal_command_e2e_integration_test.go
+++ b/internal/daemon/loop_goal_command_e2e_integration_test.go
@@ -182,59 +182,71 @@ func TestDaemonE2EGoalCommandsShouldSurviveControlsDisconnectAndRestart(t *testi
 	// Invariant: explicit stop/removal cancels a session Goal and run cancellation remains usable without the session.
 	// Owner: daemon lifecycle integration; canonical public Goal commands E2E suite.
 	t.Run("Should cancel a stopped or removed session Goal through independent public reads", func(t *testing.T) {
-		for _, remove := range []bool{false, true} {
-			target := createFixtureBackedSession(t, ctx, harness, "goal-clear", "goal-lifecycle")
-			status, started := callGoalCommandUDS(
-				ctx,
-				t,
-				harness,
-				target.ID,
-				"/goal Keep working until I stop this session",
-			)
-			if status != http.StatusAccepted || started.Snapshot == nil {
-				t.Fatalf("start = %d %#v", status, started)
-			}
-			path := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/sessions/" + url.PathEscape(target.ID)
-			if remove {
-				if err := harness.UDSJSON(ctx, http.MethodDelete, path, nil, nil); err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				if err := harness.StopSession(ctx, target.ID); err != nil {
-					t.Fatal(err)
-				}
-				snapshot := waitForGoalSnapshot(
+		for _, tc := range []struct {
+			name   string
+			remove bool
+		}{{"Should cancel on stop before manual cancellation", false}, {"Should cancel on removal before manual cancellation", true}} {
+			t.Run(tc.name, func(t *testing.T) {
+				target := createFixtureBackedSession(t, ctx, harness, "goal-clear", "goal-lifecycle")
+				status, started := callGoalCommandUDS(
 					ctx,
 					t,
 					harness,
 					target.ID,
-					func(goal *compozycontract.GoalSnapshot) bool {
-						return goal != nil && goal.RunStatus == compozycontract.LoopRunStatusCanceled && !goal.Live
-					},
+					"/goal Keep working until I stop this session",
 				)
-				if snapshot.Status == "active" {
-					t.Fatalf("stopped session kept an active Goal: %#v", snapshot)
+				if status != http.StatusAccepted || started.Snapshot == nil {
+					t.Fatalf("start = %d %#v", status, started)
 				}
-			}
-			runPath := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/loop-runs/" + started.Snapshot.RunID
-			for range 2 {
-				if err := harness.UDSJSON(
-					ctx,
-					http.MethodPost,
-					runPath+"/cancel",
-					map[string]string{"reason": "Stop requested"},
-					nil,
-				); err != nil {
+				path := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/sessions/" + url.PathEscape(target.ID)
+				if tc.remove {
+					if err := harness.UDSJSON(ctx, http.MethodDelete, path, nil, nil); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					if err := harness.StopSession(ctx, target.ID); err != nil {
+						t.Fatal(err)
+					}
+					snapshot := waitForGoalSnapshot(
+						ctx,
+						t,
+						harness,
+						target.ID,
+						func(goal *compozycontract.GoalSnapshot) bool {
+							return goal != nil && goal.RunStatus == compozycontract.LoopRunStatusCanceled && !goal.Live
+						},
+					)
+					if snapshot.Status == "active" {
+						t.Fatalf("stopped session kept an active Goal: %#v", snapshot)
+					}
+				}
+				runPath := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/loop-runs/" + started.Snapshot.RunID
+				runBeforeCancel, err := getGoalLoopRun(ctx, harness, started.Snapshot.RunID)
+				if err != nil {
 					t.Fatal(err)
 				}
-			}
-			run, err := getGoalLoopRun(ctx, harness, started.Snapshot.RunID)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if run.Run.Status != compozycontract.LoopRunStatusCanceled {
-				t.Fatalf("run after stop/remove = %#v", run)
-			}
+				if runBeforeCancel.Run.Status != compozycontract.LoopRunStatusCanceled {
+					t.Fatalf("stop/remove did not cancel the run independently: %#v", runBeforeCancel)
+				}
+				for range 2 {
+					if err := harness.UDSJSON(
+						ctx,
+						http.MethodPost,
+						runPath+"/cancel",
+						map[string]string{"reason": "Stop requested"},
+						nil,
+					); err != nil {
+						t.Fatal(err)
+					}
+				}
+				run, err := getGoalLoopRun(ctx, harness, started.Snapshot.RunID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if run.Run.Status != compozycontract.LoopRunStatusCanceled {
+					t.Fatalf("run after stop/remove = %#v", run)
+				}
+			})
 		}
 	})
 

--- a/internal/daemon/loop_goal_command_e2e_integration_test.go
+++ b/internal/daemon/loop_goal_command_e2e_integration_test.go
@@ -179,6 +179,65 @@ func TestDaemonE2EGoalCommandsShouldSurviveControlsDisconnectAndRestart(t *testi
 		waitForStoppedGoalJudgeSessions(ctx, t, harness, "goal-approval", 1)
 	})
 
+	// Invariant: explicit stop/removal cancels a session Goal and run cancellation remains usable without the session.
+	// Owner: daemon lifecycle integration; canonical public Goal commands E2E suite.
+	t.Run("Should cancel a stopped or removed session Goal through independent public reads", func(t *testing.T) {
+		for _, remove := range []bool{false, true} {
+			target := createFixtureBackedSession(t, ctx, harness, "goal-clear", "goal-lifecycle")
+			status, started := callGoalCommandUDS(
+				ctx,
+				t,
+				harness,
+				target.ID,
+				"/goal Keep working until I stop this session",
+			)
+			if status != http.StatusAccepted || started.Snapshot == nil {
+				t.Fatalf("start = %d %#v", status, started)
+			}
+			path := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/sessions/" + url.PathEscape(target.ID)
+			if remove {
+				if err := harness.UDSJSON(ctx, http.MethodDelete, path, nil, nil); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if err := harness.StopSession(ctx, target.ID); err != nil {
+					t.Fatal(err)
+				}
+				snapshot := waitForGoalSnapshot(
+					ctx,
+					t,
+					harness,
+					target.ID,
+					func(goal *compozycontract.GoalSnapshot) bool {
+						return goal != nil && goal.RunStatus == compozycontract.LoopRunStatusCanceled && !goal.Live
+					},
+				)
+				if snapshot.Status == "active" {
+					t.Fatalf("stopped session kept an active Goal: %#v", snapshot)
+				}
+			}
+			runPath := "/api/workspaces/" + url.PathEscape(harness.WorkspaceID) + "/loop-runs/" + started.Snapshot.RunID
+			for range 2 {
+				if err := harness.UDSJSON(
+					ctx,
+					http.MethodPost,
+					runPath+"/cancel",
+					map[string]string{"reason": "Stop requested"},
+					nil,
+				); err != nil {
+					t.Fatal(err)
+				}
+			}
+			run, err := getGoalLoopRun(ctx, harness, started.Snapshot.RunID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if run.Run.Status != compozycontract.LoopRunStatusCanceled {
+				t.Fatalf("run after stop/remove = %#v", run)
+			}
+		}
+	})
+
 	t.Run("Should clear an active Goal without a late turn", func(t *testing.T) {
 		clearSession := createFixtureBackedSession(t, ctx, harness, "goal-clear", "goal-clear")
 		clearStartStatus, clearStart := callGoalCommandUDS(

--- a/internal/daemon/loop_goal_command_test.go
+++ b/internal/daemon/loop_goal_command_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/compozy/compozy/internal/acp"
 	looppkg "github.com/compozy/compozy/internal/loop"
 	"github.com/compozy/compozy/internal/loop/dsl"
+	goalpkg "github.com/compozy/compozy/internal/loop/goal"
 	"github.com/compozy/compozy/internal/network/participation"
 	profilepkg "github.com/compozy/compozy/internal/profile"
 	"github.com/compozy/compozy/internal/session"
@@ -78,6 +79,80 @@ func TestSessionGoalDefinitionShouldKeepFreeFormClausesInsideAgentJudgeRubric(t 
 
 func TestDaemonGoalCommandHandlerShouldExecuteCanonicalSessionLifecycle(t *testing.T) {
 	t.Parallel()
+
+	// Invariant: terminal Run truth and live quarantine outrank stale active checkpoints.
+	// Owner: daemon Goal snapshot projection; canonical Goal command suite.
+	t.Run("Should project terminal runs and quarantined live work coherently", func(t *testing.T) {
+		t.Parallel()
+		for _, test := range []struct {
+			run         looppkg.Status
+			quarantined bool
+			want        string
+		}{
+			{looppkg.StatusCanceled, false, "paused"}, {looppkg.StatusFailed, false, "blocked"},
+			{looppkg.StatusDone, false, "complete"}, {looppkg.StatusRunning, true, "blocked"},
+			{looppkg.StatusRunning, false, "active"},
+		} {
+			projection := goalpkg.SessionProjection{RunStatus: test.run, Quarantined: test.quarantined,
+				Checkpoint: &goalpkg.Checkpoint{Status: "active", TurnsUsed: 2, TurnLimit: 5}}
+			snapshot := composeSessionGoalSnapshot(
+				projection,
+				dsl.GoalParams{},
+				"goal",
+				"objective",
+				session.GoalContextSnapshot{},
+			)
+			if snapshot.Status != test.want || snapshot.Live != test.run.Live() || snapshot.TurnsUsed != 2 {
+				t.Fatalf("snapshot = %#v for %#v", snapshot, test)
+			}
+			if test.quarantined && (snapshot.Cause == nil || *snapshot.Cause != "node_quarantined") {
+				t.Fatal("quarantine has no actionable cause")
+			}
+		}
+	})
+
+	// Invariant: stopping a Goal origin cancels its run without crossing profile/workspace boundaries.
+	// Owner: daemon Goal lifecycle dispatcher; canonical session Goal command suite.
+	t.Run("Should cancel a stopped session Goal and preserve its terminal history", func(t *testing.T) {
+		t.Parallel()
+		fixture := newGoalCommandHandlerFixture(t)
+		ctx := testutil.Context(t)
+		started, err := fixture.service.Handle(ctx, fixture.workspaceID, fixture.sessionID,
+			session.PromptCaller{Kind: "human", ID: "operator", Source: "http"},
+			session.GoalCommand{Verb: "set", Objective: "Retain history after stopping"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		info := session.Info{ID: fixture.sessionID, WorkspaceID: fixture.workspaceID, ProfileID: fixture.profileID}
+		for _, foreign := range []session.Info{
+			{ID: info.ID, WorkspaceID: info.WorkspaceID, ProfileID: store.DefaultProfileID},
+			{ID: info.ID, WorkspaceID: "foreign-workspace", ProfileID: info.ProfileID},
+			{ID: "foreign-session", WorkspaceID: info.WorkspaceID, ProfileID: info.ProfileID},
+		} {
+			if err := fixture.service.StopSessionGoals(ctx, &foreign); err != nil {
+				t.Fatal(err)
+			}
+			if !fixture.mustRun(t, started.Result.Snapshot.RunID).Status.Live() {
+				t.Fatal("foreign session canceled the Goal")
+			}
+		}
+		for range 2 {
+			if err := fixture.service.StopSessionGoals(ctx, &info); err != nil {
+				t.Fatal(err)
+			}
+		}
+		run := fixture.mustRun(t, started.Result.Snapshot.RunID)
+		if run.Status != looppkg.StatusCanceled {
+			t.Fatalf("run after stop = %#v", run)
+		}
+		snapshot, err := fixture.service.GetSessionGoal(ctx, info.WorkspaceID, info.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if snapshot == nil || snapshot.Live || snapshot.Status != "paused" || snapshot.RunStatus != "canceled" {
+			t.Fatalf("canceled snapshot = %#v", snapshot)
+		}
+	})
 
 	t.Run("Should preserve caller and origin identity across set replace controls and clear", func(t *testing.T) {
 		t.Parallel()

--- a/internal/daemon/loop_goal_context_runtime.go
+++ b/internal/daemon/loop_goal_context_runtime.go
@@ -54,8 +54,9 @@ func (r *loopGoalContextRuntime) UsageAtSequence(
 		return goalpkg.ContextUsage{}, errors.New("daemon: Goal context usage sequence must be positive")
 	}
 	events, err := r.sessions.Events(ctx, binding.SessionID, store.EventQuery{
-		AfterSequence:  sequence - 1,
-		BeforeSequence: sequence + 1,
+		AfterSequence: sequence - 1,
+		Forward:       true,
+		Limit:         1,
 	})
 	if err != nil {
 		return goalpkg.ContextUsage{}, err

--- a/internal/daemon/loop_goal_managed_runtime_integration_test.go
+++ b/internal/daemon/loop_goal_managed_runtime_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/compozy/compozy/internal/acp"
 	looppkg "github.com/compozy/compozy/internal/loop"
 	loopdsl "github.com/compozy/compozy/internal/loop/dsl"
+	"github.com/compozy/compozy/internal/loop/gate"
 	goalpkg "github.com/compozy/compozy/internal/loop/goal"
 	"github.com/compozy/compozy/internal/network/participation"
 	"github.com/compozy/compozy/internal/session"
@@ -93,6 +95,80 @@ func TestLoopGoalManagedRuntimeIntegration(t *testing.T) {
 			t.Fatalf("initial context checkpoint = %#v; execution error = %v", checkpoint, err)
 		}
 	})
+	// Invariant: failed checkpoint adoption retains durable binding ownership for retry or cancellation.
+	// Owner: managed Goal/store seam; canonical managed runtime integration suite.
+	for _, cancelRun := range []bool{false, true} {
+		t.Run(fmt.Sprintf("Should recover failed binding adoption with cancellation %t", cancelRun), func(t *testing.T) {
+			fixture := newLoopGoalManagedRuntimeFixture(t, "adoption-failure", nil, withoutInitialGoalBinding())
+			node := compileManagedGoalDefinition(t, "adoption-failure", fixture.agentName, "adoption-failure").Definition.Graph.Nodes[0]
+			adoptionErr := errors.New("checkpoint adoption unavailable")
+			boundary := &failingGoalBindingAdoption{ExecutorStore: fixture.goalStore, err: adoptionErr}
+			actor, err := taskpkg.DeriveHumanActorContext("adoption-recovery", taskpkg.OriginKindCLI, "cli")
+			if err != nil {
+				t.Fatal(err)
+			}
+			executor, err := goalpkg.NewExecutor(goalpkg.Dependencies{
+				Store: boundary, Binder: fixture.runtime,
+				Judge: loopGoalJudgeEvaluatorFunc(func(context.Context, goalpkg.JudgeRequest) (goalpkg.JudgeResult, error) {
+					return goalpkg.JudgeResult{Verdict: gate.Verdict{Outcome: gate.VerdictOutcomeApproved}}, nil
+				}),
+				Budget: fixture.goalStore, Context: initialGoalContextHealth{fixture.runtime}, Recovery: fixture.runtime,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			input := looppkg.ActionExecutionInput{
+				WorkspaceID: fixture.run.WorkspaceID, LoopRunID: fixture.run.ID,
+				ToolScope: toolspkg.Scope{ProfileID: store.DefaultProfileID}, Actor: &actor,
+				Generation: 1, NodeID: node.ID, CorrelationID: fixture.taskRunID,
+				RuntimeSelection: &looppkg.ActionRuntimeSelection{Catalog: integrationRuntimeCatalog{}},
+				Environment:      &loopdsl.EnvironmentSpec{Mode: loopdsl.EnvironmentRoot}, GoalSegmentEpoch: 1,
+				GoalContextNudgeRatio: new(0.8),
+			}
+			if _, err := executor.Execute(t.Context(), node, input); !errors.Is(err, adoptionErr) {
+				t.Fatalf("adoption error = %v, want %v", err, adoptionErr)
+			}
+			key := goalpkg.BindingKey{WorkspaceID: fixture.run.WorkspaceID, LoopRunID: fixture.run.ID, Handle: boundary.request.BindingHandle}
+			binding, err := fixture.goalStore.GetActiveSessionBinding(t.Context(), key)
+			if err != nil || binding.SessionID != boundary.request.SessionID || binding.Ownership != goalpkg.BindingOwnershipRunOwned {
+				t.Fatalf("durable unadopted binding = %#v, %v", binding, err)
+			}
+			checkpoint, err := fixture.goalStore.LoadCheckpoint(t.Context(), fixture.key)
+			if err != nil || checkpoint.BindingEpoch != 0 {
+				t.Fatalf("unadopted checkpoint = %#v, %v", checkpoint, err)
+			}
+			if !cancelRun {
+				if _, err := executor.Execute(t.Context(), node, input); err != nil {
+					t.Fatalf("adoption retry did not complete: %v", err)
+				}
+				checkpoint, err := fixture.goalStore.LoadCheckpoint(t.Context(), fixture.key)
+				if err != nil || checkpoint.SessionID != binding.SessionID || checkpoint.BindingEpoch != binding.BindingEpoch || checkpoint.Status != "complete" {
+					t.Fatalf("retry replaced or lost durable binding: %#v, %v", checkpoint, err)
+				}
+				return
+			}
+			aggregate, err := looppkg.NewService(fixture.goalStore, looppkg.DefinitionResolverFunc(
+				func(context.Context, looppkg.WorkspaceID, string, string) (*looppkg.ResolvedDefinition, error) {
+					return nil, looppkg.ErrDefinitionNotFound
+				}), managedTestGoalRunPolicyResolver(),
+				looppkg.WithCancellationSessionController(loopCancellationSessionController{sessions: fixture.manager}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := aggregate.CancelRun(t.Context(), fixture.run.WorkspaceID, fixture.run.ID, "cancel unadopted work", actor); err != nil {
+				t.Fatal(err)
+			}
+			closed, err := fixture.goalStore.GetSessionBindingAttempt(t.Context(), key, binding.BindingEpoch)
+			if err != nil || closed.State != goalpkg.BindingStateClosed {
+				t.Fatalf("canceled binding = %#v, %v", closed, err)
+			}
+			info, err := fixture.manager.Status(t.Context(), binding.SessionID)
+			if err != nil || info.State != session.StateStopped {
+				t.Fatalf("unadopted session survived cancellation: %#v, %v", info, err)
+			}
+		})
+	}
+
 	t.Run(
 		"Should settle a queued Goal prompt when the operator explicitly clears the shared queue",
 		func(t *testing.T) {
@@ -1459,4 +1535,21 @@ func (f loopGoalManagedRuntimeFixture) preparePrompt(
 		},
 		UsageReporter: reporter,
 	})
+}
+
+// failingGoalBindingAdoption injects one pre-commit store failure without changing binding ownership.
+type failingGoalBindingAdoption struct {
+	goalpkg.ExecutorStore
+	err     error
+	request goalpkg.BindCheckpointRequest
+}
+
+func (s *failingGoalBindingAdoption) BindCheckpoint(ctx context.Context, req goalpkg.BindCheckpointRequest) (goalpkg.Checkpoint, error) {
+	if s.err != nil {
+		err := s.err
+		s.err = nil
+		s.request = req
+		return goalpkg.Checkpoint{}, err
+	}
+	return s.ExecutorStore.BindCheckpoint(ctx, req)
 }

--- a/internal/daemon/loop_goal_managed_runtime_integration_test.go
+++ b/internal/daemon/loop_goal_managed_runtime_integration_test.go
@@ -25,6 +25,74 @@ import (
 )
 
 func TestLoopGoalManagedRuntimeIntegration(t *testing.T) {
+	// Invariant: a known context snapshot reads exactly its persisted usage event, even after newer activity.
+	// Owner: daemon context-event adapter; canonical managed runtime integration suite.
+	t.Run("Should read a pinned context observation from the real session event store", func(t *testing.T) {
+		driver := newHarnessIntegrationDriver()
+		driver.promptHook = func(_ context.Context, _ *session.AgentProcess, req acp.PromptRequest) (<-chan acp.AgentEvent, error) {
+			events := make(chan acp.AgentEvent, 3)
+			events <- acp.AgentEvent{Type: acp.EventTypeUsage, TurnID: req.TurnID, Usage: &acp.TokenUsage{ContextUsed: new(int64(10)), ContextSize: new(int64(100))}}
+			events <- acp.AgentEvent{Type: acp.EventTypeAgentMessage, TurnID: req.TurnID, Text: "Work continued after the context observation."}
+			events <- acp.AgentEvent{Type: acp.EventTypeDone, TurnID: req.TurnID}
+			close(events)
+			return events, nil
+		}
+		fixture := newLoopGoalManagedRuntimeFixture(t, "context-reread", driver)
+		events, err := fixture.manager.Prompt(t.Context(), fixture.binding.SessionID, "Calculate the billing summary")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range events {
+		}
+		runtime := loopGoalContextRuntime{sessions: fixture.manager}
+		usage, err := runtime.Usage(t.Context(), fixture.binding)
+		if err != nil || !usage.Known {
+			t.Fatalf("latest context = %#v, %v", usage, err)
+		}
+		pinned, err := runtime.UsageAtSequence(t.Context(), fixture.binding, usage.Sequence)
+		if err != nil || !pinned.Known || pinned.Sequence != usage.Sequence || pinned.Used != 10 || pinned.Size != 100 {
+			t.Fatalf("pinned context = %#v, %v", pinned, err)
+		}
+		missing, err := runtime.UsageAtSequence(t.Context(), fixture.binding, usage.Sequence+1)
+		if err != nil || missing.Known {
+			t.Fatalf("non-usage event became known context: %#v, %v", missing, err)
+		}
+	})
+
+	// Invariant: the real managed binder adopts its checkpoint before initial context observation.
+	// Owner: Goal executor/runtime seam; canonical managed runtime integration suite.
+	t.Run("Should observe known context before the first managed Goal prompt", func(t *testing.T) {
+		fixture := newLoopGoalManagedRuntimeFixture(t, "initial-context", nil, withoutInitialGoalBinding())
+		node := compileManagedGoalDefinition(t, "initial-context", fixture.agentName, "initial-context").Definition.Graph.Nodes[0]
+		judgeReached := false
+		judge := loopGoalJudgeEvaluatorFunc(func(context.Context, goalpkg.JudgeRequest) (goalpkg.JudgeResult, error) {
+			judgeReached = true
+			return goalpkg.JudgeResult{}, errors.New("known context reached the judge")
+		})
+		executor, err := goalpkg.NewExecutor(goalpkg.Dependencies{
+			Store: fixture.goalStore, Binder: fixture.runtime, Judge: judge,
+			Budget: fixture.goalStore, Context: initialGoalContextHealth{fixture.runtime}, Recovery: fixture.runtime,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = executor.Execute(t.Context(), node, looppkg.ActionExecutionInput{
+			WorkspaceID: fixture.run.WorkspaceID, LoopRunID: fixture.run.ID,
+			ToolScope:  toolspkg.Scope{ProfileID: store.DefaultProfileID},
+			Generation: 1, NodeID: node.ID, CorrelationID: fixture.taskRunID,
+			RuntimeSelection: &looppkg.ActionRuntimeSelection{Catalog: integrationRuntimeCatalog{}},
+			Environment:      &loopdsl.EnvironmentSpec{Mode: loopdsl.EnvironmentRoot}, GoalSegmentEpoch: 1,
+			GoalContextNudgeRatio: new(0.8),
+		})
+		checkpoint, readErr := fixture.goalStore.LoadCheckpoint(t.Context(), fixture.key)
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if !judgeReached || checkpoint.ContextState != "known" || checkpoint.BindingEpoch != 1 ||
+			checkpoint.UsageSequence == nil || *checkpoint.UsageSequence != 1 {
+			t.Fatalf("initial context checkpoint = %#v; execution error = %v", checkpoint, err)
+		}
+	})
 	t.Run(
 		"Should settle a queued Goal prompt when the operator explicitly clears the shared queue",
 		func(t *testing.T) {
@@ -695,6 +763,15 @@ func TestLoopGoalManagedRuntimeIntegration(t *testing.T) {
 			t.Fatalf("Goal successor = %#v metadata = %#v", successor, metadata)
 		}
 	})
+}
+
+type initialGoalContextHealth struct{ goalpkg.ContextHealth }
+
+func (initialGoalContextHealth) Usage(context.Context, looppkg.ActionSessionBinding) (goalpkg.ContextUsage, error) {
+	return goalpkg.ContextUsage{
+		Known: true, Used: 1, Size: 100, Sequence: 1,
+		ReportedAt: time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC),
+	}, nil
 }
 
 type integrationRuntimeCatalog struct{}

--- a/internal/daemon/loop_goal_session_stop.go
+++ b/internal/daemon/loop_goal_session_stop.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/session"
+	"github.com/compozy/compozy/internal/store"
+	taskpkg "github.com/compozy/compozy/internal/task"
+)
+
+var _ session.GoalSessionStopHandler = (*daemonLoopAPIService)(nil)
+
+func (s *daemonLoopAPIService) StopSessionGoals(ctx context.Context, info *session.Info) error {
+	reader, ok := s.persistence.(sessionLoopWorkReader)
+	if !ok {
+		return errors.New("daemon: session Goal lifecycle reader is unavailable")
+	}
+	rows, err := reader.ListSessionLoopWork(
+		ctx,
+		store.ReadScope{ProfileID: info.ProfileID},
+		info.WorkspaceID,
+		info.ID,
+		"",
+	)
+	if err != nil {
+		return err
+	}
+	actor := taskpkg.ActorContext{
+		Actor:  taskpkg.ActorIdentity{Kind: taskpkg.ActorKindDaemon, Ref: "session-goal-lifecycle"},
+		Origin: taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "session-goal-lifecycle"},
+	}
+	var errs []error
+	for _, row := range rows {
+		if !row.OwnsGoal {
+			continue
+		}
+		if err := s.aggregate.CancelRun(
+			ctx,
+			looppkg.WorkspaceID(info.WorkspaceID),
+			row.RunID,
+			"Goal session stopped by the operator",
+			actor,
+		); err != nil {
+			errs = append(errs, fmt.Errorf("cancel session Goal: %w", err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/daemon/loop_runtime_adapters.go
+++ b/internal/daemon/loop_runtime_adapters.go
@@ -46,6 +46,15 @@ type loopCancellationSessionController struct {
 var _ looppkg.CancellationSessionController = loopCancellationSessionController{}
 
 func (c loopCancellationSessionController) StopLoopSession(ctx context.Context, id, reason string) error {
+	if reader, ok := c.sessions.(loopSessionStatusReader); ok {
+		info, err := reader.Status(ctx, id)
+		if err == nil && info != nil && info.State == session.StateStopped {
+			return nil
+		}
+		if err != nil && !errors.Is(err, session.ErrSessionNotFound) {
+			return err
+		}
+	}
 	err := c.sessions.StopWithCause(ctx, id, session.CauseUserRequested, reason)
 	if errors.Is(err, session.ErrSessionNotFound) || errors.Is(err, session.ErrSessionNotActive) {
 		return nil

--- a/internal/daemon/loop_runtime_adapters_test.go
+++ b/internal/daemon/loop_runtime_adapters_test.go
@@ -2160,3 +2160,41 @@ func (r *loopPolicyProfileWorkspaceResolver) ResolveForProfile(
 	}
 	return r.scoped, nil
 }
+
+// Invariant: ongoing leases and admitted waits are fresh, but reads cannot renew expired evidence.
+// Owner: daemon Loop supervision adapter; canonical runtime adapters suite.
+func TestSessionLoopWorkFreshness(t *testing.T) {
+	t.Parallel()
+	t.Run("Should bound ongoing and waiting work by durable evidence", func(t *testing.T) {
+		t.Parallel()
+		now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+		work := looppkg.SessionWork{
+			RunID:      "run",
+			Status:     looppkg.StatusRunning,
+			Since:      now.Add(-time.Hour),
+			LeaseUntil: now.Add(time.Minute),
+		}
+		signal := sessionLoopWorkSignal(work)
+		if !signal.ValidUntil.Equal(work.LeaseUntil) || signal.AttentionReason != "" {
+			t.Fatalf("ongoing lease = %#v", signal)
+		}
+		work.LeaseUntil = now.Add(-time.Second)
+		signal = sessionLoopWorkSignal(work)
+		if !signal.ValidUntil.Before(now) || !signal.StaleAttention {
+			t.Fatalf("expired lease renewed: %#v", signal)
+		}
+		deadline := now.Add(time.Hour)
+		work.Waits = []looppkg.NodeWait{{ClaimState: looppkg.WaitClaimWaiting, ResumeAt: &deadline}}
+		if signal = sessionLoopWorkSignal(
+			work,
+		); !signal.ValidUntil.Equal(
+			deadline.Add(2 * defaultMechanicalSchedulerInterval),
+		) {
+			t.Fatalf("wait freshness = %#v", signal)
+		}
+		work.NeedsAttention = true
+		if signal = sessionLoopWorkSignal(work); signal.AttentionReason == "" {
+			t.Fatal("quarantine lost attention")
+		}
+	})
+}

--- a/internal/daemon/session_work_sources.go
+++ b/internal/daemon/session_work_sources.go
@@ -139,15 +139,48 @@ func (s sessionWorkSources) loops(ctx context.Context, id string) ([]session.Wor
 	}
 	result := make([]session.WorkSignal, 0, len(rows))
 	for _, row := range rows {
-		result = append(result, session.WorkSignal{
-			Kind:           session.WorkSignalLoopRun,
-			Since:          row.Since,
-			Ref:            string(row.RunID),
-			ValidUntil:     row.ReconciledAt.Add(2 * defaultMechanicalSchedulerInterval),
-			StaleAttention: true,
-		})
+		if (row.Status == looppkg.StatusPaused || row.Status == looppkg.StatusWatching) && !row.NeedsAttention &&
+			len(row.Waits) == 0 {
+			continue
+		}
+		result = append(result, sessionLoopWorkSignal(row))
 	}
 	return result, nil
+}
+
+// Durable leases and admitted wait deadlines bound activity; reading a run never renews it.
+func sessionLoopWorkSignal(row looppkg.SessionWork) session.WorkSignal {
+	until := row.ReconciledAt.Add(2 * defaultMechanicalSchedulerInterval)
+	if initial := row.Since.Add(2 * defaultMechanicalSchedulerInterval); initial.After(until) {
+		until = initial
+	}
+	if row.LeaseUntil.After(until) {
+		until = row.LeaseUntil
+	}
+	attention := ""
+	if row.NeedsAttention {
+		attention = "Loop work requires attention; inspect the run's node failures and quarantine."
+	}
+	if row.Status == looppkg.StatusNeedsApproval {
+		attention = "The Goal or Loop is waiting for approval; inspect the run's pending request."
+	}
+	for _, wait := range row.Waits {
+		if wait.ClaimState == looppkg.WaitClaimInterventionRequired {
+			attention = "A Loop wait requires intervention; inspect the run's pending request."
+			continue
+		}
+		deadline := wait.ResumeAt
+		if wait.NextEscalationAt != nil && (deadline == nil || wait.NextEscalationAt.Before(*deadline)) {
+			deadline = wait.NextEscalationAt
+		}
+		if deadline != nil && deadline.Add(2*defaultMechanicalSchedulerInterval).After(until) {
+			until = deadline.Add(2 * defaultMechanicalSchedulerInterval)
+		}
+	}
+	return session.WorkSignal{
+		Kind: session.WorkSignalLoopRun, Since: row.Since, Ref: string(row.RunID), ValidUntil: until,
+		StaleAttention: attention == "", AttentionReason: attention,
+	}
 }
 
 func (s sessionWorkSources) waits(ctx context.Context, id string) ([]session.WorkSignal, error) {

--- a/internal/loop/goal/compaction.go
+++ b/internal/loop/goal/compaction.go
@@ -364,11 +364,5 @@ func (e *Executor) reseedApprovalBoundary(
 }
 
 func (e *Executor) rotateBinding(ctx context.Context, segment *segmentState) error {
-	oldBinding := segment.binding
-	segment.checkpoint.BindingEpoch = oldBinding.BindingEpoch + 1
-	if err := e.bindSegment(ctx, segment); err != nil {
-		segment.checkpoint.BindingEpoch = oldBinding.BindingEpoch
-		return err
-	}
-	return nil
+	return e.bindSegment(ctx, segment, segment.binding.BindingEpoch+1)
 }

--- a/internal/loop/goal/context_usage.go
+++ b/internal/loop/goal/context_usage.go
@@ -36,3 +36,17 @@ func contextUsageSequence(usage *ContextUsage) *int64 {
 	sequence := usage.Sequence
 	return &sequence
 }
+
+func (e *Executor) bindCheckpoint(ctx context.Context, segment *segmentState) error {
+	updated, err := e.store.BindCheckpoint(ctx, BindCheckpointRequest{
+		Key: segment.key, ExpectedControlEpoch: segment.checkpoint.ControlEpoch,
+		ExpectedBindingEpoch: segment.checkpoint.BindingEpoch, ExpectedPhase: segment.checkpoint.Phase,
+		TaskRunID: segment.input.CorrelationID, SessionID: segment.binding.SessionID,
+		BindingHandle: segment.binding.Handle, BindingEpoch: segment.binding.BindingEpoch,
+	})
+	if err != nil {
+		return err
+	}
+	segment.checkpoint = updated
+	return nil
+}

--- a/internal/loop/goal/executor.go
+++ b/internal/loop/goal/executor.go
@@ -109,7 +109,7 @@ func (e *Executor) initializeSegment(
 	if checkpoint.Phase == checkpointPhaseAwaitingControl || checkpoint.Phase == checkpointPhaseTerminal {
 		return segment, nil
 	}
-	if err := e.bindSegment(ctx, segment); err != nil {
+	if err := e.bindSegment(ctx, segment, max(segment.checkpoint.BindingEpoch, 1)); err != nil {
 		return nil, err
 	}
 	return segment, nil
@@ -180,8 +180,8 @@ func pinnedContextNudgeRatio(in loop.ActionExecutionInput) (float64, error) {
 	return policy.ContextNudgeRatio, nil
 }
 
-func (e *Executor) bindSegment(ctx context.Context, segment *segmentState) error {
-	request, err := e.actionSessionBindRequest(segment)
+func (e *Executor) bindSegment(ctx context.Context, segment *segmentState, targetEpoch int64) error {
+	request, err := e.actionSessionBindRequest(segment, targetEpoch)
 	if err != nil {
 		return err
 	}
@@ -194,6 +194,9 @@ func (e *Executor) bindSegment(ctx context.Context, segment *segmentState) error
 				return fmt.Errorf("%w: managed Goal binding identity is incomplete", loop.ErrValidation)
 			}
 			segment.binding = binding
+			if err := e.bindCheckpoint(ctx, segment); err != nil {
+				return err
+			}
 			segment.resolvedRuntime = appliedGoalRuntime(
 				segment.resolvedRuntime,
 				binding.AppliedRuntime,
@@ -258,6 +261,7 @@ func (e *Executor) bindSegment(ctx context.Context, segment *segmentState) error
 
 func (e *Executor) actionSessionBindRequest(
 	segment *segmentState,
+	targetEpoch int64,
 ) (loop.ActionSessionBindRequest, error) {
 	handleLabel := string(segment.node.ID)
 	mode := dsl.SessionModeContinuous
@@ -273,7 +277,6 @@ func (e *Executor) actionSessionBindRequest(
 	if err != nil {
 		return loop.ActionSessionBindRequest{}, err
 	}
-	targetEpoch := max(segment.checkpoint.BindingEpoch, 1)
 	bindingAttemptID, desiredSessionID := deterministicBindingIdentity(segment.key, handle, targetEpoch)
 	contract := dsl.Contract{}
 	if segment.input.Contract != nil {

--- a/internal/loop/goal/executor.go
+++ b/internal/loop/goal/executor.go
@@ -195,6 +195,8 @@ func (e *Executor) bindSegment(ctx context.Context, segment *segmentState, targe
 			}
 			segment.binding = binding
 			if err := e.bindCheckpoint(ctx, segment); err != nil {
+				// The binding store already owns this durable session. Preserve it for
+				// fenced retry or Run cancellation; a stale executor must not close it.
 				return err
 			}
 			segment.resolvedRuntime = appliedGoalRuntime(

--- a/internal/loop/goal/executor_test_support_test.go
+++ b/internal/loop/goal/executor_test_support_test.go
@@ -487,11 +487,7 @@ func (b *fakeManagedBinder) BindActionSession(
 		b.bindErrors = b.bindErrors[1:]
 		return binding, err
 	}
-	b.store.mu.Lock()
-	b.store.checkpoint.SessionID = fmt.Sprintf("session-%d", req.TargetBindingEpoch)
-	b.store.checkpoint.BindingHandle = req.Handle
-	b.store.checkpoint.BindingEpoch = req.TargetBindingEpoch
-	b.store.mu.Unlock()
+
 	binding.ControlEpoch = controlEpoch
 	return binding, nil
 }
@@ -792,4 +788,17 @@ func newTestExecutorWithContext(
 		t.Fatalf("NewExecutor() error = %v", err)
 	}
 	return executor
+}
+
+func (s *fakeExecutorStore) BindCheckpoint(_ context.Context, req BindCheckpointRequest) (Checkpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.checkpoint.ControlEpoch != req.ExpectedControlEpoch || s.checkpoint.BindingEpoch != req.ExpectedBindingEpoch ||
+		s.checkpoint.Phase != req.ExpectedPhase {
+		return Checkpoint{}, loop.ErrTransitionConflict
+	}
+	s.checkpoint.SessionID = req.SessionID
+	s.checkpoint.BindingHandle = req.BindingHandle
+	s.checkpoint.BindingEpoch = req.BindingEpoch
+	return cloneTestCheckpoint(s.checkpoint), nil
 }

--- a/internal/loop/goal/executor_test_support_test.go
+++ b/internal/loop/goal/executor_test_support_test.go
@@ -797,6 +797,17 @@ func (s *fakeExecutorStore) BindCheckpoint(_ context.Context, req BindCheckpoint
 		s.checkpoint.Phase != req.ExpectedPhase {
 		return Checkpoint{}, loop.ErrTransitionConflict
 	}
+	if s.checkpoint.SessionID != req.SessionID || s.checkpoint.BindingHandle != req.BindingHandle ||
+		s.checkpoint.BindingEpoch != req.BindingEpoch {
+		// Model binding activation plus checkpoint adoption. Recovery and context
+		// belong to this binding; turn budgets and judge failure streaks do not.
+		s.checkpoint.RecoveryStreak = 0
+		s.checkpoint.CompactionRecoveryRequired = false
+		s.checkpoint.ContextState = contextStateUnknown
+		s.checkpoint.UsageSequence = nil
+		s.checkpoint.UsagePendingAfterSequence = nil
+		s.checkpoint.CompactionBaselineUsed = nil
+	}
 	s.checkpoint.SessionID = req.SessionID
 	s.checkpoint.BindingHandle = req.BindingHandle
 	s.checkpoint.BindingEpoch = req.BindingEpoch

--- a/internal/loop/goal/types_checkpoint.go
+++ b/internal/loop/goal/types_checkpoint.go
@@ -181,10 +181,23 @@ type BeginCompactionCancelRequest struct {
 	Cause                string
 }
 
+// BindCheckpointRequest attaches an active binding before context observation or prompt admission.
+type BindCheckpointRequest struct {
+	Key                  TurnKey
+	ExpectedControlEpoch int64
+	ExpectedBindingEpoch int64
+	ExpectedPhase        string
+	TaskRunID            string
+	SessionID            string
+	BindingHandle        string
+	BindingEpoch         int64
+}
+
 // CheckpointStore is the durable checkpoint/control subset used by Goal execution.
 type CheckpointStore interface {
 	CreateCheckpoint(context.Context, CreateCheckpointRequest) (Checkpoint, error)
 	LoadCheckpoint(context.Context, TurnKey) (Checkpoint, error)
+	BindCheckpoint(context.Context, BindCheckpointRequest) (Checkpoint, error)
 	CheckpointControl(context.Context, ControlCheckpointRequest) error
 	GrantAndReactivate(context.Context, GrantRequest) error
 	RecordReportIntent(context.Context, RecordReportIntentRequest) (ReportIntent, error)

--- a/internal/loop/goal/types_projection.go
+++ b/internal/loop/goal/types_projection.go
@@ -10,6 +10,7 @@ import (
 type SessionProjection struct {
 	Found             bool
 	Cleared           bool
+	Quarantined       bool
 	RunID             loop.RunID
 	RunStatus         loop.Status
 	DefinitionDigest  string

--- a/internal/loop/session_work.go
+++ b/internal/loop/session_work.go
@@ -4,8 +4,12 @@ import "time"
 
 // SessionWork is durable loop evidence for a session's ephemeral supervision view.
 type SessionWork struct {
-	RunID        RunID
-	Since        time.Time
-	ReconciledAt time.Time
-	Waits        []NodeWait
+	RunID          RunID
+	Since          time.Time
+	ReconciledAt   time.Time
+	LeaseUntil     time.Time
+	Status         Status
+	NeedsAttention bool
+	OwnsGoal       bool
+	Waits          []NodeWait
 }

--- a/internal/session/manager_delete_staging.go
+++ b/internal/session/manager_delete_staging.go
@@ -312,6 +312,11 @@ func (m *Manager) stageSessionDelete(
 			target,
 		)
 	}
+	stopInfo := *info
+	stopInfo.StopCause = CauseUserRequested
+	if err := m.stopSessionGoals(ctx, &stopInfo); err != nil {
+		return stagedSessionDelete{}, fmt.Errorf("session: cancel Goals before delete: %w", err)
+	}
 	return m.stageSessionDirectoryDelete(ctx, target, info)
 }
 

--- a/internal/session/manager_delete_staging.go
+++ b/internal/session/manager_delete_staging.go
@@ -312,6 +312,9 @@ func (m *Manager) stageSessionDelete(
 			target,
 		)
 	}
+	// Deletion first stops execution irreversibly. A later staging rollback
+	// restores stopped history, never the process or its canceled Goal. This
+	// also settles Goals left live by older versions for an already stopped session.
 	stopInfo := *info
 	stopInfo.StopCause = CauseUserRequested
 	if err := m.stopSessionGoals(ctx, &stopInfo); err != nil {

--- a/internal/session/manager_delete_test.go
+++ b/internal/session/manager_delete_test.go
@@ -657,15 +657,25 @@ func TestManagerDelete(t *testing.T) {
 				shutdownQueryStoreRuntimeForTest(t, h.manager)
 				session := createSession(t, h)
 				attachmentPath := writeSessionAttachmentFixture(t, h, session.ID, "restore-me")
-				if err := h.manager.Stop(testutil.Context(t), session.ID); err != nil {
-					t.Fatalf("Stop() error = %v", err)
-				}
+				// Invariant: deletion rollback restores history without resurrecting stopped execution.
+				// Owner: session deletion; canonical manager deletion rollback case.
+				var goalCanceled atomic.Bool
+				h.manager.SetGoalCommandHandler(&stopGoalHandler{stop: func(_ context.Context, info *Info) error {
+					if info.ID != session.ID || info.StopCause != CauseUserRequested {
+						t.Errorf("deletion stop identity = %#v", info)
+					}
+					goalCanceled.Store(true)
+					return nil
+				}})
 				deleteErr := errors.New("catalog delete failed")
 				catalog.deleteErr = deleteErr
 
 				err := h.manager.Delete(testutil.Context(t), session.ID)
 				if !errors.Is(err, deleteErr) {
 					t.Fatalf("Delete() error = %v, want %v", err, deleteErr)
+				}
+				if !goalCanceled.Load() || session.Info().State != StateStopped {
+					t.Fatal("catalog rollback resurrected execution or omitted Goal cancellation")
 				}
 				if _, err := os.Stat(session.SessionDir()); err != nil {
 					t.Fatalf("Stat(restored session dir) error = %v", err)

--- a/internal/session/manager_goal_commands.go
+++ b/internal/session/manager_goal_commands.go
@@ -11,6 +11,22 @@ const (
 	goalBusyPolicyRejectIfBusy = "reject-if-busy"
 )
 
+// GoalSessionStopHandler cancels session-origin Goals when the operator stops their session.
+type GoalSessionStopHandler interface {
+	StopSessionGoals(context.Context, *Info) error
+}
+
+func (m *Manager) stopSessionGoals(ctx context.Context, info *Info) error {
+	if info == nil || info.StopCause != CauseUserRequested {
+		return nil
+	}
+	handler, ok := m.currentGoalCommandHandler().(GoalSessionStopHandler)
+	if !ok {
+		return nil
+	}
+	return handler.StopSessionGoals(ctx, info)
+}
+
 // SetGoalCommandHandler installs the late-bound daemon dispatcher before API servers start.
 func (m *Manager) SetGoalCommandHandler(handler GoalCommandHandler) {
 	if m == nil {

--- a/internal/session/manager_lifecycle_contract_test.go
+++ b/internal/session/manager_lifecycle_contract_test.go
@@ -809,6 +809,63 @@ func TestStopRequiresVerifiedProcessExit(t *testing.T) {
 }
 
 func TestSharedSessionStopOperation(t *testing.T) {
+	for _, restart := range []bool{false, true} {
+		t.Run(fmt.Sprintf("Should retry Goal cancellation settlement with restart %t", restart), func(t *testing.T) {
+			t.Parallel()
+			h := newHarness(t)
+			active := createSession(t, h)
+			cancelErr := errors.New("Goal cancellation unavailable")
+			var fail atomic.Bool
+			fail.Store(true)
+			var calls atomic.Int32
+			handler := &stopGoalHandler{stop: func(_ context.Context, info *Info) error {
+				calls.Add(1)
+				if info.ID != active.ID || info.State != StateStopped || info.StopCause != CauseUserRequested {
+					t.Errorf("Goal cancellation identity = %#v", info)
+				}
+				if fail.Load() {
+					return cancelErr
+				}
+				return nil
+			}}
+			h.manager.SetGoalCommandHandler(handler)
+			if err := h.manager.Stop(t.Context(), active.ID); !errors.Is(err, cancelErr) ||
+				!errors.Is(err, ErrRecoveryPersistence) {
+				t.Fatalf("failed Goal cancellation = %v", err)
+			}
+			if _, err := os.Stat(h.manager.recoveredStopReceiptPath(active.ID)); err != nil {
+				t.Fatalf("pending Goal cancellation lost its receipt: %v", err)
+			}
+			if err := h.manager.Delete(t.Context(), active.ID); !errors.Is(err, ErrRecoveryPersistence) {
+				t.Fatalf("delete bypassed Goal cancellation: %v", err)
+			}
+			manager := h.manager
+			if restart {
+				h.manager.removeActive(active.ID)
+				manager = newManagerWithHarness(t, h, WithGoalCommandHandler(handler))
+				cleanupTestManager(t, manager)
+				if err := manager.RecoverPendingStops(t.Context()); !errors.Is(err, cancelErr) ||
+					!errors.Is(err, ErrRecoveryPersistence) {
+					t.Fatalf("boot lost pending Goal cancellation: %v", err)
+				}
+			}
+			fail.Store(false)
+			if err := manager.Stop(t.Context(), active.ID); err != nil {
+				t.Fatalf("retry Goal cancellation: %v", err)
+			}
+			if calls.Load() < 2 || manager.hasPendingStopSettlement(active.ID) {
+				t.Fatalf("Goal cancellation did not settle: calls=%d", calls.Load())
+			}
+			if _, err := os.Stat(manager.recoveredStopReceiptPath(active.ID)); !errors.Is(err, os.ErrNotExist) {
+				t.Fatalf("settled receipt retained: %v", err)
+			}
+			if countEventType(readStoredEvents(t, active), EventTypeSessionStopped) != 1 ||
+				h.notifier.stoppedCount() != 1 {
+				t.Fatal("Goal cancellation retry duplicated or omitted terminal settlement")
+			}
+		})
+	}
+
 	t.Run("Should defer the terminal event until its recovery receipt is durable", func(t *testing.T) {
 		t.Parallel()
 		h := newHarness(t)
@@ -2332,4 +2389,14 @@ func (p *recoveredProcessTestProvider) SignalProcess(
 	ctx context.Context, state sandbox.SessionState, signal sandbox.ProcessSignal,
 ) error {
 	return p.signal(ctx, state, signal)
+}
+
+// stopGoalHandler injects only the daemon cancellation I/O boundary.
+type stopGoalHandler struct {
+	GoalCommandHandler
+	stop func(context.Context, *Info) error
+}
+
+func (h *stopGoalHandler) StopSessionGoals(ctx context.Context, info *Info) error {
+	return h.stop(ctx, info)
 }

--- a/internal/session/manager_stop_finalization.go
+++ b/internal/session/manager_stop_finalization.go
@@ -84,6 +84,11 @@ func (m *Manager) finishStoppedPersistence(ctx context.Context, session *Session
 		m.dispatchSessionPostStop(ctx, session)
 		return errors.Join(session.stopFinalizationErr, err)
 	}
+	if err := m.stopSessionGoals(ctx, session.Info()); err != nil {
+		session.setPendingStopState(true, true)
+		m.dispatchSessionPostStop(ctx, session)
+		return errors.Join(session.stopFinalizationErr, ErrRecoveryPersistence, err)
+	}
 	if err := m.removeRecoveredStopReceipt(session.ID); err != nil {
 		session.setPendingStopState(true, true)
 		m.dispatchSessionPostStop(ctx, session)
@@ -95,7 +100,6 @@ func (m *Manager) finishStoppedPersistence(ctx context.Context, session *Session
 	m.clearResumeReplay(session.ID)
 
 	m.removeActive(session.ID)
-	errs = appendLifecycleErr(errs, m.stopSessionGoals(ctx, session.Info()))
 	if m.hostedMCP != nil {
 		m.hostedMCP.ReleaseSession(session.ID)
 	}

--- a/internal/session/manager_stop_finalization.go
+++ b/internal/session/manager_stop_finalization.go
@@ -95,6 +95,7 @@ func (m *Manager) finishStoppedPersistence(ctx context.Context, session *Session
 	m.clearResumeReplay(session.ID)
 
 	m.removeActive(session.ID)
+	errs = appendLifecycleErr(errs, m.stopSessionGoals(ctx, session.Info()))
 	if m.hostedMCP != nil {
 		m.hostedMCP.ReleaseSession(session.ID)
 	}

--- a/internal/session/prompt_activity_test.go
+++ b/internal/session/prompt_activity_test.go
@@ -800,6 +800,43 @@ func storedEventsContainType(events []store.SessionEvent, eventType string) bool
 // Invariant: only fresh authoritative evidence protects a session; source failures remain explicit.
 // Owner: session signal aggregation; canonical activity/supervision suite (UT-058..061, UT-123..126/130).
 func TestWorkSignalRegistryFreshnessAndUnknownSources(t *testing.T) {
+	t.Run("Should preserve real attention during fresh progress and clear it after recovery", func(t *testing.T) {
+		now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+		registry := NewWorkSignalRegistry()
+		attention := "Loop node is quarantined; retry after repairing the failure."
+		for _, kind := range WorkSignalKindValues() {
+			registry.Register(WorkSignalSource{Kind: WorkSignalKind(kind), Source: SignalSourceFunc(
+				func(context.Context, string) ([]WorkSignal, error) { return nil, nil },
+			)})
+		}
+		for _, kind := range []WorkSignalKind{WorkSignalAgentProgress, WorkSignalLoopRun} {
+			registry.Register(
+				WorkSignalSource{
+					Kind: kind,
+					Source: SignalSourceFunc(func(context.Context, string) ([]WorkSignal, error) {
+						signal := WorkSignal{Kind: kind, Since: now, ValidUntil: now.Add(time.Minute)}
+						if kind == WorkSignalLoopRun {
+							signal.AttentionReason = attention
+						}
+						return []WorkSignal{signal}, nil
+					}),
+				},
+			)
+		}
+		if state := registry.Inspect(
+			t.Context(),
+			"session",
+			now,
+		); !supervisionNeedsAttention(state) ||
+			len(state.WorkSignals) != 2 {
+			t.Fatalf("fresh work hid real attention: %#v", state)
+		}
+		attention = ""
+		if state := registry.Inspect(t.Context(), "session", now); supervisionNeedsAttention(state) {
+			t.Fatalf("recovered run retained attention: %#v", state)
+		}
+	})
+
 	now := time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC)
 	for _, name := range WorkSignalKindValues() {
 		t.Run(name, func(t *testing.T) {

--- a/internal/session/stop_recovered_finalization.go
+++ b/internal/session/stop_recovered_finalization.go
@@ -62,6 +62,15 @@ func (m *Manager) settleRecoveredStop(
 	if !outcome.Verified {
 		return nil
 	}
+	meta, err := m.readMetaWithContext(settleCtx, run.recoveredID)
+	if err != nil {
+		return errors.Join(ErrRecoveryPersistence, err)
+	}
+	info := m.sessionInfoFromMeta(settleCtx, meta)
+	info.StopCause = outcome.Cause
+	if err := m.stopSessionGoals(settleCtx, info); err != nil {
+		return errors.Join(ErrRecoveryPersistence, err)
+	}
 	if err := m.removeRecoveredStopReceipt(run.recoveredID); err != nil {
 		return err
 	}

--- a/internal/session/work_signal_registry.go
+++ b/internal/session/work_signal_registry.go
@@ -95,6 +95,12 @@ func (r *WorkSignalRegistry) Inspect(ctx context.Context, id string, now time.Ti
 func appendInspectedSignals(state *SupervisionState, kind WorkSignalKind, signals []WorkSignal, now time.Time) {
 	status := SignalSourceState{Kind: kind, State: "absent"}
 	for _, signal := range signals {
+		if signal.AttentionReason != "" {
+			state.Sources = append(state.Sources, SignalSourceState{
+				Kind: kind, State: "attention", Ref: signal.Ref,
+				Error: diagnostics.RedactAndBound(signal.AttentionReason, 512),
+			})
+		}
 		if signal.Kind != kind || signal.Since.IsZero() || signal.ValidUntil.IsZero() {
 			state.Sources = append(state.Sources, SignalSourceState{
 				Kind:  kind,
@@ -122,6 +128,6 @@ func appendInspectedSignals(state *SupervisionState, kind WorkSignalKind, signal
 
 func supervisionNeedsAttention(state *SupervisionState) bool {
 	return state != nil && slices.ContainsFunc(state.Sources, func(source SignalSourceState) bool {
-		return source.State == signalSourceUnknown || source.State == "stale"
+		return source.State == signalSourceUnknown || source.State == "stale" || source.State == "attention"
 	})
 }

--- a/internal/session/work_signals.go
+++ b/internal/session/work_signals.go
@@ -23,8 +23,9 @@ type WorkSignal struct {
 	Since time.Time      `json:"since"`
 	Ref   string         `json:"ref,omitempty"`
 
-	ValidUntil     time.Time `json:"-"`
-	StaleAttention bool      `json:"-"`
+	ValidUntil      time.Time `json:"-"`
+	StaleAttention  bool      `json:"-"`
+	AttentionReason string    `json:"-"`
 }
 
 // SignalSource inspects one authoritative subsystem without renewing its evidence.

--- a/internal/store/globaldb/global_db_goal_checkpoint_binding.go
+++ b/internal/store/globaldb/global_db_goal_checkpoint_binding.go
@@ -1,0 +1,82 @@
+package globaldb
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/loop/goal"
+	"github.com/compozy/compozy/internal/store"
+	"github.com/compozy/compozy/internal/store/globaldb/sqlcgen"
+)
+
+// BindCheckpoint adopts the exact active binding under the checkpoint owner fence.
+func (g *GoalRepo) BindCheckpoint(ctx context.Context, req goal.BindCheckpointRequest) (goal.Checkpoint, error) {
+	if err := g.checkReady(ctx, "bind Goal checkpoint"); err != nil {
+		return goal.Checkpoint{}, err
+	}
+	if err := validateBindCheckpointRequest(req); err != nil {
+		return goal.Checkpoint{}, err
+	}
+	var updated goal.Checkpoint
+	err := g.withTaskImmediateTransaction(ctx, "bind Goal checkpoint", func(exec taskSQLExecutor) error {
+		if err := validateGoalRunWorkspace(ctx, exec, req.Key); err != nil {
+			return err
+		}
+		checkpoint, err := loadGoalCheckpointWithExecutor(ctx, exec, req.Key)
+		if err != nil {
+			return err
+		}
+		if checkpoint.ControlEpoch != req.ExpectedControlEpoch || checkpoint.BindingEpoch != req.ExpectedBindingEpoch ||
+			checkpoint.Phase != req.ExpectedPhase || checkpoint.Status != goalStatusActive ||
+			checkpoint.TaskRunID != req.TaskRunID {
+			return goalControlStaleError("Goal checkpoint binding owner changed")
+		}
+		if err := validateActiveGoalPromptBinding(
+			ctx,
+			exec,
+			req.Key,
+			req.BindingHandle,
+			req.BindingEpoch,
+			req.SessionID,
+		); err != nil {
+			return err
+		}
+		if checkpoint.BindingEpoch == req.BindingEpoch && checkpoint.SessionID == req.SessionID &&
+			checkpoint.BindingHandle == req.BindingHandle {
+			updated = checkpoint
+			return nil
+		}
+		if checkpoint.Phase != goalCheckpointPhaseIdle || checkpoint.PromptID != "" || checkpoint.QueueEntryID != "" {
+			return goalControlStaleError("Goal checkpoint cannot change binding while a prompt is pending")
+		}
+		affected, err := sqlcgen.New(exec).BindGoalCheckpoint(ctx, sqlcgen.BindGoalCheckpointParams{
+			SessionID: goalNullableString(req.SessionID), BindingHandle: goalNullableString(req.BindingHandle),
+			BindingEpoch: goalNullableInt64(&req.BindingEpoch), UpdatedAt: store.FormatTimestamp(g.now().UTC()),
+			LoopRunID: string(req.Key.LoopRunID), Generation: int64(req.Key.Generation), NodeID: string(req.Key.NodeID),
+			ItemIndex: int64(req.Key.ItemIndex), ControlEpoch: req.ExpectedControlEpoch,
+		})
+		if err != nil {
+			return fmt.Errorf("store: bind Goal checkpoint: %w", err)
+		}
+		if err := requireGoalAffectedCount(affected, "bind Goal checkpoint"); err != nil {
+			return err
+		}
+		updated, err = loadGoalCheckpointWithExecutor(ctx, exec, req.Key)
+		return err
+	})
+	return updated, err
+}
+
+func validateBindCheckpointRequest(req goal.BindCheckpointRequest) error {
+	if err := req.Key.Validate(); err != nil {
+		return err
+	}
+	if req.ExpectedControlEpoch < 1 || req.ExpectedBindingEpoch < 0 || req.BindingEpoch < 1 ||
+		!goalCheckpointPhaseValid(req.ExpectedPhase) || strings.TrimSpace(req.TaskRunID) == "" ||
+		strings.TrimSpace(req.SessionID) == "" || strings.TrimSpace(req.BindingHandle) == "" {
+		return fmt.Errorf("%w: Goal checkpoint binding identity is invalid", looppkg.ErrValidation)
+	}
+	return nil
+}

--- a/internal/store/globaldb/global_db_goal_checkpoint_integration_test.go
+++ b/internal/store/globaldb/global_db_goal_checkpoint_integration_test.go
@@ -38,21 +38,35 @@ func TestGoalCheckpointControlIntegration(t *testing.T) {
 		}
 		request := goal.BindCheckpointRequest{Key: key, ExpectedControlEpoch: 1, ExpectedPhase: "idle",
 			TaskRunID: "task-bind", SessionID: "session-bind", BindingHandle: "goal:bind", BindingEpoch: 1}
-		for _, mutate := range []func(*goal.BindCheckpointRequest){
-			func(r *goal.BindCheckpointRequest) { r.ExpectedControlEpoch++ },
-			func(r *goal.BindCheckpointRequest) { r.ExpectedBindingEpoch++ },
-			func(r *goal.BindCheckpointRequest) { r.ExpectedPhase = "prompting" },
-			func(r *goal.BindCheckpointRequest) { r.TaskRunID = "foreign-task" },
-			func(r *goal.BindCheckpointRequest) { r.SessionID = "foreign-session" },
-			func(r *goal.BindCheckpointRequest) { r.BindingHandle = "foreign-handle" },
-			func(r *goal.BindCheckpointRequest) { r.BindingEpoch++ },
-			func(r *goal.BindCheckpointRequest) { r.Key.WorkspaceID = "ws-foreign" },
+		for _, tc := range []struct {
+			name   string
+			mutate func(*goal.BindCheckpointRequest)
+			want   error
+			reason looppkg.ReasonCode
+		}{
+			{"control epoch", func(r *goal.BindCheckpointRequest) { r.ExpectedControlEpoch++ }, looppkg.ErrTransitionConflict, looppkg.ReasonCodeGoalControlStale},
+			{"checkpoint binding epoch", func(r *goal.BindCheckpointRequest) { r.ExpectedBindingEpoch++ }, looppkg.ErrTransitionConflict, looppkg.ReasonCodeGoalControlStale},
+			{"phase", func(r *goal.BindCheckpointRequest) { r.ExpectedPhase = "prompting" }, looppkg.ErrTransitionConflict, looppkg.ReasonCodeGoalControlStale},
+			{"task", func(r *goal.BindCheckpointRequest) { r.TaskRunID = "foreign-task" }, looppkg.ErrTransitionConflict, looppkg.ReasonCodeGoalControlStale},
+			{"session", func(r *goal.BindCheckpointRequest) { r.SessionID = "foreign-session" }, looppkg.ErrTransitionConflict, looppkg.ReasonCodeContinuousBindingMismatch},
+			{"handle", func(r *goal.BindCheckpointRequest) { r.BindingHandle = "foreign-handle" }, looppkg.ErrTransitionConflict, looppkg.ReasonCodeContinuousBindingMismatch},
+			{"active binding epoch", func(r *goal.BindCheckpointRequest) { r.BindingEpoch++ }, looppkg.ErrTransitionConflict, looppkg.ReasonCodeContinuousBindingMismatch},
+			{"workspace", func(r *goal.BindCheckpointRequest) { r.Key.WorkspaceID = "ws-foreign" }, looppkg.ErrRunNotFound, ""},
 		} {
-			invalid := request
-			mutate(&invalid)
-			if _, err := db.BindCheckpoint(ctx, invalid); err == nil {
-				t.Fatalf("accepted foreign binding owner: %#v", invalid)
-			}
+			t.Run("Should reject foreign "+tc.name, func(t *testing.T) {
+				invalid := request
+				tc.mutate(&invalid)
+				_, err := db.BindCheckpoint(ctx, invalid)
+				if !errors.Is(err, tc.want) {
+					t.Fatalf("binding ownership error = %v, want %v", err, tc.want)
+				}
+				if tc.reason != "" {
+					var reason *looppkg.ReasonError
+					if !errors.As(err, &reason) || reason.Code != tc.reason {
+						t.Fatalf("binding ownership reason = %v, want %s", err, tc.reason)
+					}
+				}
+			})
 		}
 		if _, err := db.BindCheckpoint(ctx, request); err != nil {
 			t.Fatal(err)

--- a/internal/store/globaldb/global_db_goal_checkpoint_integration_test.go
+++ b/internal/store/globaldb/global_db_goal_checkpoint_integration_test.go
@@ -19,6 +19,62 @@ import (
 func TestGoalCheckpointControlIntegration(t *testing.T) {
 	t.Parallel()
 
+	// Invariant: binding adoption is fenced and cannot erase same-binding context freshness.
+	// Owner: Goal checkpoint store; canonical checkpoint control integration suite.
+	t.Run("Should adopt an active binding before context observation with exact ownership", func(t *testing.T) {
+		t.Parallel()
+		db := openLoopTestGlobalDB(t, "ws-bind", "ws-foreign")
+		insertGoalSchemaLoopRun(t, db, "run-bind", "ws-bind", "catalog", nil)
+		ctx := testutil.Context(t)
+		now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+		key := goal.TurnKey{WorkspaceID: "ws-bind", LoopRunID: "run-bind", Generation: 1, NodeID: "goal"}
+		seedActiveGoalBindingForTest(t, db, "run-bind", "ws-bind", "goal:bind", 1, "session-bind", now)
+		_, err := db.CreateCheckpoint(ctx, goal.CreateCheckpointRequest{Checkpoint: goal.Checkpoint{
+			Key: key, TaskRunID: "task-bind", ControlEpoch: 1, Phase: "idle", Status: "active",
+			TurnLimit: 10, ContextState: "unknown", ContextNudgeRatio: 0.8, UpdatedAt: now,
+		}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		request := goal.BindCheckpointRequest{Key: key, ExpectedControlEpoch: 1, ExpectedPhase: "idle",
+			TaskRunID: "task-bind", SessionID: "session-bind", BindingHandle: "goal:bind", BindingEpoch: 1}
+		for _, mutate := range []func(*goal.BindCheckpointRequest){
+			func(r *goal.BindCheckpointRequest) { r.ExpectedControlEpoch++ },
+			func(r *goal.BindCheckpointRequest) { r.ExpectedBindingEpoch++ },
+			func(r *goal.BindCheckpointRequest) { r.ExpectedPhase = "prompting" },
+			func(r *goal.BindCheckpointRequest) { r.TaskRunID = "foreign-task" },
+			func(r *goal.BindCheckpointRequest) { r.SessionID = "foreign-session" },
+			func(r *goal.BindCheckpointRequest) { r.BindingHandle = "foreign-handle" },
+			func(r *goal.BindCheckpointRequest) { r.BindingEpoch++ },
+			func(r *goal.BindCheckpointRequest) { r.Key.WorkspaceID = "ws-foreign" },
+		} {
+			invalid := request
+			mutate(&invalid)
+			if _, err := db.BindCheckpoint(ctx, invalid); err == nil {
+				t.Fatalf("accepted foreign binding owner: %#v", invalid)
+			}
+		}
+		if _, err := db.BindCheckpoint(ctx, request); err != nil {
+			t.Fatal(err)
+		}
+		_, err = db.RecordContextUsage(ctx, goal.RecordContextUsageRequest{
+			Key: key, ExpectedControlEpoch: 1, ExpectedBindingEpoch: 1, ExpectedPhase: "idle",
+			SessionID: "session-bind", BindingHandle: "goal:bind",
+			Usage: goal.ContextUsage{Known: true, Used: 5, Size: 10, Sequence: 7, ReportedAt: now},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		request.ExpectedBindingEpoch = 1
+		checkpoint, err := db.BindCheckpoint(ctx, request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if checkpoint.ContextState != "known" || checkpoint.UsageSequence == nil || *checkpoint.UsageSequence != 7 {
+			t.Fatalf("binding replay erased context: %#v", checkpoint)
+		}
+	})
+
 	t.Run("Should fence control mutation by the exact checkpoint owner tuple", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/store/globaldb/global_db_goal_projection_reader.go
+++ b/internal/store/globaldb/global_db_goal_projection_reader.go
@@ -70,6 +70,7 @@ func readSessionGoalProjection(
 	}
 	var projection goal.SessionProjection
 	projection.Found = true
+	projection.Quarantined = row.Quarantined
 	projection.RunID = looppkg.RunID(strings.TrimSpace(row.ID))
 	projection.RunStatus = looppkg.Status(strings.TrimSpace(row.Status))
 	projection.DefinitionDigest = strings.TrimSpace(row.DefinitionDigest)

--- a/internal/store/globaldb/global_db_goal_turn_runtime_integration_test.go
+++ b/internal/store/globaldb/global_db_goal_turn_runtime_integration_test.go
@@ -3136,6 +3136,35 @@ func seedGoalTurnRuntime(
 func TestGoalSessionProjectionReader(t *testing.T) {
 	t.Parallel()
 
+	// Invariant: session Goal reads retain durable quarantine and clear it only when its control recovers.
+	// Owner: store projection; canonical session Goal projection suite.
+	t.Run("Should read quarantine from current node controls", func(t *testing.T) {
+		t.Parallel()
+		db := openLoopTestGlobalDB(t, "ws-quarantine")
+		sessionID := "session-quarantine"
+		insertGoalSchemaLoopRun(t, db, "run-quarantine", "ws-quarantine", "session", &sessionID)
+		ctx := testutil.Context(t)
+		if _, err := db.db.ExecContext(ctx, `INSERT INTO loop_node_controls
+			(loop_run_id, node_id, quarantined, quarantine_entry_json, quarantined_at, revision, updated_at)
+			VALUES ('run-quarantine', 'goal', 1, '{"node_id":"goal"}', ?, 1, ?)`, time.Now().UTC(), time.Now().UTC()); err != nil {
+			t.Fatal(err)
+		}
+		projection, err := db.GetSessionGoalProjection(ctx, "ws-quarantine", sessionID)
+		if err != nil || !projection.Quarantined {
+			t.Fatalf("quarantine projection = %#v, %v", projection, err)
+		}
+		if _, err := db.db.ExecContext(
+			ctx,
+			`UPDATE loop_node_controls SET quarantined = 0 WHERE loop_run_id = 'run-quarantine'`,
+		); err != nil {
+			t.Fatal(err)
+		}
+		projection, err = db.GetSessionGoalProjection(ctx, "ws-quarantine", sessionID)
+		if err != nil || projection.Quarantined {
+			t.Fatalf("recovered projection = %#v, %v", projection, err)
+		}
+	})
+
 	t.Run("Should apply clear only after selecting the newest session Goal", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/store/globaldb/global_db_loop_read_integration_test.go
+++ b/internal/store/globaldb/global_db_loop_read_integration_test.go
@@ -13,11 +13,72 @@ import (
 
 	looppkg "github.com/compozy/compozy/internal/loop"
 	"github.com/compozy/compozy/internal/loop/dsl"
+	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/testutil"
 )
 
 func TestGlobalDBLoopReadServiceIntegration(t *testing.T) {
 	t.Parallel()
+
+	// Invariant: Loop work exposes ongoing task leases and exact Goal ownership without crossing session scope.
+	// Owner: durable Loop read model; canonical read integration suite.
+	t.Run("Should expose a live lease before the first coordinator completes", func(t *testing.T) {
+		t.Parallel()
+		db, key, taskID, now := seedGoalTurnRuntime(t, "run-work-evidence")
+		ctx := testutil.Context(t)
+		until := now.Add(time.Minute)
+		if _, err := db.db.ExecContext(
+			ctx,
+			`UPDATE task_runs SET status = 'running', ended_at = NULL, lease_until = ? WHERE id = ?`,
+			store.FormatTimestamp(until),
+			taskID,
+		); err != nil {
+			t.Fatal(err)
+		}
+		read := func(sessionID string) []looppkg.SessionWork {
+			rows, err := db.ListSessionLoopWork(
+				ctx,
+				store.ReadScope{ProfileID: store.DefaultProfileID},
+				string(key.WorkspaceID),
+				sessionID,
+				"",
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return rows
+		}
+		rows := read("session-goal-runtime")
+		if len(rows) != 1 || !rows[0].LeaseUntil.Equal(until) || !rows[0].ReconciledAt.IsZero() || rows[0].OwnsGoal {
+			t.Fatalf("catalog Goal evidence = %#v", rows)
+		}
+		if _, err := db.db.ExecContext(
+			ctx,
+			`UPDATE loop_runs SET origin_kind = 'session', origin_session_id = 'session-origin', origin_creation_profile_ref = 'profile', origin_policy_spec_digest = 'policy', origin_creation_digest = 'creation' WHERE id = ?`,
+			key.LoopRunID,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if rows = read("session-goal-runtime"); len(rows) != 1 || !rows[0].OwnsGoal {
+			t.Fatalf("bound session does not own Goal: %#v", rows)
+		}
+		if rows = read("session-origin"); len(rows) != 1 || !rows[0].OwnsGoal {
+			t.Fatalf("origin does not own Goal: %#v", rows)
+		}
+		if rows = read("foreign-session"); len(rows) != 0 {
+			t.Fatalf("foreign session received evidence: %#v", rows)
+		}
+		if _, err := db.db.ExecContext(
+			ctx,
+			`UPDATE loop_runs SET status = 'canceled' WHERE id = ?`,
+			key.LoopRunID,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if rows = read("session-goal-runtime"); len(rows) != 0 {
+			t.Fatalf("terminal run retained active evidence: %#v", rows)
+		}
+	})
 
 	t.Run("Should satisfy IT-017 IT-019 and IT-020 with faithful roster and briefing rereads", func(t *testing.T) {
 		t.Parallel()

--- a/internal/store/globaldb/global_db_loop_session_work.go
+++ b/internal/store/globaldb/global_db_loop_session_work.go
@@ -31,13 +31,24 @@ func (g *LoopRepo) ListSessionLoopWork(
 	}
 	result := make([]looppkg.SessionWork, 0, len(rows))
 	for _, row := range rows {
-		work := looppkg.SessionWork{RunID: looppkg.RunID(row.ID)}
+		work := looppkg.SessionWork{
+			RunID:          looppkg.RunID(row.ID),
+			Status:         looppkg.Status(row.Status),
+			NeedsAttention: row.NeedsAttention,
+			OwnsGoal:       row.OwnsGoal != 0,
+		}
 		work.Since, err = store.ParseTimestamp(row.CreatedAt)
 		if err != nil {
 			return nil, err
 		}
 		if row.ReconciledAt != "" {
 			work.ReconciledAt, err = store.ParseTimestamp(row.ReconciledAt)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if row.LeaseUntil != "" {
+			work.LeaseUntil, err = store.ParseTimestamp(row.LeaseUntil)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/store/globaldb/queries/goal_core.sql
+++ b/internal/store/globaldb/queries/goal_core.sql
@@ -20,6 +20,16 @@ WHERE loop_run_id = sqlc.arg(loop_run_id) AND generation = sqlc.arg(generation)
   AND phase = sqlc.arg(phase) AND goal_status = 'active'
   AND session_id = sqlc.arg(session_id) AND binding_handle = sqlc.arg(binding_handle);
 
+-- name: BindGoalCheckpoint :execrows
+UPDATE loop_goal_checkpoints
+SET session_id = sqlc.narg(session_id), binding_handle = sqlc.narg(binding_handle),
+    binding_epoch = sqlc.narg(binding_epoch), context_state = 'unknown', usage_sequence = NULL,
+    usage_pending_after_sequence = NULL, compaction_baseline_used = NULL,
+    updated_at = CAST(sqlc.arg(updated_at) AS TEXT)
+WHERE loop_run_id = sqlc.arg(loop_run_id) AND generation = sqlc.arg(generation)
+  AND node_id = sqlc.arg(node_id) AND item_index = sqlc.arg(item_index)
+  AND control_epoch = sqlc.arg(control_epoch) AND goal_status = 'active' AND phase = 'idle';
+
 -- name: SettleGoalCompactionCheckpoint :execrows
 UPDATE loop_goal_checkpoints
 SET phase = 'idle', goal_status = 'active', control_cause = NULL,

--- a/internal/store/globaldb/queries/goal_runtime.sql
+++ b/internal/store/globaldb/queries/goal_runtime.sql
@@ -38,7 +38,9 @@ FROM loop_goal_session_outbox
 WHERE event_id = sqlc.arg(event_id);
 
 -- name: ReadGoalSessionProjection :one
-SELECT id, status, definition_digest, origin_session_id, goal_context_nudge_ratio, goal_cleared_at
+SELECT id, status, definition_digest, origin_session_id, goal_context_nudge_ratio, goal_cleared_at,
+ EXISTS(SELECT 1 FROM loop_node_controls control WHERE control.loop_run_id = loop_runs.id
+  AND control.quarantined = 1) AS quarantined
 FROM loop_runs
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND origin_kind = 'session'

--- a/internal/store/globaldb/queries/loop_lifecycle.sql
+++ b/internal/store/globaldb/queries/loop_lifecycle.sql
@@ -156,7 +156,17 @@ WHERE loop_run_id = sqlc.arg(loop_run_id)
   AND state = 'pending';
 
 -- name: ListSessionLoopWork :many
-SELECT lr.id, lr.created_at,
+SELECT lr.id, lr.created_at, lr.status,
+ CAST((lr.origin_kind = 'session' AND (lr.origin_session_id = sqlc.arg(session_id)
+  OR EXISTS (SELECT 1 FROM loop_session_bindings binding
+   JOIN loop_goal_checkpoints checkpoint ON checkpoint.loop_run_id = binding.loop_run_id
+    AND checkpoint.binding_handle = binding.handle AND checkpoint.binding_epoch = binding.binding_epoch
+   WHERE binding.loop_run_id = lr.id AND binding.session_id = sqlc.arg(session_id)
+    AND binding.state = 'active'))) AS INTEGER) AS owns_goal,
+ CAST(COALESCE((SELECT MAX(tr.lease_until) FROM task_runs tr
+  WHERE tr.loop_run_id = lr.id AND tr.status IN ('claimed','starting','running')), '') AS TEXT) AS lease_until,
+ EXISTS(SELECT 1 FROM loop_node_controls control WHERE control.loop_run_id = lr.id
+  AND (control.attention_flag != '' OR control.quarantined = 1)) AS needs_attention,
  CAST(COALESCE((SELECT MAX(tr.ended_at) FROM task_runs tr
   WHERE tr.loop_run_id = lr.id AND tr.run_kind = 'coordinator' AND tr.status = 'completed'), '') AS TEXT) AS reconciled_at
 FROM loop_runs lr
@@ -164,7 +174,9 @@ WHERE lr.workspace_id = sqlc.arg(workspace_id)
 AND (sqlc.arg(all_profiles) = 1 OR lr.profile_id = sqlc.arg(profile_id))
 AND lr.status NOT IN ('done','no-op','blocked','failed','exhausted','stalled','canceled')
 AND (lr.origin_session_id = sqlc.arg(session_id) OR lr.id = sqlc.arg(owner_run_id)
- OR EXISTS (SELECT 1 FROM task_runs bound WHERE bound.loop_run_id = lr.id AND bound.session_id = sqlc.arg(session_id)))
+ OR EXISTS (SELECT 1 FROM task_runs bound WHERE bound.loop_run_id = lr.id AND bound.session_id = sqlc.arg(session_id))
+ OR EXISTS (SELECT 1 FROM loop_session_bindings binding WHERE binding.loop_run_id = lr.id
+  AND binding.session_id = sqlc.arg(session_id) AND binding.state = 'active'))
 ORDER BY lr.id;
 
 -- name: ListExpirylessLoopEventWaits :many

--- a/internal/store/globaldb/sqlcgen/goal_core.sql.go
+++ b/internal/store/globaldb/sqlcgen/goal_core.sql.go
@@ -38,6 +38,47 @@ func (q *Queries) ActiveGoalPromptBindingExists(ctx context.Context, arg ActiveG
 	return column_1, err
 }
 
+const bindGoalCheckpoint = `-- name: BindGoalCheckpoint :execrows
+UPDATE loop_goal_checkpoints
+SET session_id = ?1, binding_handle = ?2,
+    binding_epoch = ?3, context_state = 'unknown', usage_sequence = NULL,
+    usage_pending_after_sequence = NULL, compaction_baseline_used = NULL,
+    updated_at = CAST(?4 AS TEXT)
+WHERE loop_run_id = ?5 AND generation = ?6
+  AND node_id = ?7 AND item_index = ?8
+  AND control_epoch = ?9 AND goal_status = 'active' AND phase = 'idle'
+`
+
+type BindGoalCheckpointParams struct {
+	SessionID     sql.NullString `json:"session_id"`
+	BindingHandle sql.NullString `json:"binding_handle"`
+	BindingEpoch  sql.NullInt64  `json:"binding_epoch"`
+	UpdatedAt     string         `json:"updated_at"`
+	LoopRunID     string         `json:"loop_run_id"`
+	Generation    int64          `json:"generation"`
+	NodeID        string         `json:"node_id"`
+	ItemIndex     int64          `json:"item_index"`
+	ControlEpoch  int64          `json:"control_epoch"`
+}
+
+func (q *Queries) BindGoalCheckpoint(ctx context.Context, arg BindGoalCheckpointParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, bindGoalCheckpoint,
+		arg.SessionID,
+		arg.BindingHandle,
+		arg.BindingEpoch,
+		arg.UpdatedAt,
+		arg.LoopRunID,
+		arg.Generation,
+		arg.NodeID,
+		arg.ItemIndex,
+		arg.ControlEpoch,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getGoalPromptRow = `-- name: GetGoalPromptRow :one
 SELECT id, session_id, status, text, task_run_id, run_generation,
        loop_run_id, owner_kind, owner_epoch, binding_epoch, prompt_id, prompt_kind,

--- a/internal/store/globaldb/sqlcgen/goal_runtime.sql.go
+++ b/internal/store/globaldb/sqlcgen/goal_runtime.sql.go
@@ -292,7 +292,9 @@ func (q *Queries) GetLoopSessionCleanup(ctx context.Context, cleanupID string) (
 }
 
 const readGoalSessionProjection = `-- name: ReadGoalSessionProjection :one
-SELECT id, status, definition_digest, origin_session_id, goal_context_nudge_ratio, goal_cleared_at
+SELECT id, status, definition_digest, origin_session_id, goal_context_nudge_ratio, goal_cleared_at,
+ EXISTS(SELECT 1 FROM loop_node_controls control WHERE control.loop_run_id = loop_runs.id
+  AND control.quarantined = 1) AS quarantined
 FROM loop_runs
 WHERE workspace_id = ?1
   AND origin_kind = 'session'
@@ -314,6 +316,7 @@ type ReadGoalSessionProjectionRow struct {
 	OriginSessionID       sql.NullString `json:"origin_session_id"`
 	GoalContextNudgeRatio float64        `json:"goal_context_nudge_ratio"`
 	GoalClearedAt         sql.NullTime   `json:"goal_cleared_at"`
+	Quarantined           bool           `json:"quarantined"`
 }
 
 func (q *Queries) ReadGoalSessionProjection(ctx context.Context, arg ReadGoalSessionProjectionParams) (ReadGoalSessionProjectionRow, error) {
@@ -326,6 +329,7 @@ func (q *Queries) ReadGoalSessionProjection(ctx context.Context, arg ReadGoalSes
 		&i.OriginSessionID,
 		&i.GoalContextNudgeRatio,
 		&i.GoalClearedAt,
+		&i.Quarantined,
 	)
 	return i, err
 }

--- a/internal/store/globaldb/sqlcgen/loop_lifecycle.sql.go
+++ b/internal/store/globaldb/sqlcgen/loop_lifecycle.sql.go
@@ -741,38 +741,54 @@ func (q *Queries) ListRetryingLoopNodeInventory(ctx context.Context, arg ListRet
 }
 
 const listSessionLoopWork = `-- name: ListSessionLoopWork :many
-SELECT lr.id, lr.created_at,
+SELECT lr.id, lr.created_at, lr.status,
+ CAST((lr.origin_kind = 'session' AND (lr.origin_session_id = ?1
+  OR EXISTS (SELECT 1 FROM loop_session_bindings binding
+   JOIN loop_goal_checkpoints checkpoint ON checkpoint.loop_run_id = binding.loop_run_id
+    AND checkpoint.binding_handle = binding.handle AND checkpoint.binding_epoch = binding.binding_epoch
+   WHERE binding.loop_run_id = lr.id AND binding.session_id = ?1
+    AND binding.state = 'active'))) AS INTEGER) AS owns_goal,
+ CAST(COALESCE((SELECT MAX(tr.lease_until) FROM task_runs tr
+  WHERE tr.loop_run_id = lr.id AND tr.status IN ('claimed','starting','running')), '') AS TEXT) AS lease_until,
+ EXISTS(SELECT 1 FROM loop_node_controls control WHERE control.loop_run_id = lr.id
+  AND (control.attention_flag != '' OR control.quarantined = 1)) AS needs_attention,
  CAST(COALESCE((SELECT MAX(tr.ended_at) FROM task_runs tr
   WHERE tr.loop_run_id = lr.id AND tr.run_kind = 'coordinator' AND tr.status = 'completed'), '') AS TEXT) AS reconciled_at
 FROM loop_runs lr
-WHERE lr.workspace_id = ?1
-AND (?2 = 1 OR lr.profile_id = ?3)
+WHERE lr.workspace_id = ?2
+AND (?3 = 1 OR lr.profile_id = ?4)
 AND lr.status NOT IN ('done','no-op','blocked','failed','exhausted','stalled','canceled')
-AND (lr.origin_session_id = ?4 OR lr.id = ?5
- OR EXISTS (SELECT 1 FROM task_runs bound WHERE bound.loop_run_id = lr.id AND bound.session_id = ?4))
+AND (lr.origin_session_id = ?1 OR lr.id = ?5
+ OR EXISTS (SELECT 1 FROM task_runs bound WHERE bound.loop_run_id = lr.id AND bound.session_id = ?1)
+ OR EXISTS (SELECT 1 FROM loop_session_bindings binding WHERE binding.loop_run_id = lr.id
+  AND binding.session_id = ?1 AND binding.state = 'active'))
 ORDER BY lr.id
 `
 
 type ListSessionLoopWorkParams struct {
+	SessionID   sql.NullString `json:"session_id"`
 	WorkspaceID string         `json:"workspace_id"`
 	AllProfiles any            `json:"all_profiles"`
 	ProfileID   string         `json:"profile_id"`
-	SessionID   sql.NullString `json:"session_id"`
 	OwnerRunID  string         `json:"owner_run_id"`
 }
 
 type ListSessionLoopWorkRow struct {
-	ID           string `json:"id"`
-	CreatedAt    string `json:"created_at"`
-	ReconciledAt string `json:"reconciled_at"`
+	ID             string `json:"id"`
+	CreatedAt      string `json:"created_at"`
+	Status         string `json:"status"`
+	OwnsGoal       int64  `json:"owns_goal"`
+	LeaseUntil     string `json:"lease_until"`
+	NeedsAttention bool   `json:"needs_attention"`
+	ReconciledAt   string `json:"reconciled_at"`
 }
 
 func (q *Queries) ListSessionLoopWork(ctx context.Context, arg ListSessionLoopWorkParams) ([]ListSessionLoopWorkRow, error) {
 	rows, err := q.db.QueryContext(ctx, listSessionLoopWork,
+		arg.SessionID,
 		arg.WorkspaceID,
 		arg.AllProfiles,
 		arg.ProfileID,
-		arg.SessionID,
 		arg.OwnerRunID,
 	)
 	if err != nil {
@@ -782,7 +798,15 @@ func (q *Queries) ListSessionLoopWork(ctx context.Context, arg ListSessionLoopWo
 	items := []ListSessionLoopWorkRow{}
 	for rows.Next() {
 		var i ListSessionLoopWorkRow
-		if err := rows.Scan(&i.ID, &i.CreatedAt, &i.ReconciledAt); err != nil {
+		if err := rows.Scan(
+			&i.ID,
+			&i.CreatedAt,
+			&i.Status,
+			&i.OwnsGoal,
+			&i.LeaseUntil,
+			&i.NeedsAttention,
+			&i.ReconciledAt,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/packages/site/content/docs/loops/goals.mdx
+++ b/packages/site/content/docs/loops/goals.mdx
@@ -139,7 +139,7 @@ change the objective with expected-Run replacement or clear the projection inste
 
 ## Stop, remove, or recover a Goal
 
-Stopping the origin or current bound session explicitly cancels its session Goal. If cancellation fails, stop settlement remains pending and retains its recovery receipt. Retry the stop, or restart the daemon to replay the pending cancellation. Removing that
+Stopping the origin or current bound session explicitly cancels its session Goal. Removal first stops execution; if deleting history later fails, the retained session stays stopped and the Goal stays canceled. If cancellation fails, stop settlement remains pending and retains its recovery receipt. Retry the stop, or restart the daemon to replay the pending cancellation. Removing that
 session cancels its Goal before removing session history. The Run, turns, and task audit stay
 inspectable. Closing only a window, disconnecting a stream, or restarting the daemon does not cancel
 a committed Goal. Informational origins of catalog Loops retain their separate lifecycle.

--- a/packages/site/content/docs/loops/goals.mdx
+++ b/packages/site/content/docs/loops/goals.mdx
@@ -139,7 +139,7 @@ change the objective with expected-Run replacement or clear the projection inste
 
 ## Stop, remove, or recover a Goal
 
-Stopping the origin or current bound session explicitly cancels its session Goal. Removing that
+Stopping the origin or current bound session explicitly cancels its session Goal. If cancellation fails, stop settlement remains pending and retains its recovery receipt. Retry the stop, or restart the daemon to replay the pending cancellation. Removing that
 session cancels its Goal before removing session history. The Run, turns, and task audit stay
 inspectable. Closing only a window, disconnecting a stream, or restarting the daemon does not cancel
 a committed Goal. Informational origins of catalog Loops retain their separate lifecycle.

--- a/packages/site/content/docs/loops/goals.mdx
+++ b/packages/site/content/docs/loops/goals.mdx
@@ -137,6 +137,34 @@ Pause and approval re-entry enqueue one successor segment under a new control ep
 resume/approve calls do not create multiple successors. A terminal `blocked` Run stays terminal;
 change the objective with expected-Run replacement or clear the projection instead of resuming it.
 
+## Stop, remove, or recover a Goal
+
+Stopping the origin or current bound session explicitly cancels its session Goal. Removing that
+session cancels its Goal before removing session history. The Run, turns, and task audit stay
+inspectable. Closing only a window, disconnecting a stream, or restarting the daemon does not cancel
+a committed Goal. Informational origins of catalog Loops retain their separate lifecycle.
+
+A canceled Goal shows a terminal `run_status: canceled`, `live: false`, and Goal status `paused`,
+including when it stopped before the first work turn. Resume is unavailable. A quarantined Goal
+shows `blocked` with `node_quarantined`; inspect its Run and requeue the node after repairing the
+cause, or cancel it. Previous failed attempts remain in the audit.
+
+If an older Goal outlived a session that was already removed, use its Run controls:
+
+```bash
+compozy loop runs --origin session --origin-session sess_123 -o json
+compozy loop cancel --run-id run_123 -o json
+compozy loop status --run-id run_123 -o json
+```
+
+Cancellation is idempotent and does not require the missing session. A missing-session error on
+session controls and a connection refusal from an unavailable daemon are different failures;
+reconnect to the owning daemon before operating on its Run.
+
+Active task leases keep ongoing Goal work fresh even before its first completed coordinator pass.
+Status reads do not extend those leases or wait deadlines. Real expired work, quarantine, approval,
+and intervention still surface Needs attention, including while the agent produces other progress.
+
 ## Audit turns
 
 Every durably started work prompt consumes one monotonic Goal turn. Compaction does not. Read the

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -280,6 +280,33 @@ bounded criterion diagnostics and aggregate warnings. Command criteria include o
 standard output, standard error, blockers, and warnings when present; continuation prompts and the
 Web timeline use that durable evidence.
 
+### Session stop, removal, and recovery
+
+Explicitly stopping a session-origin Goal's origin or current bound session cancels its live Run
+through the canonical cancellation path. Removing the session does the same before deleting its
+session history. Run, turn, and task audit records remain available. Catalog Loop origin lineage
+stays informational; stopping that origin does not cancel independent catalog work. Daemon shutdown
+and closing a window or disconnecting a stream do not mean an operator stopped the Goal session.
+
+A canceled Run is terminal even when it never reached its first Goal checkpoint. Its Goal projection
+is non-live, with `run_status: canceled` and `status: paused`; it cannot resume. A live quarantined
+Goal reports `status: blocked` and `cause: node_quarantined`. Inspect the node audit and use node
+requeue after repairing the cause, or cancel the Run. Repeated failed generations remain history,
+not new work; the reserved quarantine continuation is parked for explicit recovery.
+
+For older orphaned Goals whose session is already gone, use `compozy loop runs --origin session
+--origin-session <id> -o json`, then `compozy loop cancel --run-id <run-id> -o json`.
+Run cancellation does not require a live session and is idempotent. Verify terminal truth through
+`compozy loop status --run-id <run-id> -o json`; retained turns and node/task audit remain inspectable.
+A missing-session response from a session-scoped control is not evidence that Run cancellation failed.
+Connection refusal means the daemon is unavailable; reconnect to the owning daemon before retrying.
+
+Known context is adopted under the exact active binding before the first Goal prompt and is reread
+from its pinned event sequence. Unknown context remains unknown; pending compaction still requires
+newer evidence. Initial admission, ongoing task leases, and admitted wait deadlines bound Loop work
+freshness. Status reads never extend those bounds. Expired evidence remains stale attention, while
+quarantine, intervention, and approval retain explicit attention even alongside fresh agent progress.
+
 ## Terminal Outcomes And Live States
 
 When a Loop reaches a terminal state, CompozyOS settles its coordinator and cell task records in the

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -284,7 +284,9 @@ Web timeline use that durable evidence.
 
 Explicitly stopping a session-origin Goal's origin or current bound session cancels its live Run
 through the canonical cancellation path. Removing the session does the same before deleting its
-session history. Run, turn, and task audit records remain available. Catalog Loop origin lineage
+session history. If Goal cancellation fails, the existing stop settlement receipt remains durable;
+retrying the stop or restarting the daemon retries cancellation before settlement completes.
+Run, turn, and task audit records remain available. Catalog Loop origin lineage
 stays informational; stopping that origin does not cancel independent catalog work. Daemon shutdown
 and closing a window or disconnecting a stream do not mean an operator stopped the Goal session.
 


### PR DESCRIPTION
## Problem and result

Closes #595.

Starting a session's own Goal could immediately fail context validation while the ordinary prompt kept working. The Goal strip still reported an active Run with zero turns, Tasks showed failed or quarantined work, and session supervision raised stale Loop attention. Explicitly stopping or removing the session also left its Goal alive, making session-based cancellation unusable after removal.

This change adopts the active binding before the first context observation, repairs pinned context reads, derives bounded Loop activity from durable execution evidence, and routes explicit session stop/removal through canonical Run cancellation. Terminal Run state and quarantine now govern the Goal projection. Historical attempts remain inspectable.

## Evidenced root causes

1. **Initial binding was ahead of the checkpoint.** The managed binder had activated a binding, but the checkpoint still had `BindingEpoch=0`. `recordContextUsage` combined that old checkpoint epoch with the new binding's session and handle. The first context observation therefore failed before prompt preparation could advance the checkpoint. A real SQLite/managed-runtime regression reproduced the exact zero epoch; the old executor fake had hidden it by mutating the checkpoint during binding.
2. **Known-context reads used incompatible cursors.** The first isolated Codex walk exposed a second failure: `UsageAtSequence` supplied both `AfterSequence` and `BeforeSequence`, which the session event store rejects. The corrected forward, one-result query still requires the exact pinned sequence; missing or non-usage events remain unknown.
3. **Freshness only recognized completed coordinators.** Initial ongoing work can have no completed coordinator timestamp. Active task leases and admitted wait deadlines now contribute bounded freshness. Status reads never renew that evidence, and expired work remains stale. Quarantine, approvals, and intervention remain explicit attention even alongside fresh agent progress.
4. **Ordinary Goal sessions had no stop/removal cancellation hook.** The existing coordinator-stop path did not cover a user session's own Goal. The session lifecycle now invokes canonical cancellation for session-origin Goals, using the existing durable cleanup outbox. The cancellation adapter avoids re-entering an already stopped session while retaining missing/inactive-session handling and propagation of real stop failures.

## Implementation and compatibility

- Added transactional checkpoint binding adoption with task, control epoch, binding epoch, phase, session, handle, and workspace validation. Re-adopting the same binding preserves context freshness floors; changing a binding is prohibited while a prompt is pending.
- Retained the existing stop settlement receipt until Goal cancellation succeeds, with retry and boot recovery under the original stop cause. The cancellation handler is installed before boot settlement.
- Kept compaction rotation under the original checkpoint fence until the replacement binding is adopted.
- Extended internal Loop work/projection queries and regenerated their sqlc consumers through `make codegen`.
- Made canceled/terminal Run truth override stale active checkpoints; live quarantine projects as `blocked` with `node_quarantined`.
- Preserved the current base's canonical quarantine task parking and historical attempt semantics, with existing requeue/parking coverage.
- Updated the operator guide, official Compozy Loop reference, affected QA scenario slices, and the owning `docs/_memory/change-impact.md` record and QA report.

No public DTO shape, tool ID, configuration key, hook, extension SDK, or database schema changes. Immutable profile/workspace scoping remains in place. Catalog Loop origin lineage remains informational. Window-only dismissal, stream disconnect, and daemon shutdown do not acquire Goal cancellation semantics. A historical orphan can still be canceled through `compozy loop cancel --run-id ...` without its missing session.

## Verification

- Canonical Goal executor/context tests and real-store ownership, projection, supervision, quarantine/parking, and requeue suites passed.
- Existing public daemon subprocess E2E passed controls, approval recovery, disconnect/restart, and new stop/removal followed by repeated Run cancellation.
- Isolated real **Codex / gpt-6-astra / high** self-activation during ordinary prompts: current context and Loop supervision; approved Goals completed in two turns and one turn respectively. The second delivery reused the first billing utility and passed twelve actual CLI tests.
- Real explicit stop: the session became stopped and its Run/Tasks canceled before manual cancellation; supervision emptied. Real removal: the session returned 404 while canceled Run/Task history remained readable; repeated Run cancellation succeeded.
- Browser: expanded Goal strip showed Done, settled, known context, and approved verdict. Window-only dismissal preserved a live paused Goal. Final isolated daemon restart retained canceled, done, and paused Run states, and the browser reloaded retained history.
- Site typecheck/build passed through root Turborepo: `bunx turbo run typecheck build --filter=@compozy/site`.
- React Doctor changed-source scan found no changed React source files. Its current-head PR check and all Greptile/CodeRabbit findings, including nitpicks and outside-diff comments, remain delivery requirements.
- Isolated lab teardown completed with `clean: true`.

At the author’s request, complete delivery gates run in CI. Before local gates were stopped, code generation, lint, and the full daemon race suite passed; the global database race suite was interrupted and is not claimed as passed. Current-head CI results will be updated after completion.

## Remaining validation boundary

A real structured clarification correctly surfaced waiting-for-input. Execution approval review blocked the synthetic operator answer, so that answer-and-continue step is **not claimed as validated**. No alternate answer path was used; the agent did not guess and paused its Goal after the question expired. The fixture-backed public E2E approval-recovery flow did pass. The focused lab does not claim a full multi-agent Network sweep, live-provider Linux dogfooding, or Electron execution.

Detailed sanitized evidence and cross-surface impact: `docs/qa/reports/2026-09-10-issue-595-goal-lifecycle.md`.
