### PR TITLE
fix: verify private Tailscale endpoints through tsnet

### DIFF
--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -27,3 +27,11 @@ owns the follow-up audit: captured terminal creation scope, stale-navigation
 rejection, explicit title-disclosure action names, public session imports, and
 review/CI disposition. Existing native, persisted, configuration, and official
 skill contracts remain unchanged.
+
+## Issue 602 — Embedded private endpoint verification
+
+- **Native tools:** Gateway status/audit, CLI and HTTP/UDS keep their IDs, DTOs and authorization. Existing provider causes gain safe failure classification; only a core-verified route becomes advertised.
+- **Extensibility and hooks:** The connectivity endpoint wire contract adds optional `verification_address` for a bounded loopback TCP relay. Go/TypeScript SDKs co-ship through codegen. Omission retains existing behavior; public proof rejects the field. No config, hook or manifest permission changes.
+- **Workspace data isolation:** Provider transports remain global gateway runtime resources, owned per tier and torn down before the node closes. No persisted schema or data migration. Public addresses exclude the relay; endpoint identity comparisons include it.
+- **Official Compozy skill:** Runtime Gateway guidance explains embedded private proof and safe diagnostic classes.
+- **Web/Docs:** Existing Gateway views consume provider causes without new UI state. Tailscale and extension-authoring guides describe transport, proof and recovery. `RT-connectivity-provider-route` owns the affected scenario. TLS, nonce, redirects, tier binding and public outbound policy retain their owning gateway suites; provider tests cover relay lifecycle.

--- a/docs/qa/reports/2026-09-10-issue-602-endpoint-verification.md
+++ b/docs/qa/reports/2026-09-10-issue-602-endpoint-verification.md
@@ -1,0 +1,52 @@
+# Issue 602: embedded private endpoint verification
+
+## Cause and scope
+
+The bundled provider owns a userspace tsnet node in its extension subprocess. The core verifier
+previously resolved and dialed private endpoints using the host network. A connected tsnet node
+does not install the corresponding host DNS or Tailnet route. A successful remote GET `/` does
+not prove that the daemon can retrieve the assigned tier challenge.
+
+The private provider now supplies a loopback relay whose sole upstream is its own private listener,
+dialed with `tsnet.Server.Dial`. TLS terminates at the advertised endpoint, not at the relay. The
+core still checks certificate trust and hostname, response bounds, no redirects, exact challenge
+path and nonce. Public proof rejects a relay and retains authenticated public DNS and outbound
+address restrictions. Provider teardown closes both forwarders before closing the embedded node.
+
+`verification_address` is additive and optional in the provider protocol. Existing providers retain
+the direct probe path. No persisted state, authentication, origin checks, config or public address
+shapes change. Runtime retries keep failed proofs staged and unadvertised.
+
+## Evidence
+
+- Core endpoint tests exercise real TLS sockets: private relay success without host DNS, wrong
+  certificate/hostname, exact nonce, public relay rejection, and invalid relay addresses. Existing
+  tests retain redirect/body/deadline/public-address rejection and tier challenge ownership.
+- Provider lifecycle tests exercise real TLS through both relay and private-listener forwarding, unchanged Host and challenge path,
+  exact response, stable status descriptor and connection refusal after teardown.
+- Safe error classification tests preserve `ErrEndpointUnverified` without printing wrapped URLs,
+  hostnames or nonces; HTTP status remains numeric.
+- `CGO_ENABLED=1 go test -race tailscale.com/tsnet -run '^TestSelfDial$' -count=1` passed on the pinned
+  Tailscale v1.100.0 dependency (2.644s). Its control server and virtual node are local test fixtures;
+  this proves upstream userspace self-dial, not access from a real remote Tailnet device.
+- Focused gateway/provider/extension suites passed with race detection. The gateway and provider integration suites passed. The broad extension integration run exposed
+  a daemon fixture inheriting `COMPOZY_INTERNAL_RESTART_OPERATION_ID` and a supervision timeout
+  under unconstrained parallel load. Both cases passed with that inherited restart variable unset
+  and the canonical `-p 2 -parallel 4` settings; assertions were unchanged. The final gate uses the
+  isolated environment and validates all affected packages, both SDKs and generated artifacts.
+- `make codegen` passed after installing this worktree's locked JavaScript dependencies. Only the
+  optional Go/TypeScript connectivity endpoint field changed in generated artifacts.
+- The SDK test configuration now uses typed CommonJS to match the existing package format and
+  eliminate Vite's native-loader compatibility warning without suppression or a package-format change.
+- The test-shape checker passed the endpoint suite. Its three provider-file findings concern
+  unchanged pre-existing top-level tests; the added lifecycle case uses a parallel `Should` subtest.
+
+## External limits
+
+This environment is macOS. No isolated Linux VPS, authorized disposable Tailnet account/auth key,
+HTTPS certificate issuance setup or remote Tailnet test device was supplied for this assignment.
+The reporter's Linux/systemd environment and public certificate chain were not reproduced. No
+active gateway, host Tailscale installation, auth key, node state or Tailnet device was changed.
+`RT-connectivity-provider-route` therefore retains its real-Tailnet `blocked-verify` status. Run its
+private route, failed-proof recovery, public isolation and teardown steps in an authorized isolated
+Linux lab before claiming that external scenario passed.

--- a/docs/qa/scenarios/RT-connectivity-provider-route.md
+++ b/docs/qa/scenarios/RT-connectivity-provider-route.md
@@ -31,3 +31,12 @@ QA impact 2026-08-08: bundled provider renamed to `tailscale` (extension ID and 
 name); `compozy gateway provider enable` and `/api/gateway/providers/{name}` take the new name.
 Walk attempt: rename covered mechanically by the Go suite in the full gate; real route establishment
 stays blocked on the same missing authorized Tailscale account, so the scenario remains blocked-verify.
+
+QA impact 2026-09-10 (issue #602): verify the embedded private endpoint without host Tailscale or
+host Tailnet routes. Require core TLS authentication and exact tier nonce through the provider's
+fixed-destination relay; reject a relay for public proof, wrong certificate/hostname/tier/nonce,
+redirects, invalid response size and deadlines. Confirm failed proof remains unadvertised, a later
+successful attempt recovers, and teardown closes the relay. Inspect safe DNS/connectivity/TLS/HTTP
+failure classes. Local automated evidence and external limits are tracked in
+`docs/qa/reports/2026-09-10-issue-602-endpoint-verification.md`. Real Tailnet/Linux validation remains
+blocked until an isolated authorized account/environment is supplied; never reuse active node state.

--- a/extensions/connectivity/tailscale/forwarder.go
+++ b/extensions/connectivity/tailscale/forwarder.go
@@ -21,6 +21,7 @@ type tierForwarder struct {
 	listener net.Listener
 	target   string
 	logger   *slog.Logger
+	dial     func(context.Context, string, string) (net.Conn, error)
 
 	stopLifecycle context.CancelFunc
 	done          chan struct{}
@@ -52,6 +53,7 @@ func newTierForwarder(listener net.Listener, target string, logger *slog.Logger)
 		listener:    listener,
 		target:      target,
 		logger:      logger,
+		dial:        (&net.Dialer{Timeout: forwardDialTimeout}).DialContext,
 		done:        make(chan struct{}),
 		closed:      make(chan struct{}),
 		slots:       make(chan struct{}, maxForwardConnections),
@@ -145,7 +147,9 @@ func (f *tierForwarder) forward(ctx context.Context, inbound net.Conn) {
 	defer f.wg.Done()
 	defer func() { <-f.slots }()
 	defer f.closeTracked(inbound)
-	upstream, err := (&net.Dialer{Timeout: forwardDialTimeout}).DialContext(ctx, "tcp", f.target)
+	dialCtx, cancel := context.WithTimeout(ctx, forwardDialTimeout)
+	defer cancel()
+	upstream, err := f.dial(dialCtx, "tcp", f.target)
 	if err != nil {
 		if ctx.Err() == nil {
 			f.recordForwardFailure()

--- a/extensions/connectivity/tailscale/node.go
+++ b/extensions/connectivity/tailscale/node.go
@@ -14,6 +14,7 @@ import (
 
 type tailscaleNode interface {
 	Up(context.Context) error
+	Dial(context.Context, string, string) (net.Conn, error)
 	ListenPrivate(context.Context) (net.Listener, error)
 	ListenPublic(context.Context) (net.Listener, error)
 	CertificateDomains() []string
@@ -66,6 +67,10 @@ func (n *tsnetNode) Up(ctx context.Context) error {
 		return fmt.Errorf("tailscale: connect operator tailnet: %w", err)
 	}
 	return nil
+}
+
+func (n *tsnetNode) Dial(ctx context.Context, network, address string) (net.Conn, error) {
+	return n.server.Dial(ctx, network, address)
 }
 
 func (n *tsnetNode) ListenPrivate(ctx context.Context) (net.Listener, error) {

--- a/extensions/connectivity/tailscale/provider.go
+++ b/extensions/connectivity/tailscale/provider.go
@@ -23,9 +23,10 @@ const (
 )
 
 type activeTier struct {
-	endpoint  compozysdk.ConnectivityAdvertisedEndpoint
-	domain    string
-	forwarder *tierForwarder
+	endpoint     compozysdk.ConnectivityAdvertisedEndpoint
+	domain       string
+	forwarder    *tierForwarder
+	verification *tierForwarder
 }
 
 type activeTierEntry struct {
@@ -114,8 +115,15 @@ func (p *Provider) Establish(
 	if err != nil {
 		return result, errors.Join(err, closeListener(listener))
 	}
+	verification, err := startVerificationRelay(callCtx, node, tier, domain, p.logger)
+	if err != nil {
+		return result, errors.Join(err, closeListener(listener))
+	}
+	if verification != nil {
+		endpoint.VerificationAddress = verification.listener.Addr().String()
+	}
 	forwarder.Start()
-	active := &activeTier{endpoint: endpoint, domain: domain, forwarder: forwarder}
+	active := &activeTier{endpoint: endpoint, domain: domain, forwarder: forwarder, verification: verification}
 	p.mu.Lock()
 	p.tiers[tier] = active
 	p.mu.Unlock()
@@ -192,7 +200,7 @@ func (p *Provider) Teardown(
 	active := p.active(tier)
 	var stopErr error
 	if active != nil {
-		stopErr = active.forwarder.Close(stopCtx)
+		stopErr = errors.Join(active.verification.Close(stopCtx), active.forwarder.Close(stopCtx))
 		if stopErr == nil {
 			p.removeActiveIf(tier, active)
 		}
@@ -223,7 +231,7 @@ func (p *Provider) Close(ctx context.Context) error {
 	p.mu.RUnlock()
 	var errs []error
 	for _, entry := range entries {
-		if err := entry.active.forwarder.Close(ctx); err != nil {
+		if err := errors.Join(entry.active.verification.Close(ctx), entry.active.forwarder.Close(ctx)); err != nil {
 			errs = append(errs, err)
 			continue
 		}

--- a/extensions/connectivity/tailscale/provider_test.go
+++ b/extensions/connectivity/tailscale/provider_test.go
@@ -2,15 +2,20 @@ package tailscale
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"io"
 	"io/fs"
 	"log/slog"
 	"maps"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -232,6 +237,103 @@ func TestTierForwarderBridgesToDaemonLoopback(t *testing.T) {
 	if err := forwarder.Close(ctx); err != nil {
 		t.Fatalf("Close(forwarder) error = %v", err)
 	}
+}
+
+func TestPrivateVerificationRelayLifecycle(t *testing.T) {
+	t.Parallel()
+	t.Run("Should forward the challenge through the private listener and close the relay", func(t *testing.T) {
+		t.Parallel()
+		target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != challengePathPrefix+"private" || r.Host != "example.com:8443" {
+				t.Errorf("changed challenge request: %s %s", r.Host, r.URL.Path)
+			}
+			if _, err := io.WriteString(w, "exact-nonce"); err != nil {
+				t.Errorf("write challenge: %v", err)
+			}
+		}))
+		t.Cleanup(target.Close)
+		certificateSource := httptest.NewTLSServer(http.NotFoundHandler())
+		t.Cleanup(certificateSource.Close)
+		roots := x509.NewCertPool()
+		roots.AddCert(certificateSource.Certificate())
+		privateListener := tls.NewListener(newTestListener(t), certificateSource.TLS.Clone())
+		node := &fakeTailscaleNode{privateListener: privateListener, domains: []string{"example.com"}}
+		provider, err := NewProvider(t.TempDir(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		provider.newNode = func(string, *slog.Logger) (tailscaleNode, error) { return node, nil }
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if err := provider.Close(ctx); err != nil {
+				t.Errorf("close provider: %v", err)
+			}
+		})
+		req := compozysdk.ConnectivityEstablishRequest{
+			Tier:          tierPrivate,
+			ForwardTarget: strings.TrimPrefix(target.URL, "http://"),
+			ChallengePath: challengePathPrefix + "private",
+			Deadline:      time.Now().Add(time.Second),
+		}
+		reachable, err := provider.Establish(t.Context(), compozysdk.ExtensionContext{}, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		address := reachable.Endpoints[0].VerificationAddress
+		if address == "" {
+			t.Fatal("missing verification address")
+		}
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots},
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, network, address)
+			},
+		}
+		t.Cleanup(transport.CloseIdleConnections)
+		client := &http.Client{Transport: transport, Timeout: time.Second}
+		request, err := http.NewRequestWithContext(
+			t.Context(),
+			http.MethodGet,
+			"https://example.com:8443"+req.ChallengePath,
+			http.NoBody,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		response, err := client.Do(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, readErr := io.ReadAll(response.Body)
+		closeErr := response.Body.Close()
+		if readErr != nil || closeErr != nil || response.StatusCode != http.StatusOK || string(body) != "exact-nonce" {
+			t.Fatalf("challenge: status=%d body=%q read=%v close=%v", response.StatusCode, body, readErr, closeErr)
+		}
+		status, err := provider.Status(
+			t.Context(),
+			compozysdk.ExtensionContext{},
+			compozysdk.ConnectivityStatusRequest{Tier: tierPrivate},
+		)
+		if err != nil || status.Endpoints[0] != reachable.Endpoints[0] {
+			t.Fatalf("status drift: %#v %v", status, err)
+		}
+		stopped, err := provider.Teardown(
+			t.Context(),
+			compozysdk.ExtensionContext{},
+			compozysdk.ConnectivityTeardownRequest{Tier: tierPrivate, Deadline: time.Now().Add(time.Second)},
+		)
+		if err != nil || !stopped.Stopped {
+			t.Fatalf("teardown: %#v %v", stopped, err)
+		}
+		conn, err := (&net.Dialer{Timeout: time.Second}).DialContext(t.Context(), "tcp", address)
+		if err == nil {
+			if closeErr := conn.Close(); closeErr != nil {
+				t.Errorf("close connection: %v", closeErr)
+			}
+			t.Fatal("relay remained reachable after teardown")
+		}
+	})
 }
 
 func TestBundledManagedInstall(t *testing.T) {
@@ -524,6 +626,13 @@ func (n *fakeTailscaleNode) Up(context.Context) error {
 		<-release
 	}
 	return nil
+}
+
+func (n *fakeTailscaleNode) Dial(ctx context.Context, network, address string) (net.Conn, error) {
+	if network != "tcp" || len(n.domains) == 0 || address != net.JoinHostPort(n.domains[0], privateListenerPort) {
+		return nil, errors.New("unexpected private verification destination")
+	}
+	return (&net.Dialer{}).DialContext(ctx, network, n.privateListener.Addr().String())
 }
 
 func (n *fakeTailscaleNode) ListenPrivate(context.Context) (net.Listener, error) {

--- a/extensions/connectivity/tailscale/verification.go
+++ b/extensions/connectivity/tailscale/verification.go
@@ -1,0 +1,30 @@
+package tailscale
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+)
+
+func startVerificationRelay(
+	ctx context.Context,
+	node tailscaleNode,
+	tier, domain string,
+	logger *slog.Logger,
+) (*tierForwarder, error) {
+	if tier != tierPrivate {
+		return nil, nil
+	}
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, errors.New("tailscale: cannot bind private verification transport")
+	}
+	relay, err := newTierForwarder(listener, net.JoinHostPort(domain, privateListenerPort), logger)
+	if err != nil {
+		return nil, errors.Join(err, closeListener(listener))
+	}
+	relay.dial = node.Dial
+	relay.Start()
+	return relay, nil
+}

--- a/internal/extension/contract/gateway_source.go
+++ b/internal/extension/contract/gateway_source.go
@@ -31,10 +31,11 @@ type ConnectivityReachability struct {
 
 // ConnectivityAdvertisedEndpoint is one provider-owned external address.
 type ConnectivityAdvertisedEndpoint struct {
-	URL          string `json:"url"`
-	Scheme       string `json:"scheme"`
-	SchemePolicy string `json:"scheme_policy,omitempty"`
-	Stability    string `json:"stability"`
+	URL                 string `json:"url"`
+	Scheme              string `json:"scheme"`
+	SchemePolicy        string `json:"scheme_policy,omitempty"`
+	Stability           string `json:"stability"`
+	VerificationAddress string `json:"verification_address,omitempty"`
 }
 
 // ConnectivityTeardownResponse acknowledges that the tier stopped forwarding.

--- a/internal/extension/gateway_source.go
+++ b/internal/extension/gateway_source.go
@@ -206,8 +206,9 @@ func connectivityReachabilityFromWire(value extensioncontract.ConnectivityReacha
 	for index, endpoint := range value.Endpoints {
 		mapped := gateway.AdvertisedEndpoint{
 			URL: strings.TrimSpace(endpoint.URL), Scheme: strings.TrimSpace(endpoint.Scheme),
-			SchemePolicy: gateway.EndpointSchemePolicy(strings.TrimSpace(endpoint.SchemePolicy)),
-			Stability:    gateway.EndpointStability(strings.TrimSpace(endpoint.Stability)),
+			SchemePolicy:        gateway.EndpointSchemePolicy(strings.TrimSpace(endpoint.SchemePolicy)),
+			Stability:           gateway.EndpointStability(strings.TrimSpace(endpoint.Stability)),
+			VerificationAddress: endpoint.VerificationAddress,
 		}
 		mapped, err := normalizeConnectivityEndpoint(mapped)
 		if err != nil {

--- a/internal/gateway/connectivity.go
+++ b/internal/gateway/connectivity.go
@@ -45,10 +45,11 @@ func (s EndpointStability) Validate() error {
 
 // AdvertisedEndpoint is one untrusted provider endpoint pending core verification.
 type AdvertisedEndpoint struct {
-	URL          string
-	Scheme       string
-	SchemePolicy EndpointSchemePolicy
-	Stability    EndpointStability
+	URL                 string
+	Scheme              string
+	SchemePolicy        EndpointSchemePolicy
+	VerificationAddress string
+	Stability           EndpointStability
 }
 
 // Validate checks the provider-owned descriptor without performing network I/O.
@@ -74,6 +75,9 @@ func (e AdvertisedEndpoint) Validate() error {
 	case scheme != endpointSchemeHTTPS && scheme != "http" && policy == EndpointSchemePolicyTailnetInternal:
 	default:
 		return errors.New("gateway: endpoint scheme is not allowed by policy")
+	}
+	if err := validateVerificationAddress(e.VerificationAddress); err != nil {
+		return err
 	}
 	return e.Stability.Validate()
 }

--- a/internal/gateway/endpoint_transport.go
+++ b/internal/gateway/endpoint_transport.go
@@ -1,0 +1,70 @@
+package gateway
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"syscall"
+
+	"github.com/compozy/compozy/internal/outboundpolicy"
+)
+
+// The relay carries opaque TLS bytes; the original URL still owns SNI, certificate and nonce checks.
+type verificationRelayResolver struct{ address netip.Addr }
+
+func (r verificationRelayResolver) LookupNetIP(context.Context, string, string) ([]netip.Addr, error) {
+	return []netip.Addr{r.address}, nil
+}
+
+type verificationRelayDialer struct {
+	address string
+	dialer  outboundpolicy.NetworkDialer
+}
+
+func (d verificationRelayDialer) DialContext(ctx context.Context, network, _ string) (net.Conn, error) {
+	return outboundpolicy.NewDialer(outboundpolicy.New(true), net.DefaultResolver, d.dialer).
+		DialContext(ctx, network, d.address)
+}
+
+var errEndpointRedirect = errors.New("gateway: endpoint verification redirects are forbidden")
+
+func endpointProbeError(err error) error {
+	reason := "endpoint transport failed; inspect provider connectivity"
+	switch {
+	case errors.Is(err, errEndpointRedirect):
+		reason = "endpoint redirect refused; forward the exact challenge path"
+	case errors.Is(err, outboundpolicy.ErrBlockedDestination):
+		reason = "endpoint address policy refused the destination"
+	case errors.Is(err, context.Canceled):
+		reason = "endpoint probe canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		reason = "endpoint probe timed out; check provider routing and listener readiness"
+	case errors.Is(err, syscall.ECONNREFUSED):
+		reason = "endpoint connection refused; check provider listener readiness"
+	case errors.Is(err, syscall.ENETUNREACH), errors.Is(err, syscall.EHOSTUNREACH):
+		reason = "endpoint network unreachable; check the provider network route"
+	default:
+		if dnsErr, ok := errors.AsType[*net.DNSError](err); ok && dnsErr != nil {
+			reason = "endpoint DNS resolution failed; check the provider resolver"
+		} else if certErr, ok := errors.AsType[*tls.CertificateVerificationError](err); ok && certErr != nil {
+			reason = "endpoint TLS certificate verification failed; check hostname, trust and certificate validity"
+		} else if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
+			reason = "endpoint probe timed out; check provider routing and listener readiness"
+		}
+	}
+	return fmt.Errorf("%w: %s", ErrEndpointUnverified, reason)
+}
+
+func validateVerificationAddress(value string) error {
+	if value == "" {
+		return nil
+	}
+	address, err := netip.ParseAddrPort(value)
+	if err != nil || !address.Addr().IsLoopback() || address.Addr().Zone() != "" || address.Port() == 0 {
+		return errors.New("gateway: verification address must be a loopback IP with a non-zero port")
+	}
+	return nil
+}

--- a/internal/gateway/endpoint_verify.go
+++ b/internal/gateway/endpoint_verify.go
@@ -129,6 +129,9 @@ func (v *EndpointVerifier) Verify(
 	}
 	body, readErr := readBoundedChallengeBody(response.Body)
 	closeErr := response.Body.Close()
+	if errors.Is(readErr, context.DeadlineExceeded) || errors.Is(readErr, context.Canceled) {
+		return endpointProbeError(readErr)
+	}
 	if readErr != nil || closeErr != nil {
 		return fmt.Errorf("%w: challenge response is invalid", ErrEndpointUnverified)
 	}

--- a/internal/gateway/endpoint_verify.go
+++ b/internal/gateway/endpoint_verify.go
@@ -100,24 +100,16 @@ func (v *EndpointVerifier) Verify(
 	if timeout <= 0 || resolver == nil || publicResolver == nil || dialer == nil {
 		return errors.New("gateway: endpoint verifier is not configured")
 	}
-	if err := tier.Validate(); err != nil {
-		return err
-	}
-	if err := endpoint.Validate(); err != nil {
-		return fmt.Errorf("%w: invalid endpoint descriptor", ErrEndpointUnverified)
-	}
-	if tier == TierPublic && !strings.EqualFold(endpoint.Scheme, endpointSchemeHTTPS) {
-		return fmt.Errorf("%w: HTTPS is required", ErrEndpointUnverified)
-	}
-	if !strings.HasPrefix(challengePath, ChallengePathPrefix) || strings.TrimSpace(nonce) == "" {
-		return fmt.Errorf("%w: challenge is unavailable", ErrEndpointUnverified)
-	}
-	challengeURL, err := endpointChallengeURL(endpoint, challengePath)
+	challengeURL, err := validateEndpointChallenge(tier, endpoint, challengePath, nonce)
 	if err != nil {
-		return fmt.Errorf("%w: invalid challenge URL", ErrEndpointUnverified)
+		return err
 	}
 	if tier == TierPublic {
 		resolver = publicResolver
+	}
+	if endpoint.VerificationAddress != "" {
+		resolver = verificationRelayResolver{address: netip.MustParseAddrPort(endpoint.VerificationAddress).Addr()}
+		dialer = verificationRelayDialer{address: endpoint.VerificationAddress, dialer: dialer}
 	}
 	client, err := endpointVerificationClient(tier, challengeURL, timeout, resolver, dialer, rootCAs)
 	if err != nil {
@@ -133,7 +125,7 @@ func (v *EndpointVerifier) Verify(
 	request.Close = true
 	response, err := client.Do(request)
 	if err != nil {
-		return fmt.Errorf("%w: endpoint probe failed", ErrEndpointUnverified)
+		return endpointProbeError(err)
 	}
 	body, readErr := readBoundedChallengeBody(response.Body)
 	closeErr := response.Body.Close()
@@ -141,7 +133,7 @@ func (v *EndpointVerifier) Verify(
 		return fmt.Errorf("%w: challenge response is invalid", ErrEndpointUnverified)
 	}
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: challenge returned a non-success status", ErrEndpointUnverified)
+		return fmt.Errorf("%w: challenge returned HTTP %d", ErrEndpointUnverified, response.StatusCode)
 	}
 	if string(body) != nonce {
 		return fmt.Errorf("%w: challenge nonce did not match", ErrEndpointUnverified)
@@ -247,7 +239,7 @@ func endpointVerificationClient(
 		Transport: transport,
 		Timeout:   timeout,
 		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return errors.New("gateway: endpoint verification redirects are forbidden")
+			return errEndpointRedirect
 		},
 	}, nil
 }
@@ -279,4 +271,27 @@ func readBoundedChallengeBody(body io.Reader) ([]byte, error) {
 		return nil, errors.New("gateway: challenge response exceeds 64 KiB")
 	}
 	return result, nil
+}
+
+func validateEndpointChallenge(tier Tier, endpoint AdvertisedEndpoint, challengePath, nonce string) (string, error) {
+	if err := tier.Validate(); err != nil {
+		return "", err
+	}
+	if err := endpoint.Validate(); err != nil {
+		return "", fmt.Errorf("%w: invalid endpoint descriptor", ErrEndpointUnverified)
+	}
+	if tier == TierPublic && endpoint.VerificationAddress != "" {
+		return "", fmt.Errorf("%w: public proof cannot use a private verification transport", ErrEndpointUnverified)
+	}
+	if tier == TierPublic && !strings.EqualFold(endpoint.Scheme, endpointSchemeHTTPS) {
+		return "", fmt.Errorf("%w: HTTPS is required", ErrEndpointUnverified)
+	}
+	if !strings.HasPrefix(challengePath, ChallengePathPrefix) || strings.TrimSpace(nonce) == "" {
+		return "", fmt.Errorf("%w: challenge is unavailable", ErrEndpointUnverified)
+	}
+	challengeURL, err := endpointChallengeURL(endpoint, challengePath)
+	if err != nil {
+		return "", fmt.Errorf("%w: invalid challenge URL", ErrEndpointUnverified)
+	}
+	return challengeURL, nil
 }

--- a/internal/gateway/endpoint_verify_test.go
+++ b/internal/gateway/endpoint_verify_test.go
@@ -423,26 +423,37 @@ func TestEndpointVerificationTransport(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, address := range []string{"example.com:443", "100.64.0.1:8443", "127.0.0.1:0", "[::1%lo]:443", "127.0.0.1:443/path"} {
-			endpoint := testEndpoint("https://example.com")
-			endpoint.VerificationAddress = address
-			if err := verifier.Verify(
-				t.Context(),
-				TierPrivate,
-				endpoint,
-				testChallengePath(),
-				"nonce",
-			); !errors.Is(
-				err,
-				ErrEndpointUnverified,
-			) {
-				t.Fatalf("accepted address %s: %v", address, err)
-			}
+			t.Run("Should reject "+address, func(t *testing.T) {
+				t.Parallel()
+				endpoint := testEndpoint("https://example.com")
+				endpoint.VerificationAddress = address
+				err := verifier.Verify(t.Context(), TierPrivate, endpoint, testChallengePath(), "nonce")
+				if !errors.Is(err, ErrEndpointUnverified) ||
+					!strings.Contains(err.Error(), "invalid endpoint descriptor") {
+					t.Fatalf("Verify() = %v, want invalid endpoint descriptor", err)
+				}
+			})
 		}
 	})
 }
 
 func TestEndpointProbeDiagnostics(t *testing.T) {
 	t.Parallel()
+	t.Run("Should classify a timeout while reading the challenge body", func(t *testing.T) {
+		t.Parallel()
+		verifier, endpoint := newChallengeVerifier(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if err := http.NewResponseController(w).Flush(); err != nil {
+				t.Errorf("flush response headers: %v", err)
+				return
+			}
+			<-r.Context().Done()
+		})
+		err := verifier.Verify(t.Context(), TierPrivate, endpoint, testChallengePath(), "nonce")
+		if !errors.Is(err, ErrEndpointUnverified) || !strings.Contains(err.Error(), "endpoint probe timed out") {
+			t.Fatalf("Verify() = %v, want endpoint probe timeout", err)
+		}
+	})
 	for _, tc := range []struct {
 		name  string
 		cause error

--- a/internal/gateway/endpoint_verify_test.go
+++ b/internal/gateway/endpoint_verify_test.go
@@ -17,9 +17,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/netip"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -358,6 +360,112 @@ func challengeHandler(registry ChallengeResolver, tier Tier) http.HandlerFunc {
 		if _, err := w.Write([]byte(nonce)); err != nil {
 			return
 		}
+	}
+}
+
+func TestEndpointVerificationTransport(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name, host, body string
+		tier             Tier
+		trust            bool
+		want             string
+	}{
+		{"Should verify through the relay without host DNS", "example.com", "nonce", TierPrivate, true, ""},
+		{"Should reject a relay for public proof", "example.com", "nonce", TierPublic, true, "public proof"},
+		{"Should authenticate the original hostname through the relay", "wrong.invalid", "nonce", TierPrivate, true, "TLS certificate"},
+		{"Should reject an untrusted certificate through the relay", "example.com", "nonce", TierPrivate, false, "TLS certificate"},
+		{"Should require the exact nonce through the relay", "example.com", "nonce\n", TierPrivate, true, "nonce did not match"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			verifier, endpoint := newChallengeVerifier(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != testChallengePath() || r.Host != tc.host+":8443" || r.TLS.ServerName != tc.host {
+					t.Errorf(
+						"challenge origin or path changed: host=%s path=%s SNI=%s",
+						r.Host,
+						r.URL.Path,
+						r.TLS.ServerName,
+					)
+				}
+				if _, err := io.WriteString(w, tc.body); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			})
+			parsed, err := url.Parse(endpoint.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			endpoint.VerificationAddress = parsed.Host
+			endpoint.URL = "https://" + tc.host + ":8443"
+			resolver := &recordingEndpointResolver{}
+			verifier.resolver = resolver
+			if !tc.trust {
+				verifier.rootCAs = nil
+			}
+			err = verifier.Verify(t.Context(), tc.tier, endpoint, testChallengePath(), "nonce")
+			if tc.want == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+			} else if !errors.Is(err, ErrEndpointUnverified) || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Verify() = %v, want %s", err, tc.want)
+			}
+			if resolver.callCount() != 0 {
+				t.Fatal("private proof used host DNS")
+			}
+		})
+	}
+	t.Run("Should reject non-loopback and malformed verification addresses", func(t *testing.T) {
+		t.Parallel()
+		verifier, err := NewEndpointVerifier(time.Second, testPublicDNSResolver)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, address := range []string{"example.com:443", "100.64.0.1:8443", "127.0.0.1:0", "[::1%lo]:443", "127.0.0.1:443/path"} {
+			endpoint := testEndpoint("https://example.com")
+			endpoint.VerificationAddress = address
+			if err := verifier.Verify(
+				t.Context(),
+				TierPrivate,
+				endpoint,
+				testChallengePath(),
+				"nonce",
+			); !errors.Is(
+				err,
+				ErrEndpointUnverified,
+			) {
+				t.Fatalf("accepted address %s: %v", address, err)
+			}
+		}
+	})
+}
+
+func TestEndpointProbeDiagnostics(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name  string
+		cause error
+		want  string
+	}{
+		{"Should classify DNS failures", &net.DNSError{Name: "secret.invalid", Err: "private nonce"}, "DNS resolution failed"},
+		{"Should classify connection refusal", syscall.ECONNREFUSED, "connection refused"},
+		{"Should classify missing routes", syscall.ENETUNREACH, "network unreachable"},
+		{"Should classify timeouts", context.DeadlineExceeded, "timed out"},
+		{"Should classify cancellation", context.Canceled, "canceled"},
+		{"Should classify redirects", errEndpointRedirect, "redirect refused"},
+		{"Should withhold unknown transport details", errors.New("private nonce"), "transport failed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := endpointProbeError(&url.Error{Op: "Get", URL: "https://secret.invalid/private-nonce", Err: tc.cause})
+			if !errors.Is(err, ErrEndpointUnverified) || !strings.Contains(err.Error(), tc.want) ||
+				strings.Contains(err.Error(), "private nonce") ||
+				strings.Contains(err.Error(), "secret.invalid") ||
+				strings.Contains(err.Error(), "private-nonce") {
+				t.Fatalf("unsafe or incorrect diagnostic: %v", err)
+			}
+		})
 	}
 }
 

--- a/packages/site/content/docs/extensions/develop.mdx
+++ b/packages/site/content/docs/extensions/develop.mdx
@@ -340,6 +340,14 @@ requires the exact nonce from the assigned tier listener. It validates TLS, foll
 bounds the response and request time, and blocks public endpoints that resolve inward. A failed
 challenge leaves the tier unadvertised and marks the provider degraded.
 
+A private endpoint may additionally return `verification_address`, a literal loopback IP and
+non-zero port carrying a raw TCP relay to that exact endpoint. Use this only for an isolated network
+stack that the host cannot dial directly. Forward opaque TLS bytes without terminating TLS or
+rewriting HTTP; the daemon keeps the advertised URL for certificate authentication and challenge
+validation. Bind only to loopback, fix the destination to the endpoint, bound connections and
+shutdown, return the same address in status, and close it during teardown. The field is optional;
+providers that omit it retain the host-network verification path. Public endpoints cannot use it.
+
 Connectivity providers have stricter trust rules than ordinary extensions:
 
 - Install them globally. Workspace-scoped sources are rejected.

--- a/packages/site/content/docs/gateway/tailscale.mdx
+++ b/packages/site/content/docs/gateway/tailscale.mdx
@@ -129,6 +129,13 @@ Public addresses are resolved through an authenticated DNS-over-TLS resolver
 (`gateway.verify.public_dns_resolver`, default `1.1.1.1:853`) rather than this machine's resolver,
 so a private MagicDNS answer can never stand in for the public route.
 
+Private verification travels through the embedded node's own network stack. The provider opens a
+loopback TCP relay with one fixed destination: its private HTTPS listener. The daemon sends TLS
+through that relay and still authenticates the advertised hostname, requires the exact tier
+challenge response, and rejects redirects. This works without a host Tailscale installation or a
+host route to Tailnet addresses. The relay is not an advertised address and closes with the tier.
+Public Funnel verification never uses this private transport.
+
 ## Where state lives
 
 The embedded node keeps its identity, and the private key of its issued certificate, in
@@ -144,7 +151,12 @@ fresh node.
 | `tailscale: tailnet HTTPS certificate domain is unavailable` | MagicDNS or HTTPS certificates are off. Enable both under **DNS** in the admin console.                                 |
 | `tailscale: provision HTTPS certificate: …`                  | Certificate issuance failed or timed out. Confirm HTTPS certificates are enabled, then let the daemon retry.            |
 | `tailscale: listen for public gateway: …`                    | Funnel is not allowed for this node. Grant the funnel policy in the admin console (step 1) and retry.                   |
-| `gateway endpoint unverified: endpoint probe failed`         | Usually public DNS still propagating. The daemon retries on its own; recheck status after a minute.                     |
+| `endpoint DNS resolution failed` | The probe resolver could not resolve the endpoint. For public Funnel, check DNS propagation and the configured public resolver. |
+| `endpoint connection refused` or `endpoint network unreachable` | Check provider listener readiness and the network route. The embedded private provider uses its own tsnet transport. |
+| `endpoint probe timed out` | Check provider routing, listener readiness, and certificate provisioning. The daemon retries while keeping the endpoint unadvertised. |
+| `endpoint TLS certificate verification failed` | Check the endpoint hostname, certificate validity and system trust store. TLS verification must remain enabled. |
+| `challenge returned HTTP …` or `challenge nonce did not match` | The endpoint did not return the exact assigned tier challenge. Inspect forwarding and tier binding; a successful request to `/` is not sufficient proof. |
+| `endpoint transport failed` (or older `endpoint probe failed`) | Inspect provider health and network connectivity. This message alone does not identify DNS propagation as the cause. |
 | Provider degraded with `forward target is unavailable`       | The tier's loopback listener stopped. Check daemon health with `compozy status`, then `compozy gateway status -o json`. |
 
 ## Remove it cleanly

--- a/packages/site/content/docs/gateway/tailscale.mdx
+++ b/packages/site/content/docs/gateway/tailscale.mdx
@@ -145,19 +145,19 @@ fresh node.
 
 ## Troubleshooting
 
-| Symptom                                                      | Cause and fix                                                                                                           |
-| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
-| `TS_AUTHKEY binding is required`                             | No key bound, or the binding was removed. Run step 2. Expired and revoked keys fail the same way.                       |
-| `tailscale: tailnet HTTPS certificate domain is unavailable` | MagicDNS or HTTPS certificates are off. Enable both under **DNS** in the admin console.                                 |
-| `tailscale: provision HTTPS certificate: …`                  | Certificate issuance failed or timed out. Confirm HTTPS certificates are enabled, then let the daemon retry.            |
-| `tailscale: listen for public gateway: …`                    | Funnel is not allowed for this node. Grant the funnel policy in the admin console (step 1) and retry.                   |
-| `endpoint DNS resolution failed` | The probe resolver could not resolve the endpoint. For public Funnel, check DNS propagation and the configured public resolver. |
-| `endpoint connection refused` or `endpoint network unreachable` | Check provider listener readiness and the network route. The embedded private provider uses its own tsnet transport. |
-| `endpoint probe timed out` | Check provider routing, listener readiness, and certificate provisioning. The daemon retries while keeping the endpoint unadvertised. |
-| `endpoint TLS certificate verification failed` | Check the endpoint hostname, certificate validity and system trust store. TLS verification must remain enabled. |
-| `challenge returned HTTP …` or `challenge nonce did not match` | The endpoint did not return the exact assigned tier challenge. Inspect forwarding and tier binding; a successful request to `/` is not sufficient proof. |
-| `endpoint transport failed` (or older `endpoint probe failed`) | Inspect provider health and network connectivity. This message alone does not identify DNS propagation as the cause. |
-| Provider degraded with `forward target is unavailable`       | The tier's loopback listener stopped. Check daemon health with `compozy status`, then `compozy gateway status -o json`. |
+| Symptom                                                         | Cause and fix                                                                                                                                            |
+| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TS_AUTHKEY binding is required`                                | No key bound, or the binding was removed. Run step 2. Expired and revoked keys fail the same way.                                                        |
+| `tailscale: tailnet HTTPS certificate domain is unavailable`    | MagicDNS or HTTPS certificates are off. Enable both under **DNS** in the admin console.                                                                  |
+| `tailscale: provision HTTPS certificate: …`                     | Certificate issuance failed or timed out. Confirm HTTPS certificates are enabled, then let the daemon retry.                                             |
+| `tailscale: listen for public gateway: …`                       | Funnel is not allowed for this node. Grant the funnel policy in the admin console (step 1) and retry.                                                    |
+| `endpoint DNS resolution failed`                                | The probe resolver could not resolve the endpoint. For public Funnel, check DNS propagation and the configured public resolver.                          |
+| `endpoint connection refused` or `endpoint network unreachable` | Check provider listener readiness and the network route. The embedded private provider uses its own tsnet transport.                                     |
+| `endpoint probe timed out`                                      | Check provider routing, listener readiness, and certificate provisioning. The daemon retries while keeping the endpoint unadvertised.                    |
+| `endpoint TLS certificate verification failed`                  | Check the endpoint hostname, certificate validity and system trust store. TLS verification must remain enabled.                                          |
+| `challenge returned HTTP …` or `challenge nonce did not match`  | The endpoint did not return the exact assigned tier challenge. Inspect forwarding and tier binding; a successful request to `/` is not sufficient proof. |
+| `endpoint transport failed` (or older `endpoint probe failed`)  | Inspect provider health and network connectivity. This message alone does not identify DNS propagation as the cause.                                     |
+| Provider degraded with `forward target is unavailable`          | The tier's loopback listener stopped. Check daemon health with `compozy status`, then `compozy gateway status -o json`.                                  |
 
 ## Remove it cleanly
 

--- a/packages/site/vercel.json
+++ b/packages/site/vercel.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://openapi.vercel.sh/vercel.json",
+    "installCommand": "bunx bun@1.4.0 install --frozen-lockfile",
     "headers": [
         {
             "source": "/llms.txt",

--- a/sdk/go/contracts/types_006_gen.go
+++ b/sdk/go/contracts/types_006_gen.go
@@ -116,10 +116,11 @@ type Confirmation struct {
 }
 
 type ConnectivityAdvertisedEndpoint struct {
-	URL          string `json:"url"`
-	Scheme       string `json:"scheme"`
-	SchemePolicy string `json:"scheme_policy,omitempty"`
-	Stability    string `json:"stability"`
+	URL                 string `json:"url"`
+	Scheme              string `json:"scheme"`
+	SchemePolicy        string `json:"scheme_policy,omitempty"`
+	Stability           string `json:"stability"`
+	VerificationAddress string `json:"verification_address,omitempty"`
 }
 
 type ConnectivityEstablishRequest struct {

--- a/sdk/typescript/src/generated/contracts.ts
+++ b/sdk/typescript/src/generated/contracts.ts
@@ -1350,6 +1350,7 @@ export interface ConnectivityAdvertisedEndpoint {
   scheme: string;
   scheme_policy?: string;
   stability: string;
+  verification_address?: string;
 }
 
 export interface ConnectivityEstablishRequest {

--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -15,4 +15,4 @@ module.exports = {
       exclude: ["dist/**", "**/*.d.ts", "src/index.ts"],
     },
   },
-} satisfies import("vitest/config").UserConfig;
+} satisfies import("vitest/config").ViteUserConfig;

--- a/sdk/typescript/vitest.config.ts
+++ b/sdk/typescript/vitest.config.ts
@@ -1,6 +1,4 @@
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
+module.exports = {
   test: {
     name: "extension-sdk",
     environment: "node",
@@ -17,4 +15,4 @@ export default defineConfig({
       exclude: ["dist/**", "**/*.d.ts", "src/index.ts"],
     },
   },
-});
+} satisfies import("vitest/config").UserConfig;

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -634,6 +634,12 @@ The provider embeds `tsnet`; do not install or supervise a separate Tailscale cl
 manifest must include the selected tier as `gateway.private` or `gateway.public` in
 `channel_scopes`; a mismatch fails before provider code starts.
 
+Bundled private Tailscale proof uses a loopback TCP relay into the embedded tsnet node, retaining
+core TLS hostname and exact tier nonce validation. It requires no host Tailscale client or host
+Tailnet route. The relay is private-tier-only and never advertised. Probe diagnostics distinguish
+DNS, refused/unreachable connections, timeout, TLS certificate failure, HTTP status and nonce
+mismatch without exposing the challenge. Inspect the reported class; HTTP 200 at `/` is not proof.
+
 Public endpoint proof resolves through authenticated DNS-over-TLS at
 `gateway.verify.public_dns_resolver`, not the host resolver, so MagicDNS cannot turn a Funnel proof
 into a private-tailnet connection. A provider waiting for public DNS remains staged and unadvertised


### PR DESCRIPTION
## What & why

Closes #602.

When CompozyOS runs the bundled Tailscale provider on a host without a host-level Tailnet route,
the embedded node can be connected and remotely reachable while core endpoint verification fails.
The provider owns a userspace tsnet network in its subprocess, but the verifier previously used
`net.DefaultResolver` and `net.Dialer` in the host network. All HTTP transport errors became
`endpoint probe failed`, obscuring this distinction. A successful remote request to `/` does not
prove the exact daemon-owned tier challenge.

The private provider now opens a bounded loopback TCP relay to its own private endpoint using
`tsnet.Server.Dial`. The core sends TLS through that relay, retaining the advertised URL for SNI,
certificate trust/hostname verification, HTTP Host, the challenge path and exact nonce comparison.
It still follows no redirects, bounds the response/deadline, and advertises only after proof.
The relay cannot select arbitrary destinations and closes with its tier before node shutdown.

Public Funnel proof rejects private verification transports and retains authenticated public DNS
and the existing outbound address policy. Existing providers that omit the new optional
`verification_address` field keep the direct verification path. Diagnostics distinguish DNS,
connection refusal/unreachable routing, timeout, cancellation, certificate failure, redirect
refusal, HTTP status and nonce mismatch without exposing raw transport errors or challenge secrets.

## How you verified it

- Real TLS socket tests cover stalled-body timeout diagnostics, relay success without host DNS, certificate trust, original hostname,
  exact nonce, public-tier rejection and invalid relay addresses. Existing gateway suites cover
  tier binding, redirect/body/deadline/outbound policy rejection and advertisement/recovery.
- Provider tests exercise the relay through the actual forwarding lifecycle, preserve Host and the
  exact challenge path/response, check stable status identity and prove closure after teardown.
- The pinned upstream `tailscale.com/tsnet` `TestSelfDial` passed with race detection using its own
  local test control server and virtual node. No real Tailnet credentials or host setup were used.
- Focused gateway/provider/extension suites passed with race detection; owning integration suites,
  `make codegen` and `make gate` evidence are detailed in the QA report.

The host is macOS. An isolated Linux/systemd VPS, disposable authorized Tailnet credentials,
public certificate issuance and remote device were not available. These local checks do not claim
that the reporter's external Tailnet/Linux scenario passed. The affected QA scenario preserves
that limitation. No active gateway, auth key, host Tailscale installation or Tailnet device changed.

## Impact

- Additive extension protocol field with generated Go and TypeScript SDKs; no new RPC methods,
  config keys, public Gateway DTOs, migrations or authentication changes.
- Relay addresses are runtime-only and are not advertised. Existing endpoint identity checks
  include the relay address. Provider trust and private/public ownership remain unchanged.
- Updated Tailscale troubleshooting, extension authoring, official Compozy runtime guidance,
  cross-surface audit and `RT-connectivity-provider-route` QA evidence.
- SDK test configuration uses typed CommonJS, matching its package format and removing the Vite
  native-loader warning encountered in the required gate without suppressing diagnostics.
- The preview install command pins Bun 1.4.0 (the repository version) and requires the lockfile.
  The first Vercel build used Bun 1.3.14, ignored the newer lockfile and installed drifting
  dependencies, causing unrelated Fumadocs/Zod type errors. No Vercel project settings changed.
- Authored and verified by the assigned Codex agent (GPT-6 Astra); no merge performed.

See `docs/qa/reports/2026-09-10-issue-602-endpoint-verification.md` and the issue's section in
`docs/_memory/change-impact.md` for evidence boundaries and compatibility details.

First CodeRabbit review: four inline findings were fixed together in `c8e742972`; all threads
were answered with evidence and resolved. The two general warnings have documented dispositions
in [the complete review inventory](https://github.com/compozy/compozy/pull/608#issuecomment-5626244270).
Greptile reported no actionable findings. Per the updated delivery instruction, another review
round is not a completion requirement; current-head GitHub CI owns delivery validation.

---

- [x] Initial implementation and preview-install remediation passed `make gate` locally. Per the
  operator's instruction, subsequent gates run in PR CI to preserve local machine capacity.
- [x] New or changed behavior is covered by tests, with external validation limits documented above
- [x] The authoring agent is named above and verified the result through the listed checks
