### PR TITLE
fix: deduplicate delivered skill context and gate input-only roles

### DIFF
--- a/docs/qa/reports/2026-09-10-skills-prompt-dedup.md
+++ b/docs/qa/reports/2026-09-10-skills-prompt-dedup.md
@@ -1,0 +1,96 @@
+# Skills catalog delivery and input-only roles
+
+Issue: [#604](https://github.com/compozy/compozy/issues/604). Baseline:
+`ed7f2d7adc2d7ec38071677d28a2d6e87a019c28`.
+
+## Cause and correction
+
+The skills augmenter remembered rendered catalogs during preparation. Startup used different
+tags and instructions and never entered that cache. Consequently the first request repeated the
+catalog, and preparing a failed request could establish an unseen catalog as current.
+
+The augmenter now registers the complete filtered current catalog, its equivalent startup
+rendering, and the existing unchanged marker with one dispatch attempt. The ACP boundary compacts
+the registered section only when its equivalent startup is included by the current delivery mode
+or the process has confirmed the same current catalog. A successful, uncanceled ACP response
+records that context. Failure/cancellation invalidates uncertain context. Recovery retains full
+input, and a fresh process owns a fresh context record. Duplicate or omitted registered content
+is not treated as a confirmed section. No process-wide catalog LRU remains.
+
+The existing input-only role predicate now also excludes startup and live skills and situation
+context for memory extraction, automatic titles, and checkpoint summaries. Runtime identity,
+authored instructions, ordinary workers, unknown roles, and skill authorization retain their
+existing behavior.
+
+## Measurement method
+
+The owning harness integration scenario uses the production assembler, registry, role resolver,
+session manager, real SQLite, and the existing ACP mock subprocess. It seeds 23 local fixture
+skills alongside bundled skills, sends first/unchanged/changed turns, and creates the three
+input-only role sessions. Receiver diagnostics measure actual UTF-8 prompt bytes. Role fixtures
+use a common instruction and input to isolate harness overhead; these are not production
+extractor transcript sizes, tokenizer counts, provider billing, or model-compliance measurements.
+
+The baseline uses a Go overlay containing the three original daemon source files from the base
+commit; it does not modify another checkout. The same receiver scenario detects the original
+first-turn and role failures. Both runs used the same fixture and input; generated timestamps
+and session metadata can vary by a few bytes.
+
+| Received prompt | Before bytes | After bytes | Before skill entries | After skill entries |
+| --- | ---: | ---: | ---: | ---: |
+| Ordinary first turn | 22,751 | 19,947 | 48 | 24 |
+| Ordinary unchanged turn | 1,656 | 1,655 | 0 | 0 |
+| Ordinary changed turn (one addition) | 4,523 | 4,523 | 25 | 25 |
+| Memory extractor | 11,192 | 1,452 | 50 | 0 |
+| Auto title | 11,186 | 1,452 | 50 | 0 |
+| Checkpoint summary | 11,097 | 1,450 | 50 | 0 |
+
+The observed first-turn reduction is 2,804 bytes (12.3% of this complete prompt). Input-only
+reductions are 9,647–9,740 bytes (86.9–87.0%). These differences are calculated from measured
+receiver payloads, not projected token or billing savings. Ordinary situation context remains
+present. All input-only payloads omit both catalogs and situation context. The unchanged marker
+and changed full catalog remain observable after the correction.
+
+The corrected measurement scenario passes with the race detector. Running the same scenario
+against the baseline overlay fails specifically on first-turn duplication and all three role
+context assertions, reproducing the reported defects.
+
+## Verification ownership
+
+- Registry visibility, provider filtering, activation, and exact-source invocation remain owned
+  by the existing daemon skill suites.
+- `TestPromptCompactsDeliveredSections` owns startup/native delivery, unchanged/changed turns,
+  failed preparation, provider error, cancellation, removed context, and fresh-process behavior.
+- Harness resolver and integration suites own role gating and persisted-role resume.
+- The extension-agent E2E scenario owns startup catalog availability plus explicit invocation
+  through the real daemon, HTTP, hosted MCP, and ACP subprocess.
+- The test-shape checker passes the changed daemon suites. Its four ACP findings are unchanged
+  baseline cases outside this change; new cases use the canonical subtest form.
+
+## Cross-surface impact
+
+Audit under `docs/_memory/change-impact.md`:
+
+| Surface | Impact |
+| --- | --- |
+| Native tools | No IDs, schemas, permissions, approval gates, or dispatch changes. Catalog prompt compaction is not authorization. |
+| Extensions, hooks, configuration | Current registry resolution and provider filtering remain live. No new configuration or extension contract. Explicit skill activation retains its existing path. |
+| Workspace data | Confirmed context belongs to one ACP process; only hashes persist in its memory. Recovery requests retain their own full section copies. No database shape or stored-user-state change. |
+| Official skill | Existing unchanged-marker and latest-full-context guidance remains applicable; native skill reads and resources are unchanged. |
+| Web and docs | No UI or public wire changes. The bundled-skills guide and ET-049 explain the delivery and role behavior. |
+| Compatibility | Internal prompt preparation changes only. No migration, compatibility alias, or user action is required. |
+
+Executed validation:
+
+- Focused race suites for ACP section delivery, daemon catalog resolution, and role policy: pass.
+- `TestHarnessContextIntegrationScopesToolGuidanceForInternalCallers` with `-race -tags=integration`:
+  pass, including persisted-role resume with skills enabled and disabled.
+- `TestHarnessContextIntegrationMeasuresDeliveredSkillCatalogs` with `-race -tags=integration`:
+  pass; measurements above come from its ACP receiver diagnostics.
+- `TestDaemonE2EExtensionPublishedAgentSessionCommandsAndPrompt` with `-race -tags=integration`:
+  pass through the real daemon, HTTP, hosted MCP, and ACP fixture subprocess.
+- `make gate`: final result recorded in the PR validation evidence.
+
+Runtime checks use isolated temporary homes and owned subprocess cleanup. The user's daemon is
+not restarted. Linux race parity remains subject to current-head CI; no live inference-provider
+or Windows runtime validation is claimed.

--- a/docs/qa/scenarios/ET-049.md
+++ b/docs/qa/scenarios/ET-049.md
@@ -77,3 +77,21 @@ Owning automated checks: `TestComposedAssemblerAssembleStartupLoadsBundledToolsS
 `TestHarnessContextIntegrationScopesToolGuidanceForInternalCallers`, and the existing native skill
 catalog dispatch case in `TestDaemonNativeTools`. Record assembled prompt byte counts and the
 integration/E2E result in [the scoped startup guidance report](../reports/2026-09-09-scoped-tool-prompts.md).
+
+## Catalog delivery and input-only context
+
+Verify the first ACP request advertises each skill once when startup and live catalogs match,
+using the live `unchanged` marker. An unchanged second turn retains the marker; adding, removing,
+or changing visible skills sends a full current catalog. Preserve provider/policy filtering and
+explicit skill invocation. A failed or canceled request must not make unseen context reusable;
+a new process or recovered ACP binding must receive sufficient full context again.
+
+Memory extraction, automatic title generation, and checkpoint summarization omit startup/live
+skill catalogs and situation context while retaining runtime identity and their input instructions.
+Ordinary workers and unknown roles retain useful context. Exercise persisted roles through resume.
+
+Owning suites: `TestPromptCompactsDeliveredSections`,
+`TestHarnessContextResolverScopesInputOnlyContext`,
+`TestHarnessContextIntegrationMeasuresDeliveredSkillCatalogs`, and the existing extension-agent
+E2E skill invocation scenario. Record receiver payload measurements and their scope in the
+[catalog delivery report](../reports/2026-09-10-skills-prompt-dedup.md).

--- a/internal/acp/agent_process.go
+++ b/internal/acp/agent_process.go
@@ -2,6 +2,7 @@ package acp
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"os/exec"
 	"sync"
@@ -74,6 +75,7 @@ type AgentProcess struct {
 	systemPromptMu       sync.Mutex
 	systemPrompt         string
 	systemPromptSent     bool
+	deliveredSections    map[string][sha256.Size]byte
 	systemPromptDelivery SystemPromptDeliveryMode
 	promptCacheControl   *promptCacheControl
 

--- a/internal/acp/client_prompt.go
+++ b/internal/acp/client_prompt.go
@@ -14,7 +14,11 @@ import (
 )
 
 func (d *Driver) runPrompt(ctx context.Context, proc *AgentProcess, active *activePromptState, req PromptRequest) {
+	sectionsDelivered := false
 	defer func() {
+		if !sectionsDelivered {
+			proc.forgetPromptSections(req.Sections)
+		}
 		if active != nil && active.cancel != nil {
 			active.cancel()
 		}
@@ -52,6 +56,10 @@ func (d *Driver) runPrompt(ctx context.Context, proc *AgentProcess, active *acti
 	if _, included := promptRequest.Meta["system"]; included {
 		proc.markSystemPromptSent()
 	}
+	if ctx.Err() == nil && response.StopReason != acpsdk.StopReasonCancelled {
+		proc.markPromptSectionsDelivered(req)
+		sectionsDelivered = true
+	}
 
 	usage := proc.mergePromptUsage(tokenUsageFromPromptResponse(req.TurnID, response.Usage))
 	doneEvent := AgentEvent{
@@ -73,7 +81,8 @@ func buildWirePromptRequest(proc *AgentProcess, req PromptRequest) (acpsdk.Promp
 	if err != nil {
 		return acpsdk.PromptRequest{}, err
 	}
-	promptText, includedSystemPrompt, promptDelivery := proc.nextPromptText(req.Message)
+	message := proc.compactPromptSections(req.Message, req.Sections)
+	promptText, includedSystemPrompt, promptDelivery := proc.nextPromptText(message)
 	prompt := make([]acpsdk.ContentBlock, 0, 1+len(req.Attachments))
 	if promptText != "" {
 		prompt = append(prompt, textBlockWithPromptCacheControl(promptText, proc.promptCacheControl))

--- a/internal/acp/client_prompt_contract_test.go
+++ b/internal/acp/client_prompt_contract_test.go
@@ -192,6 +192,122 @@ func TestPromptPrependsSystemPromptOnce(t *testing.T) {
 	}
 }
 
+func TestPromptCompactsDeliveredSections(t *testing.T) {
+	t.Parallel()
+	for _, native := range []bool{false, true} {
+		t.Run(
+			fmt.Sprintf("Should compact startup and confirmed catalogs with native delivery %t", native),
+			func(t *testing.T) {
+				t.Parallel()
+				section := PromptSection{Key: "skills", Content: "<current>alpha</current>",
+					StartupContent: "<startup>alpha</startup>", UnchangedContent: "<unchanged/>"}
+				opts := StartOpts{SystemPrompt: section.StartupContent}
+				if native {
+					opts.SystemPromptDelivery = SystemPromptDeliveryNative
+				}
+				driver := New()
+				proc := startHelperProcess(t, driver, "echo_prompt", "", opts)
+				defer stopProcess(t, driver, proc)
+				for index, change := range []bool{false, false, true, false} {
+					if change {
+						section.Content = "<current>alpha beta</current>"
+						section.StartupContent = "<startup>alpha beta</startup>"
+					}
+					request := PromptRequest{
+						TurnID:   fmt.Sprintf("turn-%d", index),
+						Message:  section.Content + "\nrequest",
+						Sections: []PromptSection{section},
+					}
+					events, err := driver.Prompt(t.Context(), proc, request)
+					if err != nil {
+						t.Fatal(err)
+					}
+					got := collectEvents(t, events)
+					if len(got) == 0 {
+						t.Fatal("missing echoed wire payload")
+					}
+					if strings.Contains(got[0].Text, section.Content) != change ||
+						strings.Contains(got[0].Text, section.UnchangedContent) == change {
+						t.Fatalf("turn %d wire payload = %q", index, got[0].Text)
+					}
+					if request.Message != section.Content+"\nrequest" {
+						t.Fatal("compaction mutated retry input")
+					}
+				}
+			},
+		)
+	}
+	t.Run("Should resend unseen sections after build failure and on a fresh process", func(t *testing.T) {
+		t.Parallel()
+		section := PromptSection{
+			Key:              "skills",
+			Content:          "<current>new</current>",
+			StartupContent:   "<startup>new</startup>",
+			UnchangedContent: "<unchanged/>",
+		}
+		req := PromptRequest{TurnID: "turn", Message: section.Content, Sections: []PromptSection{section}}
+		proc := &AgentProcess{systemPrompt: "<startup>old</startup>"}
+		invalid := req
+		invalid.Attachments = []PromptAttachment{{Name: "image.png", MIMEType: "image/png", Data: []byte("image")}}
+		if _, err := buildWirePromptRequest(proc, invalid); !errors.Is(err, ErrPromptImagesUnsupported) {
+			t.Fatalf("attachment error = %v", err)
+		}
+		for range 2 {
+			wire, err := buildWirePromptRequest(proc, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(wire.Prompt[0].Text.Text, section.Content) {
+				t.Fatal("preparing an unsent request advanced context")
+			}
+		}
+		proc.markPromptSectionsDelivered(req)
+		if got := proc.compactPromptSections(req.Message, req.Sections); got != section.UnchangedContent {
+			t.Fatalf("confirmed context = %q", got)
+		}
+		fresh := &AgentProcess{}
+		if got := fresh.compactPromptSections(req.Message, req.Sections); got != section.Content {
+			t.Fatalf("fresh process reused unseen context: %q", got)
+		}
+		proc.markPromptSectionsDelivered(PromptRequest{Message: "empty", Sections: []PromptSection{{Key: "skills"}}})
+		if got := proc.compactPromptSections(req.Message, req.Sections); got != section.Content {
+			t.Fatalf("removed context remained current: %q", got)
+		}
+	})
+	for _, scenario := range []string{"prompt_request_error_with_reason", "block_prompt_until_cancel"} {
+		t.Run("Should invalidate uncertain context after "+scenario, func(t *testing.T) {
+			t.Parallel()
+			driver := New()
+			proc := startHelperProcess(t, driver, scenario, "", StartOpts{})
+			defer stopProcess(t, driver, proc)
+			section := PromptSection{Key: "skills", Content: "full catalog", UnchangedContent: "unchanged"}
+			req := PromptRequest{TurnID: "failed-turn", Message: section.Content, Sections: []PromptSection{section}}
+			proc.markPromptSectionsDelivered(req)
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			events, err := driver.Prompt(ctx, proc, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario == "block_prompt_until_cancel" {
+				select {
+				case event := <-events:
+					if event.Text != "blocking" {
+						t.Fatalf("unexpected event: %#v", event)
+					}
+				case <-t.Context().Done():
+					t.Fatal("prompt never started")
+				}
+				cancel()
+			}
+			collectEvents(t, events)
+			if got := proc.compactPromptSections(req.Message, req.Sections); got != section.Content {
+				t.Fatalf("failed delivery retained uncertain context: %q", got)
+			}
+		})
+	}
+}
+
 func TestPromptAttachesSystemPromptDeliveryMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/acp/prompt_sections.go
+++ b/internal/acp/prompt_sections.go
@@ -1,0 +1,92 @@
+package acp
+
+import (
+	"context"
+	"crypto/sha256"
+	"slices"
+	"strings"
+	"sync"
+)
+
+// PromptSection retains full context until the transport confirms its delivery.
+type PromptSection struct {
+	Key              string
+	Content          string
+	StartupContent   string
+	UnchangedContent string
+}
+
+type promptSectionsKey struct{}
+
+type promptSections struct {
+	mu       sync.Mutex
+	sections []PromptSection
+}
+
+// CollectPromptSections collects daemon-owned context for one dispatch attempt.
+func CollectPromptSections(ctx context.Context) (context.Context, func() []PromptSection) {
+	collector := &promptSections{}
+	return context.WithValue(ctx, promptSectionsKey{}, collector), func() []PromptSection {
+		collector.mu.Lock()
+		defer collector.mu.Unlock()
+		return slices.Clone(collector.sections)
+	}
+}
+
+// RegisterPromptSection keeps compaction metadata out of provider-visible prompt metadata.
+func RegisterPromptSection(ctx context.Context, section PromptSection) {
+	collector, ok := ctx.Value(promptSectionsKey{}).(*promptSections)
+	if !ok {
+		return
+	}
+	collector.mu.Lock()
+	defer collector.mu.Unlock()
+	collector.sections = append(collector.sections, section)
+}
+
+func (p *AgentProcess) compactPromptSections(message string, sections []PromptSection) string {
+	p.systemPromptMu.Lock()
+	defer p.systemPromptMu.Unlock()
+	for _, section := range sections {
+		if section.Key == "" || section.Content == "" || section.UnchangedContent == "" {
+			continue
+		}
+		if strings.Count(message, section.Content) != 1 {
+			continue
+		}
+		signature, delivered := p.deliveredSections[section.Key]
+		unchanged := delivered && signature == sha256.Sum256([]byte(section.Content))
+		startup := !p.systemPromptSent && section.StartupContent != "" &&
+			strings.Contains(p.systemPrompt, section.StartupContent)
+		if unchanged || startup {
+			message = strings.Replace(message, section.Content, section.UnchangedContent, 1)
+		}
+	}
+	return message
+}
+
+func (p *AgentProcess) markPromptSectionsDelivered(req PromptRequest) {
+	p.systemPromptMu.Lock()
+	defer p.systemPromptMu.Unlock()
+	for _, section := range req.Sections {
+		if section.Key == "" {
+			continue
+		}
+		if section.Content == "" || strings.Count(req.Message, section.Content) != 1 {
+			delete(p.deliveredSections, section.Key)
+			continue
+		}
+		if p.deliveredSections == nil {
+			p.deliveredSections = make(map[string][sha256.Size]byte)
+		}
+		p.deliveredSections[section.Key] = sha256.Sum256([]byte(section.Content))
+	}
+}
+
+func (p *AgentProcess) forgetPromptSections(sections []PromptSection) {
+	p.systemPromptMu.Lock()
+	defer p.systemPromptMu.Unlock()
+	for _, section := range sections {
+		delete(p.deliveredSections, section.Key)
+	}
+}

--- a/internal/acp/types.go
+++ b/internal/acp/types.go
@@ -177,6 +177,7 @@ type PromptRequest struct {
 	RunID                     string
 	Generation                int64
 	Message                   string
+	Sections                  []PromptSection
 	Attachments               []PromptAttachment
 	Meta                      PromptMeta
 	ActivityReporter          PromptActivityReporter

--- a/internal/daemon/daemon_extension_agent_fixture_e2e_integration_test.go
+++ b/internal/daemon/daemon_extension_agent_fixture_e2e_integration_test.go
@@ -41,8 +41,9 @@ var (
 	extensionCurrentPromptCatalogPattern = regexp.MustCompile(
 		`(?s)<current-available-skills>(.*?)</current-available-skills>`,
 	)
-	extensionPromptSkillNamePattern = regexp.MustCompile(`<skill name="([^"]+)">`)
-	reviewerSkillNames              = append([]string{"compozy"}, specCycleIntegrationSkillNames...)
+	extensionStartupPromptCatalogPattern = regexp.MustCompile(`(?s)<available-skills>(.*?)</available-skills>`)
+	extensionPromptSkillNamePattern      = regexp.MustCompile(`<skill name="([^"]+)">`)
+	reviewerSkillNames                   = append([]string{"compozy"}, specCycleIntegrationSkillNames...)
 )
 
 func TestDaemonE2EExtensionPublishedAgentSessionCommandsAndPrompt(t *testing.T) {
@@ -141,6 +142,9 @@ func assertExtensionPromptCatalog(t testing.TB, diagnosticsPath string) {
 	}
 	for _, record := range acpmock.PromptDiagnostics(records) {
 		if strings.Contains(record.Prompt, "<current-available-skills>") {
+			if !strings.Contains(record.Prompt, `<catalog-state unchanged="true">`) {
+				t.Fatal("first extension prompt duplicated its startup skill catalog")
+			}
 			assertSkillNames(
 				t,
 				"extension prompt catalog",
@@ -342,6 +346,12 @@ func extensionPromptSkillNames(prompt string) []string {
 	catalog := extensionCurrentPromptCatalogPattern.FindStringSubmatch(prompt)
 	if len(catalog) != 2 {
 		return nil
+	}
+	if strings.Contains(catalog[1], `<catalog-state unchanged="true">`) {
+		catalog = extensionStartupPromptCatalogPattern.FindStringSubmatch(prompt)
+		if len(catalog) != 2 {
+			return nil
+		}
 	}
 	matches := extensionPromptSkillNamePattern.FindAllStringSubmatch(catalog[1], -1)
 	names := make([]string, 0, len(matches))

--- a/internal/daemon/harness_context.go
+++ b/internal/daemon/harness_context.go
@@ -282,7 +282,7 @@ func (r *HarnessContextResolver) Resolve(input HarnessResolutionInput) (Resolved
 		SessionClass:         sessionCtx.SessionClass,
 		TurnOrigin:           turnCtx.Origin,
 		IncludeSections:      r.resolveSections(sessionCtx),
-		EnableAugmenters:     r.resolveAugmenters(surface, turnCtx),
+		EnableAugmenters:     r.resolveAugmenters(surface, sessionCtx, turnCtx),
 		ReentryMode:          r.resolveReentry(turnCtx),
 		DetachedRunMode:      r.resolveDetachedRunMode(sessionCtx, turnCtx),
 		SkillInjectionFilter: r.skillInjection.resolve(sessionCtx),

--- a/internal/daemon/harness_context_integration_test.go
+++ b/internal/daemon/harness_context_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/compozy/compozy/internal/store/sessiondb"
 	taskpkg "github.com/compozy/compozy/internal/task"
 	"github.com/compozy/compozy/internal/testutil"
+	"github.com/compozy/compozy/internal/testutil/acpmock"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 	skillbundled "github.com/compozy/compozy/skills"
 )
@@ -664,6 +665,170 @@ func TestHarnessContextIntegrationScopesToolGuidanceForInternalCallers(t *testin
 	}
 }
 
+func TestHarnessContextIntegrationMeasuresDeliveredSkillCatalogs(t *testing.T) {
+	t.Run("Should deliver current catalogs once and omit input-only context", func(t *testing.T) {
+		driverPath := acpmock.RequireDriver(t)
+		homePaths := integrationHomePaths(t)
+		cfg := testConfig(t, homePaths)
+		cfg.Memory.Enabled = false
+		workspace := newHarnessIntegrationWorkspace(t, homePaths, cfg, filepath.Join(homePaths.HomeDir, "workspace"))
+		for index := range 23 {
+			name := fmt.Sprintf("measured-skill-%02d", index)
+			writeDaemonFile(
+				t,
+				filepath.Join(homePaths.SkillsDir, name, "SKILL.md"),
+				"---\nname: "+name+"\ndescription: A representative skill for prompt delivery measurement.\n---\nRead this skill when requested.\n",
+			)
+		}
+		daemonInstance, deps := bootHarnessPolicyDaemon(t, homePaths, &cfg)
+		t.Cleanup(func() {
+			if err := daemonInstance.Shutdown(context.Background()); err != nil {
+				t.Errorf("Shutdown: %v", err)
+			}
+		})
+		resolver := &harnessIntegrationWorkspaceResolver{resolved: workspace}
+		skillsAugmenter := newSkillsCatalogAugmenter(
+			daemonInstance.skillsRegistry,
+			nil,
+			func() promptSkillsWorkspaceResolver { return resolver },
+			nil,
+		)
+		composite, err := newPromptInputCompositeAugmenter(
+			discardLogger(),
+			daemonInstance.harnessResolver,
+			nil,
+			defaultPromptInputAugmenterDescriptors(
+				situation.WorkspaceKnowledgeAugmenter,
+				nil,
+				skillsAugmenter,
+				daemonInstance.situationContext.Augment,
+			)...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		deps.PromptInputAugmenter = composite
+		diagnostics := filepath.Join(t.TempDir(), "prompts.jsonl")
+		command := acpmock.BuildCommand(
+			driverPath,
+			mockFixturePath(t, "browser_skills_context_fixture.json"),
+			"skills-context-agent",
+			diagnostics,
+		)
+		workspace.Config.Providers[acpmock.ProviderName] = acpmock.ProviderConfig(command)
+		workspace.Agents[0].Provider = acpmock.ProviderName
+		manager := newHarnessIntegrationManager(
+			t,
+			homePaths,
+			deps,
+			workspace,
+			session.NewACPDriverAdapter(acp.New(acp.WithProviderPreStarter(daemonInstance.providerPreStarter))),
+		)
+		send := func(sess *session.Session, label string) string {
+			t.Helper()
+			events, err := manager.Prompt(t.Context(), sess.ID, "Measure this prompt.")
+			if err != nil {
+				t.Fatal(err)
+			}
+			done := false
+			for event := range events {
+				if event.Type == acp.EventTypeError {
+					t.Fatalf("%s: %s", label, event.Error)
+				}
+				done = done || event.Type == acp.EventTypeDone
+			}
+			if !done {
+				t.Fatalf("%s did not complete", label)
+			}
+			records, err := acpmock.ReadDiagnostics(diagnostics)
+			if err != nil {
+				t.Fatal(err)
+			}
+			prompts := acpmock.PromptDiagnostics(records)
+			if len(prompts) == 0 {
+				t.Fatal("no receiver diagnostics")
+			}
+			prompt := prompts[len(prompts)-1].Prompt
+			t.Logf(
+				"payload %s bytes=%d skills=%d unchanged=%t situation=%t",
+				label,
+				len(prompt),
+				strings.Count(prompt, "<skill name="),
+				strings.Contains(prompt, `<catalog-state unchanged="true">`),
+				strings.Contains(prompt, "<compozy-situation-context>"),
+			)
+			return prompt
+		}
+		var parent *session.Session
+		create := func(role string) *session.Session {
+			t.Helper()
+			var created *session.Session
+			var err error
+			if role == session.SpawnRoleMemoryExtractor || role == session.SpawnRoleAutoTitle {
+				created, err = manager.Spawn(t.Context(), session.SpawnOpts{
+					ParentSessionID: parent.ID, AgentName: workspace.Agents[0].Name, SpawnRole: role, TTL: time.Minute,
+				})
+			} else {
+				sessionType := session.SessionTypeUser
+				if role == session.SpawnRoleCheckpointSummary {
+					sessionType = session.SessionTypeDream
+				}
+				created, err = manager.Create(t.Context(), session.CreateOpts{
+					AgentName: workspace.Agents[0].Name, Workspace: workspace.ID, Type: sessionType,
+					Lineage: &store.SessionLineage{SpawnRole: role},
+				})
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if err := manager.Stop(context.Background(), created.ID); err != nil {
+					t.Errorf("Stop: %v", err)
+				}
+			})
+			return created
+		}
+		ordinary := create("")
+		parent = ordinary
+		first := send(ordinary, "first")
+		second := send(ordinary, "unchanged")
+		writeDaemonFile(
+			t,
+			filepath.Join(homePaths.SkillsDir, "measured-added", "SKILL.md"),
+			"---\nname: measured-added\ndescription: Added during the session.\n---\nRead when requested.\n",
+		)
+		waitForConditionWithin(t, "added catalog entry", 10*time.Second, func() bool {
+			entries, err := daemonInstance.skillsRegistry.ForWorkspace(t.Context(), &workspace)
+			return err == nil && strings.Contains(skillspkg.BuildCurrentCatalog(entries), `name="measured-added"`)
+		})
+		changed := send(ordinary, "changed")
+		if !strings.Contains(first, `<catalog-state unchanged="true">`) ||
+			strings.Count(first, `name="measured-skill-00"`) != 1 {
+			t.Errorf("first payload must contain the startup catalog once and the live marker")
+		}
+		if !strings.Contains(second, `<catalog-state unchanged="true">`) ||
+			strings.Contains(second, `name="measured-skill-00"`) {
+			t.Errorf("unchanged payload must contain only the marker")
+		}
+		if !strings.Contains(changed, `name="measured-added"`) ||
+			strings.Contains(changed, `<catalog-state unchanged="true">`) {
+			t.Errorf("changed payload must contain the new full catalog")
+		}
+		for _, role := range []string{session.SpawnRoleMemoryExtractor, session.SpawnRoleAutoTitle, session.SpawnRoleCheckpointSummary} {
+			prompt := send(create(role), role)
+			for _, section := range []string{"<available-skills>", "<current-available-skills>", "<compozy-situation-context>"} {
+				if strings.Contains(prompt, section) {
+					t.Errorf("%s contains unusable %s", role, section)
+				}
+			}
+			if !strings.Contains(prompt, "<compozy-runtime-context>") ||
+				!strings.Contains(prompt, "You are a coding assistant.") ||
+				!strings.HasSuffix(prompt, "Measure this prompt.") {
+				t.Errorf("%s lost its runtime, instructions, or input", role)
+			}
+		}
+	})
+}
+
 func seedHarnessSituationTaskRun(
 	t *testing.T,
 	daemonInstance *Daemon,
@@ -762,7 +927,7 @@ func newHarnessIntegrationManager(
 	homePaths compozyconfig.HomePaths,
 	deps SessionManagerDeps,
 	resolvedWorkspace workspacepkg.ResolvedWorkspace,
-	driver *harnessIntegrationDriver,
+	driver session.AgentDriver,
 	extraOpts ...session.Option,
 ) *session.Manager {
 	t.Helper()

--- a/internal/daemon/harness_context_integration_test.go
+++ b/internal/daemon/harness_context_integration_test.go
@@ -672,8 +672,10 @@ func TestHarnessContextIntegrationMeasuresDeliveredSkillCatalogs(t *testing.T) {
 		cfg := testConfig(t, homePaths)
 		cfg.Memory.Enabled = false
 		workspace := newHarnessIntegrationWorkspace(t, homePaths, cfg, filepath.Join(homePaths.HomeDir, "workspace"))
+		expectedSkills := []string{"compozy"}
 		for index := range 23 {
 			name := fmt.Sprintf("measured-skill-%02d", index)
+			expectedSkills = append(expectedSkills, name)
 			writeDaemonFile(
 				t,
 				filepath.Join(homePaths.SkillsDir, name, "SKILL.md"),
@@ -801,16 +803,24 @@ func TestHarnessContextIntegrationMeasuresDeliveredSkillCatalogs(t *testing.T) {
 			return err == nil && strings.Contains(skillspkg.BuildCurrentCatalog(entries), `name="measured-added"`)
 		})
 		changed := send(ordinary, "changed")
-		if !strings.Contains(first, `<catalog-state unchanged="true">`) ||
-			strings.Count(first, `name="measured-skill-00"`) != 1 {
+		assertCatalog := func(label, prompt string, expected []string) {
+			t.Helper()
+			var names []string
+			for _, match := range extensionPromptSkillNamePattern.FindAllStringSubmatch(prompt, -1) {
+				names = append(names, match[1])
+			}
+			assertSkillNames(t, label, names, expected)
+		}
+		assertCatalog("first payload", first, expectedSkills)
+		assertCatalog("unchanged payload", second, nil)
+		assertCatalog("changed payload", changed, append(slices.Clone(expectedSkills), "measured-added"))
+		if !strings.Contains(first, `<catalog-state unchanged="true">`) {
 			t.Errorf("first payload must contain the startup catalog once and the live marker")
 		}
-		if !strings.Contains(second, `<catalog-state unchanged="true">`) ||
-			strings.Contains(second, `name="measured-skill-00"`) {
+		if !strings.Contains(second, `<catalog-state unchanged="true">`) {
 			t.Errorf("unchanged payload must contain only the marker")
 		}
-		if !strings.Contains(changed, `name="measured-added"`) ||
-			strings.Contains(changed, `<catalog-state unchanged="true">`) {
+		if strings.Contains(changed, `<catalog-state unchanged="true">`) {
 			t.Errorf("changed payload must contain the new full catalog")
 		}
 		for _, role := range []string{session.SpawnRoleMemoryExtractor, session.SpawnRoleAutoTitle, session.SpawnRoleCheckpointSummary} {

--- a/internal/daemon/harness_context_policy.go
+++ b/internal/daemon/harness_context_policy.go
@@ -7,13 +7,13 @@ func (r *HarnessContextResolver) resolveSections(sessionCtx HarnessSessionContex
 	if r.runtime.RuntimeIdentityPromptSectionEnabled {
 		sections = append(sections, HarnessPromptSectionRuntimeIdentity)
 	}
-	if r.runtime.SituationPromptSectionEnabled {
+	if r.runtime.SituationPromptSectionEnabled && !inputOnlyHarnessRole(sessionCtx.SpawnRole) {
 		sections = append(sections, HarnessPromptSectionSituation)
 	}
 	if r.runtime.MemoryPromptSectionEnabled {
 		sections = append(sections, HarnessPromptSectionMemory)
 	}
-	if r.runtime.SkillsPromptSectionEnabled {
+	if r.runtime.SkillsPromptSectionEnabled && !inputOnlyHarnessRole(sessionCtx.SpawnRole) {
 		sections = append(sections, HarnessPromptSectionSkills)
 	}
 	if r.runtime.ToolsPromptSectionEnabled && !inputOnlyHarnessRole(sessionCtx.SpawnRole) {
@@ -27,6 +27,7 @@ func (r *HarnessContextResolver) resolveSections(sessionCtx HarnessSessionContex
 
 func (r *HarnessContextResolver) resolveAugmenters(
 	surface ResolutionSurface,
+	sessionCtx HarnessSessionContext,
 	turnCtx HarnessTurnContext,
 ) []HarnessAugmenter {
 	if surface != ResolutionSurfaceTurn {
@@ -36,7 +37,7 @@ func (r *HarnessContextResolver) resolveAugmenters(
 	if r.runtime.WorkspaceKnowledgeAugmenter {
 		augmenters = append(augmenters, HarnessAugmenterWorkspaceKnowledge)
 	}
-	if r.runtime.SkillsAugmenter {
+	if r.runtime.SkillsAugmenter && !inputOnlyHarnessRole(sessionCtx.SpawnRole) {
 		augmenters = append(augmenters, HarnessAugmenterSkills)
 	}
 	if turnCtx.Origin == TurnOriginNetwork {
@@ -45,7 +46,7 @@ func (r *HarnessContextResolver) resolveAugmenters(
 	if turnCtx.Origin != TurnOriginUser {
 		return augmenters
 	}
-	if r.runtime.SituationAugmenter {
+	if r.runtime.SituationAugmenter && !inputOnlyHarnessRole(sessionCtx.SpawnRole) {
 		augmenters = append(augmenters, HarnessAugmenterSituation)
 	}
 	if r.runtime.DurableMemoryAugmenter {

--- a/internal/daemon/harness_context_test.go
+++ b/internal/daemon/harness_context_test.go
@@ -88,6 +88,46 @@ func TestResolveSessionNativeSkillRoots(t *testing.T) {
 	})
 }
 
+func TestHarnessContextResolverScopesInputOnlyContext(t *testing.T) {
+	t.Parallel()
+	for _, role := range []string{session.SpawnRoleMemoryExtractor, session.SpawnRoleAutoTitle, session.SpawnRoleCheckpointSummary, "custom", ""} {
+		t.Run("Should scope startup and live context for role "+role, func(t *testing.T) {
+			t.Parallel()
+			resolver := NewHarnessContextResolver(HarnessRuntimeSignals{
+				RuntimeIdentityPromptSectionEnabled: true, SituationPromptSectionEnabled: true,
+				SkillsPromptSectionEnabled: true, ToolsPromptSectionEnabled: true,
+				SkillsAugmenter: true, SituationAugmenter: true,
+			})
+			wantContext := role == "" || role == "custom"
+			for _, surface := range []ResolutionSurface{ResolutionSurfaceStartup, ResolutionSurfaceTurn} {
+				resolved, err := resolver.Resolve(HarnessResolutionInput{
+					Surface: surface, Session: HarnessSessionInput{Type: session.SessionTypeSpawned, SpawnRole: role},
+					Turn: HarnessTurnRequest{Source: session.TurnSourceUser},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, section := range []HarnessPromptSection{HarnessPromptSectionSituation, HarnessPromptSectionSkills, HarnessPromptSectionTools} {
+					if slices.Contains(resolved.Policy.IncludeSections, section) != wantContext {
+						t.Fatalf("%s sections = %v", surface, resolved.Policy.IncludeSections)
+					}
+				}
+				if !slices.Contains(resolved.Policy.IncludeSections, HarnessPromptSectionRuntimeIdentity) {
+					t.Fatal("runtime identity was removed")
+				}
+				for _, augmenter := range []HarnessAugmenter{HarnessAugmenterSkills, HarnessAugmenterSituation} {
+					if slices.Contains(
+						resolved.Policy.EnableAugmenters,
+						augmenter,
+					) != (wantContext && surface == ResolutionSurfaceTurn) {
+						t.Fatalf("%s augmenters = %v", surface, resolved.Policy.EnableAugmenters)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestHarnessSkillInjectionFilterSuppressesOnlyWinningNativePresetRoots(t *testing.T) {
 	t.Parallel()
 	t.Run("Should suppress only winning native preset roots", func(t *testing.T) {

--- a/internal/daemon/prompt_skills.go
+++ b/internal/daemon/prompt_skills.go
@@ -2,21 +2,17 @@ package daemon
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"strings"
-	"sync"
-	"sync/atomic"
 
+	"github.com/compozy/compozy/internal/acp"
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	"github.com/compozy/compozy/internal/session"
 	skillspkg "github.com/compozy/compozy/internal/skills"
 	"github.com/compozy/compozy/internal/store"
 	workspacepkg "github.com/compozy/compozy/internal/workspace"
 )
-
-const promptSkillsCatalogCacheMaxSessions = 2048
 
 type promptSkillsRegistry interface {
 	ForWorkspace(ctx context.Context, resolved *workspacepkg.ResolvedWorkspace) ([]*skillspkg.Skill, error)
@@ -51,16 +47,6 @@ type skillsCatalogAugmenter struct {
 	agentResolver     func() session.AgentResolver
 	workspaceResolver func() promptSkillsWorkspaceResolver
 	profileNames      session.ProfileNameResolver
-	sequence          atomic.Uint64
-
-	mu     sync.Mutex
-	states map[string]skillsCatalogSessionState
-}
-
-type skillsCatalogSessionState struct {
-	acpSessionID string
-	signature    [sha256.Size]byte
-	lastUsed     uint64
 }
 
 func newSkillsCatalogAugmenter(
@@ -91,7 +77,6 @@ func newSkillsCatalogAugmenterState(
 		agentResolver:     agentResolver,
 		workspaceResolver: workspaceResolver,
 		profileNames:      profileNames,
-		states:            make(map[string]skillsCatalogSessionState),
 	}
 	return augmenter
 }
@@ -152,12 +137,13 @@ func (a *skillsCatalogAugmenter) augment(
 		}
 	}
 	catalog := skillspkg.BuildCurrentCatalogWithinBudget(filtered, startupSkillsSectionBudget)
+	acp.RegisterPromptSection(ctx, acp.PromptSection{
+		Key: "skills", Content: catalog,
+		StartupContent:   skillspkg.BuildCatalogWithinBudget(filtered, startupSkillsSectionBudget),
+		UnchangedContent: skillspkg.BuildCurrentCatalogUnchanged(),
+	})
 	if strings.TrimSpace(catalog) == "" {
-		a.forgetSession(info.ID)
 		return message, nil
-	}
-	if a.catalogUnchanged(info, catalog) {
-		catalog = skillspkg.BuildCurrentCatalogUnchanged()
 	}
 	if strings.TrimSpace(message) == "" {
 		return catalog, nil
@@ -183,63 +169,6 @@ func (a *skillsCatalogAugmenter) skillsForSessionAgent(
 			return a.registry.ForAgentDefSession(ctx, workspace, resolvedAgent, sessionID)
 		},
 	})
-}
-
-func (a *skillsCatalogAugmenter) catalogUnchanged(info *session.Info, catalog string) bool {
-	if info == nil {
-		return false
-	}
-
-	key := strings.TrimSpace(info.ID)
-	if key == "" {
-		return false
-	}
-
-	acpSessionID := strings.TrimSpace(info.ACPSessionID)
-	signature := sha256.Sum256([]byte(catalog))
-	sequence := a.sequence.Add(1)
-
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	state, ok := a.states[key]
-	unchanged := ok && state.acpSessionID == acpSessionID && state.signature == signature
-	a.states[key] = skillsCatalogSessionState{
-		acpSessionID: acpSessionID,
-		signature:    signature,
-		lastUsed:     sequence,
-	}
-	a.evictOldestLocked()
-	return unchanged
-}
-
-func (a *skillsCatalogAugmenter) forgetSession(sessionID string) {
-	key := strings.TrimSpace(sessionID)
-	if key == "" {
-		return
-	}
-
-	a.mu.Lock()
-	delete(a.states, key)
-	a.mu.Unlock()
-}
-
-func (a *skillsCatalogAugmenter) evictOldestLocked() {
-	if len(a.states) <= promptSkillsCatalogCacheMaxSessions {
-		return
-	}
-
-	var oldestKey string
-	var oldestSequence uint64
-	for key, state := range a.states {
-		if oldestKey == "" || state.lastUsed < oldestSequence {
-			oldestKey = key
-			oldestSequence = state.lastUsed
-		}
-	}
-	if oldestKey != "" {
-		delete(a.states, oldestKey)
-	}
 }
 
 func resolvePromptSkillsWorkspace(

--- a/internal/daemon/prompt_skills_test.go
+++ b/internal/daemon/prompt_skills_test.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/compozy/compozy/internal/acp"
 	commandpkg "github.com/compozy/compozy/internal/command"
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	"github.com/compozy/compozy/internal/session"
@@ -21,53 +22,31 @@ import (
 )
 
 func TestNewSkillsCatalogAugmenterUsesCurrentRegistryStatePerPrompt(t *testing.T) {
-	t.Run("Should compact unchanged catalog after the first prompt", func(t *testing.T) {
+	t.Run("Should retain full context until transport delivery is confirmed", func(t *testing.T) {
 		t.Parallel()
-
-		registry, augmenter := newPromptSkillsAugmenterForTest(t, []*skillspkg.Skill{
-			{
-				Meta: skillspkg.SkillMeta{
-					Name:        "qa-marker-skill",
-					Description: "Shows up while enabled.",
-				},
-				Enabled: true,
-			},
+		_, augmenter := newPromptSkillsAugmenterForTest(t, []*skillspkg.Skill{
+			{Meta: skillspkg.SkillMeta{Name: "qa-marker-skill", Description: "Shows up while enabled."}, Enabled: true},
 		})
-		_ = registry
 		sess := newPromptSkillsSession("sess-compact")
-
-		first, err := augmenter(context.Background(), sess, "list current skills")
-		if err != nil {
-			t.Fatalf("augmenter(first) error = %v", err)
-		}
-		if !strings.Contains(first, `name="qa-marker-skill"`) {
-			t.Fatalf("first prompt = %q, want enabled skill entry", first)
-		}
-
-		second, err := augmenter(context.Background(), sess, "list current skills again")
-		if err != nil {
-			t.Fatalf("augmenter(second) error = %v", err)
-		}
-		if !strings.Contains(second, `<catalog-state unchanged="true">`) {
-			t.Fatalf("second prompt = %q, want unchanged catalog marker", second)
-		}
-		if strings.Contains(second, `name="qa-marker-skill"`) {
-			t.Fatalf("second prompt = %q, want compact marker without repeated skill entries", second)
-		}
-		if !strings.Contains(second, "resolve canonical `compozy__skill_view` for full skill/resource instructions") {
-			t.Fatalf("second prompt = %q, want compact harness-agnostic skill_view guidance", second)
-		}
-		if !strings.Contains(
-			second,
-			"Do not invoke `compozy skill view` or read skill files directly from a managed session",
-		) {
-			t.Fatalf("second prompt = %q, want native-only managed skill guidance", second)
-		}
-		if !strings.Contains(second, "`compozy skill view` is an operator-shell command only") {
-			t.Fatalf("second prompt = %q, want operator-only CLI guidance", second)
-		}
-		if !strings.HasSuffix(second, "list current skills again") {
-			t.Fatalf("second prompt = %q, want original prompt preserved", second)
+		for _, message := range []string{"first request", "retry request"} {
+			ctx, sections := acp.CollectPromptSections(t.Context())
+			prompt, err := augmenter(ctx, sess, message)
+			if err != nil {
+				t.Fatal(err)
+			}
+			registered := sections()
+			if len(registered) != 1 || !strings.Contains(prompt, registered[0].Content) ||
+				!strings.Contains(prompt, `name="qa-marker-skill"`) || !strings.HasSuffix(prompt, message) {
+				t.Fatalf("prompt lost its full retryable catalog: %q (%#v)", prompt, registered)
+			}
+			if registered[0].StartupContent != skillspkg.BuildCatalogWithinBudget([]*skillspkg.Skill{
+				{
+					Meta:    skillspkg.SkillMeta{Name: "qa-marker-skill", Description: "Shows up while enabled."},
+					Enabled: true,
+				},
+			}, startupSkillsSectionBudget) || registered[0].UnchangedContent != skillspkg.BuildCurrentCatalogUnchanged() {
+				t.Fatalf("registered section does not match startup and current catalog semantics: %#v", registered)
+			}
 		}
 	})
 
@@ -162,8 +141,8 @@ func TestNewSkillsCatalogAugmenterUsesCurrentRegistryStatePerPrompt(t *testing.T
 		if err != nil {
 			t.Fatalf("augmenter(second) error = %v", err)
 		}
-		if !strings.Contains(second, `<catalog-state unchanged="true">`) {
-			t.Fatalf("second prompt = %q, want unchanged catalog marker", second)
+		if !strings.Contains(second, `name="qa-marker-skill"`) {
+			t.Fatalf("second prompt = %q, want full context pending delivery", second)
 		}
 
 		sess.ACPSessionID = "acp-2"
@@ -475,8 +454,8 @@ func TestSkillsCatalogAugmenterFiltersBeforeCatalogSignature(t *testing.T) {
 		if err != nil {
 			t.Fatalf("AugmentWithPolicy(repeat) error = %v", err)
 		}
-		if !strings.Contains(repeat, `unchanged="true"`) {
-			t.Fatalf("repeat catalog = %q, want unchanged marker", repeat)
+		if repeat != strings.Replace(filtered, "second", "third", 1) {
+			t.Fatalf("repeat catalog = %q, want the same filtered transport input", repeat)
 		}
 	})
 }

--- a/internal/session/manager_prompt_recovery.go
+++ b/internal/session/manager_prompt_recovery.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -24,6 +25,7 @@ type promptRecoveryEventData struct {
 
 func clonePromptRecoveryRequest(request acp.PromptRequest) acp.PromptRequest {
 	cloned := request
+	cloned.Sections = slices.Clone(request.Sections)
 	cloned.Attachments = make([]acp.PromptAttachment, len(request.Attachments))
 	for index, attachment := range request.Attachments {
 		cloned.Attachments[index] = attachment

--- a/internal/session/manager_prompt_submit.go
+++ b/internal/session/manager_prompt_submit.go
@@ -176,7 +176,7 @@ func (m *Manager) submitPromptInReservedSlot(
 	proc *AgentProcess,
 	req promptRequest,
 	message string,
-	dispatchMessage string,
+	dispatchInput preparedPromptInput,
 	attachments []acp.PromptAttachment,
 	turnState *promptTurnDispatchState,
 	cancelPromptExecution context.CancelFunc,
@@ -186,7 +186,7 @@ func (m *Manager) submitPromptInReservedSlot(
 		return nil, err
 	}
 	replayBlock := m.pendingResumeReplay(session.ID)
-	dispatchMessage = promptWithResumeReplay(replayBlock, dispatchMessage)
+	dispatchMessage := promptWithResumeReplay(replayBlock, dispatchInput.message)
 	if _, err := m.persistSessionPromptActivity(ctx, session, m.now()); err != nil {
 		return nil, err
 	}
@@ -202,6 +202,7 @@ func (m *Manager) submitPromptInReservedSlot(
 		RunID:                     req.runID,
 		Generation:                session.Info().RuntimeGeneration,
 		Message:                   dispatchMessage,
+		Sections:                  dispatchInput.sections,
 		Attachments:               attachments,
 		Meta:                      req.meta,
 		ActivityReporter:          activity.report,
@@ -307,7 +308,22 @@ func closePromptPersistenceDone(done chan<- struct{}) {
 	}
 }
 
-func (m *Manager) promptDispatchMessage(ctx context.Context, session *Session, message string) (string, error) {
+type preparedPromptInput struct {
+	message  string
+	sections []acp.PromptSection
+}
+
+func (m *Manager) promptDispatchMessage(
+	ctx context.Context,
+	session *Session,
+	message string,
+) (preparedPromptInput, error) {
+	ctx, sections := acp.CollectPromptSections(ctx)
+	augmented, err := m.augmentPromptMessage(ctx, session, message)
+	return preparedPromptInput{message: augmented, sections: sections()}, err
+}
+
+func (m *Manager) augmentPromptMessage(ctx context.Context, session *Session, message string) (string, error) {
 	expanded, err := m.expandPromptSkillInvocations(ctx, session, message)
 	if err != nil {
 		return "", err

--- a/packages/site/content/docs/skills/bundled.mdx
+++ b/packages/site/content/docs/skills/bundled.mdx
@@ -71,6 +71,11 @@ the returned tool reference and `{ "name": "compozy" }`. Operators can read the 
 compozy skill view compozy
 ```
 
+Each turn resolves the current skill catalog. When it matches the startup catalog delivered in
+that request, or the catalog confirmed in an earlier turn of the same ACP process, the live section
+uses a compact `unchanged` marker. Changed catalogs are sent in full. Failed or canceled deliveries
+do not establish a reusable catalog, and fresh ACP processes establish their own context.
+
 Agents and operators read a focused resource file instead of the whole manual when the router names
 one:
 
@@ -96,7 +101,9 @@ whose roles transform supplied input into output. This uses the persisted role, 
 extractor created through `Spawn`, rather than excluding every `system`, `dream`, or `spawned`
 session. Task workers, coordinators, dream curators, interactive sessions, and unknown roles retain
 the appropriate guidance when tools are enabled. Older checkpoint sessions without an explicit role also retain
-it. The role is preserved across resume and custom background-agent routing.
+it. The role is preserved across resume and custom background-agent routing. Input-only roles also
+omit startup and live skill catalogs and situation context; their runtime identity and supplied
+instructions remain present. These prompt choices do not change permissions or explicit skill reads.
 
 | Context                        | Injected guidance                                    |
 | ------------------------------ | ---------------------------------------------------- |

--- a/packages/site/vercel.json
+++ b/packages/site/vercel.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "bunx bun@1.4.0 install --frozen-lockfile",
     "headers": [
         {
             "source": "/llms.txt",


### PR DESCRIPTION
## What & why

Closes #604.

An ordinary session's first request repeated its entire skill catalog in both startup and live context. The augmenter tracked only its own previous rendered output, so startup delivery never established a comparison point. It also recorded catalogs during preparation, before the provider confirmed receiving them. Separately, input-only daemon roles excluded tool guidance but still received situation context and skill catalogs they could not use.

This change moves catalog compaction to the ACP delivery boundary. Preparation retains the full filtered current catalog plus its equivalent startup rendering. The wire request uses the existing unchanged marker only when that equivalent startup is being delivered or the same ACP process has acknowledged that catalog. Successful, uncanceled responses establish the record; failures and cancellation invalidate uncertain context. Recovery retains full input and a new process starts with no acknowledged sections. The old session-wide catalog LRU is removed.

The existing input-only role predicate now excludes startup and live skills and situation context for memory extraction, automatic titles, and checkpoint summaries. Ordinary sessions retain useful context. Runtime identity, authored instructions, current filtering, and explicit skill invocation retain their existing paths.

### Measured receiver payloads

The same production harness/session-manager fixture ran against the base daemon files through a Go overlay and against the fix. Diagnostics come from an actual ACP fixture subprocess, with 23 seeded skills plus the bundled skill. Input-only fixtures use common instructions and input to isolate harness overhead.

| Prompt | Before bytes | After bytes | Skill entries before → after |
| --- | ---: | ---: | ---: |
| First ordinary turn | 22,751 | 19,947 | 48 → 24 |
| Unchanged ordinary turn | 1,656 | 1,655 | 0 → 0 |
| Changed ordinary turn | 4,523 | 4,523 | 25 → 25 |
| Memory extractor | 11,192 | 1,452 | 50 → 0 |
| Auto title | 11,186 | 1,452 | 50 → 0 |
| Checkpoint summary | 11,097 | 1,450 | 50 → 0 |

The first-turn reduction is 2,804 measured bytes; input-only reductions are 9,647–9,740 bytes. The one-byte unchanged-turn difference is generated metadata variation. These are measured UTF-8 payloads, not token, billing, or production transcript projections. The baseline scenario reproduces first-turn duplication and all three role failures; the corrected scenario passes.

## How you verified it

Final delivery gates run in GitHub CI on the current PR head. The earlier local evidence below remains valid for unchanged code.

- Focused race tests cover native/prefixed startup delivery, unchanged/changed catalogs, failed preparation, provider errors, cancellation, empty context, fresh processes, filtering, activation, and role policy.
- `go test -race -tags=integration ./internal/daemon -run '^TestHarnessContextIntegrationScopesToolGuidanceForInternalCallers$' -count=1`: passed, including persisted-role resume with skills enabled and disabled.
- `go test -race -tags=integration ./internal/daemon -run '^TestHarnessContextIntegrationMeasuresDeliveredSkillCatalogs$' -count=1`: passed; produces the receiver measurements above.
- `go test -race -tags=integration ./internal/daemon -run '^TestDaemonE2EExtensionPublishedAgentSessionCommandsAndPrompt$' -count=1`: passed through the real daemon, HTTP, hosted MCP, and ACP fixture subprocess, including explicit skill invocation.
- `make gate`: passed with zero lint issues; all affected ACP, daemon, session, and input-queue race suites passed. The consolidated review-remediation commit passed locally before delivery gates moved to GitHub CI. The subsequent preview-install correction is validated remotely.
- A supplementary temporary overlay of the same receiver scenario also passed live skill removal, description editing, and the unchanged turn after editing; no production code was overlaid in this additional run.
- Addressed CodeRabbit finding [discussion_r3983936133](https://github.com/compozy/compozy/pull/607#discussion_r3983936133) in `91995c030`: compare complete receiver skill lists for first, unchanged, and changed turns. The strengthened integration scenario and `make gate` passed.
- Reviewed the changed diff. Changed daemon suites pass the repository test-shape checker; its four findings in the ACP file also exist unchanged at the base revision.

Runtime tests used isolated temporary homes and owned process cleanup. No host-daemon restart, live inference-provider billing/model behavior, or Windows validation is claimed. Authored and verified by Codex (GPT-6 Astra).

### Reproducible preview installation

Vercel's default Bun 1.3.14 installer cannot read this repository's version-2 lockfile. It ignored
the lockfile and resolved newer Fumadocs/Zod packages, causing type errors even though the locked
GitHub frontend build passed. `packages/site/vercel.json` now uses
`bunx bun@1.4.0 install --frozen-lockfile`, matching the existing root `packageManager` and
[Vercel's documented version-pinning method](https://vercel.com/kb/guide/how-to-pin-a-specific-bun-version-for-vercel-builds).
This makes the preview use the committed dependency graph and fail explicitly on lockfile drift.
No dependency versions, shared project settings, or application type checks are changed.
Validation for this CI correction runs in the remote preview and current-head GitHub CI.

The complete first CodeRabbit review is addressed in one remediation commit, and Greptile
reported no actionable findings. No repeat review round is required.

## Impact

No public CLI/HTTP/UDS/native-tool schema, permission, runtime configuration, extension, or persisted-data shape changes. Compaction metadata stays internal and never enters provider-visible structured metadata. Context hashes belong to one ACP process, preserving workspace/profile/process isolation and fresh recovery semantics. No migration or user action is required.

The bundled-skills guide and ET-049 document the behavior. The official skill's existing unchanged-marker/latest-full-catalog guidance remains valid. The full cross-surface audit and measurement methodology are in `docs/qa/reports/2026-09-10-skills-prompt-dedup.md`. No rendered UI changes.

---

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests
- [x] Agent authorship and verification are identified above
