### PR TITLE
feat: truthful operator surface on remote tiers and mobile ergonomics

### DIFF
--- a/COPY.md
+++ b/COPY.md
@@ -490,6 +490,17 @@ zoomed to return to the saved placement and size. These labels describe internal
 CompozyOS windows, not native browser or application fullscreen. Resizing a zoomed
 window adopts the resized geometry instead of restoring its saved placement.
 
+Loopback-only state (shown when a remote-tier device attempts an action the
+daemon can only execute on its own machine; neutral and informative, never
+error-red; strings live in `web/src/systems/gateway/lib/gateway-copy.ts`):
+
+- Panel title: `Not available from this device`
+- Panel description: `This action can only run on the machine running CompozyOS.`
+- Panel hint: `Open CompozyOS on that machine and run it there.`
+- Banner title: `This action runs on the machine running CompozyOS`
+- Banner description: `You are connected through remote access, so this action cannot run from this device.`
+- Tasks zero-inventory (remote tier): `No tasks yet` / `Create or run tasks from the machine running CompozyOS.`
+
 Use:
 
 - current state, next action, and consequence.

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -97,3 +97,32 @@ Issue #603 delivery also pins the site preview install command to the repository
 ## PRs 607–611 — Main integration remediation
 
 The [integration report](../qa/reports/2026-09-10-pr-607-611-integration.md) records all five guarded squash results, first-round review dispositions, unpublished notification-worktree fixes and CI regressions. Approval receipts follow meaningful approval transitions; profile deletion removes owned receipts and snapshots. Continuous prose retains search indices, and window opening uses the same snapshot revision for identity lookup and command admission. Public wire/config/native-tool shapes and underlying source-state actions remain unchanged. Existing profile, observer, API, transcript and window-manager suites own verification, with delivery gates and rendered journeys in CI under the operator's explicit override.
+
+## Spec mobile-surface-truth — remote/mobile operator surface truth
+
+Owning delivery: spec set `.compozy/tasks/mobile-surface-truth/` on branch
+`mobile-browser-pwa` (PR pending). Downstream tasks cite and update this
+entry instead of restating it.
+
+- **Native tools:** unchanged — checked `compozy__gateway` and all
+  `compozy__*` IDs: the change adds machine codes to two existing 403
+  envelopes and gates SPA affordances; no tool IDs, schemas, digests, or
+  capability gates change.
+- **Extensibility and hooks:** unchanged — extension manifests, hooks,
+  bridge SDKs, MCP sidecars, and registries checked; remote mutation
+  reachability was already 403 (`loopbackMutationGuard`); config lifecycle
+  unaffected (no `config.toml` keys). SD-013: additive wire codes
+  auto-migrate (public surface ladder); no delete targets; the internal
+  sentinel re-home hard-cuts with all consumers updated together.
+- **Workspace data isolation:** unaffected — no data paths, storage, or
+  workspace scoping change; capability state is client-side, derived from
+  the latched listener tier.
+- **Official Compozy skill:** unchanged — checked `skills/compozy/`: no
+  public behavior, CLI path, hook, capability, resource, or tool semantics
+  change; the additive codes do not alter documented CLI/API journeys.
+- **Web/Docs:** `web/src/systems/{gateway,os,terminal,settings,extensions,tasks,notifications,profiles}`
+  and `web/src/lib/{api-client,gateway-access-signal}.ts` per the spec's
+  `_uiux.md`; verification owner is the QA tail pair (qa-report →
+  qa-execution) plus the owning Go/web suites. `packages/site` docs
+  unaffected; the API error-code addition is documented via the spec's
+  `_dx.md`.

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -101,7 +101,7 @@ The [integration report](../qa/reports/2026-09-10-pr-607-611-integration.md) rec
 ## Spec mobile-surface-truth — remote/mobile operator surface truth
 
 Owning delivery: spec set `.compozy/tasks/mobile-surface-truth/` on branch
-`mobile-browser-pwa` (PR pending). Downstream tasks cite and update this
+`mobile-surface-truth` (PR pending). Downstream tasks cite and update this
 entry instead of restating it.
 
 - **Native tools:** unchanged — checked `compozy__gateway` and all

--- a/docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html
+++ b/docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html
@@ -1,0 +1,409 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark">
+<title>Mobile surface truth · CompozyOS shell at 390×844</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=JetBrains+Mono:wght@400..700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../design-system/ds-core.css">
+<link rel="stylesheet" href="../design-system/ds-shell.css">
+<!--
+  mobile-surface-truth · S6 ergonomics artboard (task_04 design pass).
+  Freezes the mobile ergonomics visual language for the supported viewport
+  baseline 390×844 before implementation. Grammar: DESIGN.md + tokens.css
+  mirrored by ds-core.css; shell chrome dialect from ds-shell.css.
+
+  Frozen decisions (the implementation matches these, not the reverse):
+  T1  Touch floor 44px at the established ≤760px tier (--height-button-cta-lg,
+      same floor as dialog-shell). Menubar controls fill the 44px bar height.
+  T2  Compact shell presentation (<960px, OS_COMPACT_BREAKPOINT) is unchanged:
+      app menus collapse into the palette, tab bar replaces the dock strip,
+      traffic lights use the 44px compact targets, windows stack.
+  T3  Win-layer work area in compact reserves the tab-bar height (56px), not
+      the floating dock band (82px) — 26px returned to stream content.
+  T4  Viewport contract: viewport-fit=cover + interactive-widget=resizes-content.
+      Keyboard-open shrinks the layout viewport; flex columns keep the composer
+      above the keyboard (US-003.EC-1). No body scroll, ever.
+  T5  Command palette stays top-anchored at the touch tier (divergence from the
+      dialog bottom-surface convention, keyboard interplay outranks it); rows
+      and the input group reach the 44px floor; the results well grows to
+      min(52dvh, 440px) and scrolls under the keyboard.
+  T6  Session rail overlays the transcript at ≤760px (264px rail, --shadow-overlay)
+      instead of docking; the transcript keeps full width underneath.
+  T7  Landscape keeps the same chrome; height is the flexible axis (menubar 44 +
+      tab bar 56 leave ~282px of stack). Windows never render under the tab bar.
+  T8  S5 loopback-only banner strip sits between the menubar and the win-layer,
+      full-width, flat canvas-soft, neutral signal. It pushes the work area down;
+      it never overlays window content.
+  Residuals (recorded, not frozen as debt-free): profile-switcher trigger keeps
+  its 28px well (cross-system slot, quiet-until-plural); log bodies keep their
+  own horizontal scroll wells inside the read view.
+-->
+<style>
+  body{background:var(--canvas);overflow-y:auto}
+  .hub{max-width:1320px;margin:0 auto;padding:52px 36px 80px}
+  .hub h1{font-size:22px;font-weight:600;letter-spacing:-.02em;color:var(--fg-strong)}
+  .hub__lede{margin-top:10px;font-size:var(--text-small-body);line-height:1.6;color:var(--muted);max-width:88ch;text-wrap:pretty}
+  .hub__lede code{font-family:var(--font-mono);font-size:11.5px;color:var(--subtle)}
+  .boards{margin-top:36px;display:flex;flex-wrap:wrap;gap:36px;align-items:flex-start}
+  .board{display:flex;flex-direction:column;gap:10px}
+  .board__t{font-size:12px;font-weight:510;color:var(--subtle)}
+  .board__t b{color:var(--fg);font-weight:560}
+  .frame{position:relative;flex:none;background:var(--rail);border:1px solid var(--line);border-radius:var(--radius-lg);overflow:hidden;box-shadow:var(--shadow-overlay)}
+
+  /* ---- shell specimens (ds-shell dialect, board-local geometry) ---- */
+  .os{position:relative;display:flex;flex-direction:column;width:390px;height:844px}
+  .os--landscape{width:844px;height:390px}
+  .menubar{position:relative;z-index:500;flex:none;display:flex;align-items:center;justify-content:space-between;height:44px;flex:none;
+    border-bottom:1px solid var(--line);background:var(--shell-glass);backdrop-filter:blur(var(--blur-shell)) saturate(var(--saturate-shell))}
+  .mb-side{display:flex;align-items:center;gap:4px;min-width:0;padding:0 8px;height:100%}
+  .mb-control{display:grid;place-items:center;width:44px;height:44px;color:var(--muted)} /* T1: the bar is the target */
+  .mb-control svg{width:18px;height:18px}
+  .mb-logo{color:var(--fg)}
+  .mb-chip{display:flex;align-items:center;gap:7px;min-width:0;height:44px;padding:0 8px;border-radius:var(--radius-md)}
+  .mb-mono{flex:none;display:grid;place-items:center;width:18px;height:18px;border:1px solid var(--line-strong);border-radius:3px;background:var(--elevated);
+    font-family:var(--font-mono);font-size:9px;font-weight:600;color:var(--fg)}
+  .mb-name{font-size:13px;font-weight:560;color:var(--fg-strong);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:96px} /* T1 tier: truncated */
+  .mb-chev{width:12px;height:12px;color:var(--subtle);flex:none}
+
+  /* T8 — S5 loopback-only banner strip: flat, neutral, between menubar and desk */
+  .loopback-strip{z-index:490;flex:none;display:flex;align-items:center;gap:10px;padding:9px 12px;border-bottom:1px solid var(--line);background:var(--canvas-soft)}
+  .loopback-strip svg{width:15px;height:15px;color:var(--neutral);flex:none}
+  .loopback-strip__t{font-size:12px;font-weight:560;color:var(--fg)}
+  .loopback-strip__d{font-size:11px;line-height:1.45;color:var(--muted)}
+
+  .desk{position:relative;flex:1;min-height:0}
+  .win{position:absolute;inset:0;display:flex;flex-direction:column;border:1px solid var(--line-strong);border-radius:var(--r-win);
+    background:var(--canvas-soft);box-shadow:var(--shadow-win);overflow:hidden}
+  .win-head{flex:none;display:flex;align-items:center;gap:12px;height:44px;padding:0 10px;border-bottom:1px solid var(--line-soft)}
+  .tl{display:flex;align-items:center}
+  .tl i{width:15px;height:15px;border-radius:4px;border:1px solid var(--line-strong);background:var(--btn-fill)}
+  .tl i + i{margin-left:0} /* compact: 44px targets touch */
+  .win-title{flex:1;min-width:0;text-align:center;font-size:12px;font-weight:560;color:var(--fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .win-head svg{width:15px;height:15px;color:var(--muted);flex:none}
+  .win-body{flex:1;min-height:0;display:flex;flex-direction:column;background:var(--canvas)}
+
+  /* session stream (T6 rail overlay shown open on board 02) */
+  .stream{position:relative;flex:1;min-height:0;display:flex}
+  .rail{position:absolute;inset:0 auto 0 0;z-index:20;width:264px;display:flex;flex-direction:column;background:var(--rail);border-right:1px solid var(--line);
+    box-shadow:var(--shadow-overlay)}
+  .rail--closed{display:none}
+  .rail__head{flex:none;display:flex;align-items:center;justify-content:space-between;padding:10px 12px 8px}
+  .rail__t{font-size:11px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--subtle)}
+  .rail__x{display:grid;place-items:center;width:44px;height:44px;margin:-8px -8px -8px 0;color:var(--muted)}
+  .rail__row{display:flex;align-items:center;gap:8px;min-height:44px;padding:0 12px;border-top:1px solid var(--line-soft);font-size:13px;color:var(--muted)}
+  .rail__row.is-active{background:var(--elevated);color:var(--fg-strong)}
+  .rail__row i{width:7px;height:7px;border-radius:50%;background:var(--success);flex:none}
+  .transcript{flex:1;min-height:0;overflow:hidden;padding:14px 16px;display:flex;flex-direction:column;gap:14px}
+  .msg{max-width:86%;display:flex;flex-direction:column;gap:4px}
+  .msg--agent{align-self:flex-start}
+  .msg--user{align-self:flex-end;align-items:flex-end}
+  .msg__meta{font-size:10px;color:var(--faint);font-family:var(--font-mono)}
+  .msg__body{font-size:13.5px;line-height:1.55;color:var(--fg);background:var(--canvas-soft);border:1px solid var(--line-soft);border-radius:10px;padding:8px 11px}
+  .msg--user .msg__body{background:var(--surface-glaze2,rgba(255,255,255,.045))}
+
+  .composer{flex:none;border-top:1px solid var(--line);background:var(--canvas);padding:6px 12px 14px}
+  .composer__well{display:flex;align-items:flex-end;gap:8px;min-height:44px;border:1px solid var(--line);border-radius:10px;background:var(--canvas-tint);padding:8px 10px}
+  .composer__ph{flex:1;font-size:13.5px;color:var(--subtle)}
+  .composer__send{display:grid;place-items:center;width:30px;height:30px;border-radius:8px;background:var(--accent);color:var(--accent-ink)}
+  .composer__send svg{width:14px;height:14px}
+
+  /* tab bar (existing compact dock, ratified) */
+  .tabbar{z-index:600;flex:none;display:flex;align-items:stretch;height:calc(56px + env(safe-area-inset-bottom,0px));position:relative;
+    border-top:1px solid var(--line);background:var(--shell-glass);backdrop-filter:blur(var(--blur-shell)) saturate(var(--saturate-shell))}
+  .tabbar__scroll{flex:1;display:flex;align-items:center;gap:2px;overflow:hidden;padding:6px 6px calc(6px + env(safe-area-inset-bottom,0px))}
+  .tab-item{position:relative;display:grid;place-items:center;width:44px;height:44px;border-radius:13px;color:var(--muted)}
+  .tab-item svg{width:21px;height:21px}
+  .tab-item.is-running::after{content:"";position:absolute;bottom:3px;left:50%;transform:translateX(-50%);width:4px;height:4px;border-radius:50%;background:var(--muted)}
+  .tab-item.is-badge::before{content:"2";position:absolute;top:2px;right:2px;min-width:15px;height:15px;padding:0 3px;border-radius:7px;background:var(--accent);
+    color:var(--accent-ink);font-family:var(--font-mono);font-size:10px;font-weight:700;display:grid;place-items:center}
+  .tabbar__actions{flex:none;display:flex;align-items:center;border-left:1px solid var(--line);padding:6px 8px calc(6px + env(safe-area-inset-bottom,0px))}
+  .tab-new{display:grid;place-items:center;width:44px;height:44px;border-radius:13px;background:var(--accent);color:var(--accent-ink)}
+  .tab-new svg{width:18px;height:18px}
+
+  /* keyboard-open board (EC-1, T4): the shell compresses to the visual
+     viewport (resizes-content) — the keyboard graphic is drawn as a separate
+     specimen below the frame, never over the composer. */
+  .kbd{position:relative;height:296px;display:flex;flex-direction:column;border-radius:var(--radius-lg);overflow:hidden;border:1px solid var(--line)}
+  .kbd__kbd{flex:1;width:100%;background:#242220;display:grid;grid-template-columns:repeat(10,minmax(0,1fr));gap:5px;padding:10px 8px;align-content:start}
+  .kbd__kbd i{height:34px;border-radius:5px;background:var(--elevated);border:1px solid var(--line-strong)}
+  .kbd__home{flex:none;height:22px;display:grid;place-items:center;background:#242220}
+  .kbd__home i{width:110px;height:4px;border-radius:2px;background:var(--line-strong)}
+  .vpline{position:relative;display:flex;align-items:center;gap:8px;margin-top:8px;font-family:var(--font-mono);font-size:10px;color:var(--subtle)}
+  .vpline::before{content:"";flex:none;width:14px;border-top:1px dashed color-mix(in oklab,var(--accent) 55%,transparent)}
+
+  /* palette board (T5) */
+  .palette{position:absolute;top:34px;left:8px;right:8px;z-index:800;display:flex;flex-direction:column;border-radius:8px;background:var(--canvas-soft);
+    box-shadow:var(--shadow-overlay);overflow:hidden}
+  .palette__input{display:flex;align-items:center;gap:8px;min-height:44px;margin:4px 4px 0;padding:0 10px;border:1px solid var(--line);border-radius:8px;background:var(--canvas-tint)}
+  .palette__input svg{width:15px;height:15px;color:var(--subtle);flex:none}
+  .palette__ph{font-size:13.5px;color:var(--subtle)}
+  .palette__list{max-height:292px;overflow:hidden;padding:12px 4px 12px}
+  .prow{display:flex;align-items:center;gap:10px;min-height:44px;padding:0 12px;border-radius:7px;font-size:13px;color:var(--fg)}
+  .prow.is-sel{background:var(--elevated);color:var(--fg-strong)}
+  .prow svg{width:15px;height:15px;color:var(--muted);flex:none}
+  .prow__kbd{margin-left:auto;font-family:var(--font-keys);font-size:10.5px;color:var(--faint)}
+  .palette__foot{display:flex;align-items:center;gap:12px;border-top:1px solid var(--line);padding:8px 14px;font-size:10.5px;color:var(--faint)}
+  .scrim{position:absolute;inset:0;background:rgba(0,0,0,.55)}
+
+  /* frozen-map table */
+  .map{margin-top:44px;max-width:1040px}
+  .map h2{font-size:14px;font-weight:600;color:var(--fg-strong);padding-bottom:10px}
+  .callout{position:absolute;z-index:900;display:flex;align-items:center;gap:6px;height:22px;padding:0 8px;border-radius:999px;
+    background:var(--canvas-tint);border:1px solid var(--line-strong);font-family:var(--font-mono);font-size:10px;color:var(--fg)}
+  .callout b{color:var(--accent-strong);font-weight:700}
+  .legend{margin-top:44px;max-width:1040px;font-size:12px;line-height:1.6;color:var(--muted)}
+  .legend code{font-family:var(--font-mono);font-size:11px;color:var(--subtle)}
+</style>
+</head>
+<body>
+<div class="hub">
+  <h1>CompozyOS · mobile shell ergonomics — 390×844</h1>
+  <p class="hub__lede">
+    Frozen ergonomics map for surface S6 (task_04, workflow <code>mobile-surface-truth</code>).
+    The compact shell presentation (&lt;960px) already exists — tab bar, stacked windows, compact
+    traffic lights, collapsed menubar menus. This pass freezes the touch-tier layer that rides on
+    it: the 44px floor at the established ≤760px tier, the keyboard-open viewport contract, the
+    compact work-area reservation, the overlay session rail, and the S5 banner strip placement.
+    Boards below are specimens — production components own the real chrome.
+  </p>
+
+  <div class="boards">
+    <!-- BOARD 01 — portrait shell -->
+    <div class="board">
+      <div class="board__t"><b>01 · Portrait shell 390×844</b> — monitoring journey: session stream</div>
+      <div class="frame">
+        <div class="os">
+          <div class="menubar">
+            <div class="mb-side">
+              <span class="mb-control mb-logo"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="7"/></svg></span>
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c3 3.5 3 14 0 18M12 3c-3 3.5-3 14 0 18"/></svg></span>
+              <span class="mb-chip"><span class="mb-mono">CO</span><span class="mb-name">compozy</span><svg class="mb-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m7 9 5-5 5 5M7 15l5 5 5-5"/></svg></span>
+            </div>
+            <div class="mb-side">
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0"/></svg></span>
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M22 2 11 13M22 2 15 22l-4-9-9-4Z"/></svg></span>
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></span>
+            </div>
+          </div>
+          <div class="loopback-strip">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/><path d="M6 7h.01M6 17h.01"/></svg>
+            <span><span class="loopback-strip__t">This action runs on the machine running CompozyOS.</span><br>
+            <span class="loopback-strip__d">Paired devices can read, not change settings. Open Compozy on the host to make changes.</span></span>
+          </div>
+          <div class="desk">
+            <div class="win">
+              <div class="win-head">
+                <span class="tl"><i></i><i></i></span>
+                <span class="win-title">iris-coder · session</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+              </div>
+              <div class="win-body">
+                <div class="stream">
+                  <div class="transcript">
+                    <div class="msg msg--user"><span class="msg__meta">you · 14:02</span><span class="msg__body">Check the failing deploy loop and summarize the last run.</span></div>
+                    <div class="msg msg--agent"><span class="msg__meta">iris-coder · running</span><span class="msg__body">The last run failed at the integration stage — 2 of 9 checks red. Pulling the run log now…</span></div>
+                    <div class="msg msg--agent"><span class="msg__meta">iris-coder</span><span class="msg__body">Retries are within budget; the failure is deterministic (missing fixture).</span></div>
+                  </div>
+                </div>
+                <div class="composer">
+                  <div class="composer__well"><span class="composer__ph">Message iris-coder…</span><span class="composer__send"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2 11 13M22 2 15 22l-4-9-9-4Z"/></svg></span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="tabbar">
+            <div class="tabbar__scroll">
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg></span>
+              <span class="tab-item is-running is-badge"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z"/></svg></span>
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/></svg></span>
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/></svg></span>
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg></span>
+            </div>
+            <div class="tabbar__actions"><span class="tab-new"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5v14"/></svg></span></div>
+          </div>
+          <span class="callout" style="top:11px;right:6px"><b>T1</b> 44px bar controls</span>
+          <span class="callout" style="top:96px;left:6px"><b>T8</b> S5 strip · flat · neutral</span>
+          <span class="callout" style="bottom:70px;left:6px"><b>T3</b> work area = tab-bar 56px</span>
+          <span class="callout" style="bottom:8px;right:6px"><b>T2</b> tab bar ratified</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- BOARD 02 — keyboard open -->
+    <div class="board">
+      <div class="board__t"><b>02 · Keyboard open (US-003.EC-1)</b> — shell compresses to the 548px visual viewport</div>
+      <div class="frame">
+        <div class="os" style="height:548px">
+          <div class="menubar">
+            <div class="mb-side">
+              <span class="mb-control mb-logo"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="7"/></svg></span>
+              <span class="mb-chip"><span class="mb-mono">CO</span><span class="mb-name">compozy</span><svg class="mb-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m7 9 5-5 5 5M7 15l5 5 5-5"/></svg></span>
+            </div>
+            <div class="mb-side">
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M22 2 11 13M22 2 15 22l-4-9-9-4Z"/></svg></span>
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82 2 2 0 1 1-2.83 2.83 1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0 1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33 2 2 0 1 1-2.83-2.83 1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4 1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82 2 2 0 1 1 2.83-2.83 1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0 1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33 2 2 0 1 1 2.83 2.83 1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></span>
+            </div>
+          </div>
+          <div class="desk">
+            <div class="win">
+              <div class="win-head">
+                <span class="tl"><i></i><i></i></span>
+                <span class="win-title">iris-coder · session</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+              </div>
+              <div class="win-body">
+                <div class="stream">
+                  <div class="rail">
+                    <div class="rail__head"><span class="rail__t">Sessions</span><span class="rail__x"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6 6 18M6 6l12 12"/></svg></span></div>
+                    <div class="rail__row is-active"><i></i>deploy-triage</div>
+                    <div class="rail__row"><i></i>fixture-repair</div>
+                    <div class="rail__row"><i></i>release-notes</div>
+                  </div>
+                  <div class="transcript">
+                    <div class="msg msg--user"><span class="msg__meta">you · 14:02</span><span class="msg__body">Check the failing deploy loop and summarize the last run.</span></div>
+                    <div class="msg msg--agent"><span class="msg__meta">iris-coder · running</span><span class="msg__body">The last run failed at the integration stage — 2 of 9 checks red.</span></div>
+                  </div>
+                </div>
+                <div class="composer">
+                  <div class="composer__well"><span class="composer__ph">Message iris-coder…</span><span class="composer__send"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2 11 13M22 2 15 22l-4-9-9-4Z"/></svg></span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="tabbar">
+            <div class="tabbar__scroll">
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg></span>
+              <span class="tab-item is-running"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z"/></svg></span>
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/></svg></span>
+            </div>
+            <div class="tabbar__actions"><span class="tab-new"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5v14"/></svg></span></div>
+          </div>
+          <span class="callout" style="top:210px;right:6px"><b>T6</b> rail overlays, transcript keeps width</span>
+        </div>
+      </div>
+      <div class="vpline">548px visual viewport line — <b style="color:var(--accent-strong)">&nbsp;T4&nbsp;</b> composer + tab bar stay above it</div>
+      <div class="kbd" aria-hidden="true">
+        <div class="kbd__kbd"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></div>
+        <div class="kbd__home"><i></i></div>
+      </div>
+    </div>
+
+    <!-- BOARD 03 — landscape -->
+    <div class="board">
+      <div class="board__t"><b>03 · Landscape 844×390 (US-003.EC-2)</b> — same chrome, height flexes</div>
+      <div class="frame">
+        <div class="os os--landscape">
+          <div class="menubar">
+            <div class="mb-side">
+              <span class="mb-control mb-logo"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="7"/></svg></span>
+              <span class="mb-chip"><span class="mb-mono">CO</span><span class="mb-name">compozy</span><svg class="mb-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m7 9 5-5 5 5M7 15l5 5 5-5"/></svg></span>
+            </div>
+            <div class="mb-side">
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M22 2 11 13M22 2 15 22l-4-9-9-4Z"/></svg></span>
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82 2 2 0 1 1-2.83 2.83 1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0 1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33 2 2 0 1 1-2.83-2.83 1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4 1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82 2 2 0 1 1 2.83-2.83 1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0 1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33 2 2 0 1 1 2.83 2.83 1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></span>
+            </div>
+          </div>
+          <div class="desk">
+            <div class="win">
+              <div class="win-head">
+                <span class="tl"><i></i><i></i></span>
+                <span class="win-title">iris-coder · session</span>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+              </div>
+              <div class="win-body">
+                <div class="stream">
+                  <div class="transcript" style="padding:10px 16px">
+                    <div class="msg msg--agent"><span class="msg__meta">iris-coder · running</span><span class="msg__body">Integration stage — 2 of 9 checks red. Failure is deterministic.</span></div>
+                  </div>
+                </div>
+                <div class="composer" style="padding-bottom:8px">
+                  <div class="composer__well" style="min-height:38px"><span class="composer__ph">Message iris-coder…</span><span class="composer__send"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 2 11 13M22 2 15 22l-4-9-9-4Z"/></svg></span></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="tabbar">
+            <div class="tabbar__scroll">
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg></span>
+              <span class="tab-item is-running"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z"/></svg></span>
+              <span class="tab-item"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/></svg></span>
+            </div>
+            <div class="tabbar__actions"><span class="tab-new"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5v14"/></svg></span></div>
+          </div>
+          <span class="callout" style="top:52px;left:6px"><b>T7</b> 390 − 44 − 56 → ~282px stack; no window under the tab bar</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- BOARD 04 — palette -->
+    <div class="board">
+      <div class="board__t"><b>04 · Command palette at 390 (T5)</b> — top-anchored, keyboard-safe</div>
+      <div class="frame">
+        <div class="os">
+          <div class="menubar">
+            <div class="mb-side">
+              <span class="mb-control mb-logo"><svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="7"/></svg></span>
+              <span class="mb-chip"><span class="mb-mono">CO</span><span class="mb-name">compozy</span><svg class="mb-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m7 9 5-5 5 5M7 15l5 5 5-5"/></svg></span>
+            </div>
+            <div class="mb-side">
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9M13.7 21a2 2 0 0 1-3.4 0"/></svg></span>
+              <span class="mb-control"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82 2 2 0 1 1-2.83 2.83 1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0 1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33 2 2 0 1 1-2.83-2.83 1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4 1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82 2 2 0 1 1 2.83-2.83 1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0 1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33 2 2 0 1 1 2.83 2.83 1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/></svg></span>
+            </div>
+          </div>
+          <div class="desk">
+            <div class="scrim"></div>
+            <div class="palette">
+              <div class="palette__input">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+                <span class="palette__ph">Search apps, sessions, and actions…</span>
+              </div>
+              <div class="palette__list">
+                <div class="prow is-sel"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z"/></svg>New session<span class="prow__kbd">⌘N</span></div>
+                <div class="prow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><rect x="2" y="3" width="20" height="8" rx="2"/><rect x="2" y="13" width="20" height="8" rx="2"/></svg>Open settings<span class="prow__kbd">⌘,</span></div>
+                <div class="prow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>deploy-triage — resume<span class="prow__kbd">↵</span></div>
+                <div class="prow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>Switch profile<span class="prow__kbd">⌘P</span></div>
+                <div class="prow"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><path d="M3 6h18M3 12h18M3 18h18"/></svg>Go to tasks<span class="prow__kbd">⌘G</span></div>
+              </div>
+              <div class="palette__foot"><span>↑↓ select</span><span>↵ open</span><span>esc close</span></div>
+            </div>
+          </div>
+          <span class="callout" style="top:44px;right:6px"><b>T5</b> top anchor · rows 44px · well 52dvh</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="map">
+    <h2>Frozen ergonomics map — what the implementation must match</h2>
+    <table class="matrix">
+      <tr><th style="width:64px">Rule</th><th style="width:220px">Region</th><th>Frozen decision</th><th style="width:250px">Production owner</th></tr>
+      <tr><td>T1</td><td>Touch floor</td><td>44px interactive targets at ≤760px (the established <code>--height-button-cta-lg</code> tier, same floor as <code>dialog-shell</code>). Menubar icon controls fill the 44px bar; palette rows and input reach the floor; the scroll-to-bottom pill grows to it.</td><td><code>os-menubar.tsx</code>, <code>global-scope-toggle.tsx</code>, <code>palette-view-inset.ts</code>, <code>scroll-to-bottom-pill.tsx</code></td></tr>
+      <tr><td>T2</td><td>Compact shell</td><td>Unchanged: &lt;960px collapses app menus into the palette, replaces the dock strip with the 56px tab bar (44px items, safe-area aware, tap = switch, never minimize), compacts traffic lights (44px targets, zoom hidden), stacks windows.</td><td><code>os-dock-tab-bar.tsx</code>, <code>os-traffic-lights.tsx</code>, <code>window-manager-view.ts</code></td></tr>
+      <tr><td>T3</td><td>Work area</td><td>Compact presentation reserves the tab-bar height (56px + safe-area) for the win layer, not the floating dock band (82px). 26px returns to stream content; nothing renders under the tab bar.</td><td><code>os-win-layer.tsx</code> (presentation-driven)</td></tr>
+      <tr><td>T4</td><td>Keyboard open (EC-1)</td><td>Viewport contract <code>viewport-fit=cover, interactive-widget=resizes-content</code>. The layout viewport shrinks; flex columns keep the session composer and palette input above the keyboard. No helper prose, no floating toolbars over the keyboard.</td><td><code>web/index.html</code></td></tr>
+      <tr><td>T5</td><td>Command palette</td><td>Stays top-anchored at the touch tier (a documented divergence from the dialog bottom-surface convention — the keyboard would cover a bottom sheet's input). Input group ≥44px, rows ≥44px, results well grows to min(52dvh, 440px) and scrolls under the keyboard.</td><td><code>os-command-palette.tsx</code>, <code>palette-view-inset.ts</code></td></tr>
+      <tr><td>T6</td><td>Session rail</td><td>At ≤760px the 264px rail overlays the transcript (z-raised, <code>--shadow-overlay</code>) instead of docking; the transcript keeps full width underneath. Toggle semantics unchanged.</td><td><code>session-window-content.tsx</code> (composition wrapper)</td></tr>
+      <tr><td>T7</td><td>Landscape (EC-2)</td><td>Same chrome; height is the flexible axis. 390px height − 44 menubar − 56 tab bar leaves ~282px of stack; the composer and goal strip compress with flex. No landscape-specific chrome is added.</td><td>existing flex shell + T3</td></tr>
+      <tr><td>T8</td><td>S5 banner strip</td><td>Between the menubar and the win-layer, full-width, flat <code>canvas-soft</code>, neutral signal — it pushes the work area down and never overlays window content. Wraps to two lines at 390px.</td><td><code>desktop-shell.tsx</code> (already placed here — ratified)</td></tr>
+    </table>
+  </div>
+
+  <div class="legend">
+    <p><b>Touch-tier boundary.</b> ≤760px is the repo's established touch floor (dialog hosts, help tips);
+    the shell's compact presentation boundary stays 960px. Between 760–960 the compact layout renders
+    with desktop target sizes — tablet landscape in UI-13 keeps its current shape, so &gt;1024px
+    rendering stays pixel-identical by construction.</p>
+    <p><b>Residuals, recorded:</b> the profile-switcher trigger keeps its 28px well (cross-system slot in
+    <code>systems/profiles</code>, quiet-until-plural — a follow-up if the QA walk flags it); log bodies keep
+    their own horizontal scroll wells inside the read view (extension log panel is a read view composed
+    of existing grammar; no change).</p>
+    <p><b>Journeys owned elsewhere:</b> E2E-002 at 390×844 belongs to the task_06 QA pair; terminal surfaces
+    are absent on remote tiers (task_03 gating) and appear in no mobile board.</p>
+  </div>
+</div>
+</body>
+</html>

--- a/docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html
+++ b/docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html
@@ -38,6 +38,13 @@
   T8  S5 loopback-only banner strip sits between the menubar and the win-layer,
       full-width, flat canvas-soft, neutral signal. It pushes the work area down;
       it never overlays window content.
+  Real-device deltas (Android/Brave ~390×844, private-tier walk):
+  T9  The desktop pager must not lead the touch dock: a single desktop rendered
+      an orphaned position pill beside a 50vw dead zone. Compact renders the
+      pager only when a second desktop exists, shrink-wrapped (capped at 50vw).
+  T10 Compact window controls carry their identification glyph at rest — close
+      (X) and minimize (−) — because hover tones do not exist on touch. The
+      2-of-3 count is per-design (zoom is meaningless in a stack; close stays).
   Residuals (recorded, not frozen as debt-free): profile-switcher trigger keeps
   its 28px well (cross-system slot, quiet-until-plural); log bodies keep their
   own horizontal scroll wells inside the read view.
@@ -80,7 +87,8 @@
     background:var(--canvas-soft);box-shadow:var(--shadow-win);overflow:hidden}
   .win-head{flex:none;display:flex;align-items:center;gap:12px;height:44px;padding:0 10px;border-bottom:1px solid var(--line-soft)}
   .tl{display:flex;align-items:center}
-  .tl i{width:15px;height:15px;border-radius:4px;border:1px solid var(--line-strong);background:var(--btn-fill)}
+  .tl i{display:grid;place-items:center;width:15px;height:15px;border-radius:4px;border:1px solid var(--line-strong);background:var(--btn-fill)}
+  .tl i svg{width:9px;height:9px;color:var(--fg-strong)}
   .tl i + i{margin-left:0} /* compact: 44px targets touch */
   .win-title{flex:1;min-width:0;text-align:center;font-size:12px;font-weight:560;color:var(--fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .win-head svg{width:15px;height:15px;color:var(--muted);flex:none}
@@ -197,7 +205,7 @@
           <div class="desk">
             <div class="win">
               <div class="win-head">
-                <span class="tl"><i></i><i></i></span>
+                <span class="tl"><i><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6 6 18M6 6l12 12"/></svg></i><i><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14"/></svg></i></span>
                 <span class="win-title">iris-coder · session</span>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
               </div>
@@ -229,6 +237,8 @@
           <span class="callout" style="top:96px;left:6px"><b>T8</b> S5 strip · flat · neutral</span>
           <span class="callout" style="bottom:70px;left:6px"><b>T3</b> work area = tab-bar 56px</span>
           <span class="callout" style="bottom:8px;right:6px"><b>T2</b> tab bar ratified</span>
+          <span class="callout" style="bottom:8px;left:6px"><b>T9</b> no pager lead · 1 desktop</span>
+          <span class="callout" style="top:60px;left:6px"><b>T10</b> close/minimize glyphs at rest</span>
         </div>
       </div>
     </div>
@@ -251,7 +261,7 @@
           <div class="desk">
             <div class="win">
               <div class="win-head">
-                <span class="tl"><i></i><i></i></span>
+                <span class="tl"><i><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6 6 18M6 6l12 12"/></svg></i><i><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14"/></svg></i></span>
                 <span class="win-title">iris-coder · session</span>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
               </div>
@@ -310,7 +320,7 @@
           <div class="desk">
             <div class="win">
               <div class="win-head">
-                <span class="tl"><i></i><i></i></span>
+                <span class="tl"><i><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 6 6 18M6 6l12 12"/></svg></i><i><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M5 12h14"/></svg></i></span>
                 <span class="win-title">iris-coder · session</span>
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75"><circle cx="12" cy="12" r="3"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
               </div>
@@ -389,6 +399,8 @@
       <tr><td>T6</td><td>Session rail</td><td>At ≤760px the 264px rail overlays the transcript (z-raised, <code>--shadow-overlay</code>) instead of docking; the transcript keeps full width underneath. Toggle semantics unchanged.</td><td><code>session-window-content.tsx</code> (composition wrapper)</td></tr>
       <tr><td>T7</td><td>Landscape (EC-2)</td><td>Same chrome; height is the flexible axis. 390px height − 44 menubar − 56 tab bar leaves ~282px of stack; the composer and goal strip compress with flex. No landscape-specific chrome is added.</td><td>existing flex shell + T3</td></tr>
       <tr><td>T8</td><td>S5 banner strip</td><td>Between the menubar and the win-layer, full-width, flat <code>canvas-soft</code>, neutral signal — it pushes the work area down and never overlays window content. Wraps to two lines at 390px.</td><td><code>desktop-shell.tsx</code> (already placed here — ratified)</td></tr>
+      <tr><td>T9</td><td>Dock pager <span style="color:var(--accent-strong)">· real-device delta</span></td><td>The desktop pager must not lead the touch dock: with a single desktop it rendered an orphaned position pill beside a 50vw dead zone (the "estranho" spacing). Compact renders the pager only when a second desktop exists, shrink-wrapped and capped at half the bar; the floating dock keeps the position pill at every count.</td><td><code>desktop-pager.tsx</code></td></tr>
+      <tr><td>T10</td><td>Window-control identification <span style="color:var(--accent-strong)">· real-device delta</span></td><td>Compact controls carry their identification glyph at rest — close (X), minimize (−), in the same neutral ink; hover tones remain the hover/focus affordance. The 2-of-3 count is per-design: compact hides zoom (meaningless in a stack), never close — a phone closes a window from its own bar. Inert chrome stays glyphless (no implied controls).</td><td><code>os-traffic-lights.tsx</code></td></tr>
     </table>
   </div>
 

--- a/docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html
+++ b/docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html
@@ -45,6 +45,11 @@
   T10 Compact window controls carry their identification glyph at rest — close
       (X) and minimize (−) — because hover tones do not exist on touch. The
       2-of-3 count is per-design (zoom is meaningless in a stack; close stays).
+  T11 Menubar at the touch tier: the scope label is the give-way element (an
+      unbroken min-w-0 chain from the leading div to the label truncates it
+      before anything can overlap), and the profile switcher is dropped from
+      the trailing cluster — the one control the 390px bar cannot afford.
+      Profiles stay reachable via Settings → Profiles and the palette.
   Residuals (recorded, not frozen as debt-free): profile-switcher trigger keeps
   its 28px well (cross-system slot, quiet-until-plural); log bodies keep their
   own horizontal scroll wells inside the read view.
@@ -401,6 +406,7 @@
       <tr><td>T8</td><td>S5 banner strip</td><td>Between the menubar and the win-layer, full-width, flat <code>canvas-soft</code>, neutral signal — it pushes the work area down and never overlays window content. Wraps to two lines at 390px.</td><td><code>desktop-shell.tsx</code> (already placed here — ratified)</td></tr>
       <tr><td>T9</td><td>Dock pager <span style="color:var(--accent-strong)">· real-device delta</span></td><td>The desktop pager must not lead the touch dock: with a single desktop it rendered an orphaned position pill beside a 50vw dead zone (the "estranho" spacing). Compact renders the pager only when a second desktop exists, shrink-wrapped and capped at half the bar; the floating dock keeps the position pill at every count.</td><td><code>desktop-pager.tsx</code></td></tr>
       <tr><td>T10</td><td>Window-control identification <span style="color:var(--accent-strong)">· real-device delta</span></td><td>Compact controls carry their identification glyph at rest — close (X), minimize (−), in the same neutral ink; hover tones remain the hover/focus affordance. The 2-of-3 count is per-design: compact hides zoom (meaningless in a stack), never close — a phone closes a window from its own bar. Inert chrome stays glyphless (no implied controls).</td><td><code>os-traffic-lights.tsx</code></td></tr>
+      <tr><td>T11</td><td>Menubar scope vs. cluster <span style="color:var(--accent-strong)">· real-device delta</span></td><td>The bar never overlaps at any scope state. The scope label is the give-way element: an unbroken <code>min-w-0</code> chain (leading div → identity → menubar → chip → label) truncates the label before the identity segment can spill under the trailing cluster; mark, globe, and the trailing 44px floors never shrink. Trailing priority at the touch tier: attention bell &gt; command palette &gt; settings &gt; update indicator &gt; profile switcher — the switcher is dropped (absent, not cramped; reachable via Settings → Profiles and the palette). The worktree-fallback notice keeps its slot and is a recorded squeeze residual.</td><td><code>os-menubar.tsx</code>, <code>desktop-menubar.tsx</code></td></tr>
     </table>
   </div>
 

--- a/docs/qa/bugs/BUG-20260911-private-tier-loopback-guard-inert.md
+++ b/docs/qa/bugs/BUG-20260911-private-tier-loopback-guard-inert.md
@@ -1,0 +1,59 @@
+# BUG-20260911-private-tier-loopback-guard-inert: A paired remote device can change settings and drain the daemon — the "paired devices can read, not change" enforcement is absent on the private tier
+
+- **Status:** open
+- **Impact (user-side):** Trust-Damage
+- **Severity:** High · **Priority:** P1
+- **Persona Affected:** Iris
+- **Journey Step:** J-expose-and-pair-gateway, paired operator session (Truthful Surface Tour)
+- **Scenarios:** RT-gateway-operator-surface-truth; RT-gateway-paired-device
+- **Found:** 2026-09-11 · **Report:** docs/qa/reports/2026-09-11-mobile-surface-truth.md
+
+## Summary
+
+The product promises paired devices read-only operator access — the UI hides
+every write affordance on remote tiers and the loopback-only strip says
+"Paired devices can read, not change settings." The server does not enforce
+that on the private tier. With only a paired device credential (the HttpOnly
+cookie the pairing flow issues), a remote client successfully executed
+daemon-authority mutations over the verified private address: `POST /api/drain`
+returned 200 and actually drained the daemon (`admission_closed: true`), and a
+guarded settings mutation (`PATCH /api/settings/general`) passed the loopback
+mutation guard and reached handler validation instead of being refused with
+`loopback_mutation_required`. The UI-side hiding (BR-1) is presentation only;
+the server-side enforcement the same feature promises (BR-6) is missing.
+
+Root cause direction: the loopback mutation guard is decided once from the
+listener's bound host (`handlers.boundHost`), and the private-tier listener is
+by design bound to `127.0.0.1` (the provider fronts it), so the guard evaluates
+"loopback" and allows every guarded mutation from any paired remote client.
+
+## Reproduction
+
+- **Charter:** CH-gateway-paired-operator-surface · **Tour:** Truthful Surface Tour
+- **Environment:** authorized tailscale provider, private tier live; documented pairing redeem issued the device credential; requests sent over the verified private HTTPS address
+
+1. Pair a device (redeem a minted artifact with `actor_kind=operator_device` over the private address) and keep the issued device cookie.
+2. `POST https://<private-address>/api/drain` with the device cookie.
+3. Observe `200` with `{"state":"draining","admission_closed":true,…}` — the daemon drained.
+4. Independently confirm on the local surface that the daemon state changed, then `POST /api/undrain` remotely to restore (also 200).
+5. `PATCH https://<private-address>/api/settings/general` with the device cookie — observe `400 settings validation error` (handler validation), not `403 loopback_mutation_required`.
+
+**Expected:** guarded mutations from a paired remote device are refused with
+`403 loopback_mutation_required` (the truthful server-side backstop behind the
+read-only UI).
+**Actual:** guarded mutations execute with the paired device credential; the
+enforcement boundary is absent on the private tier.
+
+## Evidence
+
+- Walk transcript reproduced in docs/qa/reports/2026-09-11-mobile-surface-truth.md ("remote-leg walk with authorized provider" addendum, enforcement-gap section)
+- Independent read path: local `GET /api/status` confirmed the drained state transition and the restore after remote `undrain`
+- Route/composition facts: private-tier server registered with `WithHost("127.0.0.1")`; `loopbackMutationGuard` allows when the bound host is loopback
+
+## Fix
+
+<!-- filled when status moves to fixed -->
+
+## Verification
+
+<!-- filled when status moves to verified -->

--- a/docs/qa/bugs/BUG-20260911-private-tier-loopback-guard-inert.md
+++ b/docs/qa/bugs/BUG-20260911-private-tier-loopback-guard-inert.md
@@ -1,6 +1,6 @@
 # BUG-20260911-private-tier-loopback-guard-inert: A paired remote device can change settings and drain the daemon — the "paired devices can read, not change" enforcement is absent on the private tier
 
-- **Status:** open
+- **Status:** verified
 - **Impact (user-side):** Trust-Damage
 - **Severity:** High · **Priority:** P1
 - **Persona Affected:** Iris
@@ -52,8 +52,11 @@ enforcement boundary is absent on the private tier.
 
 ## Fix
 
-<!-- filled when status moves to fixed -->
+- **Root cause:** `loopbackMutationGuard` decided "allowed" once from the listener's bound host, and the private tier is by design bound to `127.0.0.1` (the provider fronts it), so the guard never refused remote paired clients.
+- **Fix commit:** 17304fe8f (`privilegedMutationGuard()` keys on the listener surface set: remote tiers (private/public operator) always 403 `loopback_mutation_required` regardless of bind host; the local surface keeps loopback semantics — loopback bind → 200, non-loopback bind → `loopback_api_required`)
+- **Regression test:** `internal/api/httpapi/gateway_routes_test.go` + `middleware_refac_test.go` (tier-keyed mutation policy cases) — failed before the fix, passes after
 
 ## Verification
 
-<!-- filled when status moves to verified -->
+- **Retested:** 2026-09-11, same persona/journey, fresh lab `compozy-mobile-surface-truth-verify2-20260911-141455-792161` · **Report:** docs/qa/reports/2026-09-11-mobile-surface-truth.md (Addendum 2)
+- **Result:** with a paired device cookie over the verified private address, `POST /api/drain` → 403 `loopback_mutation_required` (drain state confirmed unchanged by an independent local read) and guarded `PATCH /api/settings/general` → 403 same code, while reads stay 200; on the local loopback daemon `drain`/`undrain` still return 200 (BR-5 canary). In-product, a deep-linked settings write from the paired session is refused and the shell renders the truthful loopback-only strip (evidence `ts2-15`)

--- a/docs/qa/bugs/BUG-20260911-private-ui-origin-rejected-on-forwarded-tier.md
+++ b/docs/qa/bugs/BUG-20260911-private-ui-origin-rejected-on-forwarded-tier.md
@@ -1,6 +1,6 @@
 # BUG-20260911-private-ui-origin-rejected-on-forwarded-tier: On the paired private tier, the operator UI never loads — every app module is refused with "origin not allowed"
 
-- **Status:** open
+- **Status:** verified
 - **Impact (user-side):** Blocks-Completion
 - **Severity:** Critical · **Priority:** P0
 - **Persona Affected:** Iris
@@ -46,8 +46,11 @@ load — which is why the blank page shows the served HTML but no app.
 
 ## Fix
 
-<!-- filled when status moves to fixed -->
+- **Root cause:** the provider's tier forwarder was a raw-TCP copier, so the daemon saw forwarded requests as plain `http` and the CORS/browser-protection origin allowance (scheme-comparing) refused the browser's same-origin `https` Origin sent by ES module loads.
+- **Fix commit:** 17304fe8f (forwarder rewritten as an HTTP-aware reverse proxy forcing truthful `X-Forwarded-Proto: https` / `X-Forwarded-Host`, stripping client-supplied forwarding headers, SSE flush, 502 on unreachable target)
+- **Regression test:** `extensions/connectivity/tailscale/provider_test.go` (forwarder header/scheme cases) — failed before the fix, passes after
 
 ## Verification
 
-<!-- filled when status moves to verified -->
+- **Retested:** 2026-09-11, same persona/journey (Iris, paired private-tier operator session), fresh lab `compozy-mobile-surface-truth-verify2-20260911-141455-792161` · **Report:** docs/qa/reports/2026-09-11-mobile-surface-truth.md (Addendum 2)
+- **Result:** the paired SPA boots over the verified private address — `networkidle` in 858ms, zero `/assets/*` rejections, only the expected unauthenticated `/api` 401s; the "Pair this device" gate renders pre-filled from the `#pair=` fragment and redeeming lands the full paired operator session (evidence `ts2-01`, `ts2-05`, `ts2-07`)

--- a/docs/qa/bugs/BUG-20260911-private-ui-origin-rejected-on-forwarded-tier.md
+++ b/docs/qa/bugs/BUG-20260911-private-ui-origin-rejected-on-forwarded-tier.md
@@ -1,0 +1,53 @@
+# BUG-20260911-private-ui-origin-rejected-on-forwarded-tier: On the paired private tier, the operator UI never loads — every app module is refused with "origin not allowed"
+
+- **Status:** open
+- **Impact (user-side):** Blocks-Completion
+- **Severity:** Critical · **Priority:** P0
+- **Persona Affected:** Iris
+- **Journey Step:** J-expose-and-pair-gateway, paired operator session (Truthful Surface Tour)
+- **Scenarios:** RT-gateway-paired-device; RT-gateway-operator-surface-truth
+- **Found:** 2026-09-11 · **Report:** docs/qa/reports/2026-09-11-mobile-surface-truth.md
+
+## Summary
+
+Iris pairs her second device over the verified private address and opens the
+pairing link. The page stays blank: the HTML document loads, but every
+JavaScript module and stylesheet under `/assets/` is refused with
+`403 {"error":"origin not allowed"}`, so the operator UI can never boot on the
+private tier. Pairing therefore cannot be completed through the product's own
+QR/link flow, and no paired-operator surface exists at all.
+
+The refusal comes from the CORS/browser-protection origin check: the provider
+terminates TLS and forwards raw TCP to the daemon-owned loopback listener, so
+the daemon sees the request scheme as `http`; the middleware's
+forwarded-target allowance compares canonical origins including scheme, and
+the browser's same-origin `https://compozy-gateway…:8443` Origin (sent by ES
+module loads) never matches. Plain document navigations (no `Origin` header)
+load — which is why the blank page shows the served HTML but no app.
+
+## Reproduction
+
+- **Charter:** CH-gateway-paired-operator-surface · **Tour:** Truthful Surface Tour
+- **Environment:** authorized tailscale provider, private tier advertised and live; Chromium (Playwright) against the verified private address; also reproduced with serialized single-request loads (not a concurrency artifact)
+
+1. Bring up the private tier with a verified address (`gateway status` shows the live `https://…ts.net:8443` endpoint).
+2. Mint a pairing code (Web Settings → Remote access → Pair a device; dialog shows QR + link).
+3. On a second device/browser, open the pairing link.
+4. Observe a blank page; the console shows `403` for every `/assets/*.js` and `/assets/*.css`.
+
+**Expected:** the pairing link opens the operator UI, which completes the redeem and lands in the paired operator session.
+**Actual:** `403 {"error":"origin not allowed"}` for every module/stylesheet; the UI never renders.
+
+## Evidence
+
+- docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-03-second-device-redeem.png (blank page after opening the pairing link)
+- docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-02-pairing-with-address.png (the QR + link dialog backed by the verified address)
+- Diagnostic capture: failing request carries `origin: https://compozy-gateway…:8443`; response `403`, `content-type: application/json`, `content-length: 30`, body `{"error":"origin not allowed"}`; direct navigation of the same asset URL (no Origin header) returns 200 with the correct body.
+
+## Fix
+
+<!-- filled when status moves to fixed -->
+
+## Verification
+
+<!-- filled when status moves to verified -->

--- a/docs/qa/bugs/BUG-20260911-session-rail-docks-on-touch-tier.md
+++ b/docs/qa/bugs/BUG-20260911-session-rail-docks-on-touch-tier.md
@@ -1,0 +1,107 @@
+# BUG-20260911-session-rail-docks-on-touch-tier: On a phone-sized screen, opening the sessions list squeezes the composer to a sliver instead of overlaying it
+
+- **Status:** fixed
+- **Impact (user-side):** Friction
+- **Severity:** Medium · **Priority:** P2
+- **Persona Affected:** Marina
+- **Journey Step:** J-operate-desktop-shell, session stream step (Touch Tier Tour, T6)
+- **Scenarios:** APP-mobile-touch-tier
+- **Found:** 2026-09-11 · **Report:** docs/qa/reports/2026-09-11-mobile-surface-truth.md
+
+## Summary
+
+Marina opens a session on her phone (390×844) and taps the sessions-list toggle to switch
+sessions. Instead of the sessions rail sliding over the transcript as an overlay, it docks as a
+solid 264px column: the transcript is compressed and the message composer is crushed into the
+remaining ~110px strip (editor measured 68px wide; "Send a…" placeholder clipped, controls
+stacked vertically). The screen is unusable while the rail is open; she has to close the rail to
+type. The frozen mobile ergonomics map (T6 in
+`docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html`) promises the
+opposite: at ≤760px the 264px rail overlays the transcript with an overlay shadow and the
+transcript keeps its full width underneath.
+
+## Reproduction
+
+- **Charter:** CH-mobile-shell-touch-tier · **Tour:** Touch Tier Tour
+- **Environment:** phone viewport 390×844 (device-emulated, touch), lab daemon `http://127.0.0.1:53001`, en-US
+
+1. Open the operator shell, pick the registered workspace via the workspace picker (⌃⇧O palette entry).
+2. Open a session (command palette → "New session" → Start session).
+3. In the session window header, tap "Open sessions sidebar" (`session-sidebar-toggle`).
+
+**Expected:** the 264px sessions rail overlays the transcript (shadow overlay), transcript keeps
+full width; the composer stays intact and usable (T6).
+**Actual:** the rail docks: it occupies x=0..264 as a layout column, the transcript/composer
+compress into the remaining 126px, and the composer editor renders 68px wide.
+
+## Evidence
+
+- docs/qa/evidence/2026-09-11-mobile-surface-truth/m-23-rail-open-390.png (portrait 390: rail docked, composer crushed)
+- docs/qa/evidence/2026-09-11-mobile-surface-truth/m-26-rail-portrait-evidence.png (second portrait capture)
+- docs/qa/evidence/2026-09-11-mobile-surface-truth/m-28-landscape-rail-open.png (landscape 844×390: same docked shape — correct there per >760px desktop rule)
+- Measured: rail column 0..264 at both viewports; portrait editor x=295 w=68; landscape editor x=295 w=522. No overlay shadow on the rail panel in either state.
+
+## Fix
+
+**Root cause:** the task_04 composition wrapper in
+`web/src/systems/os/apps/session/session-window-content.tsx` relied on CSS
+blockification — `display: contents` on the wrapper with media-scoped
+`max-[760px]:absolute/inset-y-0/left-0/z-30/shadow-overlay` classes, assuming
+`position: absolute` would force the contents wrapper to generate a box at the
+touch tier. Chromium never blockifies `display: contents`: a minimal repro
+(Playwright 1.62.1 Chromium) showed the computed display staying `contents`
+with `position: absolute` set, no wrapper box, and the rail still participating
+in the parent flex flow (transcript squeezed to 110px at a 390px viewport —
+the bug's 126px shape). The built CSS did contain all the media-scoped rules
+(verified in `web/dist/assets/index-*.css`), so the utilities shipped but were
+inert: the rail docked at every width, and landscape only looked correct
+because docking *is* the >760px desktop contract.
+
+**Change (web/src/systems/os/apps/session/session-window-content.tsx only):**
+the wrapper now opts back into a real display at the touch tier with
+`max-[760px]:block`, so the absolutely positioned overlay box actually exists
+at ≤760px (the media-scoped display rule sorts after the base `contents`
+utility and wins the cascade inside the breakpoint). The overlay shadow rides
+on the rail's open state (`sidebar.open && "max-[760px]:shadow-overlay"`), so a
+closed rail cannot paint the shadow token's 1px ring down the transcript's
+left edge. `SessionSidebar` and every other surface are untouched; desktop
+(>760px) keeps the byte-identical `contents` wrapper. Added two regression
+tests to the owning suite (`__tests__/session-window-content.test.tsx`)
+pinning the touch-tier overlay composition (block/absolute/inset/z/shadow
+while open) and the shadowless closed state.
+
+## Verification
+
+**Repair re-walk 2026-09-11** — fresh isolated lab
+`compozy-mobile-surface-truth-repair-20260911-20260911-055549-379543`
+(eng-qa-bootstrap, daemon `http://127.0.0.1:34657`, `COMPOZY_WEB_DIST_DIR`
+serving a fresh `web/dist` build of the fix, lab `COMPOZY_HOME`/UDS per
+manifest, teardown `clean: true`), Playwright 1.62.1 Chromium,
+device-emulated 390×844 touch (DSF 3, en-US):
+
+- **390×844, rail open (T6):** wrapper computes `display: block`,
+  `position: absolute`, `z-index: 30`, `left/top: 0`; rail rect x=0 w=264
+  (overlay, not a layout column); transcript rect x=0 **w=390 (full width
+  kept)**; composer editor x=31 w=**332** (was 68) with the send button
+  intact; computed `box-shadow` carries the `--shadow-overlay` layers
+  (`rgba(0, 0, 0, 0.65) 0px 24px 48px -12px` plus the 1px light ring,
+  browser-resolved `rgba(255, 255, 255, 0.043)`) over Tailwind's empty
+  composition slots. Evidence:
+  `docs/qa/evidence/2026-09-11-mobile-surface-truth/r-2-rail-open-390.png`,
+  `r-6-shadow-check-390.png`.
+- **390×844, rail closed:** wrapper box w=0, `box-shadow: none` (no sliver
+  ring), transcript full width. Evidence: `r-3-rail-closed-390.png`.
+- **Landscape 844×390 control:** rail docks x=0..264 as a layout column,
+  transcript x=264 w=580, editor w=522 — identical to the pre-fix landscape
+  shape, which is correct per the >760px desktop rule; no overlay shadow.
+  Evidence: `r-4-landscape-rail-open.png`.
+- **Desktop 1440×900 spot-check:** rail docked beside the transcript
+  (aside x=174 w=264 in the windowed shell), no shadow — behaviorally
+  identical to the pre-fix desktop rendering. Evidence:
+  `r-5-desktop-1440-rail-open.png`.
+- Zero browser console errors / page errors across all legs.
+- Scoped validation from the repo root: `bunx turbo run typecheck --filter=./web`
+  PASS (2/2 tasks); `bunx turbo run test --filter=./web` PASS — 776 test
+  files / 7212 tests, 0 failures (baseline 7210 + 2 new regression tests);
+  `bunx turbo run lint --filter=./web` PASS (0 warnings / 0 errors, format
+  clean).

--- a/docs/qa/charters/CH-gateway-paired-operator-surface.md
+++ b/docs/qa/charters/CH-gateway-paired-operator-surface.md
@@ -1,0 +1,33 @@
+# CH-gateway-paired-operator-surface: The paired operator sees only what the tier can execute
+
+```yaml
+charter:
+  id: CH-gateway-paired-operator-surface
+  mission: "As Iris working from a paired device on the private tier, run the Truthful Surface Tour through the paired operator session — every affordance shown must be one the tier can actually execute, terminal and write controls are absent (never disabled), a deep-linked loopback-only mutation lands in the truthful host-naming state, and local desktop behavior is unchanged."
+  mode: charter-with-tour
+  persona:
+    name: Iris
+    device: laptop
+    network: wifi-fast
+    locale: en-US
+  journey: J-expose-and-pair-gateway
+  scenarios: [RT-gateway-paired-device, RT-gateway-operator-surface-truth]
+  tour: Truthful Surface Tour
+  time_box_minutes: 60
+  guidance:
+    must_try:
+      - "Pair from the second device (fragment redeem → HttpOnly cookie) and open the operator UI on the private tier: terminal and local task-lifecycle affordances are absent from shell, dock, palette, and nav; settings/extensions show read views without save bars; notification/profile enablement renders read-only states instead of toggles."
+      - "Deep-link a settings/extensions write from the paired device: the 403 envelope carries loopback_mutation_required and the shell renders the truthful loopback-only strip naming the machine running CompozyOS — no generic error toast, no retry queue."
+      - "Follow a logs/session stream from the paired device: fresh single-use tickets per connect, reconnection re-mints, and the session rail behaves per the touch/compact tier."
+      - "On the local desktop host, walk the same surfaces: every affordance that existed before the mobile-surface-truth change is still present and functional (BR-5 regression walk)."
+      - "Check the device inventory agrees across web, HTTP/UDS, and compozy device list -o json while paired; then revoke and confirm the access-ended boundary still wins over capability gating."
+    must_avoid:
+      - "Public-tier/Funnel legs (RT-gateway-public-ui-consent and public ingress own them; blocked-verify pending the authorized TS_AUTHKEY)."
+      - "Mobile viewport ergonomics (CH-mobile-shell-touch-tier owns the 390×844 walk)."
+  evidence_expectations:
+    - "Screenshots of the paired private-tier shell showing absent terminal/write affordances and the truthful loopback-only strip after a deep-linked write."
+    - "Local-desktop before/after spot-checks proving no affordance regression."
+    - "Device inventory reads across web + structured surfaces; revocation closing live work."
+```
+
+<!-- The charter is durable and immutable: each run's debrief belongs in that run's dated report. -->

--- a/docs/qa/charters/CH-mobile-shell-touch-tier.md
+++ b/docs/qa/charters/CH-mobile-shell-touch-tier.md
@@ -1,0 +1,34 @@
+# CH-mobile-shell-touch-tier: The shell is operable at phone size without lying about state
+
+```yaml
+charter:
+  id: CH-mobile-shell-touch-tier
+  mission: "As Marina checking Compozy from her phone between meetings, run the Touch Tier Tour through the operator shell at 390×844 — every control reachable with a thumb per the frozen T1–T8 artboard, keyboard-open and landscape stay usable, streams stay readable, and the desktop rendering shows no drift."
+  mode: charter-with-tour
+  persona:
+    name: Marina
+    device: phone
+    network: wifi-fast
+    locale: en-US
+  journey: J-operate-desktop-shell
+  scenarios: [APP-mobile-touch-tier]
+  tour: Touch Tier Tour
+  time_box_minutes: 60
+  guidance:
+    must_try:
+      - "Walk the menubar, dock, and command palette at 390×844: 44px touch floor holds (T1), palette stays top-anchored with 44px rows and the grown results well (T5), compact win-layer reserves the tab-bar height so stream content gains the dock band (T3)."
+      - "Open a logs/session stream, scroll it, and open the on-screen keyboard: the layout viewport shrinks (T4), the composer/input stays above the keyboard, and the keyboard-open board in the artboard matches."
+      - "Rotate to landscape: the same chrome flexes height — verify the height-flex story, not 44px chrome in landscape (T7 recorded residual)."
+      - "Open and dismiss the session rail: it overlays the transcript at ≤760px (T6) and restores desktop docking above the breakpoint."
+      - "Trigger the loopback-only strip on a remote tier and check its placement and touch floor (T8); then spot-check desktop >1024px for pixel identity."
+      - "Confirm or bounce the recorded residuals: profile-switcher 28px well, log bodies' horizontal scroll wells."
+    must_avoid:
+      - "The loop visual editor canvas (recorded desktop-only skip)."
+      - "Remote-tier capability gating (CH-gateway-paired-operator-surface owns it); pairing/redeem flows (owned by the gateway scenarios)."
+  evidence_expectations:
+    - "Screenshots per artboard board (portrait, keyboard-open, landscape, palette) compared against `docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html`."
+    - "Touch-target measurements on the menubar/dock/palette rows at the tier; keyboard-open and landscape captures."
+    - "Desktop spot-check captures proving no drift."
+```
+
+<!-- The charter is durable and immutable: each run's debrief belongs in that run's dated report. -->

--- a/docs/qa/reports/2026-09-11-mobile-surface-truth.md
+++ b/docs/qa/reports/2026-09-11-mobile-surface-truth.md
@@ -21,11 +21,11 @@
 
 | # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
 |---|---|---|---|---|---|---|---|
-| 1 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-paired-device | Iris | Truthful Surface Tour | Blocked (needs human verify) | | |
-| 2 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-operator-surface-truth | Iris | Truthful Surface Tour | Blocked (needs human verify) | | |
-| 3 | CH-mobile-shell-touch-tier | J-operate-desktop-shell / APP-mobile-touch-tier | Marina | Touch Tier Tour | Fixed | BUG-20260911-session-rail-docks-on-touch-tier | |
+| 1 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-paired-device | Iris | Truthful Surface Tour | Fail | BUG-20260911-private-ui-origin-rejected-on-forwarded-tier | |
+| 2 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-operator-surface-truth | Iris | Truthful Surface Tour | Fail | BUG-20260911-private-tier-loopback-guard-inert | |
+| 3 | CH-mobile-shell-touch-tier | J-operate-desktop-shell / APP-mobile-touch-tier | Marina | Touch Tier Tour | Fail | BUG-20260911-session-rail-docks-on-touch-tier | |
 
-Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+Status legend: `Pending | Pass | Fixed | Fail | Skipped | Blocked (needs human verify) | Blocked (human decision)` — `Fail` = walked, expected observable not confirmed, fix pending (tracker `fail` / `blocked-verify` per row; see Session Debriefs and the addendum for which applies and why). Rows 1–2 verdicts come from the remote-leg addendum below (earlier same-day blocked-verify runs retained in scenario history).
 
 > Row 3 updated by the repair re-walk addendum at the end of this report.
 
@@ -117,6 +117,52 @@ None this run. BUG-20260911-session-rail-docks-on-touch-tier is recorded with ev
 - **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 1 · Cosmetic 0
 - **Coverage:** 2/2 charters walked to a recorded verdict; 3/3 in-scope scenarios settled (1 fail, 2 blocked-verify); T8, stream-ticket, remote-admission, and live-stream legs disclosed as not reachable in-lab (named blockers).
 - **Verdict: not ready** — the changed operator surface is truthful locally and the touch-tier chrome holds except T6: fix and re-walk `BUG-20260911-session-rail-docks-on-touch-tier`; the remote-tier legs stay blocked-verify pending the user-provisioned authorized `TS_AUTHKEY`.
+
+---
+
+## Addendum — 2026-09-11 (later): remote-leg walk with authorized provider
+
+- **Scope:** the previously blocked remote-tier legs of `CH-gateway-paired-operator-surface` (Truthful Surface Tour), after the user provisioned an authorized Tailscale auth key. Branch renamed `mobile-surface-truth`; build rebuilt at HEAD `b74d29927` (daemon + web bundle).
+- **Environment:** fresh isolated lab `compozy-mobile-surface-truth-remote-20260911-125112-264736` — daemon `http://127.0.0.1:32821`, lab `COMPOZY_HOME` `/tmp/compozyqa-924e1a6ed906/runtime`; bundled tailscale extension installed with network confirmation recorded; `TS_AUTHKEY` bound through the product's extension-secret vault (`extension secrets set … --value-stdin`; never echoed, never persisted in logs or evidence — verified by byte-scan). Browser driver: Playwright 1.62.1 Chromium as before.
+- **Secret handling:** the key was read only into the lab daemon's environment and the extension vault binding; `/tmp/opencode/ts-authkey` was deleted after the walk; device-credential cookie jars were deleted with it; no log, evidence file, report, or memory file contains the key or the issued device credentials (byte-level scan performed).
+- **Teardown:** manifest `TEARDOWN_COMMAND` executed with `clean: true`; the lab runtime home was additionally purged (`PURGE=1`) because it held the secret binding and tailscale node state.
+
+### Bring-up recipe deltas vs the blocked-run expectations
+
+1. `--digest` on `gateway provider enable` must be the extension's **network-participation requirement digest** (`c014…`, echoed by the install confirmation), not the extension.json checksum.
+2. `--source` must be the registry's own source string (`user` for a local-path install), not a filesystem path — otherwise reconcile fails `gateway provider trust stale` and the provider never establishes.
+3. The daemon env alone satisfies `missing_env` but the provider subprocess only receives `TS_AUTHKEY` through the **extension secret binding**; after binding, bounce the extension (`disable` → `enable`) so the subprocess re-reads it.
+4. Provider establishment needs several recovery cycles (`observed: down → establishing → degraded → up`); `gateway status` is the wait signal.
+
+### Per-leg outcomes
+
+| Leg (must-try) | Outcome |
+|---|---|
+| Verified private address advertised and reachable | **Verified** — provider `up/healthy`; `addresses[0].live: true` (`https://compozy-gateway…ts.net:8443`); unauthenticated `GET /api/gateway/status` → 401 `gateway_device_unauthenticated` with `X-Compozy-Gateway-Tier: private`; UI document serves 200 |
+| Mint pairing with QR + copyable link | **Verified** — dialog shows the QR and the full link `https://…ts.net:8443/#pair=cpz_gwp_…` with expiry; posture card reads "Reachable — Verified: this address was proven to reach this machine" |
+| Redeem over the private endpoint → paired session | **Split** — redeem verified through the documented API (`actor_kind=operator_device` → 200 + `Secure; HttpOnly; SameSite=Lax` cookie; reuse → 409 `gateway_pairing_spent`); the **link-open UI path is broken**: the page boots blank because every `/assets/*` ES-module request is refused `403 {"error":"origin not allowed"}` → `BUG-20260911-private-ui-origin-rejected-on-forwarded-tier` (Blocks-Completion) |
+| BR-1 walk on the paired remote session (absent affordances, read-only views, truthful loopback-only strip / T8) | **Blocked (in-product defect)** — the paired UI cannot boot (origin bug above); the UI-level walk is unreachable until it is fixed |
+| **Server-side enforcement behind those surfaces (BR-6)** | **FAILED — new defect** — with the paired device credential, guarded mutations execute over the private tier: `POST /api/drain` → 200 with real state change (`admission_closed: true`, confirmed by an independent local read; restored via remote `undrain` 200), and a guarded `PATCH /api/settings/general` passed the loopback mutation guard into handler validation instead of refusing `loopback_mutation_required`. The private-tier listener is by design bound to `127.0.0.1`, which makes the bind-host-keyed guard inert → `BUG-20260911-private-tier-loopback-guard-inert` (Trust-Damage, High/P1) |
+| Streams: single-use tickets, reconnect re-mints | **Verified (API-level)** — ticket mint 201 with TTL; connect consumed the ticket (reuse → 401 `gateway_stream_ticket_invalid`); re-mint issues a fresh ticket |
+| Device inventory agreement across Web/HTTP/UDS/CLI | **Verified** — same device id/name across all four surfaces plus a device-authenticated read over the private endpoint |
+| Revocation closes live work, then rejects the credential | **Verified** — `device revoke` closed an open SSE catalog-stream mid-flight (`canceled: 1`; curl exited immediately, not at timeout) and the cookie then refused 401 `gateway_device_unauthenticated` |
+| Local BR-5 regression canary on the new build | **Verified** — local shell, onboarding, settings, and Remote access pages render normally on `b74d29927` |
+
+### New bugs filed this addendum
+
+- `BUG-20260911-private-ui-origin-rejected-on-forwarded-tier` — Blocks-Completion/Critical/P0: paired private-tier operator UI never loads (origin check rejects ES-module requests on the forwarded hop).
+- `BUG-20260911-private-tier-loopback-guard-inert` — Trust-Damage/High/P1: paired devices can execute guarded daemon mutations (drain/undrain, settings) over the private tier; the loopback mutation guard keys on the loopback bind and never refuses remote paired clients.
+
+### Addendum verdicts
+
+- `RT-gateway-paired-device` → **fail** (fix pending): lifecycle + admission + revocation verified over the real private tier, but the product's own QR/link pairing flow dead-ends in a blank page (origin bug); both new bugs linked.
+- `RT-gateway-operator-surface-truth` → **blocked-verify** (fix pending): live-address presentation now verified in-product; the paired operator surface walk (BR-1 absences, truthful loopback-only strip/T8) is unreachable behind the origin bug, and the enforcement behind those surfaces is absent (guard bug). Both linked.
+
+### Addendum final status
+
+- **Issues by user impact (addendum):** Blocks-Completion 1 · Data-Loss 0 · Trust-Damage 1 · Friction 0 · Cosmetic 0
+- **Secret disposition:** authorized `TS_AUTHKEY` deleted from `/tmp/opencode/ts-authkey` after the walk; zero occurrences in any persisted artifact (byte-scan); lab runtime purged. The user should revoke the key at the tailscale tailnet as it was live during the session.
+- **Verdict (addendum): not ready** — the remote-tier story is architecturally alive (provider establishes, pairing/admission/streams/revocation all behave), but two P0/P1-class defects (UI origin refusal; missing server-side enforcement) must be fixed and the paired session re-walked before the surface-truth promise holds.
 
 ## Repair Re-walk Addendum — 2026-09-11 (BUG-20260911-session-rail-docks-on-touch-tier)
 

--- a/docs/qa/reports/2026-09-11-mobile-surface-truth.md
+++ b/docs/qa/reports/2026-09-11-mobile-surface-truth.md
@@ -1,6 +1,6 @@
 # QA Run Report — 2026-09-11 — Mobile Surface Truth
 
-- **Scope:** `mobile-surface-truth` workflow (branch `mobile-browser-pwa`) — truthful operator-surface gating on gateway tiers and mobile (390×844) shell ergonomics; E2E-001 + E2E-002 tail QA pair
+- **Scope:** `mobile-surface-truth` workflow (branch `mobile-surface-truth`) — truthful operator-surface gating on gateway tiers and mobile (390×844) shell ergonomics; E2E-001 + E2E-002 tail QA pair
 - **Cadence tier:** targeted
 - **Build:** `029c3773a` (HEAD, clean tree) · **Environment:** isolated lab `compozy-mobile-surface-truth-20260911-041346-834544` — daemon `http://127.0.0.1:53001` serving the built web bundle (`COMPOZY_WEB_DIST_DIR`, production parity), lab `COMPOZY_HOME` `/tmp/compozyqa-4dc542177684/runtime`, UDS socket per manifest; browser driver: Playwright 1.62.1 Chromium (repo-installed) — `agent-browser`/`browser-use` CLIs unavailable in this environment
 - **Started:** 2026-09-11T04:15Z · **Status:** closed <!-- in-progress | closed -->

--- a/docs/qa/reports/2026-09-11-mobile-surface-truth.md
+++ b/docs/qa/reports/2026-09-11-mobile-surface-truth.md
@@ -1,0 +1,172 @@
+# QA Run Report — 2026-09-11 — Mobile Surface Truth
+
+- **Scope:** `mobile-surface-truth` workflow (branch `mobile-browser-pwa`) — truthful operator-surface gating on gateway tiers and mobile (390×844) shell ergonomics; E2E-001 + E2E-002 tail QA pair
+- **Cadence tier:** targeted
+- **Build:** `029c3773a` (HEAD, clean tree) · **Environment:** isolated lab `compozy-mobile-surface-truth-20260911-041346-834544` — daemon `http://127.0.0.1:53001` serving the built web bundle (`COMPOZY_WEB_DIST_DIR`, production parity), lab `COMPOZY_HOME` `/tmp/compozyqa-4dc542177684/runtime`, UDS socket per manifest; browser driver: Playwright 1.62.1 Chromium (repo-installed) — `agent-browser`/`browser-use` CLIs unavailable in this environment
+- **Started:** 2026-09-11T04:15Z · **Status:** closed <!-- in-progress | closed -->
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Marina | Power User | phone 390×844 (device-emulated viewport, touch) / wifi-fast / en-US | CH-mobile-shell-touch-tier |
+| Iris | Power User | laptop (desktop 1440×900) / wifi-fast / en-US | CH-gateway-paired-operator-surface |
+
+## Flows in Scope
+
+- `J-expose-and-pair-gateway` — paired private-tier operator sees only executable affordances; device lifecycle local legs (scope per CH-gateway-paired-operator-surface; journey file not yet materialized under `journeys/`)
+- `J-operate-desktop-shell` — the operator shell is operable at phone size without lying about state (scope per CH-mobile-shell-touch-tier and the frozen T1–T8 artboard)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-paired-device | Iris | Truthful Surface Tour | Blocked (needs human verify) | | |
+| 2 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-operator-surface-truth | Iris | Truthful Surface Tour | Blocked (needs human verify) | | |
+| 3 | CH-mobile-shell-touch-tier | J-operate-desktop-shell / APP-mobile-touch-tier | Marina | Touch Tier Tour | Fixed | BUG-20260911-session-rail-docks-on-touch-tier | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+> Row 3 updated by the repair re-walk addendum at the end of this report.
+
+## Session Debriefs
+
+### CH-gateway-paired-operator-surface — Iris
+
+- **Ran:** 2026-09-11T04:45Z → 05:35Z (box respected: yes)
+- **Entry:** lab daemon operator UI at 1440×900 (local host), Settings → Remote access, plus the documented HTTP/UDS/CLI structured planes.
+- **Findings:**
+  - **Honest discovery (the session's first question):** the private-tier listener does **not** answer on its loopback bind without an authorized provider. The reconciler preflights/establishes the connectivity provider *before* binding; with the bundled tailscale extension active but `TS_AUTHKEY` missing, enable fails-closed, recovery retries keep the tier `observed: down` and the `operator_ui` surface `observed: off`, and no listener socket ever exists (`ss` shows only the main daemon on 53001). Admission therefore cannot be probed on the private tier in-lab. On the main daemon, a direct loopback hit latches `X-Compozy-Gateway-Tier: local` (full local surface, no device auth consulted).
+  - **Pairing mechanics (local legs) re-passed on this build:** the Web pairing dialog mints a one-time code with expiry and truthful copy — "There is no verified private address yet, so the other device has nowhere to open…" — no QR, no plausible dead URL (RT-gateway-operator-surface-truth contract held). HTTP mint returned `{artifact, expires_at}`; documented redeem (`POST /api/gateway/pairings/redeem`, `{"artifact","name","actor_kind":"operator_device"}`) returned 200 with a `Secure; HttpOnly; SameSite=Lax` `compozy_gateway_device` cookie. `compozy pair redeem` (CLI profile path) truthfully refuses a non-HTTPS origin.
+  - **Device inventory cross-surface agreement:** Web ("1 paired device", row with origin + last-active) == HTTP == UDS == `compozy device list -o json` for the same device id. Rename via CLI landed (UI pencil affordance present). Revoke via Web confirm dialog (truthful copy: session closed immediately, streams closed, cannot be undone) and via CLI; `revoke_epoch` bumped to 1 with `revoked_at` set; structured planes retain the marked record while the Web shows "0 paired devices" — consistent active-count semantics (2026-08-07 behavior preserved).
+  - **Surface-truth states re-passed:** Settings → Remote access, `compozy gateway status`, HTTP, and UDS agreed on the same posture; the degraded provider row keeps its actionable cause ("Bind TS_AUTHKEY for tailscale in Settings → Extensions") and shows `Down` without inventing an address; the private-overlay card shows the truthful "Establishing" state.
+  - **BR-5 local regression walk:** dock Terminal launcher present; palette Terminal section present ("Open Terminal"); settings save surfaces render their normal mutable chrome; notifications/attention switches present (toggles, not read-only pills); profile creation present; tasks surface opens. No affordance regression observed on the local desktop host from the mobile-surface-truth change.
+  - **Stream tickets:** not exercisable — the `POST /api/gateway/stream-tickets` route is registered on gateway-tier listeners only, and no gateway listener exists in-lab (above). Recorded as part of the blocked-verify set.
+- **Bugs filed/updated:** none (no new defects on the walked legs).
+- **Scenarios settled:** RT-gateway-paired-device → blocked-verify; RT-gateway-operator-surface-truth → blocked-verify.
+- **Paper cuts:** the structured device list retains revoked records (with `revoked_at`) while the Web shows 0 paired devices — machine-readable and consistent, but a consumer filtering only by name may miscount (dull).
+- **Surprises:** `gateway.surface enable` / `provider enable` transitions surfaced `gateway_generation_conflict` until the expected `--generation` was supplied; the error is correct (optimistic-concurrency fence) but the CLI could name the expected generation in the failure (dull).
+- **Suggested next charter:** with an authorized `TS_AUTHKEY` provisioned: paired private-tier operator session (absent terminal/write affordances, deep-linked write → truthful loopback-only strip), fresh stream tickets, live revocation during a stream, and the public consent/ingress legs.
+- **goal_reached:** partial · **true_end_state:** blocked (remote-tier legs require the user-provisioned authorized `TS_AUTHKEY`; all local legs walked to their end state)
+
+### CH-mobile-shell-touch-tier — Marina
+
+- **Ran:** 2026-09-11T04:20Z → 05:30Z (box respected: yes)
+- **Entry:** lab daemon operator UI at 390×844 (device-emulated, DSF 3, touch), onboarding completed through the product's own wizard (model catalog loaded live; operator's env-var API-key path available; workspace registered through the in-product folder browser).
+- **Findings (vs the frozen T1–T8 map):**
+  - **T1 PASS** — menubar 44px tall; logo/scope/attention/palette/settings controls all exactly 44×44; tab-bar items 44×44 in a 56px bar; traffic lights 44×44 targets in the session window head; palette rows exactly 44px; no body scroll at 390×844 (`scrollHeight == clientHeight == 844`).
+  - **T2 PASS** — compact presentation (<960px): dock strip replaced by the 56px tab bar, windows stacked, compact traffic lights; desktop dock returns at 1440×900.
+  - **T3 PASS** — window content ends at the tab-bar top in portrait and landscape (work area reserves 56px, not the 82px dock band); nothing renders under the tab bar.
+  - **T4 PASS (with parity note)** — viewport meta is exactly `width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content`; simulating the keyboard-open visual viewport (548px line from artboard board 02) keeps the composer and tab bar above the bottom edge via flex compression. Headless desktop Chromium has no virtual keyboard, so the `resizes-content` behavior itself was verified by viewport-shrink emulation + the meta contract; a real-device keyboard-open remains a human-verification residual.
+  - **T5 PASS** — palette top-anchored (dialog top 76px, below the 44px menubar); rows 44px; results well max-height exactly `min(52dvh, 440px)` = 438.88px at 844px viewport height.
+  - **T6 FAIL — BUG-20260911-session-rail-docks-on-touch-tier** — at 390×844 the sessions rail docks as a solid 264px column instead of overlaying the transcript: the transcript/composer compress into the remaining 126px and the composer editor measures 68px wide ("Send a…" clipped, controls stacked). The frozen map promises the overlay + full-width transcript at ≤760px. At 844×390 the same rail docks correctly (>760px desktop rule), isolating the defect to the touch tier.
+  - **T7 PASS** — landscape 844×390 keeps the same chrome (menubar 44 + tab bar 56–57, stack ≈289px); height flexes; no window under the tab bar; no landscape-specific chrome.
+  - **T8 BLOCKED-VERIFY (in-product)** — the loopback-only strip cannot be triggered in-lab (no remote tier without the authorized provider); placement/touch-floor evidence stays with UT-008 (component suite, reused) and the artboard.
+  - **Residuals:** profile-switcher trigger 28×28 well **confirmed** at 390 (and 1440) exactly as recorded in the artboard (dull, cross-system slot); log bodies' horizontal scroll wells **not reached** (extensions log view not opened within the box); scroll-to-bottom pill **not reached** (no scrollable stream: the lab's session truthfully failed to start — "Claude model claude-sonnet-5 is not advertised by the live ACP catalog" — because this machine has no provider CLI binary; no fabricated provider spend was attempted).
+  - **Desktop >1024px spot-check PASS** — 1440×900 renders the pre-change shape (44px menubar, floating dock, no tab bar); consistent with UI-13 for unchanged surfaces. Zero console errors and zero page errors across all walks.
+- **Bugs filed/updated:** BUG-20260911-session-rail-docks-on-touch-tier (Friction/Medium/P2, linked to APP-mobile-touch-tier).
+- **Scenarios settled:** APP-mobile-touch-tier → fail (fix pending).
+- **Paper cuts:** session-window header controls are 26×26 at the touch tier (below the 44px floor) — this matches the artboard's win-head grammar (only menubar/dock/palette/scroll pill are frozen to the floor), but Marina with one hand reaches them poorly (dull, watching); a one-off invisible dialog scrim swallowed a single automated click after a rapid palette re-open/Escape cycle — not reproducible in a deliberate clean retry (dull, watching).
+- **Surprises:** the onboarding wizard cannot complete in a credential-free lab and is not Escape-dismissable — correct product behavior, but worth knowing for lab bootstrap (the operator's env-var API-key path or a provider CLI sign-in is required).
+- **Suggested next charter:** re-walk T6 (rail overlay) after the fix, then the scroll-pill and live-stream legs with a working provider, on a real device for the keyboard-open contract.
+- **goal_reached:** yes (all reachable rows walked) · **true_end_state:** confirmed for T1–T5/T7 + desktop; T6 failed with evidence; T8/live-stream legs blocked (no remote tier / no provider CLI in-lab)
+
+## What Was Fixed
+
+None this run. BUG-20260911-session-rail-docks-on-touch-tier is recorded with evidence and left to the loop controller (production web change in `systems/os/apps/session/session-window-content.tsx` composition — outside this session's lane).
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Marina | J-operate-desktop-shell, session header controls | "These header buttons are tiny for my thumb" | dull | watching (matches artboard grammar) |
+| Marina | J-operate-desktop-shell, palette rapid re-open | "The first tap after closing the palette did nothing once" | dull | not reproducible clean; watching |
+| Iris | J-expose-and-pair-gateway, device inventory | "The list still shows the device I revoked" | dull | structured planes keep `revoked_at` marker; Web shows 0 paired |
+
+## Runtime Errors Observed
+
+- Session start failed truthfully after ~1s: `Claude model "claude-sonnet-5" is not advertised by the live ACP catalog: Provider configuration is unavailable` — the lab machine has no provider CLI binary installed; expected fail-closed in this environment, no retry loop, no fabricated provider spend. Evidence: `i-…` walk + `m-22-session-started.png`.
+- Gateway reconcile failures (provider degraded) surfaced only through status `refusal`/generation fields, not the daemon log — observed during lab bring-up, consistent with fail-closed design (dull observability note).
+- Zero browser console errors / page errors across all walks (portrait, landscape, palette, settings, remote access, tasks).
+
+## Human Verifications Needed
+
+- [ ] Provision an authorized `TS_AUTHKEY` (user-provisioned external prerequisite), enable the tailscale provider for the private tier, and verify the private listener answers on its real address; then walk: paired second device admission, absent terminal/write affordances on the private tier, deep-linked write → 403 `loopback_mutation_required` → truthful loopback-only strip naming the host, fresh single-use stream tickets with reconnection re-mint, live revocation closing streams, and public consent/ingress legs (rows 1–2).
+- [ ] On a real phone (or device-emulated mobile browser with virtual keyboard), verify the keyboard-open `interactive-widget=resizes-content` contract: composer and palette input stay above the keyboard (row 3 residual).
+- [ ] After BUG-20260911 is fixed: re-walk the T6 rail overlay at 390×844, plus the scroll-pill and log-body scroll-well residuals that were not reachable this run (row 3).
+
+## Decisions for a Human
+
+### Session rail docks instead of overlaying at the touch tier (BUG-20260911-session-rail-docks-on-touch-tier)
+- What's broken: at 390×844 the sessions rail docks and crushes the composer to a 68px editor, contradicting frozen decision T6 (overlay + full-width transcript). Evidence: `m-23-rail-open-390.png`, `m-26-rail-portrait-evidence.png`.
+- Why not auto-fixed: production web change in the task_04 composition wrapper (`session-window-content.tsx` touch-tier branch not applying at ≤760px) — outside this session's lane; the fix-loop governor bounds auto-fixes to clearly-lane-owned, cheap repairs.
+- Options: 1. Fix the touch-tier branch in the rail composition wrapper and add a regression test at the ≤760px tier (small, contained — recommended). 2. Re-freeze the artboard to the docked behavior (changes the approved design contract; not recommended).
+- Recommendation: option 1, then re-walk the T6 row in a fresh session.
+
+## Learnings
+
+- The gateway reconciler binds the tier listener only *after* provider preflight/establish succeed — a degraded provider means **no listener at all**, even on loopback. In-lab private-tier walks are impossible without a real provider; the 2026-08-07 "gateway states walked locally" evidence was posture/state walks, not listener admission.
+- `gateway.surface/provider enable` CLI transitions enforce optimistic concurrency: pass `--generation` from the current status or the persist step returns `gateway_generation_conflict`.
+- The lab's operator UI is served by the daemon itself (`COMPOZY_WEB_DIST_DIR`) — the vite dev server is unnecessary for walks; onboarding is completed through the product wizard (model picker → env-var API-key path → workspace folder browser).
+- Playwright (via `@playwright/test` in `web/node_modules`) is a workable `agent-browser` substitute for evidence at device-emulated viewports when the browser CLIs are absent; record the driver substitution in the report environment line.
+- The redeem endpoint is served on the local listener too; `actor_kind=operator_device` yields the HttpOnly+Secure device cookie, while `actor_kind=cli_profile` is rejected from browser-shaped requests, and the CLI profile path requires an HTTPS origin.
+
+## Final Status
+
+- **Exit gate:** delivery gates intentionally not run by this task (loop controller owns them). Reused gate evidence: `make gate` PASS records under `.cache/gate/` (iterations 2–5, task_05) cover go-lint/test and web lint/typecheck/test for this branch; no code was changed by this QA run.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 1 · Cosmetic 0
+- **Coverage:** 2/2 charters walked to a recorded verdict; 3/3 in-scope scenarios settled (1 fail, 2 blocked-verify); T8, stream-ticket, remote-admission, and live-stream legs disclosed as not reachable in-lab (named blockers).
+- **Verdict: not ready** — the changed operator surface is truthful locally and the touch-tier chrome holds except T6: fix and re-walk `BUG-20260911-session-rail-docks-on-touch-tier`; the remote-tier legs stay blocked-verify pending the user-provisioned authorized `TS_AUTHKEY`.
+
+## Repair Re-walk Addendum — 2026-09-11 (BUG-20260911-session-rail-docks-on-touch-tier)
+
+**What changed (repair lane, web composition only):** the task_04 T6 wrapper in
+`web/src/systems/os/apps/session/session-window-content.tsx` relied on Chromium
+blockifying `display: contents` under `position: absolute` — it never does, so
+the media-scoped `max-[760px]:absolute/inset/z/shadow-overlay` classes applied
+to a wrapper that generated no box and the rail stayed a docked flex child at
+every width (landscape merely looked correct because docking is the >760px
+desktop contract). The fix opts the wrapper back into a real display at the
+touch tier (`max-[760px]:block`, which wins the cascade over the base
+`contents` utility inside the breakpoint) and scopes the overlay shadow to the
+rail's open state so a closed rail cannot paint the token's 1px ring.
+`SessionSidebar` and all other surfaces untouched; two regression tests added
+to the owning suite. Full root cause in the bug's `## Fix`.
+
+**Re-walk (fresh lab `compozy-mobile-surface-truth-repair-20260911-20260911-055549-379543`,
+daemon `http://127.0.0.1:34657` serving a fresh `web/dist` build of the fix
+via `COMPOZY_WEB_DIST_DIR`, Playwright 1.62.1 Chromium device-emulated
+390×844 touch, en-US; teardown `clean: true`):**
+
+- **T6 at 390×844 — PASS.** Rail open: wrapper computes `block`/`absolute`/`z-30`,
+  rail overlays x=0..264, transcript keeps full width (x=0, w=390), composer
+  editor 332px wide (was 68) with send control intact; computed box-shadow
+  carries the `--shadow-overlay` layers. Rail closed: no shadow, transcript
+  full width. Evidence `r-1`–`r-3`, `r-6` under
+  `docs/qa/evidence/2026-09-11-mobile-surface-truth/`.
+- **Landscape 844×390 control — unchanged/correct.** Rail docks as a layout
+  column (transcript x=264 w=580, editor w=522), no shadow — the >760px rule
+  holding as before. Evidence `r-4`.
+- **Desktop 1440×900 spot-check — unchanged.** Docked, no shadow,
+  behaviorally identical. Evidence `r-5`.
+- Zero browser console errors / page errors across all legs.
+- Scoped validation from the repo root: `bunx turbo run typecheck --filter=./web`
+  PASS (2/2); `bunx turbo run test --filter=./web` PASS (776 files / 7212
+  tests, 0 failures — baseline 7210 + 2 new regression tests);
+  `bunx turbo run lint --filter=./web` PASS (0 warnings / 0 errors).
+
+**Environment note:** no provider credential was present in this repair
+environment (`ANTHROPIC_API_KEY` absent, unlike the original walk); the
+onboarding credential step was completed through the same env-var path bound
+to a clearly-labeled placeholder value. No provider spend occurred or was
+possible (no provider CLI in the environment); session start still truthfully
+fails at the runtime step as recorded in the original walk. The T6 leg needs
+only the session window surface, which rendered fully.
+
+**Updated final status:** APP-mobile-touch-tier → `pass` (fix_status `fixed`,
+retest_status `pass`); BUG-20260911 → `fixed` with re-walk evidence. The
+friction count for this run drops to 0 open items. Overall verdict remains
+gated on the unchanged external blocker: the private-tier legs stay
+blocked-verify pending the user-provisioned authorized `TS_AUTHKEY` (rows
+1–2), and the real-device keyboard-open check remains a human-verification
+residual (row 3).

--- a/docs/qa/reports/2026-09-11-mobile-surface-truth.md
+++ b/docs/qa/reports/2026-09-11-mobile-surface-truth.md
@@ -21,11 +21,11 @@
 
 | # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
 |---|---|---|---|---|---|---|---|
-| 1 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-paired-device | Iris | Truthful Surface Tour | Fail | BUG-20260911-private-ui-origin-rejected-on-forwarded-tier | |
-| 2 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-operator-surface-truth | Iris | Truthful Surface Tour | Fail | BUG-20260911-private-tier-loopback-guard-inert | |
+| 1 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-paired-device | Iris | Truthful Surface Tour | Pass | BUG-20260911-private-ui-origin-rejected-on-forwarded-tier (fixed+verified) | 17304fe8f |
+| 2 | CH-gateway-paired-operator-surface | J-expose-and-pair-gateway / RT-gateway-operator-surface-truth | Iris | Truthful Surface Tour | Pass | BUG-20260911-private-tier-loopback-guard-inert (fixed+verified) | 17304fe8f |
 | 3 | CH-mobile-shell-touch-tier | J-operate-desktop-shell / APP-mobile-touch-tier | Marina | Touch Tier Tour | Fail | BUG-20260911-session-rail-docks-on-touch-tier | |
 
-Status legend: `Pending | Pass | Fixed | Fail | Skipped | Blocked (needs human verify) | Blocked (human decision)` — `Fail` = walked, expected observable not confirmed, fix pending (tracker `fail` / `blocked-verify` per row; see Session Debriefs and the addendum for which applies and why). Rows 1–2 verdicts come from the remote-leg addendum below (earlier same-day blocked-verify runs retained in scenario history).
+Status legend: `Pending | Pass | Fixed | Fail | Skipped | Blocked (needs human verify) | Blocked (human decision)` — rows 1–2 reached `Pass` via the addendum-2 verification walk (their earlier `fail`/`blocked-verify` history lives in the scenario bodies and Addendum 1); row 3 remains `Fail` (different charter, fix pending).
 
 > Row 3 updated by the repair re-walk addendum at the end of this report.
 
@@ -91,9 +91,9 @@ None this run. BUG-20260911-session-rail-docks-on-touch-tier is recorded with ev
 
 ## Human Verifications Needed
 
-- [ ] Provision an authorized `TS_AUTHKEY` (user-provisioned external prerequisite), enable the tailscale provider for the private tier, and verify the private listener answers on its real address; then walk: paired second device admission, absent terminal/write affordances on the private tier, deep-linked write → 403 `loopback_mutation_required` → truthful loopback-only strip naming the host, fresh single-use stream tickets with reconnection re-mint, live revocation closing streams, and public consent/ingress legs (rows 1–2).
+- [x] ~~Provision an authorized `TS_AUTHKEY` and walk the private-tier legs~~ — **done 2026-09-11** (Addendum 1 + Addendum 2): provider established, pairing/admission/streams/revocation and the BR-1 surface-truth walk all verified in-product; both forwarded-tier defects fixed and verified. **The user should revoke both keys used today.**
 - [ ] On a real phone (or device-emulated mobile browser with virtual keyboard), verify the keyboard-open `interactive-widget=resizes-content` contract: composer and palette input stay above the keyboard (row 3 residual).
-- [ ] After BUG-20260911 is fixed: re-walk the T6 rail overlay at 390×844, plus the scroll-pill and log-body scroll-well residuals that were not reachable this run (row 3).
+- [ ] After BUG-20260911-session-rail-docks-on-touch-tier is fixed: re-walk the T6 rail overlay at 390×844, plus the scroll-pill and log-body scroll-well residuals that were not reachable in the morning run (row 3).
 
 ## Decisions for a Human
 
@@ -163,6 +163,45 @@ None this run. BUG-20260911-session-rail-docks-on-touch-tier is recorded with ev
 - **Issues by user impact (addendum):** Blocks-Completion 1 · Data-Loss 0 · Trust-Damage 1 · Friction 0 · Cosmetic 0
 - **Secret disposition:** authorized `TS_AUTHKEY` deleted from `/tmp/opencode/ts-authkey` after the walk; zero occurrences in any persisted artifact (byte-scan); lab runtime purged. The user should revoke the key at the tailscale tailnet as it was live during the session.
 - **Verdict (addendum): not ready** — the remote-tier story is architecturally alive (provider establishes, pairing/admission/streams/revocation all behave), but two P0/P1-class defects (UI origin refusal; missing server-side enforcement) must be fixed and the paired session re-walked before the surface-truth promise holds.
+
+---
+
+## Addendum 2 — 2026-09-11 (verification walk): fixes for the forwarded-tier defects verified in-product
+
+- **Scope:** in-product verification that `17304fe8f` fixes `BUG-20260911-private-ui-origin-rejected-on-forwarded-tier` (P0) and `BUG-20260911-private-tier-loopback-guard-inert` (P1), and completion of the blocked BR-1 legs of `CH-gateway-paired-operator-surface`.
+- **Environment:** fresh lab `compozy-mobile-surface-truth-verify2-20260911-141455-792161` — daemon `http://127.0.0.1:35569`, lab `COMPOZY_HOME` `/tmp/compozyqa-0fa9adbe4836/runtime`, build at HEAD (`17304fe8f` + QA docs). Fresh authorized key used for bring-up only: bound via the extension vault, **secret file deleted immediately after the tier reached `up`**; zero key-material occurrences by byte-scan (daemon log, docs, memory, lab artifacts); device-cookie temp jars deleted after the walk; all five walk devices revoked at the end (empty-inventory recovery root confirmed).
+- **Bring-up note (recipe unchanged from the previous addendum, one delta):** the provider-only enable transition does not by itself drive the first establish attempt; the `operator_ui` surface enable does (it errored `gateway provider degraded` once — tsnet still negotiating — then recovery established the tier: `down → establishing → up` with a verified live address).
+
+### Fix verification measurements
+
+| Defect | Expected after fix | Observed |
+|---|---|---|
+| P0 — origin rejection on the forwarded tier | paired SPA boots over `https://…ts.net:8443`; no `/assets/*` 403s | **Verified** — `networkidle` in 858ms; zero asset rejections across portrait/desktop loads; the only 4xx are the expected `401` on unauthenticated `/api/*`; the app renders its own "Pair this device" gate, pre-filled from the `#pair=` fragment; redeem completes in-UI → paired operator session with the Secure/HttpOnly cookie |
+| P1 — loopback guard inert on the private tier | paired device cookie: guarded mutations → 403 `loopback_mutation_required`; reads → 200; local loopback keeps mutation semantics | **Verified** — `POST /api/drain` → 403 `loopback_mutation_required` (drain state unchanged, confirmed by local read); guarded `PATCH /api/settings/general` → 403 same code; `GET /api/gateway/status` (tier `private`), `GET /api/settings/general`, `GET /api/gateway/devices` → 200; on the local loopback daemon `drain`/`undrain` → 200 (BR-5 canary) |
+
+### Completed BR-1 walk on the paired remote session
+
+- Dock Terminal launcher **absent** (0 matches; local sessions show it). Settings save bar **absent** on `/settings/general`; profile creation **absent** on `/settings/profiles`.
+- Dispatching the daemon-owned "Open Terminal" palette command lands in the **truthful loopback-only window**: "This action runs on the machine running CompozyOS — You are connected through remote access, so this action cannot run from this device."
+- **Deep-linked settings write (attention toggle) → 403 → the shell renders the truthful loopback-only strip** (T8 / US-002.AC-2 in-product; screenshot `ts2-15`).
+- Streams re-verified: single-use tickets (reuse → 401 `gateway_stream_ticket_invalid`), reconnect re-mints, inventory agreement across Web/HTTP/UDS/CLI (5/5/5/5 devices), revocation closing live work (`canceled: 1`, stream closed mid-flight, credential then 401).
+
+### Disclosed residuals (non-blocking, named)
+
+- Notification-delivery toggles on `/settings/attention` still render as live switches on the paired session; toggling refuses 403 into the truthful strip. This is the recorded task_03 residual class (affordance present, server truth holds, gate is a small local edit) — disposition belongs to the loop controller.
+- The settings surface's keyboard/screen-reader rows were not re-probed this walk; the 2026-08-07 walk and UI-13 baseline remain the owning evidence for the unchanged plumbing.
+- Public tier/Funnel remains out of scope (`RT-gateway-public-ui-consent` owns it).
+
+### Addendum 2 verdicts
+
+- `RT-gateway-paired-device` → **pass** (`fix_status: fixed`, `retest_status: pass`, commit `17304fe8f`): the QR/link pairing flow works end to end through the product UI; single-use, cross-surface agreement, and revocation-closes-live-work all confirmed.
+- `RT-gateway-operator-surface-truth` → **pass** (`fix_status: fixed`, `retest_status: pass`, commit `17304fe8f`): live-address presentation, truthful states, BR-1 absences, the 403 → truthful strip backstop, and server-side enforcement all confirmed; named residuals above.
+
+### Addendum 2 final status
+
+- **Issues by user impact (cumulative run):** Blocks-Completion 0 open · Data-Loss 0 · Trust-Damage 0 open (both forwarded-tier defects verified fixed) · Friction 1 open (BUG-20260911-session-rail-docks-on-touch-tier, different charter) · Cosmetic 0
+- **Secret disposition:** fresh key deleted after bring-up; zero occurrences by byte-scan; cookie jars deleted; all walk devices revoked; the user should revoke both keys used today at the tailnet.
+- **Verdict (addendum 2): the remote-tier surface truth holds** — with the two forwarded-tier defects fixed and verified, E2E-001's paired private-tier journey is confirmed in-product; remaining work for this workflow is the T6 mobile rail fix (other charter) and the recorded non-blocking residuals.
 
 ## Repair Re-walk Addendum — 2026-09-11 (BUG-20260911-session-rail-docks-on-touch-tier)
 

--- a/docs/qa/reports/2026-09-11-mobile-surface-truth.md
+++ b/docs/qa/reports/2026-09-11-mobile-surface-truth.md
@@ -255,3 +255,23 @@ gated on the unchanged external blocker: the private-tier legs stay
 blocked-verify pending the user-provisioned authorized `TS_AUTHKEY` (rows
 1–2), and the real-device keyboard-open check remains a human-verification
 residual (row 3).
+
+## Addendum 3 — real-device walk (2026-09-11, user's phone)
+
+The paired session was walked on a real phone (Android, Brave, ~390×844) over
+the verified private endpoint. Core flows confirmed live: pairing gate → paired
+session; surface truth visible (Settings read-only, no save bars); dock, palette
+and window chrome rendering at the touch tier.
+
+Real-device findings (both fixed in-cycle, commit `2bd4ca788`):
+- **F1 (defect):** the compact DesktopPager rendered a single-desktop position
+  pill orphaned at the dock's far edge with ~195px dead zone — dock spacing
+  broken at 390px. Fixed: single desktop renders no switcher; multiple desktops
+  shrink-wrap.
+- **F2 (defect):** window controls identified only via hover tones (no hover on
+  touch); the 2-of-3 count is per-design (zoom hidden, close reachable). Fixed:
+  rest glyphs for close/minimize at the compact tier.
+
+Artboard evolved: T9 (dock pager) and T10 (window-control identification) added
+as real-device deltas. Fixes deployed to the user's runtime; on-device re-walk
+pending. T4 keyboard-open on a real device remains a human-verification residual.

--- a/docs/qa/scenarios/APP-mobile-touch-tier.md
+++ b/docs/qa/scenarios/APP-mobile-touch-tier.md
@@ -1,0 +1,82 @@
+---
+id: APP-mobile-touch-tier
+area: APP
+title: Monitor from a phone-sized viewport on the touch tier
+persona: Marina
+journey: J-operate-desktop-shell
+expected: At 390×844 the operator shell stays operable per the frozen T1–T8 artboard — 44px touch floor, keyboard-open keeps the composer above the keyboard, landscape flexes height — while desktop rendering is unchanged
+entry_points: Web / (operator shell) at a 390×844 viewport; command palette via ⌘K
+qa_status: pass
+bug_ids: BUG-20260911-session-rail-docks-on-touch-tier
+fix_status: fixed
+retest_status: pass
+fix_commits: 2adc10724
+evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/m-10-portrait-home.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/m-11-palette-open.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/m-25-keyboard-open-548.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/m-27-landscape-390h.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/m-23-rail-open-390.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/d-10-desktop-1440-home.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/r-2-rail-open-390.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/r-3-rail-closed-390.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/r-4-landscape-rail-open.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/r-5-desktop-1440-rail-open.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/r-6-shadow-check-390.png
+last_report: docs/qa/reports/2026-09-11-mobile-surface-truth.md
+overlaps:
+---
+
+Walk the mobile monitoring journey against the normative artboard
+`docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html`
+(frozen by the mobile-surface-truth design pass, branch `mobile-browser-pwa`):
+
+- T1 touch floor (44px) on menubar controls, dock, palette rows/input, scroll pill.
+- T3 compact win-layer reserves tab-bar height (stream content gains the dock band).
+- T4 viewport contract `viewport-fit=cover, interactive-widget=resizes-content`;
+  keyboard-open shrinks the layout viewport and the composer stays above it.
+- T5 palette stays top-anchored at the touch tier; results well grows to
+  min(52dvh, 440px).
+- T6 session rail overlays the transcript at ≤760px instead of docking.
+- T7 landscape keeps the same chrome and flexes height — verify the height-flex
+  story, not 44px chrome in landscape (recorded residual).
+- T8 loopback-only banner strip sits between menubar and win-layer.
+- Confirm-or-bounce residuals: profile-switcher trigger 28px well; log bodies'
+  own horizontal scroll wells.
+- Desktop (>1024px) spot-check: rendering pixel-identical.
+
+Composes with the mobile-surface-truth gating: on remote tiers the terminal
+pane is absent (RT-gateway-operator-surface-truth owns that surface); this
+scenario owns the viewport/touch ergonomics. Layout baseline UI-13
+(`docs/qa/_seeds/final-qa/_children/12-web-ui.md`) covered the pre-ergonomics
+layout and stays valid for unchanged surfaces.
+
+QA walk 2026-09-11 (CH-mobile-shell-touch-tier, lab
+`compozy-mobile-surface-truth-20260911-041346-834544`): T1 44px floor holds on
+menubar controls, tab items, traffic lights, and palette rows; T5 palette
+top-anchored at 76px with the results well at exactly min(52dvh, 440px)
+(438.88px); T3/T7 compact work area reserves the 56px tab bar (no window
+content under it; landscape stack ~289px with unchanged chrome); T4 viewport
+contract present and the keyboard-open simulation (548px visual-viewport line)
+keeps the composer and tab bar above the keyboard; desktop 1440×900 spot-check
+matches the pre-change shape (floating dock, no tab bar). Profile-switcher
+28px well confirmed as the recorded residual; log-body scroll wells and the
+scroll pill were not reachable in the box (extensions log view not opened; no
+scrollable stream without a live provider CLI). FAILS T6: at 390×844 the
+sessions rail docks and crushes the composer to a 68px editor instead of
+overlaying the transcript — BUG-20260911-session-rail-docks-on-touch-tier.
+T8 loopback-only strip placement was not reachable in-product (no remote tier
+in the lab); component-level coverage stays in UT-008. Keyboard-open was
+emulated by shrinking the layout viewport (headless Chromium has no virtual
+keyboard); the `interactive-widget=resizes-content` contract itself is
+verified in the meta tag, and a real-device keyboard-open remains a
+human-verification residual.
+
+Repair re-walk 2026-09-11: T6 overlay verified at 390×844; landscape control
+case unchanged.
+
+Repair re-walk 2026-09-11 (BUG-20260911 fix, fresh lab
+`compozy-mobile-surface-truth-repair-20260911-20260911-055549-379543`, daemon
+`http://127.0.0.1:34657` serving a fresh `web/dist` build of the fix,
+Playwright 1.62.1 device-emulated 390×844 touch): at 390×844 with the rail
+open, the sidebar wrapper computes `display: block` / `position: absolute` /
+`z-index: 30`, the rail overlays at x=0..264, the transcript keeps full width
+(x=0, w=390), and the composer editor measures 332px wide (was 68) with the
+send control intact; the wrapper's computed box-shadow carries the
+`--shadow-overlay` layers (`rgba(0, 0, 0, 0.65) 0px 24px 48px -12px` plus the
+1px light ring). Rail closed: wrapper w=0 with `box-shadow: none` (no sliver
+ring), transcript full width. Landscape 844×390 control: rail still docks as a
+layout column (transcript x=264 w=580, editor w=522) with no shadow — the
+correct >760px rule, unchanged. Desktop 1440×900 spot-check: docked, no
+shadow, behaviorally identical. Zero console errors. Root cause and
+measurements in the bug's Fix/Verification sections; evidence
+`r-1`–`r-6` under `docs/qa/evidence/2026-09-11-mobile-surface-truth/`.

--- a/docs/qa/scenarios/APP-mobile-touch-tier.md
+++ b/docs/qa/scenarios/APP-mobile-touch-tier.md
@@ -18,7 +18,7 @@ overlaps:
 
 Walk the mobile monitoring journey against the normative artboard
 `docs/design/opendesign/mobile-surface-truth/mobile-surface-truth-shell-390.html`
-(frozen by the mobile-surface-truth design pass, branch `mobile-browser-pwa`):
+(frozen by the mobile-surface-truth design pass, branch `mobile-surface-truth`):
 
 - T1 touch floor (44px) on menubar controls, dock, palette rows/input, scroll pill.
 - T3 compact win-layer reserves tab-bar height (stream content gains the dock band).

--- a/docs/qa/scenarios/APP-mobile-touch-tier.md
+++ b/docs/qa/scenarios/APP-mobile-touch-tier.md
@@ -80,3 +80,8 @@ correct >760px rule, unchanged. Desktop 1440×900 spot-check: docked, no
 shadow, behaviorally identical. Zero console errors. Root cause and
 measurements in the bug's Fix/Verification sections; evidence
 `r-1`–`r-6` under `docs/qa/evidence/2026-09-11-mobile-surface-truth/`.
+
+Real-device walk 2026-09-11 (user's phone, Android/Brave ~390×844): paired
+session verified over the private endpoint; two touch-tier findings fixed
+in-cycle (dock pager composition; window-control identification without hover)
+— commit `2bd4ca788`, artboard T9/T10. On-device re-walk pending redeploy.

--- a/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
+++ b/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
@@ -11,8 +11,8 @@ bug_ids: BUG-20260807-gateway-live-config-copy;BUG-20260807-gateway-provider-cau
 fix_status: fixed
 retest_status: pass
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-remote-gateway-20260807-202655-957508-lab/qa-artifacts/qa/screenshots/05-provider-degraded-no-address.png;/Users/pedronauck/dev/qa-labs/compozy-remote-gateway-20260807-202655-957508-lab/qa-artifacts/qa/screenshots/14-audit-no-findings.png
-last_report: docs/qa/reports/2026-08-07-remote-gateway.md
+evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/i-11-settings-remote-access.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-19-after-revoke-web.png
+last_report: docs/qa/reports/2026-09-11-mobile-surface-truth.md
 overlaps: RT-gateway-local-only-boot; RT-connectivity-provider-route
 ---
 
@@ -28,3 +28,23 @@ claims and optimistic mutations.
 QA walk 2026-08-07: Web, CLI, HTTP, and UDS agreed on local-only, degraded, refusal, and remediated
 states; three production defects were fixed and re-walked. A truthful live-address presentation
 remains blocked because the provider account is unavailable.
+
+Re-opened as untested 2026-09-11: the mobile-surface-truth change (branch `mobile-browser-pwa`)
+altered the operator surface — loopback-only affordances are now absent on remote tiers and a
+truthful loopback-only state exists for the two stable 403 codes. The surface-truth walk (including
+remote live-address presentation) re-runs under CH-gateway-paired-operator-surface; the real-address
+leg remains externally blocked pending an authorized TS_AUTHKEY.
+
+QA walk 2026-09-11 (CH-gateway-paired-operator-surface, lab
+`compozy-mobile-surface-truth-20260911-041346-834544`): local surface truth re-passed — Web
+Settings → Remote access, `compozy gateway status -o json`, HTTP, and UDS agreed on the same
+posture (`gateway.enabled` on, private tier desired=enabled with the provider down, operator_ui
+surface desired=enabled/observed=off, "local only · 0 paired devices" header); the degraded
+provider row keeps its actionable cause ("Bind TS_AUTHKEY for tailscale in Settings →
+Extensions") without inventing an address; the private-overlay card shows the truthful
+"Establishing" state instead of a plausible dead URL; the pairing dialog names the missing
+verified address and blocks device handoff honestly. Direct loopback hits on the main daemon
+latch the `X-Compozy-Gateway-Tier: local` header (full local surface), and the private-tier
+listener never binds without the provider (fail-closed, recovery retries), so the new
+loopback-only affordance gating and the truthful 403 strip remain unverifiable in-product —
+blocked-verify on the named external blocker (authorized `TS_AUTHKEY`).

--- a/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
+++ b/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
@@ -29,7 +29,7 @@ QA walk 2026-08-07: Web, CLI, HTTP, and UDS agreed on local-only, degraded, refu
 states; three production defects were fixed and re-walked. A truthful live-address presentation
 remains blocked because the provider account is unavailable.
 
-Re-opened as untested 2026-09-11: the mobile-surface-truth change (branch `mobile-browser-pwa`)
+Re-opened as untested 2026-09-11: the mobile-surface-truth change (branch `mobile-surface-truth`)
 altered the operator surface — loopback-only affordances are now absent on remote tiers and a
 truthful loopback-only state exists for the two stable 403 codes. The surface-truth walk (including
 remote live-address presentation) re-runs under CH-gateway-paired-operator-surface; the real-address

--- a/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
+++ b/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
@@ -6,12 +6,12 @@ persona: Iris
 journey: J-expose-and-pair-gateway
 expected: Gateway settings and structured status agree on named exposure modes, desired and observed state, verified addresses, provider health and cause, refusals, and local-only recovery without presenting an unsupported control or plausible dead URL.
 entry_points: Web /settings/gateway; compozy gateway status -o json; HTTP/UDS GET /api/gateway/status
-qa_status: blocked-verify
+qa_status: pass
 bug_ids: BUG-20260807-gateway-live-config-copy;BUG-20260807-gateway-provider-cause;BUG-20260807-gateway-provider-boot;BUG-20260911-private-ui-origin-rejected-on-forwarded-tier;BUG-20260911-private-tier-loopback-guard-inert
-fix_status: pending
-retest_status:
-fix_commits:
-evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-01-remote-access-live.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-02-pairing-with-address.png
+fix_status: fixed
+retest_status: pass
+fix_commits: 17304fe8f
+evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/ts2-08-br1-paired-shell.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts2-14-open-terminal-dispatch.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts2-15-loopback-strip-after-write.png
 last_report: docs/qa/reports/2026-09-11-mobile-surface-truth.md
 overlaps: RT-gateway-local-only-boot; RT-connectivity-provider-route
 ---
@@ -67,3 +67,25 @@ mechanics verified API-level: mint 201 with TTL, single-use connect (reuse → 4
 `gateway_stream_ticket_invalid`), reconnect re-mints, and revocation closed an open stream
 (`canceled: 1`) before the credential refused. Verdict `blocked-verify` — fix both bugs, then
 re-walk the paired operator session end to end.
+
+Verification walk 2026-09-11 after the fixes (commit `17304fe8f`, lab
+`compozy-mobile-surface-truth-verify2-20260911-141455-792161`, fresh authorized key, deleted after
+bring-up): both defects verified fixed in-product and the surface-truth walk completed over the
+live private tier. P0 fixed: the paired SPA boots over the forwarded TLS endpoint (858ms
+`networkidle`, zero `/assets/*` rejections; only the expected unauthenticated `/api` 401s) and even
+gates unpaired visitors to the product's own "Pair this device" redeem form. P1 fixed: with a
+paired device cookie, `POST /api/drain` and guarded `PATCH /api/settings/general` now refuse
+`403 loopback_mutation_required` (drain state confirmed unchanged by a local read) while reads stay
+200; the loopback daemon keeps local mutation semantics (drain/undrain 200 — BR-5 canary). BR-1
+verified on the paired session: dock Terminal launcher absent, settings save bar absent, profile
+creation absent, and dispatching the daemon-owned "Open Terminal" command lands in the truthful
+loopback-only window ("This action runs on the machine running CompozyOS — You are connected
+through remote access, so this action cannot run from this device."); a deep-linked settings write
+(attention toggle) is refused 403 and the shell renders the truthful loopback-only strip (T8 /
+US-002.AC-2 in-product). Streams: single-use tickets, reconnect re-mints, revocation closing live
+work (`canceled: 1`) all re-verified. Disclosed residuals, none blocking: notification-delivery
+toggles on `/settings/attention` still render as live switches on the paired session (they refuse
+403 into the truthful strip — the recorded task_03 residual class; the server-side truth holds);
+the settings surface's keyboard/screen-reader rows were not re-probed this walk (unchanged
+plumbing; 2026-08-07 walk + UI-13 baseline remain the owning evidence); public tier/Funnel stays
+out of scope. Verdict **pass** with those named residuals.

--- a/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
+++ b/docs/qa/scenarios/RT-gateway-operator-surface-truth.md
@@ -7,11 +7,11 @@ journey: J-expose-and-pair-gateway
 expected: Gateway settings and structured status agree on named exposure modes, desired and observed state, verified addresses, provider health and cause, refusals, and local-only recovery without presenting an unsupported control or plausible dead URL.
 entry_points: Web /settings/gateway; compozy gateway status -o json; HTTP/UDS GET /api/gateway/status
 qa_status: blocked-verify
-bug_ids: BUG-20260807-gateway-live-config-copy;BUG-20260807-gateway-provider-cause;BUG-20260807-gateway-provider-boot
-fix_status: fixed
-retest_status: pass
+bug_ids: BUG-20260807-gateway-live-config-copy;BUG-20260807-gateway-provider-cause;BUG-20260807-gateway-provider-boot;BUG-20260911-private-ui-origin-rejected-on-forwarded-tier;BUG-20260911-private-tier-loopback-guard-inert
+fix_status: pending
+retest_status:
 fix_commits:
-evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/i-11-settings-remote-access.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-19-after-revoke-web.png
+evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-01-remote-access-live.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-02-pairing-with-address.png
 last_report: docs/qa/reports/2026-09-11-mobile-surface-truth.md
 overlaps: RT-gateway-local-only-boot; RT-connectivity-provider-route
 ---
@@ -48,3 +48,22 @@ latch the `X-Compozy-Gateway-Tier: local` header (full local surface), and the p
 listener never binds without the provider (fail-closed, recovery retries), so the new
 loopback-only affordance gating and the truthful 403 strip remain unverifiable in-product —
 blocked-verify on the named external blocker (authorized `TS_AUTHKEY`).
+
+Remote-leg walk 2026-09-11 with the authorized provider (lab
+`compozy-mobile-surface-truth-remote-20260911-125112-264736`): the truthful live-address
+presentation VERIFIED in-product — the Reachability card shows "Reachable / Verified: this address
+was proven to reach this machine" with the live `https://…ts.net:8443` endpoint (`live: true`),
+the provider row reads "Healthy — Up", and Web/CLI/HTTP/UDS agreed on the same posture
+(`operator_ui` surface `on`, tier `up`, advertised). The paired operator surface walk itself is
+blocked by two filed defects: (1) the UI cannot boot over the private tier — every ES-module asset
+is refused `403 {"error":"origin not allowed"}` by the CORS origin check on the forwarded hop
+(BUG-20260911-private-ui-origin-rejected-on-forwarded-tier), so BR-1 absence walk, the
+deep-linked-write truthful strip (US-002.AC-2 / T8), and the remote session are unreachable;
+(2) the server-side enforcement behind those surfaces is absent — with a paired device credential,
+guarded mutations (drain/undrain proven 200 with real state change; guarded settings PATCH passed
+the guard to handler validation) execute over the private tier instead of refusing
+`loopback_mutation_required` (BUG-20260911-private-tier-loopback-guard-inert). Stream-ticket
+mechanics verified API-level: mint 201 with TTL, single-use connect (reuse → 401
+`gateway_stream_ticket_invalid`), reconnect re-mints, and revocation closed an open stream
+(`canceled: 1`) before the credential refused. Verdict `blocked-verify` — fix both bugs, then
+re-walk the paired operator session end to end.

--- a/docs/qa/scenarios/RT-gateway-paired-device.md
+++ b/docs/qa/scenarios/RT-gateway-paired-device.md
@@ -11,8 +11,8 @@ bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-remote-gateway-20260807-202655-957508-lab/qa-artifacts/qa/screenshots/06-paired-devices.png;/Users/pedronauck/dev/qa-labs/compozy-remote-gateway-20260807-202655-957508-lab/qa-artifacts/qa/screenshots/08-revoked-browser-device.png;/Users/pedronauck/dev/qa-labs/compozy-remote-gateway-20260807-202655-957508-lab/qa-artifacts/qa/test-cases/22-device-rename.json
-last_report: docs/qa/reports/2026-08-07-remote-gateway.md
+evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/i-13-pairing-code-minted.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-14-devices-listed.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-18-after-revoke.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-19-after-revoke-web.png
+last_report: docs/qa/reports/2026-09-11-mobile-surface-truth.md
 overlaps: RT-gateway-local-only-boot
 ---
 
@@ -23,3 +23,22 @@ and the empty inventory. The local daemon remains the recovery root after every 
 QA walk 2026-08-07: local pairing, rename, revoke, empty inventory, and replacement pairing passed
 through product surfaces. The remote tier admission and live-stream cancellation leg remains
 blocked without an authorized provider address and a second remote device.
+
+Re-opened as untested 2026-09-11: the mobile-surface-truth change (branch `mobile-browser-pwa`)
+altered the post-pairing operator surface (capability gating), so the paired-device experience is
+re-walked under CH-gateway-paired-operator-surface; the real-address admission leg remains
+externally blocked pending an authorized TS_AUTHKEY.
+
+QA walk 2026-09-11 (CH-gateway-paired-operator-surface, lab
+`compozy-mobile-surface-truth-20260911-041346-834544`): local legs re-passed on this build — Web
+pairing dialog mints a one-time code with truthful copy ("There is no verified private address yet,
+so the other device has nowhere to open" — no QR, no dead URL); HTTP mint + documented redeem
+(`POST /api/gateway/pairings/redeem`, `actor_kind=operator_device`) returned a `Secure; HttpOnly;
+SameSite=Lax` device cookie; inventory agreed across Web (1 paired → 0 after revoke), HTTP, UDS,
+and `compozy device list -o json`; CLI rename landed; revoke bumped `revoke_epoch` with
+`revoked_at` set, structured planes retain the marked record while the Web shows 0 paired devices.
+The `compozy pair redeem` CLI profile path truthfully refuses a non-HTTPS origin. Blocked-verify
+remains for the remote-tier admission legs: the private-tier listener never binds without an
+authorized provider (reconciler preflight/establish fails-closed before binding — recovery retries
+keep the tier `down`, surface `off`), so the redeemed device credential cannot be exercised against
+a gateway listener in-lab (named blocker: user-provisioned authorized `TS_AUTHKEY`).

--- a/docs/qa/scenarios/RT-gateway-paired-device.md
+++ b/docs/qa/scenarios/RT-gateway-paired-device.md
@@ -24,7 +24,7 @@ QA walk 2026-08-07: local pairing, rename, revoke, empty inventory, and replacem
 through product surfaces. The remote tier admission and live-stream cancellation leg remains
 blocked without an authorized provider address and a second remote device.
 
-Re-opened as untested 2026-09-11: the mobile-surface-truth change (branch `mobile-browser-pwa`)
+Re-opened as untested 2026-09-11: the mobile-surface-truth change (branch `mobile-surface-truth`)
 altered the post-pairing operator surface (capability gating), so the paired-device experience is
 re-walked under CH-gateway-paired-operator-surface; the real-address admission leg remains
 externally blocked pending an authorized TS_AUTHKEY.

--- a/docs/qa/scenarios/RT-gateway-paired-device.md
+++ b/docs/qa/scenarios/RT-gateway-paired-device.md
@@ -6,12 +6,12 @@ persona: Iris
 journey: J-expose-and-pair-gateway
 expected: A one-time local pairing shown as both QR and copyable text admits exactly one named device, device state agrees across web, HTTP, UDS, and CLI, and revocation closes live work before rejecting the credential.
 entry_points: Web /settings/gateway; UDS POST /api/gateway/pairings; private POST /api/gateway/pairings/redeem; HTTP/UDS /api/gateway/devices; compozy device list -o json
-qa_status: blocked-verify
-bug_ids:
-fix_status:
+qa_status: fail
+bug_ids: BUG-20260911-private-ui-origin-rejected-on-forwarded-tier;BUG-20260911-private-tier-loopback-guard-inert
+fix_status: pending
 retest_status:
 fix_commits:
-evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/i-13-pairing-code-minted.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-14-devices-listed.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-18-after-revoke.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/i-19-after-revoke-web.png
+evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-02-pairing-with-address.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-03-second-device-redeem.png
 last_report: docs/qa/reports/2026-09-11-mobile-surface-truth.md
 overlaps: RT-gateway-local-only-boot
 ---
@@ -42,3 +42,21 @@ remains for the remote-tier admission legs: the private-tier listener never bind
 authorized provider (reconciler preflight/establish fails-closed before binding — recovery retries
 keep the tier `down`, surface `off`), so the redeemed device credential cannot be exercised against
 a gateway listener in-lab (named blocker: user-provisioned authorized `TS_AUTHKEY`).
+
+Remote-leg walk 2026-09-11 with the authorized provider (lab
+`compozy-mobile-surface-truth-remote-20260911-125112-264736`): the private tier established —
+provider `up/healthy`, verified live address advertised (`live: true`), operator_ui surface `on`,
+and the Web card shows "Reachable — Verified: this address was proven to reach this machine". The
+pairing dialog now shows QR + copyable link backed by that address. Over the private HTTPS endpoint
+the lifecycle verified through the documented API: redeem (`actor_kind=operator_device`) → 200 with
+`Secure; HttpOnly; SameSite=Lax` device cookie; device-authenticated reads latch
+`X-Compozy-Gateway-Tier: private` (401 `gateway_device_unauthenticated` without); artifact reuse
+refused `409 gateway_pairing_spent`; inventory agreed across Web/HTTP/UDS/CLI and the
+private-endpoint read; revocation closed live work server-side (`canceled: 1` — an open SSE
+catalog-stream was closed mid-flight) before the credential started refusing (401). FAILS on the
+product's own pairing UX: opening the pairing link on the second device renders a blank page —
+every ES-module asset is refused `403 {"error":"origin not allowed"}` on the forwarded private tier
+(BUG-20260911-private-ui-origin-rejected-on-forwarded-tier), so pairing cannot be completed through
+the QR/link flow. Also linked: the paired device's credential executes guarded daemon mutations
+over the private tier (BUG-20260911-private-tier-loopback-guard-inert). Verdict `fail` — fix both
+bugs, then re-walk the link-open pairing flow and the paired session.

--- a/docs/qa/scenarios/RT-gateway-paired-device.md
+++ b/docs/qa/scenarios/RT-gateway-paired-device.md
@@ -6,12 +6,12 @@ persona: Iris
 journey: J-expose-and-pair-gateway
 expected: A one-time local pairing shown as both QR and copyable text admits exactly one named device, device state agrees across web, HTTP, UDS, and CLI, and revocation closes live work before rejecting the credential.
 entry_points: Web /settings/gateway; UDS POST /api/gateway/pairings; private POST /api/gateway/pairings/redeem; HTTP/UDS /api/gateway/devices; compozy device list -o json
-qa_status: fail
+qa_status: pass
 bug_ids: BUG-20260911-private-ui-origin-rejected-on-forwarded-tier;BUG-20260911-private-tier-loopback-guard-inert
-fix_status: pending
-retest_status:
-fix_commits:
-evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-02-pairing-with-address.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts-03-second-device-redeem.png
+fix_status: fixed
+retest_status: pass
+fix_commits: 17304fe8f
+evidence: docs/qa/evidence/2026-09-11-mobile-surface-truth/ts2-04-pairing-qr-link.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts2-05-redeem-link-landing.png;docs/qa/evidence/2026-09-11-mobile-surface-truth/ts2-07-paired-session.png
 last_report: docs/qa/reports/2026-09-11-mobile-surface-truth.md
 overlaps: RT-gateway-local-only-boot
 ---
@@ -60,3 +60,15 @@ every ES-module asset is refused `403 {"error":"origin not allowed"}` on the for
 the QR/link flow. Also linked: the paired device's credential executes guarded daemon mutations
 over the private tier (BUG-20260911-private-tier-loopback-guard-inert). Verdict `fail` — fix both
 bugs, then re-walk the link-open pairing flow and the paired session.
+
+Verification walk 2026-09-11 after the fixes (commit `17304fe8f`, lab
+`compozy-mobile-surface-truth-verify2-20260911-141455-792161`, fresh authorized key): the
+link-open pairing flow now works end to end through the product's own UI — the paired private-tier
+SPA boots (`/assets/*` clean; only the expected 401s on unauthenticated `/api` calls), renders the
+"Pair this device" gate pre-filled from the `#pair=` fragment, and redeeming lands the full paired
+operator session with the `Secure; HttpOnly; SameSite=Lax` device cookie. Single-use semantics
+re-verified (artifact reuse → 409; stream-ticket reuse → 401 `gateway_stream_ticket_invalid`;
+re-mint per connect), inventory agreed across Web/HTTP/UDS/CLI and the private read, and revocation
+again closed a live SSE stream mid-flight (`canceled: 1`) before the credential refused. With both
+defects fixed and every observable confirmed, the scenario settles **pass**; the walk key was
+deleted after bring-up and the lab runtime purged (zero key-material occurrences by byte-scan).

--- a/extensions/connectivity/tailscale/forwarder.go
+++ b/extensions/connectivity/tailscale/forwarder.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 )
@@ -17,11 +20,30 @@ const (
 	forwardIdleTimeout    = 2 * time.Minute
 )
 
+// forwardedProto is the scheme the provider terminates TLS for on behalf of
+// the daemon tier listener. The daemon listener is plaintext loopback HTTP,
+// so the forwarder must declare the browser-facing scheme per request; the
+// httpapi origin allowance compares canonical origins including scheme.
+const forwardedProto = "https"
+
+// X-Forwarded-Proto and X-Forwarded-Host are the forwarded-target headers the
+// httpapi middleware consumes (requestScheme) and that document the original
+// browser request. ReverseProxy's Rewrite mode strips client-supplied
+// Forwarded/X-Forwarded-* headers before rewriting, so remote clients cannot
+// spoof them.
+const (
+	forwardedProtoHeader = "X-Forwarded-Proto"
+	forwardedHostHeader  = "X-Forwarded-Host"
+)
+
 type tierForwarder struct {
 	listener net.Listener
-	target   string
+	backend  *url.URL
 	logger   *slog.Logger
 	dial     func(context.Context, string, string) (net.Conn, error)
+
+	proxy  *httputil.ReverseProxy
+	server *http.Server
 
 	stopLifecycle context.CancelFunc
 	done          chan struct{}
@@ -31,12 +53,11 @@ type tierForwarder struct {
 	closed        chan struct{}
 	slots         chan struct{}
 
-	mu          sync.RWMutex
-	connections map[net.Conn]struct{}
-	serveErr    error
-	forwardErr  error
-	closing     bool
-	closeErr    error
+	mu         sync.RWMutex
+	serveErr   error
+	forwardErr error
+	closing    bool
+	closeErr   error
 }
 
 func newTierForwarder(listener net.Listener, target string, logger *slog.Logger) (*tierForwarder, error) {
@@ -49,29 +70,32 @@ func newTierForwarder(listener net.Listener, target string, logger *slog.Logger)
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &tierForwarder{
-		listener:    listener,
-		target:      target,
-		logger:      logger,
-		dial:        (&net.Dialer{Timeout: forwardDialTimeout}).DialContext,
-		done:        make(chan struct{}),
-		closed:      make(chan struct{}),
-		slots:       make(chan struct{}, maxForwardConnections),
-		connections: make(map[net.Conn]struct{}),
-	}, nil
+	forwarder := &tierForwarder{
+		listener: listener,
+		backend:  &url.URL{Scheme: "http", Host: target},
+		logger:   logger,
+		dial:     (&net.Dialer{Timeout: forwardDialTimeout}).DialContext,
+		done:     make(chan struct{}),
+		closed:   make(chan struct{}),
+		slots:    make(chan struct{}, maxForwardConnections),
+	}
+	lifecycleCtx, cancel := context.WithCancel(context.Background())
+	forwarder.stopLifecycle = cancel
+	forwarder.proxy = forwarder.newProxy()
+	forwarder.server = forwarder.newServer(lifecycleCtx)
+	return forwarder, nil
 }
 
+// Start begins accepting tier connections and serving them to the daemon.
 func (f *tierForwarder) Start() {
 	f.start.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
 		f.mu.Lock()
-		f.stopLifecycle = cancel
 		closing := f.closing
 		f.mu.Unlock()
 		if closing {
-			cancel()
+			f.stopLifecycle()
 		}
-		go f.serve(ctx)
+		go f.serve()
 	})
 }
 
@@ -112,90 +136,83 @@ func (f *tierForwarder) Close(ctx context.Context) error {
 	}
 }
 
-func (f *tierForwarder) serve(ctx context.Context) {
+func (f *tierForwarder) serve() {
 	defer close(f.done)
 	defer f.wg.Wait()
-	for {
-		connection, err := f.listener.Accept()
-		if err != nil {
-			f.mu.Lock()
-			closing := f.closing
-			if !closing {
-				f.serveErr = fmt.Errorf("accept connection: %w", err)
-			}
-			f.mu.Unlock()
-			if closing {
-				return
-			}
-			return
+	if err := f.server.Serve(f.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		f.mu.Lock()
+		if !f.closing {
+			f.serveErr = fmt.Errorf("accept connection: %w", err)
 		}
-		select {
-		case f.slots <- struct{}{}:
-		default:
-			if err := connection.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-				f.logger.Warn("close excess connectivity connection", "error", err)
-			}
-			continue
-		}
-		f.track(connection)
-		f.wg.Add(1)
-		go f.forward(ctx, connection)
+		f.mu.Unlock()
 	}
 }
 
-func (f *tierForwarder) forward(ctx context.Context, inbound net.Conn) {
-	defer f.wg.Done()
-	defer func() { <-f.slots }()
-	defer f.closeTracked(inbound)
-	dialCtx, cancel := context.WithTimeout(ctx, forwardDialTimeout)
-	defer cancel()
-	upstream, err := f.dial(dialCtx, "tcp", f.target)
-	if err != nil {
-		if ctx.Err() == nil {
-			f.recordForwardFailure()
-			f.logger.Warn("connectivity forward target unavailable")
-		}
+// ServeHTTP proxies one browser request to the daemon tier listener as an
+// HTTP-aware reverse proxy so the daemon observes the forwarded scheme and
+// host of the original TLS request.
+func (f *tierForwarder) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	select {
+	case f.slots <- struct{}{}:
+		defer func() { <-f.slots }()
+	default:
+		http.Error(writer, "tailscale: forward concurrency limit reached", http.StatusServiceUnavailable)
 		return
 	}
-	f.track(upstream)
-	defer f.closeTracked(upstream)
-	inboundIdle := idleDeadlineConn{Conn: inbound, timeout: forwardIdleTimeout}
-	upstreamIdle := idleDeadlineConn{Conn: upstream, timeout: forwardIdleTimeout}
-	results := make(chan error, 2)
-	go copyConnection(results, upstreamIdle, inboundIdle)
-	go copyConnection(results, inboundIdle, upstreamIdle)
-	firstErr := <-results
-	if err := inbound.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-		f.logger.Debug("close forwarded inbound connection", "error", err)
+	f.mu.Lock()
+	if f.closing {
+		f.mu.Unlock()
+		http.Error(writer, "tailscale: forwarder is shutting down", http.StatusServiceUnavailable)
+		return
 	}
-	if err := upstream.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-		f.logger.Debug("close forwarded upstream connection", "error", err)
-	}
-	secondErr := <-results
-	for _, copyErr := range []error{firstErr, secondErr} {
-		if copyErr != nil && !errors.Is(copyErr, net.ErrClosed) && ctx.Err() == nil {
-			f.logger.Debug("copy forwarded connection", "error", copyErr)
-		}
+	f.wg.Add(1)
+	f.mu.Unlock()
+	defer f.wg.Done()
+	f.proxy.ServeHTTP(writer, request)
+}
+
+func (f *tierForwarder) newProxy() *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.SetURL(f.backend)
+			// SetURL retargets the outbound Host header at the backend; the
+			// daemon tier listener needs the original browser-facing host to
+			// evaluate its same-origin allowance.
+			pr.Out.Host = pr.In.Host
+			pr.Out.Header.Set(forwardedProtoHeader, forwardedProto)
+			if host := strings.TrimSpace(pr.In.Host); host != "" {
+				pr.Out.Header.Set(forwardedHostHeader, host)
+			}
+		},
+		Transport: &http.Transport{
+			DialContext:         f.dial,
+			MaxIdleConns:        maxForwardConnections,
+			MaxIdleConnsPerHost: maxForwardConnections,
+			IdleConnTimeout:     forwardIdleTimeout,
+			DisableCompression:  true,
+		},
+		// SSE and task streams must not buffer behind the proxy.
+		FlushInterval: -1,
+		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, _ error) {
+			// The proxy error itself is intentionally discarded: the dial
+			// failure is already recorded by recordForwardFailure as the
+			// degraded health reason surfaced through `gateway status`.
+			if request.Context().Err() == nil {
+				f.recordForwardFailure()
+				f.logger.Warn("connectivity forward target unavailable")
+			}
+			http.Error(writer, "tailscale: forward target unavailable", http.StatusBadGateway)
+		},
 	}
 }
 
-type idleDeadlineConn struct {
-	net.Conn
-	timeout time.Duration
-}
-
-func (c idleDeadlineConn) Read(payload []byte) (int, error) {
-	if err := c.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
-		return 0, err
+func (f *tierForwarder) newServer(lifecycleCtx context.Context) *http.Server {
+	return &http.Server{
+		Handler:           f,
+		BaseContext:       func(net.Listener) context.Context { return lifecycleCtx },
+		ReadHeaderTimeout: forwardIdleTimeout,
+		IdleTimeout:       forwardIdleTimeout,
 	}
-	return c.Conn.Read(payload)
-}
-
-func (c idleDeadlineConn) Write(payload []byte) (int, error) {
-	if err := c.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
-		return 0, err
-	}
-	return c.Conn.Write(payload)
 }
 
 func (f *tierForwarder) recordForwardFailure() {
@@ -208,62 +225,14 @@ func (f *tierForwarder) recordForwardFailure() {
 
 func (f *tierForwarder) shutdown() {
 	var errs []error
-	f.mu.Lock()
-	connections := make([]net.Conn, 0, len(f.connections))
-	for connection := range f.connections {
-		connections = append(connections, connection)
+	if err := f.server.Close(); err != nil &&
+		!errors.Is(err, http.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
+		errs = append(errs, fmt.Errorf("tailscale: stop forward server: %w", err))
 	}
-	f.mu.Unlock()
-	for _, connection := range connections {
-		if err := connection.Close(); err != nil && !onlyClosedNetworkError(err) {
-			errs = append(errs, fmt.Errorf("tailscale: close forwarded connection: %w", err))
-		}
-	}
-	if err := f.listener.Close(); err != nil && !onlyClosedNetworkError(err) {
-		errs = append(errs, fmt.Errorf("tailscale: close listener: %w", err))
-	}
+	// f.done closes only after every in-flight proxied request returns.
 	<-f.done
 	f.mu.Lock()
 	f.closeErr = errors.Join(errs...)
 	f.mu.Unlock()
 	close(f.closed)
-}
-
-func onlyClosedNetworkError(err error) bool {
-	if err == nil {
-		return false
-	}
-	if joined, ok := err.(interface{ Unwrap() []error }); ok {
-		children := joined.Unwrap()
-		if len(children) == 0 {
-			return false
-		}
-		for _, child := range children {
-			if !onlyClosedNetworkError(child) {
-				return false
-			}
-		}
-		return true
-	}
-	return errors.Is(err, net.ErrClosed)
-}
-
-func copyConnection(result chan<- error, destination io.Writer, source io.Reader) {
-	_, err := io.Copy(destination, source)
-	result <- err
-}
-
-func (f *tierForwarder) track(connection net.Conn) {
-	f.mu.Lock()
-	f.connections[connection] = struct{}{}
-	f.mu.Unlock()
-}
-
-func (f *tierForwarder) closeTracked(connection net.Conn) {
-	f.mu.Lock()
-	delete(f.connections, connection)
-	f.mu.Unlock()
-	if err := connection.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-		f.logger.Debug("close tracked forwarded connection", "error", err)
-	}
 }

--- a/extensions/connectivity/tailscale/provider_test.go
+++ b/extensions/connectivity/tailscale/provider_test.go
@@ -178,65 +178,123 @@ func TestTSNetNodeOperationOwnership(t *testing.T) {
 
 func TestTierForwarderBridgesToDaemonLoopback(t *testing.T) {
 	t.Parallel()
-	target := newTestListener(t)
-	external := newTestListener(t)
-	forwarder, err := newTierForwarder(external, target.Addr().String(), slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if err != nil {
-		t.Fatalf("newTierForwarder() error = %v", err)
-	}
-	forwarder.Start()
-	ctx, cancel := context.WithTimeout(testutil.Context(t), time.Second)
-	defer cancel()
-	externalConnection, err := (&net.Dialer{}).DialContext(ctx, "tcp", external.Addr().String())
-	if err != nil {
-		t.Fatalf("Dial(external) error = %v", err)
-	}
-	t.Cleanup(func() {
-		if err := externalConnection.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			t.Errorf("Close(external connection) error = %v", err)
+
+	t.Run("Should forward tier requests with the browser-facing scheme and host", func(t *testing.T) {
+		t.Parallel()
+		const tierHost = "compozy-gateway.example.ts.net:8443"
+		target := newTestListener(t)
+		captured := make(chan forwardedRequestCapture, 1)
+		backend := &http.Server{
+			Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				captured <- forwardedRequestCapture{
+					host:            request.Host,
+					forwardedProto:  request.Header.Get(forwardedProtoHeader),
+					forwardedHost:   request.Header.Get(forwardedHostHeader),
+					forwardedHeader: request.Header.Get("Forwarded"),
+				}
+				writer.Header().Set("Content-Type", "text/plain")
+				writer.WriteHeader(http.StatusOK)
+				if _, err := writer.Write([]byte("ok")); err != nil {
+					t.Errorf("write backend response error = %v", err)
+				}
+			}),
+		}
+		serveErr := make(chan error, 1)
+		go func() { serveErr <- backend.Serve(target) }()
+		t.Cleanup(func() {
+			if err := backend.Close(); err != nil && !errors.Is(err, net.ErrClosed) &&
+				!errors.Is(err, http.ErrServerClosed) {
+				t.Errorf("Close(backend) error = %v", err)
+			}
+		})
+		external := newTestListener(t)
+		forwarder, err := newTierForwarder(
+			external,
+			target.Addr().String(),
+			slog.New(slog.NewTextHandler(io.Discard, nil)),
+		)
+		if err != nil {
+			t.Fatalf("newTierForwarder() error = %v", err)
+		}
+		forwarder.Start()
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if err := forwarder.Close(ctx); err != nil {
+				t.Errorf("Close(forwarder) error = %v", err)
+			}
+		})
+
+		ctx, cancel := context.WithTimeout(testutil.Context(t), 5*time.Second)
+		defer cancel()
+		// The browser request arrives with a spoofable set of client-supplied
+		// forwarding headers; the provider terminates TLS and owns the
+		// truthful forwarded metadata.
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			"http://"+external.Addr().String()+"/assets/app.js",
+			http.NoBody,
+		)
+		if err != nil {
+			t.Fatalf("NewRequestWithContext() error = %v", err)
+		}
+		request.Host = tierHost
+		request.Header.Set("Origin", "https://"+tierHost)
+		request.Header.Set(forwardedProtoHeader, "http")
+		request.Header.Set(forwardedHostHeader, "evil.example.test")
+		request.Header.Set("Forwarded", "for=198.51.100.9")
+		response, err := (&http.Client{}).Do(request)
+		if err != nil {
+			t.Fatalf("forwarded request error = %v", err)
+		}
+		body, readErr := io.ReadAll(response.Body)
+		closeErr := response.Body.Close()
+		if err := errors.Join(readErr, closeErr); err != nil {
+			t.Fatalf("read forwarded response error = %v", err)
+		}
+		if response.StatusCode != http.StatusOK || string(body) != "ok" {
+			t.Fatalf("forwarded response = %d/%q, want 200/ok", response.StatusCode, body)
+		}
+		var got forwardedRequestCapture
+		select {
+		case got = <-captured:
+		case <-ctx.Done():
+			t.Fatalf("backend capture error = %v", ctx.Err())
+		}
+		if got.host != tierHost {
+			t.Fatalf("backend request Host = %q, want %q", got.host, tierHost)
+		}
+		if got.forwardedProto != forwardedProto {
+			t.Fatalf(
+				"backend %s = %q, want %q (client value must be overridden)",
+				forwardedProtoHeader,
+				got.forwardedProto,
+				forwardedProto,
+			)
+		}
+		if got.forwardedHost != tierHost {
+			t.Fatalf(
+				"backend %s = %q, want %q (client value must be overridden)",
+				forwardedHostHeader,
+				got.forwardedHost,
+				tierHost,
+			)
+		}
+		if got.forwardedHeader != "" {
+			t.Fatalf("backend Forwarded = %q, want stripped client header", got.forwardedHeader)
+		}
+		if err := forwarder.Close(ctx); err != nil {
+			t.Fatalf("Close(forwarder) error = %v", err)
 		}
 	})
-	type acceptResult struct {
-		connection net.Conn
-		err        error
-	}
-	accepted := make(chan acceptResult, 1)
-	go func() {
-		connection, acceptErr := target.Accept()
-		accepted <- acceptResult{connection: connection, err: acceptErr}
-		close(accepted)
-	}()
-	if _, err := externalConnection.Write([]byte("ping")); err != nil {
-		t.Fatalf("Write(external) error = %v", err)
-	}
-	var result acceptResult
-	select {
-	case result = <-accepted:
-	case <-ctx.Done():
-		t.Fatalf("Accept(target) error = %v", ctx.Err())
-	}
-	if result.err != nil {
-		t.Fatalf("Accept(target) error = %v", result.err)
-	}
-	targetConnection := result.connection
-	if targetConnection == nil {
-		t.Fatal("target connection = nil")
-	}
-	t.Cleanup(func() {
-		if err := targetConnection.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			t.Errorf("Close(target connection) error = %v", err)
-		}
-	})
-	payload := make([]byte, 4)
-	if _, err := io.ReadFull(targetConnection, payload); err != nil {
-		t.Fatalf("ReadFull(target) error = %v", err)
-	}
-	if string(payload) != "ping" {
-		t.Fatalf("forwarded payload = %q, want ping", payload)
-	}
-	if err := forwarder.Close(ctx); err != nil {
-		t.Fatalf("Close(forwarder) error = %v", err)
-	}
+}
+
+type forwardedRequestCapture struct {
+	host            string
+	forwardedProto  string
+	forwardedHost   string
+	forwardedHeader string
 }
 
 func TestPrivateVerificationRelayLifecycle(t *testing.T) {
@@ -483,21 +541,39 @@ func TestTierForwarderFailureHealth(t *testing.T) {
 			t.Fatalf("newTierForwarder() error = %v", err)
 		}
 		forwarder.Start()
-		connection, err := (&net.Dialer{}).DialContext(
-			testutil.Context(t),
-			"tcp",
-			external.Addr().String(),
+		t.Cleanup(func() {
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			if err := forwarder.Close(ctx); err != nil {
+				t.Errorf("Close(forwarder) error = %v", err)
+			}
+		})
+		// The proxy dials the daemon loopback target per request, so drive a
+		// real HTTP request to make the unavailable target observable.
+		ctx, cancel := context.WithTimeout(testutil.Context(t), 5*time.Second)
+		defer cancel()
+		request, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			"http://"+external.Addr().String()+"/api/status",
+			http.NoBody,
 		)
 		if err != nil {
-			t.Fatalf("Dial(external) error = %v", err)
+			t.Fatalf("NewRequestWithContext() error = %v", err)
 		}
-		if err := connection.Close(); err != nil {
-			t.Fatalf("Close(connection) error = %v", err)
+		response, err := (&http.Client{}).Do(request)
+		if err != nil {
+			t.Fatalf("forwarded request error = %v", err)
+		}
+		body, readErr := io.ReadAll(response.Body)
+		closeErr := response.Body.Close()
+		if err := errors.Join(readErr, closeErr); err != nil {
+			t.Fatalf("read forwarded response error = %v", err)
+		}
+		if response.StatusCode != http.StatusBadGateway {
+			t.Fatalf("unreachable-target response = %d/%s, want 502", response.StatusCode, body)
 		}
 		waitForForwarderHealth(t, forwarder, "degraded", "forward target is unavailable")
-		if err := forwarder.Close(testutil.Context(t)); err != nil {
-			t.Fatalf("Close(forwarder) error = %v", err)
-		}
 	})
 }
 

--- a/internal/api/core/errors.go
+++ b/internal/api/core/errors.go
@@ -42,6 +42,18 @@ type normalizedErrorStatus struct {
 // rejected by HTTP MaxBytesReader enforcement.
 var ErrRequestBodyTooLarge = errors.New("request body too large")
 
+// ErrLoopbackMutationRequired is the shared transport sentinel for privileged
+// HTTP mutations refused on a non-loopback listener.
+var ErrLoopbackMutationRequired = errors.New(
+	"remote HTTP settings and extension mutations are disabled in v1 unless the daemon is bound to a loopback host",
+)
+
+// ErrLoopbackAPIRequired is the shared transport sentinel for operator API
+// access refused on a non-loopback local listener.
+var ErrLoopbackAPIRequired = errors.New(
+	"remote HTTP API access is disabled unless the daemon is bound to a loopback host",
+)
+
 // RespondError writes a transport error response, optionally masking internal error details.
 func RespondError(c *gin.Context, status int, err error, maskInternalErrors bool) {
 	normalized := normalizeErrorStatus(status, err, maskInternalErrors)

--- a/internal/api/core/errors_diagnostic_payload.go
+++ b/internal/api/core/errors_diagnostic_payload.go
@@ -15,6 +15,18 @@ import (
 	"github.com/compozy/compozy/internal/worktree"
 )
 
+// loopbackGuardCode returns the stable wire code for the shared loopback
+// guard sentinels, or "" when err is not a loopback refusal.
+func loopbackGuardCode(err error) string {
+	switch {
+	case errors.Is(err, ErrLoopbackMutationRequired):
+		return "loopback_mutation_required"
+	case errors.Is(err, ErrLoopbackAPIRequired):
+		return "loopback_api_required"
+	}
+	return ""
+}
+
 func errorPayloadForMessage(message string, err error) contract.ErrorPayload {
 	message = diagnosticspkg.Redact(taskpkg.RedactClaimTokens(message))
 	payload := contract.ErrorPayload{Error: message}
@@ -34,6 +46,9 @@ func errorPayloadForMessage(message string, err error) contract.ErrorPayload {
 	case errors.Is(err, session.ErrPromptNotInProgress), errors.Is(err, session.ErrSessionNotActive),
 		errors.Is(err, session.ErrSessionArchived), errors.Is(err, store.ErrSessionArchived):
 		payload.Code = "session_not_promptable"
+	}
+	if code := loopbackGuardCode(err); code != "" {
+		payload.Code = code
 	}
 	if errors.Is(err, workspace.ErrOperatorHomeWorkspace) {
 		payload.Code = "workspace_home_forbidden"

--- a/internal/api/core/errors_test.go
+++ b/internal/api/core/errors_test.go
@@ -352,6 +352,59 @@ func TestRespondErrorFallbackBranches(t *testing.T) {
 	}
 }
 
+// IT-002 (mobile-surface-truth): the loopback guards' 403 envelopes carry the
+// stable wire codes frozen in the workflow DX contract.
+func TestRespondErrorLoopbackGuardCodes(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name     string
+		err      error
+		wantErr  string
+		wantCode string
+	}{
+		{
+			name:     "Should mark loopback mutation refusals with the stable wire code",
+			err:      ErrLoopbackMutationRequired,
+			wantErr:  ErrLoopbackMutationRequired.Error(),
+			wantCode: "loopback_mutation_required",
+		},
+		{
+			name:     "Should mark loopback API refusals with the stable wire code",
+			err:      ErrLoopbackAPIRequired,
+			wantErr:  ErrLoopbackAPIRequired.Error(),
+			wantCode: "loopback_api_required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+			ctx, _ := gin.CreateTestContext(recorder)
+			RespondError(ctx, http.StatusForbidden, tt.err, false)
+
+			if recorder.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusForbidden, recorder.Body.String())
+			}
+
+			var payload contract.ErrorPayload
+			if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if payload.Error != tt.wantErr {
+				t.Fatalf("payload.Error = %q, want %q", payload.Error, tt.wantErr)
+			}
+			if payload.Code != tt.wantCode {
+				t.Fatalf("payload.Code = %q, want %q", payload.Code, tt.wantCode)
+			}
+		})
+	}
+}
+
 func TestRespondErrorDiagnosticPayload(t *testing.T) {
 	t.Run("Should include redacted diagnostic when error carries one", func(t *testing.T) {
 		// not parallel: gin.SetMode mutates process-global state.

--- a/internal/api/core/errors_test.go
+++ b/internal/api/core/errors_test.go
@@ -353,10 +353,11 @@ func TestRespondErrorFallbackBranches(t *testing.T) {
 }
 
 // IT-002 (mobile-surface-truth): the loopback guards' 403 envelopes carry the
-// stable wire codes frozen in the workflow DX contract. Stays parallel: it
-// never touches the process-global gin mode (CreateTestContext and
-// RespondError do not read it), unlike the sibling diagnostic tests that set
-// it serially.
+// stable wire codes frozen in the workflow DX contract. Stays parallel: its
+// assertions do not depend on the process-global gin mode — CreateTestContext
+// reads that mode only for an output-only debug print (gin v1.12.0), never for
+// behavior, and RespondError is mode-independent — unlike the sibling
+// diagnostic tests that set it serially.
 func TestRespondErrorLoopbackGuardCodes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/core/errors_test.go
+++ b/internal/api/core/errors_test.go
@@ -353,11 +353,12 @@ func TestRespondErrorFallbackBranches(t *testing.T) {
 }
 
 // IT-002 (mobile-surface-truth): the loopback guards' 403 envelopes carry the
-// stable wire codes frozen in the workflow DX contract.
+// stable wire codes frozen in the workflow DX contract. Stays parallel: it
+// never touches the process-global gin mode (CreateTestContext and
+// RespondError do not read it), unlike the sibling diagnostic tests that set
+// it serially.
 func TestRespondErrorLoopbackGuardCodes(t *testing.T) {
 	t.Parallel()
-
-	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
 		name     string

--- a/internal/api/httpapi/gateway_routes_test.go
+++ b/internal/api/httpapi/gateway_routes_test.go
@@ -1032,6 +1032,204 @@ func newGatewaySurfaceTestRouter(
 	return router
 }
 
+// IT-003 (mobile-surface-truth): the remote-mutation policy keys on the
+// listener tier, not the daemon bind host. Tier listeners are loopback-bound
+// by design because the connectivity provider fronts them, so a paired device
+// cookie must never reach a guarded mutation on a remote tier, while the local
+// listener keeps its loopback-bind rules (BR-5).
+func TestGatewayTierListenerMutationPolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should refuse a paired device drain on the private tier listener", func(t *testing.T) {
+		t.Parallel()
+
+		authenticator := gatewayHTTPAuthenticatorStub{
+			authenticate: func(context.Context, string) (gateway.DeviceSession, error) {
+				return gateway.DeviceSession{
+					ID: "device-paired", ActorKind: gateway.ActorKindOperatorDevice,
+				}, nil
+			},
+		}
+		router := newGatewaySurfaceTestRouter(SurfaceSetPrivate, gatewayHTTPServiceStub{}, authenticator)
+		request := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost, "http://127.0.0.1:2123/api/drain", http.NoBody,
+		)
+		request.Header.Set("Cookie", gatewayDeviceCookieName+"=cpz_gwd_"+strings.Repeat("p", 43))
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+
+		if response.Code != http.StatusForbidden {
+			t.Fatalf(
+				"paired device drain status = %d, want %d; body=%s",
+				response.Code,
+				http.StatusForbidden,
+				response.Body.String(),
+			)
+		}
+		var payload contract.ErrorPayload
+		if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload.Code != "loopback_mutation_required" {
+			t.Fatalf("error code = %q, want %q", payload.Code, "loopback_mutation_required")
+		}
+	})
+
+	t.Run("Should refuse a paired device settings mutation on the private tier listener", func(t *testing.T) {
+		t.Parallel()
+
+		authenticator := gatewayHTTPAuthenticatorStub{
+			authenticate: func(context.Context, string) (gateway.DeviceSession, error) {
+				return gateway.DeviceSession{
+					ID: "device-paired", ActorKind: gateway.ActorKindOperatorDevice,
+				}, nil
+			},
+		}
+		router := newGatewaySurfaceTestRouter(SurfaceSetPrivate, gatewayHTTPServiceStub{}, authenticator)
+		request := httptest.NewRequestWithContext(
+			t.Context(),
+			http.MethodPatch,
+			"http://127.0.0.1:2123/api/settings/general",
+			strings.NewReader(`{"persona":"paired"}`),
+		)
+		request.Header.Set("Content-Type", "application/json")
+		request.Header.Set("Cookie", gatewayDeviceCookieName+"=cpz_gwd_"+strings.Repeat("p", 43))
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+
+		if response.Code != http.StatusForbidden {
+			t.Fatalf(
+				"paired device settings mutation status = %d, want %d; body=%s",
+				response.Code,
+				http.StatusForbidden,
+				response.Body.String(),
+			)
+		}
+		var payload contract.ErrorPayload
+		if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload.Code != "loopback_mutation_required" {
+			t.Fatalf("error code = %q, want %q", payload.Code, "loopback_mutation_required")
+		}
+	})
+
+	t.Run("Should keep a local loopback drain allowed", func(t *testing.T) {
+		t.Parallel()
+
+		router := newTierMutationPolicyLocalRouter(t, "127.0.0.1:2123")
+		request := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost, "http://127.0.0.1:2123/api/drain", http.NoBody,
+		)
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+
+		if response.Code != http.StatusOK {
+			t.Fatalf(
+				"local drain status = %d, want %d; body=%s",
+				response.Code,
+				http.StatusOK,
+				response.Body.String(),
+			)
+		}
+		var payload contract.DrainStatusResponse
+		if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload.State != contract.DrainStateDraining || !payload.AdmissionClosed {
+			t.Fatalf("drain status payload = %#v, want draining with admission closed", payload)
+		}
+	})
+
+	t.Run("Should refuse the guarded API on a local listener bound off loopback", func(t *testing.T) {
+		t.Parallel()
+
+		router := newTierMutationPolicyLocalRouter(t, "0.0.0.0:2123")
+		request := httptest.NewRequestWithContext(
+			t.Context(), http.MethodPost, "http://0.0.0.0:2123/api/drain", http.NoBody,
+		)
+		response := httptest.NewRecorder()
+		router.ServeHTTP(response, request)
+
+		if response.Code != http.StatusForbidden {
+			t.Fatalf(
+				"non-loopback local drain status = %d, want %d; body=%s",
+				response.Code,
+				http.StatusForbidden,
+				response.Body.String(),
+			)
+		}
+		var payload contract.ErrorPayload
+		if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+			t.Fatalf("json.Unmarshal() error = %v", err)
+		}
+		if payload.Code != "loopback_api_required" {
+			t.Fatalf("error code = %q, want %q", payload.Code, "loopback_api_required")
+		}
+	})
+}
+
+func newTierMutationPolicyLocalRouter(t *testing.T, boundHost string) *gin.Engine {
+	t.Helper()
+	homePaths := newTestHomePaths(t)
+	cfg := testConfigWithDisabledNetwork(homePaths)
+	cfg.HTTP.Host = boundHost
+	cfg.HTTP.Port = 2123
+	handlers := newHandlers(&handlerConfig{
+		sessions:        stubSessionManager{},
+		tasks:           &stubTaskManager{},
+		observer:        stubObserver{},
+		workspaces:      stubWorkspaceService{},
+		drainController: &stubDaemonDrainController{},
+		gateway:         gatewayHTTPServiceStub{},
+		staticFS:        mustStaticFS(t),
+		homePaths:       homePaths,
+		config:          cfg,
+		boundHost:       boundHost,
+		logger:          discardLogger(),
+		startedAt:       time.Date(2026, 9, 11, 11, 0, 0, 0, time.UTC),
+		now:             func() time.Time { return time.Date(2026, 9, 11, 11, 0, 1, 0, time.UTC) },
+		httpPort:        cfg.HTTP.Port,
+		surfaceSet:      SurfaceSetLocal,
+	})
+	router := gin.New()
+	router.Use(corsMiddleware(boundHost))
+	router.Use(requestBodyLimitMiddleware(maxAPIRequestBodyBytes))
+	router.Use(errorMiddleware())
+	RegisterSurfaceRoutes(router, handlers, SurfaceSetLocal)
+	return router
+}
+
+type stubDaemonDrainController struct {
+	draining bool
+}
+
+func (c *stubDaemonDrainController) Drain(context.Context) error {
+	c.draining = true
+	return nil
+}
+
+func (c *stubDaemonDrainController) Undrain(context.Context) error {
+	c.draining = false
+	return nil
+}
+
+func (c *stubDaemonDrainController) DrainState() contract.DrainState {
+	if c.draining {
+		return contract.DrainStateDraining
+	}
+	return contract.DrainStateActive
+}
+
+func (c *stubDaemonDrainController) DrainStatus(context.Context) (contract.DrainStatusResponse, error) {
+	draining := c.draining
+	return contract.DrainStatusResponse{
+		State:           c.DrainState(),
+		AdmissionClosed: draining,
+		SafeToStop:      draining,
+	}, nil
+}
+
 func gatewayRouteKeys(routes gin.RoutesInfo) map[string]struct{} {
 	keys := make(map[string]struct{}, len(routes))
 	for _, route := range routes {

--- a/internal/api/httpapi/gateway_routes_test.go
+++ b/internal/api/httpapi/gateway_routes_test.go
@@ -143,6 +143,8 @@ func TestGatewayTierRouteMatricesIT063IT064(t *testing.T) {
 				"POST /api/tasks/:id/runs",
 				"GET /api/scheduler",
 				"PUT /api/resources/:kind/:id",
+				"GET /api/workspaces/:workspace_id/terminals",
+				"POST /api/workspaces/:workspace_id/terminals/exec",
 			},
 		},
 		{
@@ -188,6 +190,8 @@ func TestGatewayTierRouteMatricesIT063IT064(t *testing.T) {
 				"POST /api/tasks/:id/runs",
 				"GET /api/scheduler",
 				"PUT /api/resources/:kind/:id",
+				"GET /api/workspaces/:workspace_id/terminals",
+				"POST /api/workspaces/:workspace_id/terminals/exec",
 			},
 		},
 		{
@@ -214,6 +218,8 @@ func TestGatewayTierRouteMatricesIT063IT064(t *testing.T) {
 				"POST /api/tasks/:id/runs",
 				"GET /api/scheduler",
 				"PUT /api/resources/:kind/:id",
+				"GET /api/workspaces/:workspace_id/terminals",
+				"POST /api/workspaces/:workspace_id/terminals/exec",
 			},
 		},
 	}
@@ -331,6 +337,78 @@ func isForbiddenRemoteRoute(route string) bool {
 		strings.HasPrefix(path, "/api/task-runs/") ||
 		strings.HasPrefix(path, "/api/task-reviews/") ||
 		strings.HasPrefix(path, "/api/runs/")
+}
+
+// IT-001 (mobile-surface-truth): operator tiers register the remote-write
+// refusal handler for notification and profile enablement writes instead of
+// the local mutation handlers.
+func TestGatewayOperatorTiersMapWritesToRemoteWriteRefusal(t *testing.T) {
+	t.Parallel()
+
+	authenticator := gatewayHTTPAuthenticatorStub{
+		authenticate: func(context.Context, string) (gateway.DeviceSession, error) {
+			return gateway.DeviceSession{ID: "device-operator"}, nil
+		},
+	}
+	tests := []struct {
+		name       string
+		surfaceSet SurfaceSet
+	}{
+		{name: "Should refuse writes on the private tier", surfaceSet: SurfaceSetPrivate},
+		{name: "Should refuse writes on the public operator tier", surfaceSet: SurfaceSetPublicOperator},
+		{name: "Should refuse writes on the combined public tier", surfaceSet: SurfaceSetPublicCombined},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			router := newGatewaySurfaceTestRouter(test.surfaceSet, gatewayHTTPServiceStub{}, authenticator)
+			for _, tc := range []struct {
+				name   string
+				method string
+				path   string
+			}{
+				{
+					name:   "notification preset enablement",
+					method: http.MethodPut,
+					path:   "/api/notifications/presets/demo/enablement",
+				},
+				{name: "profile selection", method: http.MethodPut, path: "/api/profiles/selection"},
+			} {
+				t.Run("Should reject "+tc.name, func(t *testing.T) {
+					t.Parallel()
+
+					request := httptest.NewRequestWithContext(
+						t.Context(), tc.method, "http://127.0.0.1:2123"+tc.path, http.NoBody,
+					)
+					response := httptest.NewRecorder()
+					router.ServeHTTP(response, request)
+
+					if response.Code != http.StatusForbidden {
+						t.Fatalf(
+							"%s %s status = %d, want %d; body=%s",
+							tc.method,
+							tc.path,
+							response.Code,
+							http.StatusForbidden,
+							response.Body.String(),
+						)
+					}
+					var payload contract.ProfileErrorPayload
+					if err := json.Unmarshal(response.Body.Bytes(), &payload); err != nil {
+						t.Fatalf("json.Unmarshal() error = %v", err)
+					}
+					if payload.Error.Code != "profile_remote_management_forbidden" {
+						t.Fatalf(
+							"payload.Error.Code = %q, want %q",
+							payload.Error.Code,
+							"profile_remote_management_forbidden",
+						)
+					}
+				})
+			}
+		})
+	}
 }
 
 func TestGatewayIngressRateLimit(t *testing.T) {

--- a/internal/api/httpapi/handlers.go
+++ b/internal/api/httpapi/handlers.go
@@ -115,6 +115,7 @@ type Handlers struct {
 	resourceAuth     []gin.HandlerFunc
 	Extensions       ExtensionService
 	boundHost        string
+	surfaceSet       SurfaceSet
 	deviceAuth       gateway.DeviceAuthenticator
 	gatewayAdmission gateway.AdmissionController
 	authLimiter      *gateway.AuthFailureLimiter
@@ -171,6 +172,7 @@ func newHandlers(cfg *handlerConfig) *Handlers {
 		resourceAuth:     append([]gin.HandlerFunc(nil), cfg.resourceAuth...),
 		Extensions:       cfg.extensions,
 		boundHost:        boundHost,
+		surfaceSet:       cfg.surfaceSet,
 		deviceAuth:       cfg.deviceAuth,
 		gatewayAdmission: gatewayAdmission,
 		authLimiter:      authLimiter,
@@ -308,7 +310,18 @@ func (h *Handlers) resourceAuthMiddleware() []gin.HandlerFunc {
 	return append([]gin.HandlerFunc(nil), h.resourceAuth...)
 }
 
+// privilegedMutationGuard returns the guard for daemon-authority mutations.
+// The decision keys on the listener's surface set, not the bind host: remote
+// tier listeners are loopback-bound by design (the provider fronts them), so
+// guarded mutations are forbidden there always, while the local listener keeps
+// the loopback-bind rules.
 func (h *Handlers) privilegedMutationGuard() gin.HandlerFunc {
+	if h != nil {
+		switch h.surfaceSet {
+		case SurfaceSetPrivate, SurfaceSetPublicOperator, SurfaceSetPublicCombined:
+			return remoteTierMutationGuard()
+		}
+	}
 	boundHost := ""
 	if h != nil {
 		boundHost = h.boundHost

--- a/internal/api/httpapi/handlers_test.go
+++ b/internal/api/httpapi/handlers_test.go
@@ -1223,8 +1223,8 @@ func TestDaemonAPIRoutesReturnForbiddenOnNonLoopbackHost(t *testing.T) {
 			}
 			var payload contract.ErrorPayload
 			decodeJSONResponse(t, recorder, &payload)
-			if payload.Error != errLoopbackAPIRequired.Error() {
-				t.Fatalf("error = %q, want %q", payload.Error, errLoopbackAPIRequired.Error())
+			if payload.Error != core.ErrLoopbackAPIRequired.Error() {
+				t.Fatalf("error = %q, want %q", payload.Error, core.ErrLoopbackAPIRequired.Error())
 			}
 		})
 	}
@@ -1241,8 +1241,8 @@ func TestDaemonAPIRoutesReturnForbiddenOnNonLoopbackHost(t *testing.T) {
 		}
 		var payload contract.ErrorPayload
 		decodeJSONResponse(t, recorder, &payload)
-		if payload.Error != errLoopbackAPIRequired.Error() {
-			t.Fatalf("error = %q, want %q", payload.Error, errLoopbackAPIRequired.Error())
+		if payload.Error != core.ErrLoopbackAPIRequired.Error() {
+			t.Fatalf("error = %q, want %q", payload.Error, core.ErrLoopbackAPIRequired.Error())
 		}
 	})
 }
@@ -1378,8 +1378,8 @@ func TestSettingsAndExtensionMutationsReturnForbiddenOnNonLoopbackHost(t *testin
 
 			var payload contract.ErrorPayload
 			decodeJSONResponse(t, recorder, &payload)
-			if payload.Error != errLoopbackAPIRequired.Error() {
-				t.Fatalf("error = %q, want %q", payload.Error, errLoopbackAPIRequired.Error())
+			if payload.Error != core.ErrLoopbackAPIRequired.Error() {
+				t.Fatalf("error = %q, want %q", payload.Error, core.ErrLoopbackAPIRequired.Error())
 			}
 		})
 	}

--- a/internal/api/httpapi/middleware.go
+++ b/internal/api/httpapi/middleware.go
@@ -376,6 +376,18 @@ func loopbackMutationGuard(boundHost string) gin.HandlerFunc {
 	return loopbackGuard(boundHost, core.ErrLoopbackMutationRequired, false)
 }
 
+// remoteTierMutationGuard forbids daemon-authority mutations on every remote
+// tier listener regardless of the listener's bind host: tier listeners are
+// loopback-bound by design because the connectivity provider fronts them, so
+// the bind host cannot express the browser-facing tier. Paired devices get
+// read-only operator access (BR-6) and the refusal never downgrades.
+func remoteTierMutationGuard() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		core.RespondError(c, http.StatusForbidden, core.ErrLoopbackMutationRequired, false)
+		c.Abort()
+	}
+}
+
 func loopbackGuard(boundHost string, guardErr error, openAICompatible bool) gin.HandlerFunc {
 	allowed := isLoopbackHost(canonicalHost(boundHost))
 	return func(c *gin.Context) {

--- a/internal/api/httpapi/middleware.go
+++ b/internal/api/httpapi/middleware.go
@@ -19,14 +19,6 @@ const (
 	sessionAttachmentUploadRoutePath = "/api/workspaces/:workspace_id/sessions/:session_id/attachments"
 )
 
-var errLoopbackMutationRequired = errors.New(
-	"remote HTTP settings and extension mutations are disabled in v1 unless the daemon is bound to a loopback host",
-)
-
-var errLoopbackAPIRequired = errors.New(
-	"remote HTTP API access is disabled unless the daemon is bound to a loopback host",
-)
-
 var (
 	errOriginNotAllowed      = errors.New("origin not allowed")
 	errRequestHostNotAllowed = errors.New("request host not allowed")
@@ -377,11 +369,11 @@ func requestBodyLimitMiddlewareWithUploadLimit(maxBytes int64, uploadMaxBytes in
 }
 
 func loopbackAPIGuard(boundHost string) gin.HandlerFunc {
-	return loopbackGuard(boundHost, errLoopbackAPIRequired, true)
+	return loopbackGuard(boundHost, core.ErrLoopbackAPIRequired, true)
 }
 
 func loopbackMutationGuard(boundHost string) gin.HandlerFunc {
-	return loopbackGuard(boundHost, errLoopbackMutationRequired, false)
+	return loopbackGuard(boundHost, core.ErrLoopbackMutationRequired, false)
 }
 
 func loopbackGuard(boundHost string, guardErr error, openAICompatible bool) gin.HandlerFunc {

--- a/internal/api/httpapi/middleware_refac_test.go
+++ b/internal/api/httpapi/middleware_refac_test.go
@@ -194,6 +194,100 @@ func TestGatewayForwardedOriginProtection(t *testing.T) {
 			t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusForbidden, recorder.Body.String())
 		}
 	})
+
+	// BUG-20260911-private-ui-origin-rejected-on-forwarded-tier: the provider
+	// terminates TLS and relays plaintext HTTP to the loopback tier listener,
+	// so the daemon can only recover the browser scheme from the forwarded
+	// proto header the forwarder sets. These cases mirror that exact wire
+	// shape: a relative request target (no URL scheme, no TLS), a public
+	// request Host, and the forwarder-supplied X-Forwarded-Proto.
+	t.Run("Should accept a same-origin https request relayed with the forwarded proto", func(t *testing.T) {
+		t.Parallel()
+
+		engine := gin.New()
+		engine.Use(corsMiddlewareWithForwardedTarget("127.0.0.1:43123", true))
+		engine.GET("/assets/app.js", func(c *gin.Context) { c.Status(http.StatusOK) })
+		request := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/assets/app.js", http.NoBody,
+		)
+		request.Host = "compozy-gateway.example.ts.net:8443"
+		request.Header.Set("Origin", "https://compozy-gateway.example.ts.net:8443")
+		request.Header.Set("Sec-Fetch-Site", "same-origin")
+		request.Header.Set("X-Forwarded-Proto", "https")
+		recorder := httptest.NewRecorder()
+		engine.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf(
+				"status = %d, want %d; body=%s",
+				recorder.Code,
+				http.StatusOK,
+				recorder.Body.String(),
+			)
+		}
+		if got := recorder.Header().
+			Get("Access-Control-Allow-Origin"); got != "https://compozy-gateway.example.ts.net:8443" {
+			t.Fatalf("Access-Control-Allow-Origin = %q", got)
+		}
+	})
+
+	t.Run("Should reject a https origin when the forwarded proto is missing", func(t *testing.T) {
+		t.Parallel()
+
+		engine := gin.New()
+		engine.Use(corsMiddlewareWithForwardedTarget("127.0.0.1:43123", true))
+		engine.GET("/assets/app.js", func(c *gin.Context) { c.Status(http.StatusOK) })
+		request := httptest.NewRequestWithContext(
+			context.Background(), http.MethodGet, "/assets/app.js", http.NoBody,
+		)
+		request.Host = "compozy-gateway.example.ts.net:8443"
+		request.Header.Set("Origin", "https://compozy-gateway.example.ts.net:8443")
+		request.Header.Set("Sec-Fetch-Site", "same-origin")
+		recorder := httptest.NewRecorder()
+		engine.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf(
+				"status = %d, want %d; body=%s",
+				recorder.Code,
+				http.StatusForbidden,
+				recorder.Body.String(),
+			)
+		}
+		var payload contract.ErrorPayload
+		decodeJSONResponse(t, recorder, &payload)
+		if payload.Error != errOriginNotAllowed.Error() {
+			t.Fatalf("error = %q, want %q", payload.Error, errOriginNotAllowed.Error())
+		}
+	})
+
+	t.Run("Should reject a cross-origin request relayed with the forwarded proto", func(t *testing.T) {
+		t.Parallel()
+
+		engine := gin.New()
+		engine.Use(corsMiddlewareWithForwardedTarget("127.0.0.1:43123", true))
+		engine.POST("/api/action", func(c *gin.Context) { c.Status(http.StatusNoContent) })
+		request := httptest.NewRequestWithContext(
+			context.Background(), http.MethodPost, "/api/action", http.NoBody,
+		)
+		request.Host = "compozy-gateway.example.ts.net:8443"
+		request.Header.Set("Origin", "https://evil.example.test")
+		request.Header.Set("Sec-Fetch-Site", "cross-site")
+		request.Header.Set("X-Forwarded-Proto", "https")
+		recorder := httptest.NewRecorder()
+		engine.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf(
+				"status = %d, want %d; body=%s",
+				recorder.Code,
+				http.StatusForbidden,
+				recorder.Body.String(),
+			)
+		}
+		var payload contract.ErrorPayload
+		decodeJSONResponse(t, recorder, &payload)
+		if payload.Error != errOriginNotAllowed.Error() {
+			t.Fatalf("error = %q, want %q", payload.Error, errOriginNotAllowed.Error())
+		}
+	})
 }
 
 func TestBrowserRequestProtectionRouteBoundary(t *testing.T) {

--- a/internal/api/httpapi/middleware_refac_test.go
+++ b/internal/api/httpapi/middleware_refac_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/compozy/compozy/internal/api/contract"
+	"github.com/compozy/compozy/internal/api/core"
 	"github.com/gin-gonic/gin"
 )
 
@@ -352,7 +353,7 @@ func TestLoopbackGuardsHandleBoundHostPorts(t *testing.T) {
 			name:       "Should block wildcard host with port",
 			boundHost:  "0.0.0.0:2123",
 			wantStatus: http.StatusForbidden,
-			wantError:  errLoopbackAPIRequired.Error(),
+			wantError:  core.ErrLoopbackAPIRequired.Error(),
 		},
 	}
 

--- a/internal/api/httpapi/server_test.go
+++ b/internal/api/httpapi/server_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/compozy/compozy/internal/api/contract"
+	"github.com/compozy/compozy/internal/api/core"
 	apitestutil "github.com/compozy/compozy/internal/api/testutil"
 	compozyconfig "github.com/compozy/compozy/internal/config"
 	extensionpkg "github.com/compozy/compozy/internal/extension"
@@ -1071,7 +1072,7 @@ func TestNonLoopbackServerBlocksDaemonAPIRoutes(t *testing.T) {
 			}
 			var payload contract.ErrorPayload
 			decodeServerJSON(t, resp, &payload)
-			if got, want := payload.Error, errLoopbackAPIRequired.Error(); got != want {
+			if got, want := payload.Error, core.ErrLoopbackAPIRequired.Error(); got != want {
 				t.Fatalf("payload.Error = %q, want %q", got, want)
 			}
 		})
@@ -1094,7 +1095,7 @@ func TestNonLoopbackServerBlocksDaemonAPIRoutes(t *testing.T) {
 		}
 		var payload contract.ErrorPayload
 		decodeServerJSON(t, resp, &payload)
-		if got, want := payload.Error, errLoopbackAPIRequired.Error(); got != want {
+		if got, want := payload.Error, core.ErrLoopbackAPIRequired.Error(); got != want {
 			t.Fatalf("payload.Error = %q, want %q", got, want)
 		}
 	})
@@ -1116,7 +1117,7 @@ func TestNonLoopbackServerBlocksDaemonAPIRoutes(t *testing.T) {
 		}
 		var payload contract.ErrorPayload
 		decodeServerJSON(t, resp, &payload)
-		if got, want := payload.Error, errLoopbackAPIRequired.Error(); got != want {
+		if got, want := payload.Error, core.ErrLoopbackAPIRequired.Error(); got != want {
 			t.Fatalf("payload.Error = %q, want %q", got, want)
 		}
 	})
@@ -1184,7 +1185,7 @@ func TestNonLoopbackServerBlocksDaemonAPIRoutes(t *testing.T) {
 			}
 			var payload contract.ErrorPayload
 			decodeServerJSON(t, resp, &payload)
-			if got, want := payload.Error, errLoopbackAPIRequired.Error(); got != want {
+			if got, want := payload.Error, core.ErrLoopbackAPIRequired.Error(); got != want {
 				t.Fatalf("payload.Error = %q, want %q", got, want)
 			}
 		})

--- a/packages/ui/src/exports/foundation.ts
+++ b/packages/ui/src/exports/foundation.ts
@@ -22,6 +22,7 @@ export {
   WIDTH_RIGHT_RAIL_DEFAULT,
   WIDTH_TABLE_CELL_LG,
 } from "../lib/layout-widths";
+export { DIALOG_TOUCH_TARGET_CLASS, DIALOG_TOUCH_TARGET_SQUARE_CLASS } from "../lib/dialog-shell";
 export { LaneTabs, type LaneTabsItem, type LaneTabsProps } from "../components/custom/lane-tabs";
 export {
   Avatar,

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Mobile ergonomics contract (S6, T4): viewport-fit=cover feeds the
+         safe-area insets the shell chrome consumes; interactive-widget=resizes-content
+         shrinks the layout viewport when the on-screen keyboard opens, so flex
+         columns keep the composer and palette input above it. Desktop unaffected. -->
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
+    />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="any" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/web/src/components/assistant-ui/scroll-to-bottom-pill.tsx
+++ b/web/src/components/assistant-ui/scroll-to-bottom-pill.tsx
@@ -1,11 +1,14 @@
 import { ArrowDown } from "lucide-react";
 
+import { DIALOG_TOUCH_TARGET_SQUARE_CLASS } from "@compozy/ui";
+
 import { cn } from "@/lib/utils";
 
 /**
  * Floating scroll-to-bottom affordance: a neutral `size-8` disc (no
  * glass/backdrop-blur) that fades + drifts in with the shared disclosure
- * motion and stays mounted so its exit animates too.
+ * motion and stays mounted so its exit animates too. At the ≤760px touch tier
+ * (S6/T1) it grows to the shared 44px floor so the stream is thumb-drivable.
  */
 export function ScrollToBottomPill({
   visible,
@@ -33,6 +36,7 @@ export function ScrollToBottomPill({
         tabIndex={visible ? 0 : -1}
         className={cn(
           "flex size-8 items-center justify-center rounded-full",
+          DIALOG_TOUCH_TARGET_SQUARE_CLASS,
           "border border-line bg-canvas-soft text-muted shadow-[var(--shadow-overlay)]",
           "transition-colors hover:bg-hover hover:text-fg",
           "focus-visible:shadow-focus-ring focus-visible:outline-none",

--- a/web/src/lib/__tests__/cost-provenance.test.ts
+++ b/web/src/lib/__tests__/cost-provenance.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import { describeCost, type CostSource } from "../cost-provenance";
 
 function currency(amount: number, code: string, digits: number): string {
-  return new Intl.NumberFormat(undefined, {
+  // Mirror the production formatter's pinned en-US locale.
+  return new Intl.NumberFormat("en-US", {
     style: "currency",
     currency: code,
     minimumFractionDigits: digits,

--- a/web/src/lib/__tests__/gateway-access-signal.test.ts
+++ b/web/src/lib/__tests__/gateway-access-signal.test.ts
@@ -23,9 +23,19 @@ function jsonResponse(status: number, payload: unknown, tier?: GatewayListenerTi
   });
 }
 
+/**
+ * The transport classifies by response URL, but `Response.url` is set by fetch
+ * and cannot be passed to the constructor — shadow the read-only getter with
+ * the URL a real daemon response would carry.
+ */
+function withUrl(response: Response, url: string): Response {
+  Object.defineProperty(response, "url", { value: url });
+  return response;
+}
+
 describe("gateway access signal ordering", () => {
   let signals: GatewayAccessSignal[];
-  let tiers: GatewayListenerTier[];
+  let tiers: (GatewayListenerTier | undefined)[];
   let unobserve: () => void;
   let unobserveTier: () => void;
 
@@ -106,5 +116,88 @@ describe("gateway access signal ordering", () => {
     await apiClient.GET("/api/gateway/status");
 
     expect(signals).toEqual([]);
+  });
+});
+
+// Suite: gateway status tier latch
+// Invariant: `/api/status` is the tier's authoritative source — a response from
+// it without a parsable tier header publishes unknown (US-001.EC-2, so the
+// default-hidden capability set applies, BR-2) instead of keeping a stale
+// latched tier. Any other response publishes only a parsable tier: random
+// non-status responses must never unlatch the shell.
+// Owning layer: the shared api-client response middleware.
+describe("gateway status tier latch", () => {
+  let tiers: (GatewayListenerTier | undefined)[];
+  let unobserveTier: () => void;
+
+  beforeEach(() => {
+    tiers = [];
+    unobserveTier = observeGatewayListenerTier(tier => tiers.push(tier));
+  });
+
+  afterEach(() => {
+    unobserveTier();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  /** A `/api/status` response with an optional raw (possibly unparsable) tier header. */
+  function statusResponse(status: number, rawTier?: string): Response {
+    return withUrl(
+      new Response(JSON.stringify({}), {
+        status,
+        headers: {
+          "Content-Type": "application/json",
+          ...(rawTier !== undefined ? { "X-Compozy-Gateway-Tier": rawTier } : {}),
+        },
+      }),
+      "https://compozy.local/api/status"
+    );
+  }
+
+  it("Should latch unknown when /api/status answers without a tier header", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(statusResponse(200)));
+
+    await apiClient.GET("/api/status");
+
+    expect(tiers).toEqual([undefined]);
+  });
+
+  it("Should latch unknown when the /api/status tier header does not parse", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(statusResponse(200, "interior")));
+
+    await apiClient.GET("/api/status");
+
+    expect(tiers).toEqual([undefined]);
+  });
+
+  it("Should unlatch a stale tier when /api/status stops carrying a parsable one", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, {}, "local")));
+    await apiClient.GET("/api/gateway/status");
+    expect(tiers).toEqual(["local"]);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(statusResponse(200)));
+    await apiClient.GET("/api/status");
+
+    expect(tiers).toEqual(["local", undefined]);
+  });
+
+  it("Should keep the last latched tier when other responses omit the header", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, {}, "local")));
+    await apiClient.GET("/api/gateway/status");
+    expect(tiers).toEqual(["local"]);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(200, {})));
+    await apiClient.GET("/api/gateway/status");
+
+    expect(tiers).toEqual(["local"]);
+  });
+
+  it("Should latch a parsable tier from /api/status", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(statusResponse(200, "private")));
+
+    await apiClient.GET("/api/status");
+
+    expect(tiers).toEqual(["private"]);
   });
 });

--- a/web/src/lib/cost-provenance.ts
+++ b/web/src/lib/cost-provenance.ts
@@ -60,7 +60,8 @@ function currencyFormatter(currency: string, digits: number): Intl.NumberFormat 
   const key = `${currency}:${digits}`;
   const cached = currencyFormatters.get(key);
   if (cached) return cached;
-  const formatter = Intl.NumberFormat(undefined, {
+  // Pin en-US: product copy is English, so digits/separators must not vary by host locale.
+  const formatter = Intl.NumberFormat("en-US", {
     style: "currency",
     currency,
     minimumFractionDigits: digits,

--- a/web/src/lib/gateway-access-signal.ts
+++ b/web/src/lib/gateway-access-signal.ts
@@ -21,9 +21,17 @@ const GATEWAY_TIER_HEADER = "X-Compozy-Gateway-Tier";
 
 type AccessSignalListener = (signal: GatewayAccessSignal) => void;
 type TierListener = (tier: GatewayListenerTier) => void;
+/**
+ * Forbidden envelopes are handed over raw: this transport knows only that the
+ * daemon refused, never which refusals mean what. Deciding that a 403 code is
+ * a domain signal (e.g. loopback-only) belongs to the gateway system, which
+ * subscribes here and classifies.
+ */
+type ForbiddenResponseListener = (status: number, payload: unknown) => void;
 
 const listeners = new Set<AccessSignalListener>();
 const tierListeners = new Set<TierListener>();
+const forbiddenListeners = new Set<ForbiddenResponseListener>();
 
 /** Reads the daemon's stable machine code out of an error envelope. */
 export function gatewayErrorCode(payload: unknown): string | undefined {
@@ -78,6 +86,10 @@ export function readGatewayListenerTier(response: Response): GatewayListenerTier
 
 export async function reportGatewayResponse(response: Response): Promise<void> {
   reportGatewayListenerTier(response.headers.get(GATEWAY_TIER_HEADER));
+  if (response.status === 403) {
+    await reportForbiddenResponse(response);
+    return;
+  }
   if (response.status !== 401) return;
   try {
     reportGatewayAccess(response.status, await response.clone().json());
@@ -86,11 +98,34 @@ export async function reportGatewayResponse(response: Response): Promise<void> {
   }
 }
 
+/**
+ * Publishes a 403 envelope to forbidden-response observers. Fired only for
+ * 403s (other statuses say nothing a listener classified) and skipped entirely
+ * when nobody observes, so unobserved refusals cost no body parse.
+ */
+async function reportForbiddenResponse(response: Response): Promise<void> {
+  if (forbiddenListeners.size === 0) return;
+  try {
+    const payload: unknown = await response.clone().json();
+    for (const listener of forbiddenListeners) listener(response.status, payload);
+  } catch {
+    // A 403 without a JSON envelope carries nothing to classify.
+  }
+}
+
 /** Subscribes to access signals. Returns the unsubscribe function. */
 export function observeGatewayAccess(listener: AccessSignalListener): () => void {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
+  };
+}
+
+/** Subscribes to 403 envelopes. Returns the unsubscribe function. */
+export function observeGatewayForbiddenResponse(listener: ForbiddenResponseListener): () => void {
+  forbiddenListeners.add(listener);
+  return () => {
+    forbiddenListeners.delete(listener);
   };
 }
 

--- a/web/src/lib/gateway-access-signal.ts
+++ b/web/src/lib/gateway-access-signal.ts
@@ -11,6 +11,11 @@
  * stream ticket are *not* access decisions — a flaky link must never eject the
  * operator from the app, and a spent single-use ticket is resolved by minting a
  * fresh one, not by tearing the session down.
+ *
+ * The tier latch is similarly narrow: a parsable `X-Compozy-Gateway-Tier`
+ * publishes on any response, and only the authoritative `/api/status` response
+ * may publish *unknown* (a missing or unparsable header there resets to the
+ * default-hidden set). Other responses never unlatch a latched tier.
  */
 export type GatewayAccessSignal = "unauthenticated" | "revoked";
 export type GatewayListenerTier = "local" | "private" | "public";
@@ -20,7 +25,12 @@ const REVOKED_CODE = "gateway_device_revoked";
 const GATEWAY_TIER_HEADER = "X-Compozy-Gateway-Tier";
 
 type AccessSignalListener = (signal: GatewayAccessSignal) => void;
-type TierListener = (tier: GatewayListenerTier) => void;
+/**
+ * Tier observations carry a parsable `GatewayListenerTier`, or `undefined`
+ * when the authoritative `/api/status` response proves the tier unknown
+ * (US-001.EC-2) — the default-hidden capability set applies (BR-2).
+ */
+type TierListener = (tier: GatewayListenerTier | undefined) => void;
 /**
  * Forbidden envelopes are handed over raw: this transport knows only that the
  * daemon refused, never which refusals mean what. Deciding that a 403 code is
@@ -84,8 +94,34 @@ export function readGatewayListenerTier(response: Response): GatewayListenerTier
   return parseGatewayListenerTier(response.headers.get(GATEWAY_TIER_HEADER));
 }
 
+/**
+ * Tier latch for one response. A parsable tier header publishes on any
+ * response. A missing or unparsable one keeps the last latched tier — except
+ * on `/api/status` itself, the tier's authoritative source, where it publishes
+ * unknown instead (US-001.EC-2): a proxy that strips the header must not leave
+ * a stale tier latched. Random non-status responses never unlatch.
+ */
+function reportResponseGatewayTier(response: Response): void {
+  const tier = parseGatewayListenerTier(response.headers.get(GATEWAY_TIER_HEADER));
+  if (!tier && !isGatewayStatusResponse(response)) return;
+  for (const listener of tierListeners) listener(tier);
+}
+
+/**
+ * True only for the daemon status endpoint — the one response allowed to
+ * publish an unknown tier. `Response.url` is empty for synthesized responses,
+ * which therefore never count as the status endpoint.
+ */
+function isGatewayStatusResponse(response: Response): boolean {
+  try {
+    return new URL(response.url).pathname === "/api/status";
+  } catch {
+    return false;
+  }
+}
+
 export async function reportGatewayResponse(response: Response): Promise<void> {
-  reportGatewayListenerTier(response.headers.get(GATEWAY_TIER_HEADER));
+  reportResponseGatewayTier(response);
   if (response.status === 403) {
     await reportForbiddenResponse(response);
     return;

--- a/web/src/routes/_app/settings/-hooks-section.tsx
+++ b/web/src/routes/_app/settings/-hooks-section.tsx
@@ -167,13 +167,26 @@ function HookRow({
       </div>
       <div className="flex items-center justify-end gap-2">
         {pending ? <Spinner className="size-3 text-subtle" /> : null}
-        <Switch
-          data-testid={`settings-page-hooks-row-${entry.name}-toggle`}
-          checked={enabled}
-          disabled={pending || !canMutate}
-          onCheckedChange={checked => onToggle(entry, checked)}
-          aria-label={`Toggle hook ${entry.name}`}
-        />
+        {canMutate ? (
+          <Switch
+            data-testid={`settings-page-hooks-row-${entry.name}-toggle`}
+            checked={enabled}
+            disabled={pending}
+            onCheckedChange={checked => onToggle(entry, checked)}
+            aria-label={`Toggle hook ${entry.name}`}
+          />
+        ) : (
+          // Remote tiers register no hook enablement writes: the toggle is
+          // absent; the enablement state stays readable (BR-1).
+          <Pill
+            data-testid={`settings-page-hooks-row-${entry.name}-state`}
+            mono
+            size="xs"
+            tone={enabled ? "success" : "neutral"}
+          >
+            {enabled ? "enabled" : "off"}
+          </Pill>
+        )}
       </div>
     </li>
   );

--- a/web/src/routes/_app/settings/__tests__/-defaults-settings-page.test.tsx
+++ b/web/src/routes/_app/settings/__tests__/-defaults-settings-page.test.tsx
@@ -2,7 +2,9 @@
 // Owning layer: Defaults route. Canonical suite: this route-level regression.
 // Boundary IN: independent settings queries. Boundary OUT: loading/error/retry page state.
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 const mocks = vi.hoisted(() => ({
   page: {
@@ -50,7 +52,11 @@ vi.mock("@/systems/settings", async importOriginal => {
 import { DefaultsSettingsPage } from "../-defaults-settings-page";
 
 describe("DefaultsSettingsPage", () => {
+  let unlatch: () => void;
   beforeEach(() => {
+    // Defaults writes render their save bar only where the tier can execute
+    // them; this suite owns the local shape.
+    unlatch = latchGatewayTierForTest("local");
     mocks.page.error = null;
     mocks.page.isLoading = false;
     mocks.page.handleRetry.mockReset();
@@ -64,6 +70,7 @@ describe("DefaultsSettingsPage", () => {
     mocks.sandboxes.data.sandboxes = [];
     mocks.sandboxes.refetch.mockReset();
   });
+  afterEach(() => unlatch());
 
   it("Should wait for every runtime option catalog before rendering defaults", () => {
     mocks.providers.isLoading = true;

--- a/web/src/routes/_app/settings/__tests__/-general.test.tsx
+++ b/web/src/routes/_app/settings/__tests__/-general.test.tsx
@@ -2,7 +2,9 @@ import { fireEvent, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithTopbar as render } from "@/test/render-with-topbar";
 import { createElement, type ReactNode, type SetStateAction } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 import type {
   SettingsUpdateApplyResult,
@@ -208,7 +210,11 @@ vi.mock("@/systems/tool-approvals", () => ({
     createElement("div", { "data-testid": "settings-page-general-tool-approvals" }),
 }));
 
+let unlatchGatewayTier: () => void;
+
 beforeEach(() => {
+  // The save bar and restart banner render where the tier can execute writes.
+  unlatchGatewayTier = latchGatewayTierForTest("local");
   pageState = {
     isLoading: false,
     error: null,
@@ -271,6 +277,10 @@ beforeEach(() => {
 });
 
 import { GeneralSettingsPage } from "../-general-settings-page";
+
+afterEach(() => {
+  unlatchGatewayTier();
+});
 
 describe("GeneralSettingsPage", () => {
   it("renders a loading indicator while fetching", () => {

--- a/web/src/routes/_app/settings/__tests__/-roles.test.tsx
+++ b/web/src/routes/_app/settings/__tests__/-roles.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, screen, within } from "@testing-library/react";
 import { renderWithTopbar as render } from "@/test/render-with-topbar";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 import type { RolesDisclosure, RolesRuntimeOptions } from "@/systems/settings";
 import { buildRolesViewModel, type RoleViewModel } from "@/systems/settings";
@@ -102,7 +104,10 @@ vi.mock("@/systems/settings/hooks/use-settings-roles-page", () => ({
   useSettingsRolesPage: () => pageState,
 }));
 
+let unlatchGatewayTier: () => void;
+
 beforeEach(() => {
+  unlatchGatewayTier = latchGatewayTierForTest("local");
   pageState = {
     isLoading: false,
     isEmpty: false,
@@ -140,6 +145,10 @@ import { RolesSettingsPage } from "../-roles-settings-page";
 function group(role: string): HTMLElement {
   return screen.getByTestId(`settings-page-roles-group-${role}`);
 }
+
+afterEach(() => {
+  unlatchGatewayTier();
+});
 
 describe("RolesSettingsPage", () => {
   it("renders a loading indicator while either read is pending", () => {

--- a/web/src/systems/gateway/components/__tests__/loopback-only-state.test.tsx
+++ b/web/src/systems/gateway/components/__tests__/loopback-only-state.test.tsx
@@ -1,0 +1,43 @@
+// Suite: loopback-only truthful state (UT-008, S5)
+// Invariant: when the loopback-only signal fires, the state names the machine
+// running CompozyOS as where the action belongs — neutral/informative, never
+// error-red — and reads from the registered COPY.md strings, not ad-hoc prose.
+// Owning layer: the gateway system's domain component.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { LOOPBACK_ONLY_STATE_COPY } from "../../lib/gateway-copy";
+import { LoopbackOnlyState } from "../loopback-only-state";
+
+describe("LoopbackOnlyState", () => {
+  it("Should render daemon-host guidance in the panel layout", () => {
+    render(<LoopbackOnlyState />);
+
+    const state = screen.getByTestId("gateway-loopback-only-state");
+    expect(state).toHaveTextContent(LOOPBACK_ONLY_STATE_COPY.panel.title);
+    expect(state).toHaveTextContent(LOOPBACK_ONLY_STATE_COPY.panel.description);
+    expect(state).toHaveTextContent(LOOPBACK_ONLY_STATE_COPY.panel.hint);
+    // The guidance names the daemon host, never the wire codes or "daemon".
+    expect(state).toHaveTextContent("machine running CompozyOS");
+    expect(state).not.toHaveTextContent("daemon");
+    expect(state).not.toHaveTextContent("loopback_mutation_required");
+  });
+
+  it("Should render the slim shell banner layout with the same host guidance", () => {
+    render(<LoopbackOnlyState layout="banner" />);
+
+    const banner = screen.getByTestId("gateway-loopback-only-banner");
+    expect(banner).toHaveTextContent(LOOPBACK_ONLY_STATE_COPY.banner.title);
+    expect(banner).toHaveTextContent(LOOPBACK_ONLY_STATE_COPY.banner.description);
+    expect(banner).toHaveTextContent("machine running CompozyOS");
+  });
+
+  it("Should stay an informative signal, not an alert-severity failure", () => {
+    render(<LoopbackOnlyState layout="banner" />);
+
+    // Neutral variant on the banner: the daemon did not fail, it told the
+    // truth about where the action belongs (BR-3's tone contract).
+    const banner = screen.getByTestId("gateway-loopback-only-banner");
+    expect(banner).toHaveAttribute("data-variant", "neutral");
+  });
+});

--- a/web/src/systems/gateway/components/loopback-only-state.tsx
+++ b/web/src/systems/gateway/components/loopback-only-state.tsx
@@ -1,0 +1,57 @@
+import { Server } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle, Empty } from "@compozy/ui";
+
+import { LOOPBACK_ONLY_STATE_COPY } from "../lib/gateway-copy";
+
+export interface LoopbackOnlyStateProps {
+  /**
+   * `panel` — the framed full state for a surface slot (a deep-linked window,
+   * a mutation view). `banner` — the slim shell-level strip for the 403
+   * backstop, so a refused call never lands as a generic error toast.
+   */
+  layout?: "panel" | "banner";
+  "data-testid"?: string;
+}
+
+/**
+ * The truthful loopback-only state (S5, BR-3): the daemon refused because this
+ * listener cannot execute the action — it belongs on the machine running
+ * CompozyOS. Neutral/informative signal, never error-red: nothing failed, the
+ * capability boundary explained itself. It persists until the tier latches
+ * `local` again (US-002.EC-1), so there is no dismiss control to lose the
+ * explanation behind.
+ */
+export function LoopbackOnlyState({
+  layout = "panel",
+  "data-testid": testId,
+}: LoopbackOnlyStateProps) {
+  if (layout === "banner") {
+    return (
+      <Alert
+        className="border-line bg-canvas-soft"
+        data-testid={testId ?? "gateway-loopback-only-banner"}
+        variant="neutral"
+      >
+        <Server aria-hidden="true" />
+        <AlertTitle>{LOOPBACK_ONLY_STATE_COPY.banner.title}</AlertTitle>
+        <AlertDescription>{LOOPBACK_ONLY_STATE_COPY.banner.description}</AlertDescription>
+      </Alert>
+    );
+  }
+  return (
+    <div
+      className="flex min-h-0 flex-1 items-center justify-center px-6 py-10"
+      data-testid={testId ?? "gateway-loopback-only-state"}
+    >
+      <Empty
+        className="max-w-md"
+        description={LOOPBACK_ONLY_STATE_COPY.panel.description}
+        framed
+        hint={LOOPBACK_ONLY_STATE_COPY.panel.hint}
+        icon={Server}
+        title={LOOPBACK_ONLY_STATE_COPY.panel.title}
+      />
+    </div>
+  );
+}

--- a/web/src/systems/gateway/hooks/use-gateway-capabilities.ts
+++ b/web/src/systems/gateway/hooks/use-gateway-capabilities.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useSelector } from "@xstate/store-react";
+
+import {
+  startGatewayCapabilityObserver,
+  gatewayCapabilityStore,
+} from "../stores/gateway-capability-store";
+import type { GatewayCapabilities } from "../lib/gateway-capabilities";
+import type { GatewayLoopbackSignal } from "../lib/gateway-loopback";
+
+/**
+ * What this browser's listener can execute, per the latched tier. Subscribing
+ * here also binds the store to the shared transport — an external-system
+ * subscription, which is what `useEffect` is for. Until the tier latches, the
+ * all-false set applies: loopback-only affordances stay hidden (BR-2), and a
+ * tier change re-evaluates without a restart (BR-4).
+ */
+export function useGatewayCapabilities(): GatewayCapabilities {
+  useEffect(() => startGatewayCapabilityObserver(), []);
+  return useSelector(gatewayCapabilityStore, snapshot => snapshot.context.capabilities);
+}
+
+/**
+ * The most recent loopback-only 403 classification, if any — the backstop
+ * evidence behind the truthful loopback-only state (US-002).
+ */
+export function useGatewayLoopbackOnly(): GatewayLoopbackSignal | undefined {
+  useEffect(() => startGatewayCapabilityObserver(), []);
+  return useSelector(gatewayCapabilityStore, snapshot => snapshot.context.loopbackOnly);
+}

--- a/web/src/systems/gateway/index.ts
+++ b/web/src/systems/gateway/index.ts
@@ -117,6 +117,15 @@ export {
   startGatewayAccessObserver,
   type GatewayAccessState,
 } from "./stores/gateway-access-store";
+export {
+  gatewayCapabilityStore,
+  startGatewayCapabilityObserver,
+  type GatewayCapabilityState,
+} from "./stores/gateway-capability-store";
+
+// Capability model (tier → what the listener can execute, per the SurfaceSet matrices)
+export { capabilitiesForTier, type GatewayCapabilities } from "./lib/gateway-capabilities";
+export { classifyGatewayLoopback, type GatewayLoopbackSignal } from "./lib/gateway-loopback";
 
 // API
 export { gatewayApi } from "./adapters/gateway-api";

--- a/web/src/systems/gateway/index.ts
+++ b/web/src/systems/gateway/index.ts
@@ -36,6 +36,7 @@ export {
   useRedeemGatewayPairing,
   type RedeemPairingInput,
 } from "./hooks/use-gateway-access";
+export { useGatewayCapabilities, useGatewayLoopbackOnly } from "./hooks/use-gateway-capabilities";
 export {
   useDisableGatewayProvider,
   useEnableGatewayProvider,
@@ -73,6 +74,7 @@ export { GatewayProviderRow } from "./components/gateway-provider-row";
 export { GatewayProviderSection } from "./components/gateway-provider-section";
 export { GatewayPublicConsentDialog } from "./components/gateway-public-consent-dialog";
 export { GatewayStatusChip } from "./components/gateway-status-chip";
+export { LoopbackOnlyState, type LoopbackOnlyStateProps } from "./components/loopback-only-state";
 
 // Utilities
 export {
@@ -95,6 +97,7 @@ export {
   REACHABILITY_COPY,
   SURFACE_LABEL,
   TIER_LABEL,
+  LOOPBACK_ONLY_STATE_COPY,
   type GatewaySignalTone,
 } from "./lib/gateway-copy";
 export {

--- a/web/src/systems/gateway/lib/__tests__/gateway-capabilities.test.ts
+++ b/web/src/systems/gateway/lib/__tests__/gateway-capabilities.test.ts
@@ -1,0 +1,51 @@
+// Suite: gateway capability model
+// Invariant: the capability set mirrors the backend SurfaceSet route matrices — every flag on
+// for the local tier, every flag off for both remote tiers, and the all-false set while the tier
+// is unlatched (default-hidden, BR-2), so the UI never offers an affordance the tier cannot run.
+// Owning layer: the gateway system's tier→capability mapping.
+import { describe, expect, it } from "vitest";
+
+import { capabilitiesForTier } from "../gateway-capabilities";
+
+describe("capabilitiesForTier", () => {
+  it("Should enable every capability on the local tier", () => {
+    // UT-001: the local surface set registers every operator route group.
+    expect(capabilitiesForTier("local")).toEqual({
+      localTaskLifecycle: true,
+      privilegedMutations: true,
+      profileEnablementWrites: true,
+      agentKernel: true,
+      fullResourceRoutes: true,
+    });
+  });
+
+  it("Should disable every capability on the private tier", () => {
+    // UT-002: the private tier registers the remote read subset only.
+    expect(capabilitiesForTier("private")).toEqual({
+      localTaskLifecycle: false,
+      privilegedMutations: false,
+      profileEnablementWrites: false,
+      agentKernel: false,
+      fullResourceRoutes: false,
+    });
+  });
+
+  it("Should disable every capability on the public tier", () => {
+    // UT-003: the public operator matrix differs from private only in gateway
+    // management scope, which the tier-aware gateway settings page owns — not
+    // a capability flag here.
+    expect(capabilitiesForTier("public")).toEqual(capabilitiesForTier("private"));
+  });
+
+  it("Should default to all-hidden while the tier is unlatched", () => {
+    // UT-004: loopback-only affordances stay hidden until `/api/status` proves
+    // `local` (BR-2) — no flash-then-hide on first paint.
+    expect(capabilitiesForTier(undefined)).toEqual({
+      localTaskLifecycle: false,
+      privilegedMutations: false,
+      profileEnablementWrites: false,
+      agentKernel: false,
+      fullResourceRoutes: false,
+    });
+  });
+});

--- a/web/src/systems/gateway/lib/__tests__/gateway-loopback.test.ts
+++ b/web/src/systems/gateway/lib/__tests__/gateway-loopback.test.ts
@@ -1,0 +1,30 @@
+// Suite: loopback 403 classification
+// Invariant: only an HTTP 403 carrying one of the two explicit loopback daemon codes classifies.
+// Any other status, a missing code, or an unrelated code says nothing about loopback capability
+// and must not drive the loopback-only state — the seam stays narrow.
+// Owning layer: the gateway system's forbidden-envelope classifier.
+import { describe, expect, it } from "vitest";
+
+import { classifyGatewayLoopback } from "../gateway-loopback";
+
+describe("classifyGatewayLoopback", () => {
+  it("Should classify only the two loopback daemon codes on a 403", () => {
+    // UT-005: shapes frozen in the spec's DX contract.
+    expect(classifyGatewayLoopback(403, { code: "loopback_mutation_required" })).toBe("mutation");
+    expect(classifyGatewayLoopback(403, { code: "loopback_api_required" })).toBe("api");
+  });
+
+  it("Should ignore a 403 without a code or with an unrelated code", () => {
+    // UT-006: ordinary authorization refusals are not loopback signals.
+    expect(classifyGatewayLoopback(403, { error: "forbidden" })).toBeUndefined();
+    expect(classifyGatewayLoopback(403, { code: "workspace_home_forbidden" })).toBeUndefined();
+    expect(classifyGatewayLoopback(403, { code: "" })).toBeUndefined();
+    expect(classifyGatewayLoopback(403, null)).toBeUndefined();
+  });
+
+  it("Should ignore non-403 responses even when the codes appear", () => {
+    expect(classifyGatewayLoopback(401, { code: "loopback_mutation_required" })).toBeUndefined();
+    expect(classifyGatewayLoopback(500, { code: "loopback_api_required" })).toBeUndefined();
+    expect(classifyGatewayLoopback(200, { code: "loopback_mutation_required" })).toBeUndefined();
+  });
+});

--- a/web/src/systems/gateway/lib/gateway-capabilities.ts
+++ b/web/src/systems/gateway/lib/gateway-capabilities.ts
@@ -1,0 +1,84 @@
+/**
+ * What the latched listener tier can execute, mirroring the backend SurfaceSet
+ * route matrices (`internal/api/httpapi/surface_routes.go`).
+ *
+ * The backend remains the sole enforcement authority (BR-6): this map only
+ * keeps the UI from offering affordances the tier's route matrix never
+ * registers. It keys off the tier alone — no per-route discovery — so a web
+ * unit test per flag plus the Go route-matrix tests own the drift risk.
+ *
+ * Both remote tiers (`private`, `public`) resolve to the same capability set:
+ * their operator matrices differ only in gateway-management scope, which the
+ * existing tier-aware gateway settings page already owns.
+ */
+import type { GatewayListenerTier } from "@/lib/gateway-access-signal";
+
+export interface GatewayCapabilities {
+  /**
+   * Terminal routes and local-only task lifecycle (task/run mutations,
+   * scheduler, task-review verdicts). The backend registers these only when
+   * `includeLocalOnlyTaskLifecycle` is true, i.e. the local surface set
+   * (`surface_routes.go:71-73`, `routes.go:25/85`, `routes.go:167-213`);
+   * remote tiers register the read subset.
+   */
+  readonly localTaskLifecycle: boolean;
+  /**
+   * Settings/extension writes and other privileged mutations. These sit
+   * behind `privilegedMutationGuard` → `loopbackMutationGuard`, which 403s
+   * with `loopback_mutation_required` unless the daemon is loopback-bound
+   * (`routes.go` privileged registrations; `handlers.go:311-317`,
+   * `middleware.go:379-401`). Gateway listeners are non-loopback by
+   * construction, so no remote tier can execute them.
+   */
+  readonly privilegedMutations: boolean;
+  /**
+   * Notification-preset enablement, extension enablement, and profile-state
+   * writes. On non-local tiers the backend swaps these handlers for
+   * `ProfileRemoteWriteForbidden` (403 "profile management is available only
+   * on the local Compozy surface") — `routes.go:58-72`, `routes.go:368-395`,
+   * `profile_routes.go:9-40`.
+   */
+  readonly profileEnablementWrites: boolean;
+  /**
+   * Agent kernel routes (`/api/agent-kernel/*`). Registered only on the local
+   * surface set (`routes.go:26`); the private and public tier registrations
+   * (`surface_routes.go:27-59`) never include them.
+   */
+  readonly agentKernel: boolean;
+  /**
+   * Full resource routes (`registerResourceRoutes`, local set only,
+   * `routes.go:27`). Remote tiers register `registerRemoteResourceReadRoutes`
+   * instead — a read subset (`surface_routes.go:34,56`).
+   */
+  readonly fullResourceRoutes: boolean;
+}
+
+/** The local surface set registers every operator route group. */
+const LOCAL_CAPABILITIES: GatewayCapabilities = {
+  localTaskLifecycle: true,
+  privilegedMutations: true,
+  profileEnablementWrites: true,
+  agentKernel: true,
+  fullResourceRoutes: true,
+};
+
+/**
+ * Both remote tiers: read/monitor surface only. Every loopback- or
+ * local-only group above is absent from their route matrices.
+ */
+const REMOTE_CAPABILITIES: GatewayCapabilities = {
+  localTaskLifecycle: false,
+  privilegedMutations: false,
+  profileEnablementWrites: false,
+  agentKernel: false,
+  fullResourceRoutes: false,
+};
+
+/**
+ * Capability set for a latched tier. `undefined` (tier not yet latched from
+ * `/api/status`) resolves to the all-false set — loopback-only affordances
+ * stay hidden until the tier proves `local` (BR-2, no flash-then-hide).
+ */
+export function capabilitiesForTier(tier: GatewayListenerTier | undefined): GatewayCapabilities {
+  return tier === "local" ? LOCAL_CAPABILITIES : REMOTE_CAPABILITIES;
+}

--- a/web/src/systems/gateway/lib/gateway-copy.ts
+++ b/web/src/systems/gateway/lib/gateway-copy.ts
@@ -142,6 +142,25 @@ function isGatewayIngressReachability(value: string): value is GatewayIngressRea
   return Object.prototype.hasOwnProperty.call(INGRESS_REACHABILITY_COPY, value);
 }
 
+/**
+ * The truthful loopback-only state (S5): what the operator hit, and where the
+ * action can actually run. Registered in `COPY.md` (§8 Web UI Microcopy) —
+ * edit the two together. Neutral and informative, never error-red: the daemon
+ * did not fail, it told the truth about where this action belongs.
+ */
+export const LOOPBACK_ONLY_STATE_COPY = {
+  panel: {
+    title: "Not available from this device",
+    description: "This action can only run on the machine running CompozyOS.",
+    hint: "Open CompozyOS on that machine and run it there.",
+  },
+  banner: {
+    title: "This action runs on the machine running CompozyOS",
+    description:
+      "You are connected through remote access, so this action cannot run from this device.",
+  },
+} as const;
+
 export const DEVICE_ORIGIN_LABEL: Record<string, string> = {
   local: "This machine",
   private: "Private overlay",

--- a/web/src/systems/gateway/lib/gateway-loopback.ts
+++ b/web/src/systems/gateway/lib/gateway-loopback.ts
@@ -1,0 +1,47 @@
+/**
+ * Classification of the two loopback-guard 403 envelopes into a gateway
+ * domain signal.
+ *
+ * The wire shapes are frozen in the spec's DX contract: a 403 whose JSON body
+ * carries `code: "loopback_mutation_required"` or `code:
+ * "loopback_api_required"` means the daemon cannot execute the call from this
+ * listener and the action belongs on the daemon host. The codes are owned
+ * here (the gateway system), not in the transport seam — the transport hands
+ * forbidden envelopes over raw and never learns what they mean.
+ *
+ * Deliberately narrow: only an HTTP 403 carrying one of the two explicit
+ * daemon codes classifies. Any other status, a missing code, or an unrelated
+ * code returns `undefined` — ordinary authorization refusals are not
+ * loopback signals and must not render the loopback-only state.
+ */
+import { gatewayErrorCode } from "@/lib/gateway-access-signal";
+
+const LOOPBACK_MUTATION_CODE = "loopback_mutation_required";
+const LOOPBACK_API_CODE = "loopback_api_required";
+
+/**
+ * Which loopback guard refused, mirroring the two wire codes one-to-one:
+ * `mutation` ← `loopback_mutation_required`, `api` ← `loopback_api_required`.
+ * Both render the same truthful loopback-only state; the distinction records
+ * which guard fired.
+ */
+export type GatewayLoopbackSignal = "mutation" | "api";
+
+/**
+ * Returns the loopback signal a response represents, or `undefined` when the
+ * failure says nothing about loopback capability.
+ */
+export function classifyGatewayLoopback(
+  status: number,
+  payload: unknown
+): GatewayLoopbackSignal | undefined {
+  if (status !== 403) return undefined;
+  switch (gatewayErrorCode(payload)) {
+    case LOOPBACK_MUTATION_CODE:
+      return "mutation";
+    case LOOPBACK_API_CODE:
+      return "api";
+    default:
+      return undefined;
+  }
+}

--- a/web/src/systems/gateway/stores/__tests__/gateway-capability-store.integration.test.ts
+++ b/web/src/systems/gateway/stores/__tests__/gateway-capability-store.integration.test.ts
@@ -1,0 +1,113 @@
+// Suite: transport → capability store re-evaluation (IT-003, US-002.AC-1/AC-2, US-004.AC-1)
+// Invariant: the real api-client response middleware hands a 403 loopback
+// envelope to the gateway system, and the capability store re-evaluates from
+// the refusing response — the backstop signal records, the capability set
+// re-derives from the same response's latched tier, and a later `local`
+// observation clears the refusal without an app restart.
+// Owning layer: the app-wide capability state over the shared transport
+// (MSW fakes the network; everything between the request and the store is the
+// production wiring).
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { apiClient } from "@/lib/api-client";
+import { capabilitiesForTier } from "../../lib/gateway-capabilities";
+import {
+  gatewayCapabilityStore,
+  startGatewayCapabilityObserver,
+} from "../gateway-capability-store";
+
+const SCHEDULER_PATH = "/api/scheduler";
+
+function loopbackEnvelope(code: string): { error: string; code: string } {
+  // Mirrors the daemon's 403 envelope: top-level machine `code` next to the
+  // message (`contract.ErrorPayload`, IT-002's wire shape).
+  return { error: "this action can only run on the machine running CompozyOS", code };
+}
+
+const server = setupServer();
+
+describe("gateway capability store over the real client wiring", () => {
+  let stop: () => void;
+
+  beforeEach(() => {
+    gatewayCapabilityStore.trigger.capabilitiesReset();
+    stop = startGatewayCapabilityObserver();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    stop();
+    gatewayCapabilityStore.trigger.capabilitiesReset();
+    server.close();
+  });
+
+  it("Should record the backstop and re-evaluate capabilities from a loopback 403 envelope", async () => {
+    server.use(
+      http.get(`*${SCHEDULER_PATH}`, () =>
+        HttpResponse.json(loopbackEnvelope("loopback_mutation_required"), {
+          status: 403,
+          headers: { "X-Compozy-Gateway-Tier": "private" },
+        })
+      )
+    );
+    server.listen({ onUnhandledRequest: "bypass" });
+
+    await apiClient.GET(SCHEDULER_PATH);
+
+    const { context } = gatewayCapabilityStore.getSnapshot();
+    expect(context.tier).toBe("private");
+    // Capabilities re-derived from the refusing response's tier header
+    // (stale-map convergence, US-002.EC-2) — the remote read set.
+    expect(context.capabilities).toEqual(capabilitiesForTier("private"));
+    expect(context.loopbackOnly).toBe("mutation");
+  });
+
+  it("Should classify loopback_api_required the same way", async () => {
+    server.use(
+      http.get(`*${SCHEDULER_PATH}`, () =>
+        HttpResponse.json(loopbackEnvelope("loopback_api_required"), {
+          status: 403,
+          headers: { "X-Compozy-Gateway-Tier": "private" },
+        })
+      )
+    );
+    server.listen({ onUnhandledRequest: "bypass" });
+
+    await apiClient.GET(SCHEDULER_PATH);
+
+    expect(gatewayCapabilityStore.getSnapshot().context.loopbackOnly).toBe("api");
+  });
+
+  it("Should clear the refusal when a later response latches the local tier", async () => {
+    server.use(
+      http.get(
+        `*${SCHEDULER_PATH}`,
+        () =>
+          new HttpResponse(JSON.stringify(loopbackEnvelope("loopback_api_required")), {
+            status: 403,
+            headers: { "X-Compozy-Gateway-Tier": "private" },
+          })
+      )
+    );
+    server.listen({ onUnhandledRequest: "bypass" });
+
+    await apiClient.GET(SCHEDULER_PATH);
+    expect(gatewayCapabilityStore.getSnapshot().context.loopbackOnly).toBe("api");
+
+    // The operator reconnects at the daemon host: the next observation latches
+    // `local` and the stale refusal clears (BR-4, US-002.EC-1 counterpart).
+    server.use(
+      http.get(`*${SCHEDULER_PATH}`, () =>
+        HttpResponse.json({ paused: false }, { headers: { "X-Compozy-Gateway-Tier": "local" } })
+      )
+    );
+    await apiClient.GET(SCHEDULER_PATH);
+
+    const { context } = gatewayCapabilityStore.getSnapshot();
+    expect(context.tier).toBe("local");
+    expect(context.capabilities).toEqual(capabilitiesForTier("local"));
+    expect(context.loopbackOnly).toBeUndefined();
+  });
+});

--- a/web/src/systems/gateway/stores/__tests__/gateway-capability-store.test.ts
+++ b/web/src/systems/gateway/stores/__tests__/gateway-capability-store.test.ts
@@ -1,0 +1,120 @@
+// Suite: gateway capability store
+// Invariant: capabilities derive from the latched tier alone and re-evaluate on every tier
+// observation without an app restart (BR-4). A loopback 403 re-evaluates from the refusing
+// response (stale-map convergence, US-002.EC-2) and records the backstop signal; unrelated 403
+// codes never classify, and a `local` latch clears a stale loopback refusal.
+// Owning layer: the app-wide capability state between the shared transport and the gating consumers.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { reportGatewayListenerTier, reportGatewayResponse } from "@/lib/gateway-access-signal";
+
+import { capabilitiesForTier } from "../../lib/gateway-capabilities";
+import {
+  gatewayCapabilityStore,
+  startGatewayCapabilityObserver,
+} from "../gateway-capability-store";
+
+function jsonResponse(status: number, payload: unknown, tier?: string): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...(tier ? { "X-Compozy-Gateway-Tier": tier } : {}),
+    },
+  });
+}
+
+describe("gateway capability store", () => {
+  let stop: () => void;
+
+  beforeEach(() => {
+    gatewayCapabilityStore.trigger.capabilitiesReset();
+    stop = startGatewayCapabilityObserver();
+  });
+
+  afterEach(() => {
+    stop();
+    gatewayCapabilityStore.trigger.capabilitiesReset();
+  });
+
+  it("Should start unlatched and default-hidden", () => {
+    const { context } = gatewayCapabilityStore.getSnapshot();
+    expect(context.tier).toBeUndefined();
+    expect(context.capabilities).toEqual(capabilitiesForTier(undefined));
+  });
+
+  it("Should re-evaluate capabilities when the tier latches or changes, without a restart", () => {
+    // UT-007 (state, tier side): a new `/api/status` observation moves the
+    // capability set with no app restart (US-004.AC-1).
+    reportGatewayListenerTier("private");
+    expect(gatewayCapabilityStore.getSnapshot().context.capabilities).toEqual(
+      capabilitiesForTier("private")
+    );
+
+    reportGatewayListenerTier("local");
+    expect(gatewayCapabilityStore.getSnapshot().context.capabilities).toEqual(
+      capabilitiesForTier("local")
+    );
+  });
+
+  it("Should re-evaluate from a loopback 403 response", async () => {
+    // UT-007 (state, response side): one refusing response latches its tier
+    // header and records the loopback signal — a stale map converges from the
+    // response itself (US-002.EC-2).
+    await reportGatewayResponse(
+      jsonResponse(403, { error: "forbidden", code: "loopback_mutation_required" }, "private")
+    );
+
+    expect(gatewayCapabilityStore.getSnapshot().context).toMatchObject({
+      tier: "private",
+      capabilities: capabilitiesForTier("private"),
+      loopbackOnly: "mutation",
+    });
+  });
+
+  it("Should record the loopback backstop without degrading a latched local tier", async () => {
+    // A non-loopback local bind (e.g. LAN address) latches `local` yet still
+    // refuses privileged mutations: the tier map stays truthful and the
+    // backstop records exactly what the daemon refused.
+    reportGatewayListenerTier("local");
+
+    await reportGatewayResponse(jsonResponse(403, { code: "loopback_api_required" }));
+
+    expect(gatewayCapabilityStore.getSnapshot().context).toMatchObject({
+      tier: "local",
+      capabilities: capabilitiesForTier("local"),
+      loopbackOnly: "api",
+    });
+  });
+
+  it("Should not record the loopback backstop for an unrelated 403 code", async () => {
+    await reportGatewayResponse(
+      jsonResponse(403, { error: "forbidden", code: "workspace_home_forbidden" }, "private")
+    );
+
+    expect(gatewayCapabilityStore.getSnapshot().context.loopbackOnly).toBeUndefined();
+  });
+
+  it("Should keep the loopback backstop across remote tiers and clear it on a local latch", async () => {
+    await reportGatewayResponse(
+      jsonResponse(403, { code: "loopback_mutation_required" }, "private")
+    );
+    reportGatewayListenerTier("public");
+    expect(gatewayCapabilityStore.getSnapshot().context.loopbackOnly).toBe("mutation");
+
+    // On a loopback-bound listener the refused call would succeed, so a
+    // `local` latch makes the recorded refusal stale.
+    reportGatewayListenerTier("local");
+    expect(gatewayCapabilityStore.getSnapshot().context.loopbackOnly).toBeUndefined();
+  });
+
+  it("Should keep exactly one subscription when started more than once", async () => {
+    const second = startGatewayCapabilityObserver();
+    second();
+
+    await reportGatewayResponse(
+      jsonResponse(403, { code: "loopback_mutation_required" }, "private")
+    );
+    expect(gatewayCapabilityStore.getSnapshot().context.loopbackOnly).toBe("mutation");
+  });
+});

--- a/web/src/systems/gateway/stores/__tests__/gateway-capability-store.test.ts
+++ b/web/src/systems/gateway/stores/__tests__/gateway-capability-store.test.ts
@@ -57,6 +57,22 @@ describe("gateway capability store", () => {
     );
   });
 
+  it("Should fall back to the default-hidden set when /api/status latches unknown", async () => {
+    // US-001.EC-2: the authoritative status response carries no parsable tier
+    // header, so the tier publishes unknown and the all-false default-hidden
+    // set applies (BR-2) — the previously latched tier does not survive.
+    reportGatewayListenerTier("local");
+    expect(gatewayCapabilityStore.getSnapshot().context.tier).toBe("local");
+
+    const response = jsonResponse(200, {});
+    Object.defineProperty(response, "url", { value: "https://compozy.local/api/status" });
+    await reportGatewayResponse(response);
+
+    const { context } = gatewayCapabilityStore.getSnapshot();
+    expect(context.tier).toBeUndefined();
+    expect(context.capabilities).toEqual(capabilitiesForTier(undefined));
+  });
+
   it("Should re-evaluate from a loopback 403 response", async () => {
     // UT-007 (state, response side): one refusing response latches its tier
     // header and records the loopback signal — a stale map converges from the

--- a/web/src/systems/gateway/stores/gateway-access-store.ts
+++ b/web/src/systems/gateway/stores/gateway-access-store.ts
@@ -36,7 +36,7 @@ export const gatewayAccessStore = createStore({
       if (context.state === "ok" && context.tier === undefined) return undefined;
       return { ...context, state: "ok" as GatewayAccessState, tier: undefined };
     },
-    tierSignalled: (context, event: { tier: GatewayListenerTier }) => {
+    tierSignalled: (context, event: { tier: GatewayListenerTier | undefined }) => {
       if (context.tier === event.tier) return undefined;
       return { ...context, tier: event.tier };
     },

--- a/web/src/systems/gateway/stores/gateway-capability-store.ts
+++ b/web/src/systems/gateway/stores/gateway-capability-store.ts
@@ -1,0 +1,119 @@
+import { createStore } from "@xstate/store";
+
+import {
+  observeGatewayForbiddenResponse,
+  observeGatewayListenerTier,
+  type GatewayListenerTier,
+} from "@/lib/gateway-access-signal";
+
+import { capabilitiesForTier, type GatewayCapabilities } from "../lib/gateway-capabilities";
+import { classifyGatewayLoopback, type GatewayLoopbackSignal } from "../lib/gateway-loopback";
+
+export interface GatewayCapabilityState {
+  /** Latched listener tier; `undefined` until an observation carries a parsable tier. */
+  tier: GatewayListenerTier | undefined;
+  /** Derived from the tier alone; re-derived whenever the tier latches or changes. */
+  capabilities: GatewayCapabilities;
+  /**
+   * The most recent loopback-only 403 classification, if any — the backstop
+   * evidence that the daemon refused a call this listener cannot execute
+   * (US-002). Cleared when the tier latches `local`, where the same call
+   * would succeed; a retry on a remote tier re-sets it (US-002.EC-1).
+   */
+  loopbackOnly: GatewayLoopbackSignal | undefined;
+}
+
+/**
+ * What this browser's listener can execute, plus the loopback backstop.
+ *
+ * App-wide and module-scoped, like the access store: the tier is a property of
+ * the page's connection, not of any component. Capabilities derive from the
+ * latched tier only (no per-route discovery), so every tier observation
+ * re-evaluates visibility without an app restart (BR-4).
+ */
+export const gatewayCapabilityStore = createStore({
+  context: {
+    tier: undefined as GatewayListenerTier | undefined,
+    capabilities: capabilitiesForTier(undefined),
+    loopbackOnly: undefined as GatewayLoopbackSignal | undefined,
+  },
+  on: {
+    tierSignalled: (context, event: { tier: GatewayListenerTier }) => {
+      const capabilities = capabilitiesForTier(event.tier);
+      // A `local` latch makes any recorded loopback refusal stale: on a
+      // loopback-bound listener the refused call would succeed. Remote-to-
+      // remote changes keep it — the daemon-host guidance still holds.
+      const loopbackOnly = event.tier === "local" ? undefined : context.loopbackOnly;
+      if (
+        context.tier === event.tier &&
+        context.capabilities === capabilities &&
+        context.loopbackOnly === loopbackOnly
+      ) {
+        return undefined;
+      }
+      return { ...context, tier: event.tier, capabilities, loopbackOnly };
+    },
+    loopbackRefused: (context, event: { signal: GatewayLoopbackSignal }) => {
+      // Re-derive from the latched tier: `reportGatewayResponse` latched the
+      // refusing response's tier header first, so a stale capability map
+      // converges from the same response (US-002.EC-2).
+      const capabilities = capabilitiesForTier(context.tier);
+      if (context.loopbackOnly === event.signal && context.capabilities === capabilities) {
+        return undefined;
+      }
+      return { ...context, loopbackOnly: event.signal, capabilities };
+    },
+    // Returns the store to its unlatched initial state. The access boundary
+    // fires this when this browser's device standing resets (a restored
+    // session re-latches the tier from the next response); tests use it to
+    // start each case unlatched.
+    capabilitiesReset: context => {
+      if (
+        context.tier === undefined &&
+        context.capabilities === capabilitiesForTier(undefined) &&
+        context.loopbackOnly === undefined
+      ) {
+        return undefined;
+      }
+      return {
+        tier: undefined,
+        capabilities: capabilitiesForTier(undefined),
+        loopbackOnly: undefined,
+      };
+    },
+  },
+});
+
+let unobserve: (() => void) | null = null;
+let observerLeases = 0;
+
+/**
+ * Binds the store to the shared transport. Idempotent so several mounts (or a
+ * StrictMode double-invoke) keep exactly one subscription.
+ */
+export function startGatewayCapabilityObserver(): () => void {
+  if (observerLeases === 0) {
+    const stopTier = observeGatewayListenerTier(tier =>
+      gatewayCapabilityStore.trigger.tierSignalled({ tier })
+    );
+    const stopForbidden = observeGatewayForbiddenResponse((status, payload) => {
+      const signal = classifyGatewayLoopback(status, payload);
+      if (!signal) return;
+      gatewayCapabilityStore.trigger.loopbackRefused({ signal });
+    });
+    unobserve = () => {
+      stopTier();
+      stopForbidden();
+    };
+  }
+  observerLeases += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    observerLeases -= 1;
+    if (observerLeases !== 0) return;
+    unobserve?.();
+    unobserve = null;
+  };
+}

--- a/web/src/systems/gateway/stores/gateway-capability-store.ts
+++ b/web/src/systems/gateway/stores/gateway-capability-store.ts
@@ -10,7 +10,11 @@ import { capabilitiesForTier, type GatewayCapabilities } from "../lib/gateway-ca
 import { classifyGatewayLoopback, type GatewayLoopbackSignal } from "../lib/gateway-loopback";
 
 export interface GatewayCapabilityState {
-  /** Latched listener tier; `undefined` until an observation carries a parsable tier. */
+  /**
+   * Latched listener tier; `undefined` until a tier latches. An `/api/status`
+   * response without a parsable tier header also leaves it `undefined`
+   * (unknown — US-001.EC-2), re-deriving the default-hidden set (BR-2).
+   */
   tier: GatewayListenerTier | undefined;
   /** Derived from the tier alone; re-derived whenever the tier latches or changes. */
   capabilities: GatewayCapabilities;
@@ -38,7 +42,7 @@ export const gatewayCapabilityStore = createStore({
     loopbackOnly: undefined as GatewayLoopbackSignal | undefined,
   },
   on: {
-    tierSignalled: (context, event: { tier: GatewayListenerTier }) => {
+    tierSignalled: (context, event: { tier: GatewayListenerTier | undefined }) => {
       const capabilities = capabilitiesForTier(event.tier);
       // A `local` latch makes any recorded loopback refusal stale: on a
       // loopback-bound listener the refused call would succeed. Remote-to-

--- a/web/src/systems/notifications/components/__tests__/notification-presets-panel.test.tsx
+++ b/web/src/systems/notifications/components/__tests__/notification-presets-panel.test.tsx
@@ -294,4 +294,41 @@ describe("NotificationPresetsPanel", () => {
 
     expect(screen.getByText("Deliveries for archived profiles are paused.")).toBeInTheDocument();
   });
+
+  it("renders the registry read-only when the tier cannot mutate, with affordances absent", () => {
+    // Remote tiers register no enablement writes: create/toggle/delete go
+    // absent rather than disabled (BR-1); the enablement state stays readable.
+    render(
+      <NotificationPresetsPanel
+        presets={[builtInPreset, customPreset]}
+        isLoading={false}
+        error={null}
+        pendingName={null}
+        profile={marketingProfile}
+        canMutate={false}
+        onCreate={vi.fn()}
+        onToggle={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByTestId("settings-page-hooks-notification-preset-new")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("settings-page-hooks-notification-preset-row-task_terminal-toggle")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("settings-page-hooks-notification-preset-row-custom_failure-delete")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("settings-page-hooks-notification-preset-row-task_terminal-state")
+    ).toHaveTextContent("off");
+    expect(
+      screen.getByTestId("settings-page-hooks-notification-preset-row-custom_failure-state")
+    ).toHaveTextContent("enabled");
+    expect(
+      screen.getByTestId("settings-page-hooks-notification-preset-row-task_terminal")
+    ).toHaveTextContent("built-in");
+  });
 });

--- a/web/src/systems/notifications/components/notification-presets-panel.tsx
+++ b/web/src/systems/notifications/components/notification-presets-panel.tsx
@@ -102,18 +102,20 @@ export function NotificationPresetsPanel({
               {profile.name}
             </span>
           ) : null}
-          <Button
-            aria-expanded={createOpen}
-            data-testid="settings-page-hooks-notification-preset-new"
-            disabled={!canMutate || createPending}
-            onClick={() => setCreateOpen(open => !open)}
-            size="sm"
-            type="button"
-            variant="neutral"
-          >
-            <Plus className="size-3.5" />
-            New preset
-          </Button>
+          {canMutate ? (
+            <Button
+              aria-expanded={createOpen}
+              data-testid="settings-page-hooks-notification-preset-new"
+              disabled={createPending}
+              onClick={() => setCreateOpen(open => !open)}
+              size="sm"
+              type="button"
+              variant="neutral"
+            >
+              <Plus className="size-3.5" />
+              New preset
+            </Button>
+          ) : null}
         </div>
       }
     >
@@ -327,22 +329,37 @@ function NotificationPresetRow({
       </div>
       <div className="flex items-center justify-end gap-2">
         {showPending ? <Spinner className="size-3.5 text-muted" /> : null}
-        <Switch
-          aria-label={"Toggle " + preset.name}
-          checked={preset.enabled}
-          disabled={!canMutate || mutationPending}
-          onCheckedChange={next => onToggle(preset, next)}
-          data-testid={"settings-page-hooks-notification-preset-row-" + preset.name + "-toggle"}
-        />
-        {preset.built_in ? (
-          <Tooltip>
-            <TooltipTrigger render={<span className="inline-flex" />}>
-              {deleteButton}
-            </TooltipTrigger>
-            <TooltipContent>Built-in presets cannot be deleted.</TooltipContent>
-          </Tooltip>
+        {canMutate ? (
+          <>
+            <Switch
+              aria-label={"Toggle " + preset.name}
+              checked={preset.enabled}
+              disabled={mutationPending}
+              onCheckedChange={next => onToggle(preset, next)}
+              data-testid={"settings-page-hooks-notification-preset-row-" + preset.name + "-toggle"}
+            />
+            {preset.built_in ? (
+              <Tooltip>
+                <TooltipTrigger render={<span className="inline-flex" />}>
+                  {deleteButton}
+                </TooltipTrigger>
+                <TooltipContent>Built-in presets cannot be deleted.</TooltipContent>
+              </Tooltip>
+            ) : (
+              deleteButton
+            )}
+          </>
         ) : (
-          deleteButton
+          // Remote tiers register no enablement writes: the toggle and delete
+          // affordances are absent; the enablement state stays readable.
+          <Pill
+            data-testid={"settings-page-hooks-notification-preset-row-" + preset.name + "-state"}
+            mono
+            size="xs"
+            tone={preset.enabled ? "success" : "neutral"}
+          >
+            {preset.enabled ? "enabled" : "off"}
+          </Pill>
         )}
       </div>
     </li>

--- a/web/src/systems/os/apps/session/__tests__/session-window-content.test.tsx
+++ b/web/src/systems/os/apps/session/__tests__/session-window-content.test.tsx
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   forkMutation: { isPending: false, mutate: vi.fn() },
   selectSession: vi.fn(),
   sessionThreadProps: vi.fn(),
+  sidebarOpen: false,
   toastError: vi.fn(),
 }));
 
@@ -63,7 +64,7 @@ vi.mock("../use-session-window-controller", () => ({
       onNewSession: vi.fn(),
       onSelectSession: mocks.selectSession,
       onToggleThread: vi.fn(),
-      open: false,
+      open: mocks.sidebarOpen,
       rowDeleteDialog: { open: false },
       rowRenameDialog: { open: false },
       sessionActions: {},
@@ -215,7 +216,36 @@ describe("SessionWindowContent", () => {
     mocks.forkMutation.mutate.mockReset();
     mocks.selectSession.mockReset();
     mocks.sessionThreadProps.mockReset();
+    mocks.sidebarOpen = false;
     mocks.toastError.mockReset();
+  });
+
+  // Invariant (T6, frozen map in mobile-surface-truth-shell-390.html): at the
+  // touch tier the 264px sessions rail overlays the transcript instead of
+  // docking. The wrapper must opt back into a real display under the media
+  // query — Chromium never blockifies display:contents, so the rail would
+  // stay a docked flex child — and cast the overlay shadow only while open.
+  it("Should compose the touch-tier rail overlay on the sidebar wrapper", async () => {
+    mocks.sidebarOpen = true;
+    render(renderContent(deadSession));
+
+    const overlay = await screen.findByTestId("session-sidebar-overlay");
+    expect(overlay).toHaveClass("contents");
+    expect(overlay).toHaveClass("max-[760px]:block");
+    expect(overlay).toHaveClass("max-[760px]:absolute");
+    expect(overlay).toHaveClass("max-[760px]:inset-y-0");
+    expect(overlay).toHaveClass("max-[760px]:left-0");
+    expect(overlay).toHaveClass("max-[760px]:z-30");
+    expect(overlay).toHaveClass("max-[760px]:shadow-overlay");
+  });
+
+  it("Should keep the closed rail shadowless over the transcript", async () => {
+    render(renderContent(deadSession));
+
+    const overlay = await screen.findByTestId("session-sidebar-overlay");
+    expect(overlay).toHaveClass("contents");
+    expect(overlay).toHaveClass("max-[760px]:absolute");
+    expect(overlay).not.toHaveClass("max-[760px]:shadow-overlay");
   });
 
   it("Should bind Stop generation to prompt cancellation instead of session stopping", async () => {

--- a/web/src/systems/os/apps/session/session-window-content.tsx
+++ b/web/src/systems/os/apps/session/session-window-content.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 
 import { ThreadContentRail } from "@/components/assistant-ui/session-thread-content-rail";
 import { SESSION_THREAD_CONTENT_INSET_DEFAULT } from "@/components/assistant-ui/session-thread-content-rail-constants";
+import { cn } from "@/lib/utils";
 import { SessionThread } from "./session-thread-lazy";
 import { useSessionWindowController } from "./use-session-window-controller";
 import { WorktreeDialogActionsContext } from "../../contexts/worktree-dialog-actions-context";
@@ -218,8 +219,19 @@ export function SessionWindowContent({
     <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
       {/* Touch tier (S6/T6): at ≤760px the 264px sessions rail overlays the
           transcript instead of docking — the stream keeps full width and the
-          rail casts the overlay shadow. Desktop keeps the docked flex child. */}
-      <div className="contents max-[760px]:absolute max-[760px]:inset-y-0 max-[760px]:left-0 max-[760px]:z-30 max-[760px]:shadow-overlay">
+          rail casts the overlay shadow. Desktop keeps the docked flex child.
+          The box must opt back into a real display at the touch tier: Chromium
+          never blockifies display:contents, so an absolutely positioned
+          contents wrapper generates no box and the rail would stay docked.
+          The overlay shadow rides on the open state only, or a closed rail
+          would paint a 1px shadow ring down the transcript's left edge. */}
+      <div
+        data-testid="session-sidebar-overlay"
+        className={cn(
+          "contents max-[760px]:block max-[760px]:absolute max-[760px]:inset-y-0 max-[760px]:left-0 max-[760px]:z-30",
+          sidebar.open && "max-[760px]:shadow-overlay"
+        )}
+      >
         <SessionSidebar
           open={sidebar.open}
           sessions={sidebar.sessions}

--- a/web/src/systems/os/apps/session/session-window-content.tsx
+++ b/web/src/systems/os/apps/session/session-window-content.tsx
@@ -215,19 +215,24 @@ export function SessionWindowContent({
   };
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 overflow-hidden">
-      <SessionSidebar
-        open={sidebar.open}
-        sessions={sidebar.sessions}
-        disconnected={sidebar.disconnected}
-        collapsedThreadIds={sidebar.collapsedThreadIds}
-        view={sidebar.view}
-        currentSessionId={sessionId}
-        onToggleThread={sidebar.onToggleThread}
-        onSelectSession={sidebar.onSelectSession}
-        onNewSession={sidebar.onNewSession}
-        sessionActions={sidebar.sessionActions}
-      />
+    <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+      {/* Touch tier (S6/T6): at ≤760px the 264px sessions rail overlays the
+          transcript instead of docking — the stream keeps full width and the
+          rail casts the overlay shadow. Desktop keeps the docked flex child. */}
+      <div className="contents max-[760px]:absolute max-[760px]:inset-y-0 max-[760px]:left-0 max-[760px]:z-30 max-[760px]:shadow-overlay">
+        <SessionSidebar
+          open={sidebar.open}
+          sessions={sidebar.sessions}
+          disconnected={sidebar.disconnected}
+          collapsedThreadIds={sidebar.collapsedThreadIds}
+          view={sidebar.view}
+          currentSessionId={sessionId}
+          onToggleThread={sidebar.onToggleThread}
+          onSelectSession={sidebar.onSelectSession}
+          onNewSession={sidebar.onNewSession}
+          sessionActions={sidebar.sessionActions}
+        />
+      </div>
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <SessionWindowNotice
           agentName={agentName}

--- a/web/src/systems/os/apps/tasks/__tests__/task-detail-location.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/task-detail-location.test.tsx
@@ -1,0 +1,222 @@
+// Suite: task detail page body composition
+// Invariant: the page body offers exactly the affordances the latched tier's
+// route matrix registers — task/run lifecycle mutations (including clear-block
+// and the task PATCH behind the rail's priority/auto-enqueue editors) register
+// only on the local surface set, so the Now-strip lifecycle actions, the
+// properties-rail approval buttons and inline editors, and Start run are
+// absent (never disabled) on remote tiers (BR-1), while the read states
+// (attention bands, approval rows, editor read rows) stay on every tier; the
+// local latch keeps the full shape (BR-5).
+// Boundary IN: the detail location's handler wiring and affordance presence.
+// Boundary OUT: the head chrome (task-detail-topbar suite), the presentational
+// components (task-overview-panel / task-properties-rail / task-runs-panel
+// suites), and the page hook verbs (use-task-detail-page suite).
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactElement, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
+import { renderWithTopbar } from "@/test/render-with-topbar";
+
+vi.mock("@tanstack/react-router", async importOriginal => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: Record<string, unknown>) => (
+      <a href={typeof to === "string" ? to : "#"} {...(props as Record<string, unknown>)}>
+        {children as ReactNode}
+      </a>
+    ),
+  };
+});
+
+vi.mock("../task-detail-overlays", () => ({ TaskDetailOverlays: () => null }));
+vi.mock("../task-detail-topbar", () => ({ TaskDetailTopbar: () => null }));
+
+const mocks = vi.hoisted(() => ({
+  controller: null as unknown,
+}));
+
+vi.mock("../use-task-detail-location", () => ({
+  useTaskDetailLocation: () => mocks.controller,
+}));
+
+import { buildDetailFixture } from "@/systems/tasks/mocks/fixtures";
+import type { TaskCommandState } from "@/systems/tasks";
+import { TaskDetailLocation } from "../task-detail-location";
+import type { TaskDetailLocationController } from "../use-task-detail-location";
+
+/** A start-able draft: the Runs tab can offer Start run on the local tier. */
+const START_COMMAND: TaskCommandState = {
+  canFanOut: false,
+  overflow: {
+    cancel: false,
+    delete: false,
+    edit: false,
+    pause: false,
+    resume: false,
+    startNewRun: false,
+  },
+  primary: { kind: "start" },
+  secondary: { edit: false, pause: false, reject: false },
+};
+
+function buildController({ tab = "overview" }: { tab?: "overview" | "runs" } = {}) {
+  const detail = buildDetailFixture({
+    runs: [],
+    summary: { active_run: null, status: "needs_attention" },
+    task: {
+      approval_state: "pending",
+      blocked_reasons: [
+        { reason: "Paused by operator", source: "paused" },
+        { block_id: "block_001", reason: "Waiting on creator input", source: "block" },
+      ],
+      status: "needs_attention",
+    },
+  } as never);
+  return {
+    activeElapsed: "",
+    backToTasks: vi.fn(),
+    command: START_COMMAND,
+    copyTaskId: vi.fn(),
+    detail,
+    openRun: vi.fn(),
+    openTask: vi.fn(),
+    page: {
+      detailError: null,
+      detailLoading: false,
+      fatalError: null,
+      handleApproveTask: vi.fn(),
+      handleClearBlock: vi.fn(),
+      handleEnqueueRun: vi.fn(),
+      handleRejectTask: vi.fn(),
+      handleRecoverTask: vi.fn(),
+      handleResumeTask: vi.fn(),
+      isApprovePending: false,
+      isClearBlockPending: false,
+      isEnqueuePending: false,
+      isLive: false,
+      isRejectPending: false,
+      isRecoverPending: false,
+      isResumePending: false,
+      isTimelineSaturated: false,
+      notFound: false,
+      profile: null,
+      reviews: [],
+      runs: [],
+      runsError: null,
+      runsLoading: false,
+      timeline: [],
+      timelineError: null,
+      timelineLoading: false,
+    },
+    record: detail.task,
+    runDurations: new Map<string, string>(),
+    scrollToResult: vi.fn(),
+    search: { tab },
+    setInspectOpen: vi.fn(),
+    setSetupOpen: vi.fn(),
+    setTab: vi.fn(),
+    updatePending: false,
+  } as unknown as TaskDetailLocationController;
+}
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function detailUi(tab: "overview" | "runs"): ReactElement {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TaskDetailLocation search={{ tab }} taskId="task_001" />
+    </QueryClientProvider>
+  );
+}
+
+function renderDetail(controller: TaskDetailLocationController) {
+  mocks.controller = controller;
+  return renderWithTopbar(detailUi("overview"));
+}
+
+/** Switches to the Runs tab by swapping the controller fixture and rerendering. */
+function rerenderRunsTab(view: { rerender: (ui: ReactNode) => void }) {
+  mocks.controller = buildController({ tab: "runs" });
+  view.rerender(detailUi("runs"));
+}
+
+describe("TaskDetailLocation", () => {
+  let unlatch: () => void;
+  beforeEach(() => {
+    // Task/run lifecycle affordances render on the local tier (BR-5).
+    unlatch = latchGatewayTierForTest("local");
+  });
+  afterEach(() => unlatch());
+
+  it("Should keep the lifecycle affordances and the read states on the local tier", () => {
+    renderDetail(buildController());
+
+    expect(screen.getByTestId("tasks-detail-now-approval")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-approve")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-reject")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-resume")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-recover")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-clear-block-block_001")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-rail-approve")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-rail-reject")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-rail-priority")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-rail-auto-enqueue")).toBeInTheDocument();
+  });
+
+  it("Should wire the overview approval buttons to the page verbs", async () => {
+    const user = userEvent.setup();
+    const controller = buildController();
+    renderDetail(controller);
+
+    await user.click(screen.getByTestId("tasks-detail-now-approve"));
+
+    expect(controller.page.handleApproveTask).toHaveBeenCalledTimes(1);
+  });
+
+  it("Should offer Start run on the local tier when the command state allows it", () => {
+    const view = renderDetail(buildController());
+    rerenderRunsTab(view);
+
+    expect(screen.getByTestId("tasks-runs-start")).toBeInTheDocument();
+  });
+
+  it("Should keep the read states while dropping every lifecycle affordance on a remote tier", () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    const view = renderDetail(buildController());
+
+    // Read states stay on every tier; only the mutation affordances go absent.
+    expect(screen.getByTestId("tasks-detail-now-approval")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-paused")).toBeInTheDocument();
+    // The block band itself is a read state; its Clear-block button is not.
+    expect(screen.getByTestId("tasks-detail-now-block-block_001")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-stuck")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-rail")).toBeInTheDocument();
+
+    expect(screen.queryByTestId("tasks-detail-now-approve")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-reject")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-resume")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-recover")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-clear-block-block_001")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-rail-approve")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-rail-reject")).not.toBeInTheDocument();
+
+    // The PATCH-backed rail editors go absent while their read rows keep the
+    // current values (BR-1 — absent, never disabled).
+    const rail = within(screen.getByTestId("tasks-detail-rail"));
+    expect(screen.queryByTestId("tasks-rail-priority")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-rail-auto-enqueue")).not.toBeInTheDocument();
+    expect(rail.getByText("Priority")).toBeInTheDocument();
+    expect(rail.getByText("High")).toBeInTheDocument();
+    expect(rail.getByText("Auto-enqueue")).toBeInTheDocument();
+    expect(rail.getByText("Off")).toBeInTheDocument();
+
+    rerenderRunsTab(view);
+
+    expect(screen.queryByTestId("tasks-runs-start")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/systems/os/apps/tasks/__tests__/task-detail-topbar.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/task-detail-topbar.test.tsx
@@ -1,0 +1,151 @@
+// Suite: task detail topbar composition
+// Invariant: the window head offers exactly the affordances the latched tier's
+// route matrix registers — task/run lifecycle mutations register only on the
+// local surface set, so they are absent (never disabled) on remote tiers
+// (BR-1), while reads (open run, copy id) stay on every tier.
+// Boundary IN: the topbar composition over the task command state.
+// Boundary OUT: the command state machine (task-command-state suite) and the
+// presentational action/overflow components (task-page-head suite).
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
+import { renderWithTopbar } from "@/test/render-with-topbar";
+
+vi.mock("@tanstack/react-router", async importOriginal => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: Record<string, unknown>) => (
+      <a href={typeof to === "string" ? to : "#"} {...(props as Record<string, unknown>)}>
+        {children as ReactNode}
+      </a>
+    ),
+  };
+});
+
+import type { TaskCommandState } from "@/systems/tasks";
+import type { TaskDetailLocationController } from "../use-task-detail-location";
+import { TaskDetailTopbar } from "../task-detail-topbar";
+
+/** A mid-lifecycle task: every mutation affordance the head can offer. */
+const MUTATION_COMMAND: TaskCommandState = {
+  canFanOut: true,
+  overflow: {
+    cancel: true,
+    delete: true,
+    edit: true,
+    pause: true,
+    resume: true,
+    startNewRun: true,
+  },
+  primary: { kind: "retry", runId: "run_001" },
+  secondary: { edit: true, pause: true, reject: true },
+};
+
+const OPEN_RUN_COMMAND: TaskCommandState = {
+  canFanOut: false,
+  overflow: {
+    cancel: false,
+    delete: false,
+    edit: false,
+    pause: false,
+    resume: false,
+    startNewRun: false,
+  },
+  primary: { kind: "open_run", runId: "run_001" },
+  secondary: { edit: false, pause: false, reject: false },
+};
+
+type DetailOverrides = Partial<Pick<TaskDetailLocationController, "command" | "showFanOut">>;
+
+function detailController({ command = MUTATION_COMMAND, showFanOut = true }: DetailOverrides = {}) {
+  return {
+    backToTasks: vi.fn(),
+    command,
+    copyTaskId: vi.fn(),
+    openEdit: vi.fn(),
+    openRun: vi.fn(),
+    page: {
+      handleApproveTask: vi.fn(),
+      handleCancelTask: vi.fn(),
+      handleEnqueueRun: vi.fn(),
+      handlePublishTask: vi.fn(),
+      handleRecoverTask: vi.fn(),
+      handleRejectTask: vi.fn(),
+      handleResumeTask: vi.fn(),
+      handleRetryRun: vi.fn(),
+      isApprovePending: false,
+      isCancelPending: false,
+      isEnqueuePending: false,
+      isPausePending: false,
+      isPublishPending: false,
+      isRecoverPending: false,
+      isRejectPending: false,
+      isResumePending: false,
+      isRetryPending: false,
+    },
+    pauseDialog: { open: vi.fn() },
+    record: { id: "task_001", status: "failed", title: "Scratch plan" },
+    setDeleteOpen: vi.fn(),
+    setFanOutOpen: vi.fn(),
+    showFanOut,
+    taskId: "task_001",
+  } as unknown as TaskDetailLocationController;
+}
+
+describe("TaskDetailTopbar", () => {
+  let unlatch: () => void;
+  beforeEach(() => {
+    unlatch = latchGatewayTierForTest("local");
+  });
+  afterEach(() => unlatch());
+
+  it("Should offer the lifecycle mutations on the local tier", async () => {
+    const user = userEvent.setup();
+    renderWithTopbar(<TaskDetailTopbar controller={detailController()} />);
+
+    expect(screen.getByTestId("tasks-detail-primary-retry")).toHaveTextContent("Retry");
+    expect(screen.getByTestId("tasks-detail-edit-button")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-reject-button")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    expect(await screen.findByTestId("tasks-detail-cancel")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-start-new-run")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-fan-out")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-delete")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-copy-id")).toBeInTheDocument();
+  });
+
+  it("Should drop the lifecycle mutations on a remote tier while keeping the reads", async () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    const user = userEvent.setup();
+    renderWithTopbar(<TaskDetailTopbar controller={detailController()} />);
+
+    expect(screen.queryByTestId("tasks-detail-primary-retry")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-edit-button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-reject-button")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    expect(await screen.findByTestId("tasks-detail-copy-id")).toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-cancel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-start-new-run")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-fan-out")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-delete")).not.toBeInTheDocument();
+  });
+
+  it("Should keep the open-run read affordance on a remote tier", () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    renderWithTopbar(
+      <TaskDetailTopbar
+        controller={detailController({ command: OPEN_RUN_COMMAND, showFanOut: false })}
+      />
+    );
+
+    expect(screen.getByTestId("tasks-detail-primary-open_run")).toBeInTheDocument();
+  });
+});

--- a/web/src/systems/os/apps/tasks/__tests__/task-editor-dialogs.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/task-editor-dialogs.test.tsx
@@ -1,0 +1,139 @@
+// Suite: task editor dialog tier presence
+// Invariant: the deep-linkable task editor dialogs offer the interactive modal
+// only on a tier whose route matrix registers the task create/PATCH routes —
+// POST /api/tasks (and the first-run enqueue) and PATCH /api/tasks/:id register
+// only under `includeTaskMutations` (`routes.go:216-221`), with no 403 code for
+// the truthful loopback-only state to render (BR-3). On remote tiers the
+// modals go absent (never disabled), so the deep links land on the read view
+// the window renders beneath; the local latch keeps the editor (BR-5).
+// Boundary IN: the dialog components' tier gating and modal presence.
+// Boundary OUT: the editor state hooks (use-task-editor-state suite), the
+// presentational modal (task-editor-modal suite), and the window underlays
+// (tasks-catalog-location / task-detail-location suites).
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider, UIProvider } from "@compozy/ui";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  createSubmit: vi.fn(),
+  createTemplateChange: vi.fn(),
+  createSetDraft: vi.fn(),
+  editSubmit: vi.fn(),
+  editSetDraft: vi.fn(),
+}));
+
+vi.mock("@/systems/status", () => ({
+  useDaemonStatus: () => ({ data: undefined }),
+}));
+
+vi.mock("../hooks/use-tasks-navigation", () => ({
+  useTasksNavigation: () => mocks.navigate,
+}));
+
+vi.mock("../../../hooks/use-window-live-data-enabled", () => ({
+  useCurrentWindowLiveDataEnabled: () => true,
+}));
+
+vi.mock("@/systems/workspace/hooks/use-active-workspace", () => ({
+  useActiveWorkspace: () => ({
+    workspaces: [{ id: "ws_alpha", name: "Alpha", root_dir: "/workspace/alpha" }],
+  }),
+}));
+
+vi.mock("@/systems/tasks", async importOriginal => {
+  const actual = await importOriginal<typeof import("@/systems/tasks")>();
+  const editorLib = await import("@/systems/tasks/lib/task-editor");
+  const draft = { ...editorLib.createTaskEditorDraft("one_shot", "ws_alpha"), title: "Review" };
+  return {
+    ...actual,
+    useTaskCreateState: () => ({
+      draft,
+      handleTemplateChange: mocks.createTemplateChange,
+      handleSubmit: mocks.createSubmit,
+      isScopeResolving: false,
+      isSubmitting: false,
+      profileDestination: null,
+      setDraft: mocks.createSetDraft,
+      templateId: "one_shot",
+      workspaces: [],
+    }),
+    useTaskEditState: () => ({
+      draft,
+      handleSubmit: mocks.editSubmit,
+      isInitialized: true,
+      isLoading: false,
+      isSubmitting: false,
+      setDraft: mocks.editSetDraft,
+      task: null,
+    }),
+  };
+});
+
+import { TaskCreateDialog, TaskEditDialog } from "../task-editor-dialogs";
+
+function renderDialog(ui: ReactElement) {
+  return render(
+    <UIProvider reducedMotion="always">
+      <TooltipProvider delay={0}>{ui}</TooltipProvider>
+    </UIProvider>
+  );
+}
+
+describe("TaskEditorDialogs", () => {
+  let unlatch: () => void;
+  beforeEach(() => {
+    // The editors render their interactive shape on the local tier (BR-5).
+    unlatch = latchGatewayTierForTest("local");
+  });
+  afterEach(() => unlatch());
+
+  it("Should render the create editor on the local tier", () => {
+    renderDialog(<TaskCreateDialog catalogMode="list" search={{}} />);
+
+    expect(screen.getByTestId("task-editor-modal")).toHaveAttribute("data-mode", "new");
+  });
+
+  it("Should render the edit editor on the local tier", () => {
+    renderDialog(<TaskEditDialog search={{ tab: "overview" }} taskId="task_001" />);
+
+    expect(screen.getByTestId("task-editor-modal")).toHaveAttribute("data-mode", "edit");
+  });
+
+  // Invariant: the deep-linked /tasks/$id/edit offers no editor modal on a
+  // remote tier (BR-1 — absent, never disabled); the window underlay's task
+  // detail read view is what the location lands on, and no save path exists
+  // to fire the doomed PATCH.
+  // Owning layer: task editor dialog composition.
+  // Canonical suite: TaskEditorDialogs component tests.
+  it("Should not offer the edit editor on a remote tier, leaving the deep link on the read view", () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    const { container } = renderDialog(
+      <TaskEditDialog search={{ tab: "overview" }} taskId="task_001" />
+    );
+
+    expect(screen.queryByTestId("task-editor-modal")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+    expect(mocks.editSubmit).not.toHaveBeenCalled();
+  });
+
+  // Invariant: the deep-linked /tasks/new offers no editor modal on a remote
+  // tier (BR-1 — absent, never disabled); the window underlay's catalog read
+  // view is what the location lands on, and no save path exists to fire the
+  // doomed POST.
+  // Owning layer: task editor dialog composition.
+  // Canonical suite: TaskEditorDialogs component tests.
+  it("Should not offer the create editor on a remote tier, leaving the deep link on the catalog read view", () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    const { container } = renderDialog(<TaskCreateDialog catalogMode="list" search={{}} />);
+
+    expect(screen.queryByTestId("task-editor-modal")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
+    expect(mocks.createSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/systems/os/apps/tasks/__tests__/task-run-topbar.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/task-run-topbar.test.tsx
@@ -1,0 +1,102 @@
+// Suite: task run topbar composition
+// Invariant: the run head offers exactly the affordances the latched tier's
+// route matrix registers — run mutations (retry/cancel/recover/release/
+// force-fail) register only on the local surface set, so they are absent
+// (never disabled) on remote tiers (BR-1), while the session and copy reads
+// stay on every tier.
+// Boundary IN: the topbar composition over the run page data.
+// Boundary OUT: the presentational action/overflow components (task-run
+// page-head suite) and the run page hook suites.
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
+import { renderWithTopbar } from "@/test/render-with-topbar";
+
+import type { TaskRunLocationController } from "../use-task-run-location";
+import { TaskRunTopbar } from "../task-run-topbar";
+
+function runController({
+  runStatus = "failed",
+  canRecover = false,
+}: { runStatus?: "failed" | "running"; canRecover?: boolean } = {}) {
+  return {
+    backToTask: vi.fn(),
+    backToTasks: vi.fn(),
+    canRecover,
+    copyRunId: vi.fn(),
+    forceFailDialog: { open: vi.fn() },
+    openSession: vi.fn(),
+    page: {
+      handleCancelRun: vi.fn(),
+      handleForceReleaseRun: vi.fn(),
+      handleRecoverRun: vi.fn(),
+      handleRetryRun: vi.fn(),
+      isCancelPending: false,
+      isForceReleasePending: false,
+      isRecoverPending: false,
+      isRetryPending: false,
+      run: {
+        run: {
+          attempt: 1,
+          session_id: "sess_001",
+          status: runStatus,
+        },
+      },
+      task: { task: { max_attempts: 3, title: "Scratch plan" } },
+    },
+    record: { attempt: 1, status: runStatus },
+    taskId: "task_001",
+  } as unknown as TaskRunLocationController;
+}
+
+describe("TaskRunTopbar", () => {
+  let unlatch: () => void;
+  beforeEach(() => {
+    unlatch = latchGatewayTierForTest("local");
+  });
+  afterEach(() => unlatch());
+
+  it("Should offer the run retry on the local tier when attempts remain", () => {
+    renderWithTopbar(<TaskRunTopbar controller={runController()} />);
+
+    expect(screen.getByTestId("tasks-run-retry")).toBeInTheDocument();
+  });
+
+  it("Should drop the run retry on a remote tier while keeping the session read", () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    renderWithTopbar(<TaskRunTopbar controller={runController()} />);
+
+    expect(screen.queryByTestId("tasks-run-retry")).not.toBeInTheDocument();
+    expect(screen.getByTestId("tasks-run-open-session")).toBeInTheDocument();
+  });
+
+  it("Should offer the run mutations behind the overflow on the local tier", async () => {
+    const user = userEvent.setup();
+    renderWithTopbar(
+      <TaskRunTopbar controller={runController({ canRecover: true, runStatus: "running" })} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    expect(await screen.findByTestId("tasks-run-recover")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-run-cancel")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-run-copy-id")).toBeInTheDocument();
+  });
+
+  it("Should drop the run mutations behind the overflow on a remote tier", async () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    const user = userEvent.setup();
+    renderWithTopbar(
+      <TaskRunTopbar controller={runController({ canRecover: true, runStatus: "running" })} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "More actions" }));
+    expect(await screen.findByTestId("tasks-run-copy-id")).toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-run-recover")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-run-cancel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-run-force-fail")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/systems/os/apps/tasks/__tests__/tasks-catalog-location.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/tasks-catalog-location.test.tsx
@@ -265,12 +265,16 @@ describe("TasksCatalogLocation", () => {
 
   it("Should omit the kanban retry affordance when the tier cannot execute it", () => {
     // Re-latch over the suite's `local` default: the remote shape asserts the
-    // same board renders with both lifecycle handlers absent.
-    latchGatewayTierForTest("private");
+    // same board renders with both lifecycle handlers absent. The store is
+    // module-scoped, so the private latch's reset is captured and released
+    // here instead of leaking to tests that run after this one.
+    const unlatchPrivate = latchGatewayTierForTest("private");
     renderCatalog("kanban");
 
     expect(screen.getByTestId("tasks-kanban-view")).toBeInTheDocument();
     expect(mocks.kanbanProps?.onCreate).toBeUndefined();
     expect(mocks.kanbanProps?.onRetryTask).toBeUndefined();
+
+    unlatchPrivate();
   });
 });

--- a/web/src/systems/os/apps/tasks/__tests__/tasks-catalog-location.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/tasks-catalog-location.test.tsx
@@ -4,8 +4,9 @@
 // Canonical suite: TasksCatalogLocation component tests.
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 import { renderWithTopbar } from "@/test/render-with-topbar";
 
 const mocks = vi.hoisted(() => ({
@@ -173,7 +174,10 @@ function renderCatalog(mode?: "dashboard" | "kanban") {
 }
 
 describe("TasksCatalogLocation", () => {
+  let unlatch: () => void;
   beforeEach(() => {
+    // Task creation and lifecycle affordances render on the local tier.
+    unlatch = latchGatewayTierForTest("local");
     mocks.emptyStateProps = null;
     mocks.listSurfaceProps = null;
     mocks.page.isEmpty = false;
@@ -182,6 +186,7 @@ describe("TasksCatalogLocation", () => {
     mocks.page.profile.scopeLabel = "default";
     mocks.userOpen.mockReset();
   });
+  afterEach(() => unlatch());
 
   it("Should lead the strip with List and Kanban views while keeping them out of the head [UT-130]", () => {
     renderCatalog();

--- a/web/src/systems/os/apps/tasks/__tests__/tasks-catalog-location.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/tasks-catalog-location.test.tsx
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     workspaceName?: string | null;
   },
   listSurfaceProps: null as null | { profile: unknown },
+  kanbanProps: null as null | { onCreate?: unknown; onRetryTask?: unknown },
   navigate: vi.fn(),
   userOpen: vi.fn(),
   page: {
@@ -145,7 +146,10 @@ vi.mock("@/systems/tasks/components/public-api", () => ({
     );
   },
   TasksInboxView: () => <div data-testid="tasks-inbox-view" />,
-  TasksKanbanBoard: () => <div data-testid="tasks-kanban-view" />,
+  TasksKanbanBoard: (props: { onCreate?: unknown; onRetryTask?: unknown }) => {
+    mocks.kanbanProps = props;
+    return <div data-testid="tasks-kanban-view" />;
+  },
   TasksListSurface: (props: { profile: unknown }) => {
     mocks.listSurfaceProps = props;
     return <div data-testid="tasks-list-surface" />;
@@ -246,5 +250,27 @@ describe("TasksCatalogLocation", () => {
     expect(mocks.emptyStateProps).toMatchObject({
       profileScopeLabel: null,
     });
+  });
+
+  // Invariant: run retry hits a local-only lifecycle route, so the kanban
+  // retry affordance is absent on a remote tier and present on local (BR-1,
+  // same gate as the inbox triage handlers).
+  // Owning layer: Tasks catalog route composition.
+  // Canonical suite: TasksCatalogLocation component tests.
+  it("Should pass the local retry handler to the kanban board", () => {
+    renderCatalog("kanban");
+
+    expect(mocks.kanbanProps?.onRetryTask).toBe(mocks.page.handleRetryRun);
+  });
+
+  it("Should omit the kanban retry affordance when the tier cannot execute it", () => {
+    // Re-latch over the suite's `local` default: the remote shape asserts the
+    // same board renders with both lifecycle handlers absent.
+    latchGatewayTierForTest("private");
+    renderCatalog("kanban");
+
+    expect(screen.getByTestId("tasks-kanban-view")).toBeInTheDocument();
+    expect(mocks.kanbanProps?.onCreate).toBeUndefined();
+    expect(mocks.kanbanProps?.onRetryTask).toBeUndefined();
   });
 });

--- a/web/src/systems/os/apps/tasks/__tests__/use-task-detail-location.test.tsx
+++ b/web/src/systems/os/apps/tasks/__tests__/use-task-detail-location.test.tsx
@@ -1,13 +1,20 @@
 // Suite: Task detail location controller
-// Invariant: inspector-owned reads run only while the inspector is open in a live task window.
-// Boundary IN: task-detail location liveness and inspect URL state.
+// Invariant: inspector-owned reads run only while the inspector is open in a live task window, and
+// the controller's task PATCH/DELETE verbs (plus the profile DELETE behind clear-setup) no-op at
+// the origin when the latched tier cannot execute those local-only routes (BR-1).
+// Boundary IN: task-detail location liveness, inspect URL state, and mutation-verb origin gating.
 // Boundary OUT: operator query execution, owned by the task hook suites.
-import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 const hooks = vi.hoisted(() => ({
   liveDataEnabled: true,
   navigate: vi.fn(),
+  userOpen: vi.fn(),
+  deleteMutateAsync: vi.fn(),
+  updateMutateAsync: vi.fn(),
   useTaskSetupRuntime: vi.fn(),
   useTaskOperatorLayer: vi.fn(),
   useTaskDetailPage: vi.fn(),
@@ -18,7 +25,7 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("../../../hooks/use-os-shell", () => ({
-  useOsShell: () => ({ coordinator: { userOpen: vi.fn() } }),
+  useOsShell: () => ({ coordinator: { userOpen: hooks.userOpen } }),
 }));
 
 vi.mock("../../../hooks/use-window-live-data-enabled", () => ({
@@ -33,21 +40,27 @@ vi.mock("@/systems/tasks", () => ({
   TASK_RESULT_ANCHOR_ID: "task-result",
   computeElapsed: vi.fn(),
   resolveTaskCommandState: vi.fn(),
-  useDeleteTask: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useDeleteTask: () => ({ isPending: false, mutateAsync: hooks.deleteMutateAsync }),
   useLiveElapsed: () => 0,
   useProfileEditor: () => ({}),
   useTaskDetailPage: hooks.useTaskDetailPage,
   useTaskOperatorLayer: hooks.useTaskOperatorLayer,
   useTaskPauseDialog: () => ({}),
   useTaskSetupRuntime: hooks.useTaskSetupRuntime,
-  useUpdateTask: () => ({ isPending: false, mutateAsync: vi.fn() }),
+  useUpdateTask: () => ({ isPending: false, mutateAsync: hooks.updateMutateAsync }),
 }));
 
 import { useTaskDetailLocation } from "../use-task-detail-location";
 
+let unlatch: () => void;
+
 beforeEach(() => {
   vi.clearAllMocks();
   hooks.liveDataEnabled = true;
+  // The controller's PATCH/DELETE verbs gate on the latched tier at the
+  // origin: latch `local` so the suite's default shape keeps firing them,
+  // and unlatch so each case starts from a clean store.
+  unlatch = latchGatewayTierForTest("local");
   hooks.useTaskDetailPage.mockReturnValue({
     activeRun: null,
     detail: null,
@@ -61,6 +74,10 @@ beforeEach(() => {
   });
   hooks.useTaskOperatorLayer.mockReturnValue({});
   hooks.useTaskSetupRuntime.mockReturnValue({});
+});
+
+afterEach(() => {
+  unlatch();
 });
 
 describe("useTaskDetailLocation", () => {
@@ -118,5 +135,85 @@ describe("useTaskDetailLocation", () => {
     expect(hooks.useTaskSetupRuntime).toHaveBeenLastCalledWith("ws_northstar", {
       enabled: false,
     });
+  });
+
+  // Invariant: the controller's task PATCH/DELETE verbs (delete, priority,
+  // auto-enqueue, and the execution-profile DELETE behind clear-setup) hit
+  // routes registered only on the local surface set (`routes.go`
+  // `includeTaskMutations`), so at the origin they no-op on a remote tier —
+  // a wiring regression cannot fire a doomed request (BR-1).
+  // Owning layer: task-detail location controller.
+  // Canonical suite: useTaskDetailLocation hook tests.
+  it("Should fire the controller PATCH/DELETE verbs on the local tier", async () => {
+    hooks.useTaskDetailPage.mockReturnValue({
+      activeRun: null,
+      detail: {
+        task: { id: "task_001", priority: "low", auto_enqueue_on_ready: false },
+      },
+      handlePauseTask: vi.fn(),
+      isLive: false,
+      profile: null,
+      runs: [],
+      streamErrorMessage: null,
+      streamSeedSequence: 0,
+      streamState: "idle",
+    });
+    hooks.useTaskOperatorLayer.mockReturnValue({
+      handleSetProfile: vi.fn(),
+      handleDeleteProfile: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const { result } = renderHook(() => useTaskDetailLocation("task_001", { tab: "overview" }));
+
+    await act(async () => {
+      await result.current.handleDeleteTask("task_001");
+      await result.current.handlePriorityChange("high");
+      await result.current.handleAutoEnqueueChange(true);
+      await result.current.handleClearSetup();
+    });
+
+    expect(hooks.deleteMutateAsync).toHaveBeenCalledWith({ id: "task_001" });
+    expect(hooks.updateMutateAsync).toHaveBeenCalledWith({
+      id: "task_001",
+      data: { priority: "high" },
+    });
+    expect(hooks.updateMutateAsync).toHaveBeenCalledWith({
+      id: "task_001",
+      data: { auto_enqueue_on_ready: true },
+    });
+    expect(hooks.useTaskOperatorLayer().handleDeleteProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it("Should no-op the controller PATCH/DELETE verbs on a remote tier", async () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    hooks.useTaskDetailPage.mockReturnValue({
+      activeRun: null,
+      detail: {
+        task: { id: "task_001", priority: "low", auto_enqueue_on_ready: false },
+      },
+      handlePauseTask: vi.fn(),
+      isLive: false,
+      profile: null,
+      runs: [],
+      streamErrorMessage: null,
+      streamSeedSequence: 0,
+      streamState: "idle",
+    });
+
+    const { result } = renderHook(() => useTaskDetailLocation("task_001", { tab: "overview" }));
+
+    await act(async () => {
+      await result.current.handleDeleteTask("task_001");
+      await result.current.handlePriorityChange("high");
+      await result.current.handleAutoEnqueueChange(true);
+      await result.current.handleClearSetup();
+    });
+
+    expect(hooks.deleteMutateAsync).not.toHaveBeenCalled();
+    expect(hooks.updateMutateAsync).not.toHaveBeenCalled();
+    // The delete verb also skips its pre-mutation navigation: the operator
+    // stays on the record they were reading.
+    expect(hooks.userOpen).not.toHaveBeenCalled();
   });
 });

--- a/web/src/systems/os/apps/tasks/hooks/use-tasks-catalog-location.ts
+++ b/web/src/systems/os/apps/tasks/hooks/use-tasks-catalog-location.ts
@@ -1,0 +1,51 @@
+import { useNavigate } from "@tanstack/react-router";
+
+import { useGatewayCapabilities } from "@/systems/gateway";
+import {
+  DEFAULT_TASK_TEMPLATE_ID,
+  taskCatalogSearchFor,
+  type TasksRouteSearch,
+  type TaskTemplateId,
+  type TaskViewMode,
+  useTasksPage,
+  validateTasksSearch,
+} from "@/systems/tasks";
+
+import { useCurrentWindowLiveDataEnabled } from "../../../hooks/use-window-live-data-enabled";
+import { useOsShell } from "../../../hooks/use-os-shell";
+
+/**
+ * Tasks catalog data and behavior in one hook so the route component stays
+ * under the component-complexity budget.
+ */
+export function useTasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
+  const { coordinator } = useOsShell();
+  const liveDataEnabled = useCurrentWindowLiveDataEnabled();
+  const routeNavigate = useNavigate();
+  // Task/run mutations and the scheduler exist only on the local surface set.
+  // On remote tiers those affordances are absent, never disabled (BR-1); the
+  // read views (list, kanban, dashboard, inbox reads) render normally.
+  const { localTaskLifecycle } = useGatewayCapabilities();
+  const mode: TaskViewMode = search.mode ?? "list";
+  const page = useTasksPage({
+    liveDataEnabled,
+    search,
+    onSearchChange: update => {
+      void routeNavigate({
+        to: "/tasks",
+        search: current => update(validateTasksSearch(current)),
+        replace: true,
+      });
+    },
+  });
+  const navigate = (pathname: string, search: Record<string, unknown> = {}) =>
+    void coordinator.userOpen({ app: "tasks", route: { pathname, search } });
+  // The create dialog layers over this catalog, so the active view rides along
+  // and dismissal lands back on the view the operator was reading.
+  const openCreate = (template?: TaskTemplateId) =>
+    navigate("/tasks/new", {
+      ...taskCatalogSearchFor(mode, search),
+      ...(template && template !== DEFAULT_TASK_TEMPLATE_ID ? { template } : {}),
+    });
+  return { localTaskLifecycle, mode, navigate, openCreate, page };
+}

--- a/web/src/systems/os/apps/tasks/task-detail-location.tsx
+++ b/web/src/systems/os/apps/tasks/task-detail-location.tsx
@@ -15,6 +15,7 @@ import { TaskDetailOverlays } from "./task-detail-overlays";
 import { TASK_DETAIL_GRID_CLASS, TASK_DETAIL_RAIL_CLASS } from "./task-detail-layout";
 import { TaskDetailTopbar } from "./task-detail-topbar";
 import { useTaskDetailLocation } from "./use-task-detail-location";
+import { useGatewayCapabilities } from "@/systems/gateway";
 import {
   type ResolvedTaskDetailSearch,
   latestTaskRun,
@@ -80,6 +81,11 @@ export function TaskDetailLocation({
   search: ResolvedTaskDetailSearch;
 }) {
   const controller = useTaskDetailLocation(taskId, search);
+  // Task/run/review lifecycle mutations register only on the local surface
+  // set (`routes.go` `includeTaskMutations`): the page body renders those
+  // affordances only when the tier can execute them (BR-1 — absent, never
+  // disabled), while read affordances stay on every tier.
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const { page, detail, record, command } = controller;
   const completedRun = latestTaskRun(page.runs, "completed");
   const completedRunResult = useTaskRunResult({
@@ -175,11 +181,17 @@ export function TaskDetailLocation({
                     nowHandlers={{
                       onOpenRun: controller.openRun,
                       onOpenTask: controller.openTask,
-                      onApprove: () => void page.handleApproveTask(),
-                      onReject: () => void page.handleRejectTask(),
-                      onResume: () => void page.handleResumeTask(),
-                      onRecover: () => void page.handleRecoverTask(),
-                      onClearBlock: blockId => void page.handleClearBlock(blockId),
+                      onApprove: localTaskLifecycle
+                        ? () => void page.handleApproveTask()
+                        : undefined,
+                      onReject: localTaskLifecycle ? () => void page.handleRejectTask() : undefined,
+                      onResume: localTaskLifecycle ? () => void page.handleResumeTask() : undefined,
+                      onRecover: localTaskLifecycle
+                        ? () => void page.handleRecoverTask()
+                        : undefined,
+                      onClearBlock: localTaskLifecycle
+                        ? blockId => void page.handleClearBlock(blockId)
+                        : undefined,
                       onViewResult: controller.scrollToResult,
                     }}
                     nowPending={{
@@ -204,7 +216,14 @@ export function TaskDetailLocation({
                     errorMessage={page.runsError?.message ?? null}
                     isLoading={page.runsLoading}
                     isStartPending={page.isEnqueuePending}
-                    onStartRun={canStartRun ? () => void page.handleEnqueueRun() : undefined}
+                    // Start run enqueues a local-only run: the affordance
+                    // needs BOTH the tier capability and a start-able command
+                    // state (BR-1 — absent, never disabled).
+                    onStartRun={
+                      localTaskLifecycle && canStartRun
+                        ? () => void page.handleEnqueueRun()
+                        : undefined
+                    }
                     reviewsByRun={reviewsByRun}
                     runDurations={controller.runDurations}
                     runs={page.runs}
@@ -230,12 +249,28 @@ export function TaskDetailLocation({
                     reject: page.isRejectPending,
                   }}
                   detail={detail}
-                  onApprove={() => void page.handleApproveTask()}
-                  onAutoEnqueueChange={enabled => void controller.handleAutoEnqueueChange(enabled)}
-                  onEditSetup={() => controller.setSetupOpen(true)}
+                  onApprove={localTaskLifecycle ? () => void page.handleApproveTask() : undefined}
+                  // Priority/auto-enqueue persist through task PATCH
+                  // (`UpdateTask`), a local-only mutation route: the editors
+                  // go absent on remote tiers while their read rows stay
+                  // (BR-1 — absent, never disabled).
+                  onAutoEnqueueChange={
+                    localTaskLifecycle
+                      ? enabled => void controller.handleAutoEnqueueChange(enabled)
+                      : undefined
+                  }
+                  // Edit setup saves through the execution-profile PUT
+                  // (`SetTaskExecutionProfile`), a local-only mutation route:
+                  // the entry goes absent on remote tiers while the execution
+                  // read rows stay (BR-1 — absent, never disabled).
+                  onEditSetup={localTaskLifecycle ? () => controller.setSetupOpen(true) : undefined}
                   onInspect={() => controller.setInspectOpen(true)}
-                  onPriorityChange={priority => void controller.handlePriorityChange(priority)}
-                  onReject={() => void page.handleRejectTask()}
+                  onPriorityChange={
+                    localTaskLifecycle
+                      ? priority => void controller.handlePriorityChange(priority)
+                      : undefined
+                  }
+                  onReject={localTaskLifecycle ? () => void page.handleRejectTask() : undefined}
                   profile={page.profile}
                   runs={page.runs}
                   updatePending={controller.updatePending}

--- a/web/src/systems/os/apps/tasks/task-detail-topbar.tsx
+++ b/web/src/systems/os/apps/tasks/task-detail-topbar.tsx
@@ -1,7 +1,32 @@
 import { useTopbarSlot } from "@compozy/ui";
 
 import type { TaskDetailLocationController } from "./use-task-detail-location";
+import type { TaskCommandState } from "@/systems/tasks";
 import { TaskPageActions, TaskPageOverflow, TaskPageStatus } from "@/systems/tasks";
+import { useGatewayCapabilities } from "@/systems/gateway";
+
+/**
+ * Strips the lifecycle mutations from the command state. Task/run mutation
+ * routes register only under `includeTaskMutations` (`routes.go:216-252`), so
+ * on remote tiers those affordances go absent (BR-1) while navigation stays:
+ * `open_run` is a read, and with no primary and no secondaries left the
+ * actions render nothing.
+ */
+function readOnlyCommand(command: TaskCommandState): TaskCommandState {
+  return {
+    ...command,
+    primary: command.primary?.kind === "open_run" ? command.primary : null,
+    secondary: { edit: false, pause: false, reject: false },
+    overflow: {
+      edit: false,
+      pause: false,
+      resume: false,
+      cancel: false,
+      startNewRun: false,
+      delete: false,
+    },
+  };
+}
 
 /**
  * Publishes task-detail crumbs, status, and actions into the window topbar.
@@ -10,6 +35,10 @@ import { TaskPageActions, TaskPageOverflow, TaskPageStatus } from "@/systems/tas
  */
 export function TaskDetailTopbar({ controller }: { controller: TaskDetailLocationController }) {
   const { page, record, command } = controller;
+  // Task lifecycle mutations (publish/approve/start/pause/resume/recover/
+  // retry/cancel/fan-out/delete) register only on the local surface set: on
+  // remote tiers the affordances go absent while reads stay (BR-1).
+  const { localTaskLifecycle } = useGatewayCapabilities();
 
   useTopbarSlot(
     record && command
@@ -26,7 +55,7 @@ export function TaskDetailTopbar({ controller }: { controller: TaskDetailLocatio
           status: <TaskPageStatus status={record.status} />,
           actions: (
             <TaskPageActions
-              command={command}
+              command={localTaskLifecycle ? command : readOnlyCommand(command)}
               handlers={{
                 onPublish: () => void page.handlePublishTask(),
                 onApprove: () => void page.handleApproveTask(),
@@ -52,7 +81,7 @@ export function TaskDetailTopbar({ controller }: { controller: TaskDetailLocatio
           ),
           overflow: (
             <TaskPageOverflow
-              command={command}
+              command={localTaskLifecycle ? command : readOnlyCommand(command)}
               onCancel={() => void page.handleCancelTask()}
               onCopyId={controller.copyTaskId}
               onDelete={() => controller.setDeleteOpen(true)}
@@ -66,7 +95,9 @@ export function TaskDetailTopbar({ controller }: { controller: TaskDetailLocatio
                 resume: page.isResumePending,
                 enqueue: page.isEnqueuePending,
               }}
-              showFanOut={controller.showFanOut}
+              // Fan-out enqueues runs: local-only like the rest of the
+              // lifecycle, so the entry goes absent on remote tiers.
+              showFanOut={localTaskLifecycle && controller.showFanOut}
               taskId={record.id}
             />
           ),

--- a/web/src/systems/os/apps/tasks/task-editor-dialogs.tsx
+++ b/web/src/systems/os/apps/tasks/task-editor-dialogs.tsx
@@ -9,6 +9,7 @@ import {
   useTaskCreateState,
   useTaskEditState,
 } from "@/systems/tasks";
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useCurrentWindowLiveDataEnabled } from "../../hooks/use-window-live-data-enabled";
 import { toWorkspaceCommandSelectOptions, useActiveWorkspace } from "@/systems/workspace";
 
@@ -24,11 +25,21 @@ export function TaskCreateDialog({
   catalogMode: TaskViewMode;
   search: TaskCreateSearch;
 }) {
+  // Task create registers only on the local surface set (`routes.go`
+  // `includeTaskMutations`) — POST /api/tasks (and the first-run enqueue), with
+  // no 403 code for the truthful loopback-only state to render (BR-3). The
+  // modal goes absent on remote tiers (BR-1 — absent, never disabled), so the
+  // deep link lands on the catalog read view beneath, whose remote branch
+  // already renders the remote-note empty state instead of the local
+  // affordance.
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const navigate = useTasksNavigation();
   const liveDataEnabled = useCurrentWindowLiveDataEnabled();
   const backToCatalog = () =>
     navigate({ pathname: "/tasks", search: taskCatalogSearchFor(catalogMode, search) });
   const page = useTaskCreateState(search, navigate, { liveDataEnabled });
+
+  if (!localTaskLifecycle) return null;
 
   return (
     <TaskEditorModal
@@ -62,6 +73,14 @@ export function TaskEditDialog({
   search: ResolvedTaskDetailSearch;
   taskId: string;
 }) {
+  // Task PATCH (`UpdateTask`) registers only on the local surface set
+  // (`routes.go` `includeTaskMutations`), with no 403 code for the truthful
+  // loopback-only state to render (BR-3). The modal goes absent on remote
+  // tiers (BR-1 — absent, never disabled), so the deep link lands on the task
+  // detail read view beneath. The gate is deliberately presence-only (no
+  // redirect): firing a navigation while the tier is still unlatched would
+  // bounce a local operator off the deep link before `/api/status` resolves.
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const navigate = useTasksNavigation();
   const liveDataEnabled = useCurrentWindowLiveDataEnabled();
   // The edit chip echoes the entity's own scope; the list only resolves its name.
@@ -74,6 +93,8 @@ export function TaskEditDialog({
     : page.isInitialized
       ? "ready"
       : "unavailable";
+
+  if (!localTaskLifecycle) return null;
 
   return (
     <TaskEditorModal

--- a/web/src/systems/os/apps/tasks/task-run-topbar.tsx
+++ b/web/src/systems/os/apps/tasks/task-run-topbar.tsx
@@ -2,10 +2,15 @@ import { useTopbarSlot } from "@compozy/ui";
 
 import type { TaskRunLocationController } from "./use-task-run-location";
 import { TaskRunPageActions, TaskRunPageOverflow, TaskRunPageStatus } from "@/systems/tasks";
+import { useGatewayCapabilities } from "@/systems/gateway";
 
 /** Publishes the run-detail head (crumbs · run status · actions) into the window topbar. */
 export function TaskRunTopbar({ controller }: { controller: TaskRunLocationController }) {
   const { page, record } = controller;
+  // Run mutations (retry/cancel/recover/release/force-fail) register only on
+  // the local surface set (`routes.go` registerRunMutationRoutes): on remote
+  // tiers the affordances go absent while the session read stays (BR-1).
+  const { localTaskLifecycle } = useGatewayCapabilities();
 
   useTopbarSlot(
     page.run && record
@@ -30,13 +35,14 @@ export function TaskRunTopbar({ controller }: { controller: TaskRunLocationContr
               isRetryPending={page.isRetryPending}
               maxAttempts={page.task?.task.max_attempts}
               onOpenSession={controller.openSession}
-              onRetry={() => void page.handleRetryRun()}
+              onRetry={localTaskLifecycle ? () => void page.handleRetryRun() : undefined}
               run={page.run}
             />
           ),
           overflow: (
             <TaskRunPageOverflow
               canRecover={controller.canRecover}
+              lifecycleEnabled={localTaskLifecycle}
               onCancel={() => void page.handleCancelRun()}
               onCopyRunId={controller.copyRunId}
               onForceFail={controller.forceFailDialog.open}

--- a/web/src/systems/os/apps/tasks/tasks-catalog-location.tsx
+++ b/web/src/systems/os/apps/tasks/tasks-catalog-location.tsx
@@ -1,13 +1,10 @@
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { AlertCircle, ListChecks, Plus } from "lucide-react";
 
 import { BlockLoading, Button, Empty, ListingPage, RouteNav, useTopbarSlot } from "@compozy/ui";
 
-import { useOsShell } from "../../hooks/use-os-shell";
-import { useCurrentWindowLiveDataEnabled } from "../../hooks/use-window-live-data-enabled";
+import { useTasksCatalogLocation } from "./hooks/use-tasks-catalog-location";
 import {
-  DEFAULT_TASK_TEMPLATE_ID,
-  taskCatalogSearchFor,
   taskModeSearchFor,
   TasksDashboardView,
   TasksEmptyState,
@@ -16,10 +13,7 @@ import {
   TasksListSurface,
   TasksListToolbar,
   type TasksRouteSearch,
-  type TaskTemplateId,
   type TaskViewMode,
-  useTasksPage,
-  validateTasksSearch,
 } from "@/systems/tasks";
 
 const TASK_MODE_ITEMS: ReadonlyArray<{
@@ -34,30 +28,9 @@ const TASK_MODE_ITEMS: ReadonlyArray<{
 ];
 
 export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
-  const { coordinator } = useOsShell();
-  const liveDataEnabled = useCurrentWindowLiveDataEnabled();
-  const routeNavigate = useNavigate();
-  const mode: TaskViewMode = search.mode ?? "list";
-  const page = useTasksPage({
-    liveDataEnabled,
+  const { localTaskLifecycle, mode, navigate, openCreate, page } = useTasksCatalogLocation({
     search,
-    onSearchChange: update => {
-      void routeNavigate({
-        to: "/tasks",
-        search: current => update(validateTasksSearch(current)),
-        replace: true,
-      });
-    },
   });
-  const navigate = (pathname: string, search: Record<string, unknown> = {}) =>
-    void coordinator.userOpen({ app: "tasks", route: { pathname, search } });
-  // The create dialog layers over this catalog, so the active view rides along
-  // and dismissal lands back on the view the operator was reading.
-  const openCreate = (template?: TaskTemplateId) =>
-    navigate("/tasks/new", {
-      ...taskCatalogSearchFor(mode, search),
-      ...(template && template !== DEFAULT_TASK_TEMPLATE_ID ? { template } : {}),
-    });
   const modeNav = (
     <RouteNav aria-label="Tasks views" data-testid="tasks-mode-nav">
       {TASK_MODE_ITEMS.map(item => (
@@ -87,7 +60,7 @@ export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
   useTopbarSlot({
     glyph: <ListChecks />,
     count: mode === "list" && !page.listLoading ? page.tasksCount : undefined,
-    actions: (
+    actions: localTaskLifecycle ? (
       <Button
         data-testid="tasks-open-create"
         disabled={!page.hasActiveTaskScope}
@@ -98,7 +71,7 @@ export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
         <Plus className="size-3" />
         New task
       </Button>
-    ),
+    ) : null,
     // Route views lead the strip on every route (ADR-007/D3): the head stays
     // two-element, strip order views · filters · spacer · display-mode.
     toolbar: (
@@ -156,6 +129,7 @@ export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
           schedulerBacklogStatus={page.schedulerBacklogLoading ? "loading" : "ready"}
           schedulerErrorMessage={page.schedulerStatusError?.message ?? null}
           schedulerStatus={page.schedulerStatusLoading ? "loading" : "ready"}
+          schedulerAvailable={page.schedulerAvailable}
           schedulerPendingActions={
             new Set(
               [
@@ -177,15 +151,17 @@ export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
           isLoading={page.inboxLoading}
           isLoadingMore={page.isLoadingMoreInbox}
           laneFilter={page.inboxLaneFilter}
-          onApprove={page.handleApproveTask}
-          onArchive={page.handleArchiveTask}
-          onDismiss={page.handleDismissTask}
+          // Triage and run mutations are local-only lifecycle routes; without
+          // their handlers the rows render read-only (absent, not disabled).
+          onApprove={localTaskLifecycle ? page.handleApproveTask : undefined}
+          onArchive={localTaskLifecycle ? page.handleArchiveTask : undefined}
+          onDismiss={localTaskLifecycle ? page.handleDismissTask : undefined}
           onLaneChange={page.handleInboxLaneChange}
-          onMarkRead={page.handleMarkTaskRead}
+          onMarkRead={localTaskLifecycle ? page.handleMarkTaskRead : undefined}
           onLoadMore={page.loadMoreInbox}
           onPriorityChange={page.handleInboxPriorityChange}
-          onReject={page.handleRejectTask}
-          onRetry={page.handleRetryRun}
+          onReject={localTaskLifecycle ? page.handleRejectTask : undefined}
+          onRetry={localTaskLifecycle ? page.handleRetryRun : undefined}
           onRetryQuery={page.retryInbox}
           onSearchChange={page.setInboxSearchQuery}
           onStatusChange={page.handleInboxStatusChange}
@@ -203,11 +179,20 @@ export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
         />
       ) : page.isEmpty ? (
         <ListingPage data-testid="tasks-list-surface">
-          <TasksEmptyState
-            onSelectTemplate={openCreate}
-            profileScopeLabel={page.profile.scopeLabel}
-            workspaceName={page.activeWorkspaceName}
-          />
+          {localTaskLifecycle ? (
+            <TasksEmptyState
+              onSelectTemplate={openCreate}
+              profileScopeLabel={page.profile.scopeLabel}
+              workspaceName={page.activeWorkspaceName}
+            />
+          ) : (
+            <Empty
+              data-testid="tasks-list-remote-empty"
+              description="Create or run tasks from the machine running CompozyOS."
+              icon={ListChecks}
+              title="No tasks yet"
+            />
+          )}
         </ListingPage>
       ) : mode === "kanban" ? (
         <TasksKanbanBoard
@@ -216,7 +201,7 @@ export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
           hasMore={page.hasMoreTasks}
           isLoading={page.listLoading}
           isLoadingMore={page.isLoadingMoreTasks}
-          onCreate={() => openCreate()}
+          onCreate={localTaskLifecycle ? () => openCreate() : undefined}
           onRetryLoad={page.retryTasks}
           onRetryTask={page.handleRetryRun}
           onSelectTask={taskId => navigate(`/tasks/${encodeURIComponent(taskId)}`)}

--- a/web/src/systems/os/apps/tasks/tasks-catalog-location.tsx
+++ b/web/src/systems/os/apps/tasks/tasks-catalog-location.tsx
@@ -203,7 +203,10 @@ export function TasksCatalogLocation({ search }: { search: TasksRouteSearch }) {
           isLoadingMore={page.isLoadingMoreTasks}
           onCreate={localTaskLifecycle ? () => openCreate() : undefined}
           onRetryLoad={page.retryTasks}
-          onRetryTask={page.handleRetryRun}
+          // Run retry hits POST /api/runs/:id/retry, a local-only lifecycle
+          // route: the affordance goes absent on remote tiers, like the inbox
+          // triage handlers above (BR-1 — absent, never disabled).
+          onRetryTask={localTaskLifecycle ? page.handleRetryRun : undefined}
           onSelectTask={taskId => navigate(`/tasks/${encodeURIComponent(taskId)}`)}
           onLoadMore={page.loadMoreTasks}
           profile={page.profile}

--- a/web/src/systems/os/apps/tasks/use-task-detail-location.ts
+++ b/web/src/systems/os/apps/tasks/use-task-detail-location.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useOsShell } from "../../hooks/use-os-shell";
 import { useCurrentWindowLiveDataEnabled } from "../../hooks/use-window-live-data-enabled";
 import { copyTaskRecordId } from "./copy-record-id";
+import { useGatewayCapabilities } from "@/systems/gateway";
 import {
   computeElapsed,
   type ResolvedTaskDetailSearch,
@@ -39,6 +40,13 @@ export function useTaskDetailLocation(taskId: string, search: ResolvedTaskDetail
   const page = useTaskDetailPage(taskId, { liveDataEnabled });
   const deleteMutation = useDeleteTask();
   const updateMutation = useUpdateTask();
+  // Origin gate for the controller's task PATCH/DELETE verbs below (and the
+  // execution-profile DELETE behind clear-setup): those routes register only
+  // on the local surface set (`routes.go` `includeTaskMutations`). The
+  // affordances go absent at the composition layer (BR-1); this backstop
+  // mirrors the page-hook verbs in `useTaskDetailPage` so a wiring regression
+  // cannot fire a doomed request on a remote tier.
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const [overlay, setOverlay] = useState<"setup" | "setup_clear" | "fan_out" | "delete" | null>(
     null
   );
@@ -124,6 +132,7 @@ export function useTaskDetailLocation(taskId: string, search: ResolvedTaskDetail
   };
 
   const handleDeleteTask = async (id: string) => {
+    if (!localTaskLifecycle) return;
     void coordinator.userOpen({ app: "tasks", route: { pathname: "/tasks", search: {} } });
     try {
       await deleteMutation.mutateAsync({ id });
@@ -134,7 +143,7 @@ export function useTaskDetailLocation(taskId: string, search: ResolvedTaskDetail
   };
 
   const handlePriorityChange = async (priority: TaskPriority) => {
-    if (!record || record.priority === priority) return;
+    if (!localTaskLifecycle || !record || record.priority === priority) return;
     try {
       await updateMutation.mutateAsync({ id: record.id, data: { priority } });
     } catch (error) {
@@ -143,7 +152,7 @@ export function useTaskDetailLocation(taskId: string, search: ResolvedTaskDetail
   };
 
   const handleAutoEnqueueChange = async (enabled: boolean) => {
-    if (!record || Boolean(record.auto_enqueue_on_ready) === enabled) return;
+    if (!localTaskLifecycle || !record || Boolean(record.auto_enqueue_on_ready) === enabled) return;
     try {
       await updateMutation.mutateAsync({
         id: record.id,
@@ -155,6 +164,7 @@ export function useTaskDetailLocation(taskId: string, search: ResolvedTaskDetail
   };
 
   const handleClearSetup = async () => {
+    if (!localTaskLifecycle) return;
     try {
       await operator.handleDeleteProfile();
       setOverlay("setup");

--- a/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
+++ b/web/src/systems/os/apps/terminal/__tests__/use-terminal-window-controller-state.test.ts
@@ -10,7 +10,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, type ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { toast } from "@compozy/ui";
 import {
   closeTerminal,
@@ -33,6 +33,7 @@ import {
 import { parseSettingsWindowManagerSection } from "../../../lib/window-manager-settings-section";
 import { windowManagerClientFixture, windowManagerStorySnapshot } from "../../../mocks/fixtures";
 import { settingsWindowManagerSectionFixture } from "@/systems/settings/mocks/window-manager-fixtures";
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 import { WindowManagerRuntime } from "../../../runtime/window-manager-runtime";
 import { useTerminalWindowCreation } from "../hooks/use-terminal-window-creation";
 
@@ -72,7 +73,11 @@ const terminalExit = {
   signal: "HUP" as const,
 };
 
+let unlatchGatewayTier: () => void;
+
 beforeEach(() => {
+  // Terminal reads and the window surface render on the local tier only.
+  unlatchGatewayTier = latchGatewayTierForTest("local");
   vi.mocked(createTerminal).mockReset();
   vi.mocked(executeWindowManagerCommand).mockReset();
   vi.mocked(fetchTerminals).mockReset().mockResolvedValue([DEV_SERVER_TERMINAL]);
@@ -80,6 +85,10 @@ beforeEach(() => {
   vi.spyOn(toast, "error")
     .mockClear()
     .mockImplementation(() => "toast");
+});
+
+afterEach(() => {
+  unlatchGatewayTier();
 });
 
 // Invariant: terminal creation completes in its initiating query scope and cannot

--- a/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
+++ b/web/src/systems/os/apps/terminal/hooks/use-terminal-window-controller-state.ts
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { toast, type Filter } from "@compozy/ui";
 
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useProfileReadScope, useProfiles } from "@/systems/profiles";
 import { useSettingsGeneral } from "@/systems/settings";
 import {
@@ -87,17 +88,21 @@ export function useTerminalWindowControllerState(windowId: string) {
   const viewer: TerminalViewerIdentity | null =
     viewerId && viewerToken ? { id: viewerId, attachmentToken: viewerToken } : null;
   const workspaceId = workspace.runtimeWorkspaceId ?? "";
+  // Remote tiers register no terminal routes: the window renders the truthful
+  // loopback-only state, and none of these reads even run.
+  const { localTaskLifecycle } = useGatewayCapabilities();
+  const readsEnabled = workspaceId !== "" && localTaskLifecycle;
   const journalUnlocked = useTerminalJournalUnlocked(workspaceId);
   const catalogScope = terminalScope(workspaceId, profile.destination, profile.aggregate);
   const destinationScope = terminalScope(workspaceId, profile.destination);
   const journalScope = catalogScope;
   const catalog = useQuery({
     ...terminalCatalogQuery(catalogScope),
-    enabled: workspaceId !== "",
+    enabled: readsEnabled,
   });
   const inputRequestProjection = useQuery({
     ...terminalInputRequestsQuery(catalogScope),
-    enabled: workspaceId !== "",
+    enabled: readsEnabled,
   });
   const inputRequests = {
     data: inputRequestProjection.data?.pending,
@@ -110,7 +115,7 @@ export function useTerminalWindowControllerState(windowId: string) {
     ...terminalJournalQuery(journalScope, journalFilters),
     enabled: terminalJournalQueryEnabled(workspaceId, journalUnlocked),
   });
-  const recordings = useTerminalRecordings(catalogScope.key, workspaceId !== "");
+  const recordings = useTerminalRecordings(catalogScope.key, readsEnabled);
   const recordingScope = terminalScope(workspaceId, replay?.profile ?? profile.destination);
   const recording = useQuery({
     ...terminalRecordingQuery(recordingScope, replay?.id ?? ""),
@@ -122,7 +127,7 @@ export function useTerminalWindowControllerState(windowId: string) {
     profileKey: catalogScope.key.profileKey,
     allProfiles: profile.aggregate,
     profiles: profiles.data?.map(candidate => candidate.name) ?? [],
-    enabled: workspaceId !== "",
+    enabled: readsEnabled,
   });
 
   const terminalSelector = (terminalId: string) => ({

--- a/web/src/systems/os/apps/terminal/terminal-window.tsx
+++ b/web/src/systems/os/apps/terminal/terminal-window.tsx
@@ -1,6 +1,7 @@
 import { BlockLoading, Button, Empty, toast } from "@compozy/ui";
 import { AlertCircle, FolderOpen, TerminalSquare } from "lucide-react";
 
+import { LoopbackOnlyState, useGatewayCapabilities } from "@/systems/gateway";
 import { parsePositiveDurationMilliseconds } from "@/systems/settings";
 import {
   TerminalJournalPanel,
@@ -55,6 +56,13 @@ function TerminalWindowController({ windowId }: { windowId: string }) {
 
 function TerminalWindowLoadBoundary({ windowId }: { windowId: string }) {
   const { catalog, inputRequests, workspaceId } = useTerminalWindowControllerContext();
+  // Remote tiers register no terminal routes, so the surface never renders
+  // here — a stale dock entry, palette row, or deep link lands in the truthful
+  // loopback-only state instead of queries that can only refuse (S2, BR-3).
+  const { localTaskLifecycle } = useGatewayCapabilities();
+  if (!localTaskLifecycle) {
+    return <LoopbackOnlyState data-testid="terminal-window-loopback-only" />;
+  }
   if (workspaceId === "") {
     return (
       <div className="flex min-h-0 flex-1 items-center justify-center px-6 py-10">

--- a/web/src/systems/os/components/__tests__/desktop-menubar.test.tsx
+++ b/web/src/systems/os/components/__tests__/desktop-menubar.test.tsx
@@ -22,9 +22,12 @@ vi.mock("../../hooks/use-os-shell", () => ({
   useOsShell: () => ({ coordinator: { userOpen: vi.fn() } }),
 }));
 
+const MENUBAR_ACTIONS_STATE = vi.hoisted(() => ({ touchViewport: false }));
+
 vi.mock("../../hooks/use-menubar-actions", () => ({
   useMenubarActions: () => ({
     menusVisible: false,
+    touchViewport: MENUBAR_ACTIONS_STATE.touchViewport,
     canOpenApps: false,
     windowCommands: {},
     openApp: vi.fn(),
@@ -75,5 +78,62 @@ describe("DesktopMenubar scope control", () => {
     );
 
     expect(screen.getByTestId("os-global-scope-toggle")).toHaveAttribute("aria-disabled", "true");
+  });
+
+  // F3 real-device delta: at 390px the shrink-0 profile text row forced the
+  // identity segment under the trailing action cluster. It is the
+  // lowest-priority slot, so the touch tier drops it — absent, not cramped.
+  it("Should drop the profile switcher from the bar at the touch tier", () => {
+    MENUBAR_ACTIONS_STATE.touchViewport = true;
+    try {
+      const { container } = render(
+        <UIProvider reducedMotion="always">
+          <CmdPaletteRegistryProvider registry={paletteRegistryFixture([])}>
+            <DesktopMenubar
+              workspaces={[]}
+              activeWorkspace={undefined}
+              scope="global"
+              onSelectWorkspace={vi.fn()}
+              onAddWorkspace={vi.fn()}
+              onRunCommand={vi.fn()}
+              activeOverlay={null}
+              onOverlayOpenChange={vi.fn()}
+              attention={ATTENTION}
+              updateAvailable={false}
+              profileSwitcher={<div data-testid="profile-switcher-slot" />}
+            />
+          </CmdPaletteRegistryProvider>
+        </UIProvider>
+      );
+
+      expect(screen.queryByTestId("profile-switcher-slot")).not.toBeInTheDocument();
+      expect(container.querySelector('[data-slot="os-menubar-settings"]')).not.toBeNull();
+    } finally {
+      MENUBAR_ACTIONS_STATE.touchViewport = false;
+    }
+  });
+
+  it("Should keep the profile switcher slot on the desktop tier", () => {
+    render(
+      <UIProvider reducedMotion="always">
+        <CmdPaletteRegistryProvider registry={paletteRegistryFixture([])}>
+          <DesktopMenubar
+            workspaces={[]}
+            activeWorkspace={undefined}
+            scope="global"
+            onSelectWorkspace={vi.fn()}
+            onAddWorkspace={vi.fn()}
+            onRunCommand={vi.fn()}
+            activeOverlay={null}
+            onOverlayOpenChange={vi.fn()}
+            attention={ATTENTION}
+            updateAvailable={false}
+            profileSwitcher={<div data-testid="profile-switcher-slot" />}
+          />
+        </CmdPaletteRegistryProvider>
+      </UIProvider>
+    );
+
+    expect(screen.getByTestId("profile-switcher-slot")).toBeInTheDocument();
   });
 });

--- a/web/src/systems/os/components/__tests__/desktop-pager.test.tsx
+++ b/web/src/systems/os/components/__tests__/desktop-pager.test.tsx
@@ -147,4 +147,48 @@ describe("DesktopPager", () => {
     await user.click(screen.getByRole("button", { name: "Show 2 earlier desktops" }));
     expect(onOpenOverview).toHaveBeenCalledTimes(1);
   });
+
+  // T9 real-device delta: a lone desktop is a position indicator, not a
+  // switcher — at the touch dock it rendered as an orphaned pill beside a
+  // 50vw dead zone, so compact renders nothing for a single desktop.
+  it("Should render nothing in compact mode with a single desktop", () => {
+    const { container } = render(
+      <DesktopPager
+        desktops={[{ id: "only", name: "Only" }]}
+        activeDesktopId="only"
+        compact
+        onSelectDesktop={vi.fn()}
+        onOpenOverview={vi.fn()}
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("Should keep the single-desktop position pill in the floating dock", () => {
+    render(
+      <DesktopPager
+        desktops={[{ id: "only", name: "Only" }]}
+        activeDesktopId="only"
+        onSelectDesktop={vi.fn()}
+        onOpenOverview={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Desktop 1 of 1: Only" })).toBeInTheDocument();
+  });
+
+  it("Should render every desktop in compact mode once switching exists", () => {
+    renderPager(DESKTOPS.slice(0, 2), "build", true);
+
+    expect(screen.getByRole("button", { name: "Desktop 1 of 2: Control" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Desktop 2 of 2: Build" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByRole("navigation", { name: "Desktops" })).toHaveAttribute(
+      "data-presentation",
+      "compact"
+    );
+  });
 });

--- a/web/src/systems/os/components/__tests__/os-dock.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-dock.test.tsx
@@ -576,6 +576,23 @@ describe("OsDock", () => {
     });
   });
 
+  it("Should omit the Terminal launcher when the tier cannot execute terminal routes", () => {
+    setDockState(desktopState());
+    const { result, rerender } = renderHook(
+      (includeTerminal: boolean) => useDesktopDock({}, { onNewSession: vi.fn(), includeTerminal }),
+      { initialProps: true }
+    );
+
+    // Local default: the launcher stays in its dock group.
+    expect(result.current.entries.some(entry => entry.id === "terminal")).toBe(true);
+
+    // Remote tiers register no terminal routes: the entry is absent, never a
+    // disabled control (BR-1), and the Home launcher still leads its group.
+    rerender(false);
+    expect(result.current.entries.some(entry => entry.id === "terminal")).toBe(false);
+    expect(result.current.entries.some(entry => entry.id === "dashboard")).toBe(true);
+  });
+
   it("Should mark the sessions dock icon minimized when every session window is minimized", () => {
     const session = windowFixture("window:session-minimized", "session", {
       instanceKey: "session:minimized",

--- a/web/src/systems/os/components/__tests__/os-menubar.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-menubar.test.tsx
@@ -1,0 +1,77 @@
+// Suite: OsMenuBar touch tier
+// Invariant: at the touch tier the identity segment is the give-way element —
+// the scope label truncates through an unbroken min-w-0 chain and the trailing
+// actions keep their 44px floor; no scope state may paint under the cluster
+// (F3 real-device defect). Desktop rendering keeps its exact classes.
+// Boundary IN: OsMenuBar presentation, truncation chain, touch floors.
+// Boundary OUT: scope model wiring (desktop-menubar suite), menu contents.
+import { render } from "@testing-library/react";
+import type * as React from "react";
+import { describe, expect, it } from "vitest";
+
+import { OsMenuBar } from "../os-menubar";
+
+const SQUARE_FLOOR = "max-[760px]:size-(--height-button-cta-lg)";
+
+function renderBar(workspace: React.ComponentProps<typeof OsMenuBar>["workspace"], touch: boolean) {
+  const view = render(
+    <OsMenuBar
+      touch={touch}
+      workspace={workspace}
+      notifications={2}
+      onCommandClick={() => undefined}
+      onSettingsClick={() => undefined}
+    />
+  );
+  const slot = (name: string) => view.container.querySelector(`[data-slot="${name}"]`);
+  return { view, slot };
+}
+
+describe("OsMenuBar touch tier", () => {
+  it("Should build the min-w-0 truncation chain in Global scope at the touch tier", () => {
+    const { slot } = renderBar({ name: "Global", monogram: "~" }, true);
+
+    // Every wrapper between the shrinking leading div and the label allows
+    // the squeeze, so "Global" truncates instead of spilling under the
+    // trailing cluster.
+    expect(slot("os-menubar-identity")).toHaveClass("min-w-0");
+    const chip = slot("os-menubar-workspace");
+    expect(chip).toHaveClass("min-w-0");
+    const label = chip!.querySelector("span.truncate");
+    expect(label).toHaveTextContent("Global");
+    expect(label).toHaveClass("min-w-0", "max-w-28");
+  });
+
+  it("Should keep the mark fixed and the trailing actions at the 44px floor", () => {
+    const { slot } = renderBar({ name: "Global", monogram: "~" }, true);
+
+    expect(slot("os-menubar-logo")).toHaveClass("shrink-0", SQUARE_FLOOR);
+    expect(slot("os-menubar-bell")).toHaveClass(SQUARE_FLOOR);
+    expect(slot("os-menubar-command")).toHaveClass(SQUARE_FLOOR);
+    expect(slot("os-menubar-settings")).toHaveClass(SQUARE_FLOOR);
+  });
+
+  it("Should keep the truncation chain for named workspaces at the touch tier", () => {
+    const { slot } = renderBar({ name: "thaymel", monogram: "TH", worktree: "mobile-shell" }, true);
+
+    // Worktree segment steps aside at touch; the workspace label carries the
+    // same give-way chain regardless of scope state.
+    expect(slot("os-menubar-worktree")).not.toBeInTheDocument();
+    const chip = slot("os-menubar-workspace");
+    expect(chip!.textContent).toContain("thaymel");
+    expect(chip!.querySelector("span.truncate")).toHaveClass("min-w-0");
+  });
+
+  it("Should render desktop classes untouched without the touch tier", () => {
+    const { slot } = renderBar({ name: "compozy", monogram: "CO", worktree: "main" }, false);
+
+    expect(slot("os-menubar-identity")).not.toHaveClass("min-w-0");
+    const chip = slot("os-menubar-workspace");
+    expect(chip).not.toHaveClass("min-w-0");
+    // The scope label never truncates on desktop (the worktree span does).
+    const label = chip!.querySelector("span.truncate.text-fg-strong");
+    expect(label).toBeNull();
+    expect(slot("os-menubar-worktree")).toBeInTheDocument();
+    expect(slot("os-menubar-bell")).not.toHaveClass(SQUARE_FLOOR);
+  });
+});

--- a/web/src/systems/os/components/__tests__/os-traffic-lights.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-traffic-lights.test.tsx
@@ -1,0 +1,70 @@
+// Suite: OS traffic lights
+// Invariant: window controls are identifiable without hover (touch has none)
+// and the compact tier keeps every control a phone needs reachable.
+// Boundary IN: OsTrafficLights presentation, accessibility, compact glyphs.
+// Boundary OUT: the owning frame's command dispatch (os-window-frame suite).
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { OsTrafficLights } from "../os-traffic-lights";
+
+describe("OsTrafficLights", () => {
+  it("Should keep all three controls with distinct labels on the floating tier", () => {
+    render(<OsTrafficLights onSelect={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Close window" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Minimize window" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Zoom window" })).toBeInTheDocument();
+  });
+
+  // T2 ratified: compact hides zoom (meaningless in a stack), never close —
+  // a phone must be able to close a window from its own bar.
+  it("Should hide only zoom at the compact tier, keeping close reachable", () => {
+    render(<OsTrafficLights compact onSelect={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "Close window" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Minimize window" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Zoom window" })).not.toBeInTheDocument();
+  });
+
+  // T10 real-device delta: hover tones are the only desktop identification and
+  // touch has no hover, so compact controls carry their glyph at rest.
+  it("Should identify close and minimize by glyph at rest in compact mode", () => {
+    render(<OsTrafficLights compact onSelect={vi.fn()} />);
+
+    const close = screen.getByRole("button", { name: "Close window" });
+    expect(close.querySelector("svg")).toBeInTheDocument();
+    const minimize = screen.getByRole("button", { name: "Minimize window" });
+    expect(minimize.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("Should keep the floating tier glyph-free outside zoom", () => {
+    render(<OsTrafficLights onSelect={vi.fn()} />);
+
+    // Desktop rendering stays pixel-identical: only zoom carries a glyph.
+    expect(screen.getByRole("button", { name: "Close window" }).querySelector("svg")).toBeNull();
+    expect(screen.getByRole("button", { name: "Minimize window" }).querySelector("svg")).toBeNull();
+    expect(screen.getByRole("button", { name: "Zoom window" }).querySelector("svg")).not.toBeNull();
+  });
+
+  it("Should keep inert compact chrome glyphless — no implied controls", () => {
+    const { container } = render(<OsTrafficLights compact />);
+
+    // Inert chrome: no buttons, no glyphs, just the two separated circles.
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelectorAll("[data-action]")).toHaveLength(2);
+  });
+
+  it("Should dispatch the compact actions through the owning frame", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<OsTrafficLights compact onSelect={onSelect} />);
+
+    await user.click(screen.getByRole("button", { name: "Close window" }));
+    await user.click(screen.getByRole("button", { name: "Minimize window" }));
+    expect(onSelect).toHaveBeenNthCalledWith(1, "close");
+    expect(onSelect).toHaveBeenNthCalledWith(2, "minimize");
+  });
+});

--- a/web/src/systems/os/components/desktop-dock.tsx
+++ b/web/src/systems/os/components/desktop-dock.tsx
@@ -1,3 +1,5 @@
+import { useGatewayCapabilities } from "@/systems/gateway";
+
 import { useDesktopDock } from "../hooks/use-desktop-dock";
 import { useTerminalDockRunning } from "../hooks/use-terminal-dock-running";
 import type { ReactNode } from "react";
@@ -15,6 +17,12 @@ export interface DesktopDockProps {
   badges: OsAttentionBadges;
   /** Catalog truth: a live terminal, independent of an open window. */
   terminalLive?: boolean;
+  /**
+   * Whether the Terminal launcher belongs in the dock at all. Default keeps
+   * isolated dock tests on the local shape; production shell passes the
+   * capability truth (absent, never disabled, on remote tiers).
+   */
+  includeTerminal?: boolean;
   /** Modal overlays own keyboard and pointer interaction until they close. */
   contextMenusEnabled: boolean;
   pager: ReactNode;
@@ -40,10 +48,11 @@ export function DesktopDock({
   contextMenusEnabled,
   pager,
   dormant = false,
+  includeTerminal = true,
 }: DesktopDockProps) {
   const { entries, presentation, magnify, commandsAvailable, handleSelect } = useDesktopDock(
     badges,
-    { onNewSession, terminalLive }
+    { onNewSession, terminalLive, includeTerminal }
   );
   const dormancy = cn(WAKE, dormant && DORMANT);
 
@@ -84,10 +93,17 @@ export function DesktopDock({
 }
 
 /**
- * Production dock: Terminal's live mark reads the catalog, not window-open.
- * Isolated dock tests keep rendering `DesktopDock` without this query.
+ * Production dock: Terminal's live mark reads the catalog, not window-open,
+ * and the Terminal launcher itself is gated by the listener tier — absent on
+ * remote tiers, which register no terminal routes (BR-1). Isolated dock tests
+ * keep rendering `DesktopDock` without this query.
  */
-export function ShellDesktopDock(props: Omit<DesktopDockProps, "terminalLive">) {
+export function ShellDesktopDock(
+  props: Omit<DesktopDockProps, "terminalLive" | "includeTerminal">
+) {
   const terminalLive = useTerminalDockRunning();
-  return <DesktopDock {...props} terminalLive={terminalLive} />;
+  const { localTaskLifecycle } = useGatewayCapabilities();
+  return (
+    <DesktopDock {...props} includeTerminal={localTaskLifecycle} terminalLive={terminalLive} />
+  );
 }

--- a/web/src/systems/os/components/desktop-menubar.tsx
+++ b/web/src/systems/os/components/desktop-menubar.tsx
@@ -105,6 +105,8 @@ export function DesktopMenubar({
   const hydration = useDesktop(state => state.hydration);
   const actions = useMenubarActions();
   const paletteOpen = usePaletteCommand("palette.open");
+  // Touch tier rides the same media hook as the compact menu collapse (S6/T1).
+  const touch = actions.touchViewport;
   const scopeModel = desktopMenubarScopeModel({
     activeWorkspace,
     canDisableGlobal,
@@ -125,6 +127,7 @@ export function DesktopMenubar({
   return (
     <OsMenuBar
       className={className}
+      touch={touch}
       workspace={scopeModel.workspace}
       scopeNotice={
         scopeModel.fallback ? (
@@ -156,6 +159,7 @@ export function DesktopMenubar({
       )}
       scopeControl={
         <GlobalScopeToggle
+          touch={touch}
           checked={scopeModel.globalOn}
           locked={scopePending || toggleLocked || (scopeModel.globalOn && !canDisableGlobal)}
           lockedReason={scopeModel.toggleLockedReason}

--- a/web/src/systems/os/components/desktop-menubar.tsx
+++ b/web/src/systems/os/components/desktop-menubar.tsx
@@ -204,7 +204,13 @@ export function DesktopMenubar({
           </>
         ) : null
       }
-      profileSwitcher={profileSwitcher}
+      // Touch tier priority call (F3): the profile switcher is the one
+      // trailing control the 390px bar cannot afford — a shrink-0 text row
+      // (~120px) that forced the identity segment under the action cluster.
+      // It is the lowest-priority slot: quiet-until-plural (usually absent),
+      // and profiles stay reachable on touch via Settings → Profiles and the
+      // palette's profiles view. Truthful: absent, not cramped.
+      profileSwitcher={touch ? null : profileSwitcher}
       wrapBellTrigger={trigger => (
         <Popover
           open={activeOverlay === "bell"}

--- a/web/src/systems/os/components/desktop-pager.tsx
+++ b/web/src/systems/os/components/desktop-pager.tsx
@@ -111,6 +111,11 @@ function overflowLabel(control: OverflowControl): string {
 /**
  * Bottom-chrome desktop navigation. The 44px controls remain transparent at rest;
  * only the 6px dots and 14px active pill are visible.
+ *
+ * Compact (touch dock, T9 real-device delta): a single desktop is not a
+ * switcher — the pager renders nothing instead of an orphaned position pill,
+ * and with several desktops it shrink-wraps its pills (capped at half the bar)
+ * instead of reserving 50vw of dead space beside the app launchers.
  */
 export function DesktopPager({
   desktops,
@@ -131,6 +136,7 @@ export function DesktopPager({
   const tabStopKey = rovingKey && visibleKeys.has(rovingKey) ? rovingKey : activeKey;
 
   if (desktops.length === 0) return null;
+  if (compact && desktops.length === 1) return null;
 
   const focusControl = (position: number) => {
     const control = controls[position];
@@ -161,7 +167,7 @@ export function DesktopPager({
       data-presentation={compact ? "compact" : "floating"}
       className={cn(
         "no-scrollbar min-w-0 overflow-x-auto overscroll-x-contain p-0.5",
-        compact ? "w-[50vw] max-w-[50vw]" : "w-full max-w-full",
+        compact ? "w-fit max-w-[50vw]" : "w-full max-w-full",
         className
       )}
       {...props}

--- a/web/src/systems/os/components/desktop-shell.tsx
+++ b/web/src/systems/os/components/desktop-shell.tsx
@@ -8,8 +8,8 @@ import { useCmdPaletteRegistry } from "../hooks/use-cmd-palette-registry";
 import { WorktreeDialogActionsContext } from "../contexts/worktree-dialog-actions-context";
 import { useDesktopChromeController } from "../hooks/use-desktop-chrome-controller";
 import { useDesktopShellBody } from "../hooks/use-desktop-shell-body";
+import { useDesktopShellScopedBody } from "../hooks/use-desktop-shell-scoped-body";
 import type { DesktopShellModel } from "../hooks/use-desktop-shell-model";
-import { useProfileAutomationEnablement } from "../hooks/use-profile-automation-enablement";
 import { useDesktopWorktreeScope, WindowScopeContext } from "../hooks/use-worktree-scope";
 import type { WorktreeDialogTargets } from "../hooks/use-worktree-dialog-targets";
 import type { ClientCommandChannel } from "../lib/client-command-channel";
@@ -31,6 +31,7 @@ import { OsWinLayer } from "./os-win-layer";
 import { OsSessionsModal } from "./sessions-modal";
 import { AgentCreateDialog, AgentCreateHostProvider } from "@/systems/agent";
 import { useOnboardingStatus } from "@/systems/onboarding";
+import { LoopbackOnlyState } from "@/systems/gateway";
 import {
   ProfileLifecycleHost,
   ProfileSwitcherSlot,
@@ -41,9 +42,6 @@ import {
   SessionCreateProvider,
   SessionDeleteDialog,
   SessionRenameDialog,
-  useSessionCreateActions,
-  useSessionLifecycleActions,
-  useSessionListView,
 } from "@/systems/session";
 import { settingsUpdateIndicatorAvailable, useSettingsUpdate } from "@/systems/settings";
 import {
@@ -177,15 +175,8 @@ function DesktopShellScopedBody({
   worktreeSelection,
   clientCommandChannel,
 }: DesktopShellBodyProps & DesktopWorktreeScope) {
-  const sessionCreate = useSessionCreateActions();
-  const sessionLifecycle = useSessionLifecycleActions({ workspaceId: model.runtimeWorkspaceId });
-  const setAutomationEnabled = useProfileAutomationEnablement();
-  // Scope and order are the operator's, persisted by the daemon; the modal
-  // renders them rather than fetching its own.
-  const sessionListView = useSessionListView();
-  const openNewSession = () => {
-    sessionCreate.openForAgent("");
-  };
+  const { loopbackOnly, openNewSession, sessionLifecycle, sessionListView, setAutomationEnabled } =
+    useDesktopShellScopedBody(model);
   const {
     attention,
     desktop,
@@ -270,6 +261,7 @@ function DesktopShellScopedBody({
         onOpenWorktreeContext={worktreeDialogs.requestContext}
         onRemoveWorktree={worktreeDialogs.requestRemove}
       />
+      {loopbackOnly ? <LoopbackOnlyState layout="banner" /> : null}
       <div data-slot="os-desk" className="relative min-h-0 flex-1 overflow-hidden">
         <OsWallpaper wallpaper={desktop.wallpaper} />
         {model.activeWorkspaceId !== null ? (

--- a/web/src/systems/os/components/global-scope-toggle.tsx
+++ b/web/src/systems/os/components/global-scope-toggle.tsx
@@ -1,7 +1,15 @@
 import { useState } from "react";
 import { Globe } from "lucide-react";
 
-import { Icon, Toggle, Tooltip, TooltipContent, TooltipTrigger, cn } from "@compozy/ui";
+import {
+  DIALOG_TOUCH_TARGET_SQUARE_CLASS,
+  Icon,
+  Toggle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  cn,
+} from "@compozy/ui";
 
 import { GLOBAL_SCOPE_COPY } from "@/systems/workspace";
 
@@ -12,6 +20,11 @@ export interface GlobalScopeToggleProps {
   lockedReason?: string;
   tooltip: string;
   onCheckedChange: (checked: boolean) => void;
+  /**
+   * Touch tier (S6/T1): the globe grows to the 44px floor inside the menubar.
+   * Desktop rendering omits it and stays pixel-identical.
+   */
+  touch?: boolean;
 }
 
 /**
@@ -25,6 +38,7 @@ export function GlobalScopeToggle({
   lockedReason,
   tooltip,
   onCheckedChange,
+  touch = false,
 }: GlobalScopeToggleProps) {
   const [prevChecked, setPrevChecked] = useState(checked);
   const [announcement, setAnnouncement] = useState("");
@@ -56,6 +70,7 @@ export function GlobalScopeToggle({
               aria-label={accessibleName}
               className={cn(
                 "size-7 min-w-7 p-0 text-muted hover:bg-btn-default-fill hover:text-fg-strong",
+                touch && DIALOG_TOUCH_TARGET_SQUARE_CLASS,
                 "aria-pressed:bg-elevated aria-pressed:text-accent aria-pressed:shadow-highlight",
                 "aria-pressed:hover:text-accent data-[state=on]:bg-elevated data-[state=on]:text-accent",
                 "data-[state=on]:shadow-highlight data-[state=on]:hover:text-accent",

--- a/web/src/systems/os/components/os-menubar.tsx
+++ b/web/src/systems/os/components/os-menubar.tsx
@@ -1,6 +1,7 @@
 import { Bell, ChevronsUpDown, Command, Settings } from "lucide-react";
 
 import { Icon, Logo, Menubar, MenubarTrigger } from "@compozy/ui";
+import { DIALOG_TOUCH_TARGET_CLASS, DIALOG_TOUCH_TARGET_SQUARE_CLASS } from "@compozy/ui";
 
 import { cn } from "@/lib/utils";
 
@@ -59,6 +60,13 @@ export interface OsMenuBarProps extends React.ComponentProps<"header"> {
    * slot.
    */
   profileSwitcher?: React.ReactNode;
+  /**
+   * Touch tier (S6/T1): at or below the 760px floor the bar's controls fill the
+   * 44px bar height, the identity chip compresses, and the worktree segment
+   * steps aside (the workspace menu still names it). Desktop rendering passes
+   * nothing and stays pixel-identical.
+   */
+  touch?: boolean;
 }
 
 const WINDOW_DRAG = "[app-region:drag]";
@@ -151,17 +159,22 @@ export function OsMenuBar({
   scopeControl,
   wrapBellTrigger,
   profileSwitcher,
+  touch = false,
   className,
   ...props
 }: OsMenuBarProps) {
   // Compact (<960px, `OS_COMPACT_BREAKPOINT`): the shell stops passing `menus`;
   // mark, globe toggle, and chip stay leading. Hidden actions stay in the palette.
   const wrapMenus = Boolean(logoMenu || workspaceMenu);
+  // Touch tier (S6/T1): the shared 44px floor constants from `@compozy/ui`
+  // (`dialog-shell`) — defined once, consumed here media-scoped and only when
+  // the shell reports the touch viewport.
+  const controlClass = touch ? DIALOG_TOUCH_TARGET_SQUARE_CLASS : undefined;
   const logoControl = (
     <MenuControl
       data-slot="os-menubar-logo"
       aria-label="CompozyOS"
-      className="grid size-7 place-items-center rounded-menubar-control p-0"
+      className={cn("grid size-7 place-items-center rounded-menubar-control p-0", controlClass)}
       menu={logoMenu}
     >
       <Logo variant="symbol" decorative className="size-menubar-logo" />
@@ -170,14 +183,22 @@ export function OsMenuBar({
   const workspaceControl = (
     <MenuControl
       data-slot="os-menubar-workspace"
-      className="flex h-7 items-center gap-menubar-workspace-gap rounded-md px-2"
+      className={cn(
+        "flex h-7 items-center gap-menubar-workspace-gap rounded-md px-2",
+        touch && DIALOG_TOUCH_TARGET_CLASS,
+        touch && "px-1.5"
+      )}
       menu={workspaceMenu}
     >
       <span className="grid size-workspace-avatar place-items-center rounded-sm border border-line-strong bg-elevated font-mono text-badge font-semibold tracking-mono text-fg">
         {workspace.monogram}
       </span>
-      <span className="text-small-body font-semibold text-fg-strong">{workspace.name}</span>
-      {workspace.worktree ? (
+      <span
+        className={cn("text-small-body font-semibold text-fg-strong", touch && "max-w-28 truncate")}
+      >
+        {workspace.name}
+      </span>
+      {touch ? null : workspace.worktree ? (
         <>
           <span aria-hidden="true" className="text-small-body text-faint">
             /
@@ -242,7 +263,7 @@ export function OsMenuBar({
           ) : null}
         </div>
 
-        <div className={cn("flex items-center gap-2", WINDOW_NO_DRAG)}>
+        <div className={cn("flex items-center gap-2", WINDOW_NO_DRAG, touch && "gap-1")}>
           {/* Outside the menubar's `role="menu"` subtree on purpose: a notice is
               not a menu item, and nesting it there breaks the menu's semantics. */}
           {scopeNotice}
@@ -252,7 +273,10 @@ export function OsMenuBar({
             data-slot="os-menubar-bell"
             aria-label={notifications ? `Attention, ${notifications} waiting` : "Attention"}
             aria-haspopup={wrapBellTrigger ? "true" : undefined}
-            className="relative grid size-7 place-items-center rounded-md text-muted"
+            className={cn(
+              "relative grid size-7 place-items-center rounded-md text-muted",
+              controlClass
+            )}
             wrap={wrapBellTrigger}
           >
             <Icon as={Bell} size="lg" />
@@ -264,7 +288,7 @@ export function OsMenuBar({
             title={
               commandShortcutLabel ? `Command palette · ${commandShortcutLabel}` : "Command palette"
             }
-            className="grid size-7 place-items-center rounded-md text-muted"
+            className={cn("grid size-7 place-items-center rounded-md text-muted", controlClass)}
             onClick={onCommandClick}
           >
             <Icon as={Command} size="lg" />
@@ -277,7 +301,7 @@ export function OsMenuBar({
             data-slot="os-menubar-settings"
             aria-label="Settings"
             title="Settings"
-            className="grid size-7 place-items-center rounded-md text-muted"
+            className={cn("grid size-7 place-items-center rounded-md text-muted", controlClass)}
             onClick={onSettingsClick}
           >
             <Icon as={Settings} size="lg" />

--- a/web/src/systems/os/components/os-menubar.tsx
+++ b/web/src/systems/os/components/os-menubar.tsx
@@ -174,7 +174,12 @@ export function OsMenuBar({
     <MenuControl
       data-slot="os-menubar-logo"
       aria-label="CompozyOS"
-      className={cn("grid size-7 place-items-center rounded-menubar-control p-0", controlClass)}
+      className={cn(
+        "grid size-7 place-items-center rounded-menubar-control p-0",
+        // The 44px floor is a floor: the mark never gives its width to the squeeze.
+        touch && "shrink-0",
+        controlClass
+      )}
       menu={logoMenu}
     >
       <Logo variant="symbol" decorative className="size-menubar-logo" />
@@ -186,15 +191,21 @@ export function OsMenuBar({
       className={cn(
         "flex h-7 items-center gap-menubar-workspace-gap rounded-md px-2",
         touch && DIALOG_TOUCH_TARGET_CLASS,
-        touch && "px-1.5"
+        // Touch tier (F3): the chip is the give-way element — it must be
+        // allowed to shrink so the label truncates instead of the identity
+        // segment spilling under the trailing cluster.
+        touch && "min-w-0 px-1.5"
       )}
       menu={workspaceMenu}
     >
-      <span className="grid size-workspace-avatar place-items-center rounded-sm border border-line-strong bg-elevated font-mono text-badge font-semibold tracking-mono text-fg">
+      <span className="grid size-workspace-avatar shrink-0 place-items-center rounded-sm border border-line-strong bg-elevated font-mono text-badge font-semibold tracking-mono text-fg">
         {workspace.monogram}
       </span>
       <span
-        className={cn("text-small-body font-semibold text-fg-strong", touch && "max-w-28 truncate")}
+        className={cn(
+          "text-small-body font-semibold text-fg-strong",
+          touch && "min-w-0 max-w-28 truncate"
+        )}
       >
         {workspace.name}
       </span>
@@ -211,7 +222,7 @@ export function OsMenuBar({
           </span>
         </>
       ) : null}
-      <Icon as={ChevronsUpDown} size="sm" className="text-subtle" />
+      <Icon as={ChevronsUpDown} size="sm" className={cn("text-subtle", touch && "shrink-0")} />
     </MenuControl>
   );
 
@@ -235,9 +246,18 @@ export function OsMenuBar({
         )}
       >
         <div className={cn("flex min-w-0 items-center gap-1", WINDOW_NO_DRAG)}>
-          <div data-slot="os-menubar-identity" className="flex items-center gap-1">
+          {/* Touch tier (F3): every wrapper between the shrinking leading div
+              and the scope label needs min-w-0, or the identity segment keeps
+              its content width and paints under the trailing cluster. */}
+          <div
+            data-slot="os-menubar-identity"
+            className={cn("flex items-center gap-1", touch && "min-w-0")}
+          >
             {wrapMenus ? (
-              <Menubar aria-label="System menu" className={cn("gap-1", WINDOW_NO_DRAG)}>
+              <Menubar
+                aria-label="System menu"
+                className={cn("gap-1", WINDOW_NO_DRAG, touch && "min-w-0")}
+              >
                 {logoControl}
               </Menubar>
             ) : (
@@ -245,7 +265,10 @@ export function OsMenuBar({
             )}
             {scopeControl}
             {wrapMenus ? (
-              <Menubar aria-label="Workspace" className={cn("gap-1", WINDOW_NO_DRAG)}>
+              <Menubar
+                aria-label="Workspace"
+                className={cn("gap-1", WINDOW_NO_DRAG, touch && "min-w-0")}
+              >
                 {workspaceControl}
               </Menubar>
             ) : (

--- a/web/src/systems/os/components/os-traffic-lights.tsx
+++ b/web/src/systems/os/components/os-traffic-lights.tsx
@@ -1,4 +1,4 @@
-import { Maximize2, Minimize2 } from "lucide-react";
+import { Maximize2, Minus, Minimize2, X } from "lucide-react";
 import { Fragment } from "react";
 
 import { cn } from "@/lib/utils";
@@ -13,6 +13,11 @@ import { cn } from "@/lib/utils";
  * Compact (<960px, os-v2.css mobile block): the zoom control disappears
  * (meaningless in a stack), glyphs grow to 15px, and interactive controls get
  * non-overlapping 44px touch targets. Inert chrome uses the visual 12px gap.
+ *
+ * Touch identification (T10 real-device delta): compact controls render their
+ * glyph at rest — close (X) and minimize (−) — because hover does not exist
+ * on touch and hover tones are the only desktop identification. Same neutral
+ * ink for both: shape identifies, signal color stays hover/focus-only.
  */
 export type OsTrafficLightAction = "close" | "minimize" | "zoom";
 
@@ -47,6 +52,12 @@ export interface OsTrafficLightsProps extends Omit<React.ComponentProps<"div">, 
   zoomed?: boolean;
 }
 
+/** Rest-state identification glyphs for the touch tier — shape, not color. */
+const COMPACT_GLYPH: Partial<Record<OsTrafficLightAction, typeof X>> = {
+  close: X,
+  minimize: Minus,
+};
+
 function Light({
   action,
   onSelect,
@@ -68,6 +79,7 @@ function Light({
   if (!onSelect) {
     return <span aria-hidden="true" data-action={action} className={glyph} />;
   }
+  const CompactGlyph = compact ? COMPACT_GLYPH[action] : undefined;
   return (
     <button
       type="button"
@@ -90,9 +102,18 @@ function Light({
     >
       <span
         aria-hidden="true"
-        className={cn(glyph, ACTION_TONE[action], "grid place-items-center")}
+        className={cn(
+          glyph,
+          ACTION_TONE[action],
+          "grid place-items-center",
+          CompactGlyph && "text-fg-strong"
+        )}
       >
-        {action === "zoom" ? <ZoomIcon className="size-2.5" /> : null}
+        {action === "zoom" ? (
+          <ZoomIcon className="size-2.5" />
+        ) : CompactGlyph ? (
+          <CompactGlyph className="size-2.5" strokeWidth={2.5} />
+        ) : null}
       </span>
     </button>
   );

--- a/web/src/systems/os/components/os-win-layer.tsx
+++ b/web/src/systems/os/components/os-win-layer.tsx
@@ -2,6 +2,7 @@ import type { DesktopLayerModel, OsWinLayerModel } from "../hooks/use-os-win-lay
 import { useWindowManagerGesturePreview } from "../hooks/use-window-manager-store";
 import type { LayoutProjection } from "../lib/window-manager-types";
 import type { DesktopTransitionIntent } from "../stores/window-manager-store";
+import { cn } from "@/lib/utils";
 import { OsShortcutChords } from "./os-shortcut-chords";
 import { OsSnapOverlay } from "./os-snap-overlay";
 import { OsSnapSeamLayer, type SeamGestureHandlers } from "./os-snap-seam";
@@ -159,8 +160,15 @@ export function OsWinLayer({
     <div
       ref={layerRef}
       data-slot="os-win-layer"
-      // The measured work area stops above the Dock band so snaps and floating clamps never resolve beneath it.
-      className="absolute inset-x-0 top-0 bottom-[calc(var(--size-dock-band)+env(safe-area-inset-bottom,0px))]"
+      // The measured work area stops above the Dock band so snaps and floating
+      // clamps never resolve beneath it. Compact stacks reserve the 56px tab bar
+      // instead of the floating dock band — 26px back to stream content (S6/T3).
+      className={cn(
+        "absolute inset-x-0 top-0",
+        presentation === "compact"
+          ? "bottom-[calc(var(--height-dock-tabbar)+env(safe-area-inset-bottom,0px))]"
+          : "bottom-[calc(var(--size-dock-band)+env(safe-area-inset-bottom,0px))]"
+      )}
     >
       {desktops.map(desktop => (
         <DesktopLayer

--- a/web/src/systems/os/components/stories/os-menubar.stories.tsx
+++ b/web/src/systems/os/components/stories/os-menubar.stories.tsx
@@ -312,6 +312,26 @@ export const PresentationOnly: Story = {
 };
 
 /**
+ * Touch tier (S6/T1) — the 390×844 bar: controls fill the 44px bar height, the
+ * workspace name truncates, and the worktree segment steps aside (the workspace
+ * menu still names it). App menus are collapsed into the palette below 960px,
+ * so the bar carries only mark + globe + chip and the trailing controls.
+ */
+export const TouchTier: Story = {
+  args: {
+    workspace: { name: "compozy", monogram: "CO", worktree: "mobile-ergonomics" },
+    notifications: 2,
+  },
+  render: args => (
+    <div style={{ maxWidth: 390 }}>
+      <DesktopShell menubar={false} wallpaper="carbon" deskHint>
+        <OsMenuBar {...args} touch />
+      </DesktopShell>
+    </div>
+  ),
+};
+
+/**
  * Degraded desktop sync — the warning stays non-blocking, names the state in
  * text, and leaves every shell command available.
  */

--- a/web/src/systems/os/components/stories/os-menubar.stories.tsx
+++ b/web/src/systems/os/components/stories/os-menubar.stories.tsx
@@ -332,6 +332,26 @@ export const TouchTier: Story = {
 };
 
 /**
+ * Touch tier (F3 real-device delta) — Global scope at 390×844: the scope label
+ * is the give-way element (min-w-0 truncation chain), the profile switcher is
+ * absent (reachable via Settings and the palette), and the trailing actions
+ * keep their 44px floor. The bar must never overlap at any scope state.
+ */
+export const TouchTierGlobalScope: Story = {
+  args: {
+    workspace: { name: "Global", monogram: "~" },
+    notifications: 2,
+  },
+  render: args => (
+    <div style={{ maxWidth: 390 }}>
+      <DesktopShell menubar={false} wallpaper="carbon" deskHint>
+        <OsMenuBar {...args} touch />
+      </DesktopShell>
+    </div>
+  ),
+};
+
+/**
  * Degraded desktop sync — the warning stays non-blocking, names the state in
  * text, and leaves every shell command available.
  */

--- a/web/src/systems/os/components/stories/os-traffic-lights.stories.tsx
+++ b/web/src/systems/os/components/stories/os-traffic-lights.stories.tsx
@@ -56,3 +56,17 @@ export const CompactPresentationOnly: Story = {
     </div>
   ),
 };
+
+/**
+ * Compact interactive (touch tier, T10): close and minimize carry their
+ * identification glyph at rest — hover does not exist on touch, so shape
+ * identifies and the hover tones stay as the focus/hover affordance.
+ */
+export const CompactInteractive: Story = {
+  args: { compact: true, onSelect: fn() },
+  render: args => (
+    <div className="rounded-md border border-line bg-canvas p-4">
+      <OsTrafficLights {...args} />
+    </div>
+  ),
+};

--- a/web/src/systems/os/hooks/__tests__/use-os-attention.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-os-attention.test.tsx
@@ -5,7 +5,9 @@
 // and vanish when it is stale rather than reporting a page total.
 // Owning layer: OS attention query adapter. Canonical suite: this hook test.
 import { renderHook as renderReactHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 vi.mock("@tanstack/react-query", async importOriginal => {
   const actual = await importOriginal<typeof import("@tanstack/react-query")>();
@@ -162,7 +164,10 @@ function workspaceForCall(call: number): string | null | undefined {
 }
 
 describe("useOsAttention", () => {
+  let unlatch: () => void;
   beforeEach(() => {
+    // Terminal attention reads exist only on the local surface set.
+    unlatch = latchGatewayTierForTest("local");
     vi.clearAllMocks();
     notificationResponse = { snapshot: "snapshot", total: 0, needs_you: 0, finished: 0, items: [] };
     notificationStale = false;
@@ -201,6 +206,7 @@ describe("useOsAttention", () => {
     });
     vi.mocked(useLoopNodeExists).mockImplementation(() => false);
   });
+  afterEach(() => unlatch());
 
   it("Should read the archive only through the modal catalog leg", () => {
     vi.mocked(useSessions).mockReturnValue(sessionsQuery({}));

--- a/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
@@ -20,6 +20,8 @@ import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
+
 import {
   clearChooseSessionTerminalQuote,
   holdChooseSessionTerminalQuote,
@@ -695,11 +697,15 @@ function renderRoot(open = true, onOpenChange = vi.fn()) {
 }
 
 describe("useOsPaletteRoot", () => {
+  let unlatch: () => void;
   beforeEach(() => {
+    // Terminal palette rows exist only on the local surface set.
+    unlatch = latchGatewayTierForTest("local");
     resetPaletteHarness();
   });
 
   afterEach(() => {
+    unlatch();
     vi.clearAllMocks();
   });
 

--- a/web/src/systems/os/hooks/use-desktop-dock.ts
+++ b/web/src/systems/os/hooks/use-desktop-dock.ts
@@ -28,6 +28,13 @@ export interface UseDesktopDockOptions {
    * the same open-window rule as every other app (isolated dock tests).
    */
   terminalLive?: boolean;
+  /**
+   * Whether the Terminal launcher belongs in the dock at all. Remote tiers do
+   * not register terminal routes, so the entry is absent — never disabled
+   * (BR-1). Production passes the capability truth; isolated dock tests keep
+   * the local default.
+   */
+  includeTerminal?: boolean;
 }
 
 /**
@@ -37,7 +44,7 @@ export interface UseDesktopDockOptions {
  */
 export function useDesktopDock(
   badges: OsAttentionBadges,
-  { onNewSession, terminalLive }: UseDesktopDockOptions
+  { onNewSession, terminalLive, includeTerminal = true }: UseDesktopDockOptions
 ): DesktopDockModel {
   const { manager, coordinator } = useOsShell();
   const launchCatalog = useSessionLaunchCatalog();
@@ -75,6 +82,9 @@ export function useDesktopDock(
     // Catalog seams: Home+Terminal | Agents…Triggers | Marketplace…Knowledge | Sandbox+Vault.
     if (index > 0) entries.push({ id: `sep-${index}`, sep: true });
     for (const app of group) {
+      // Terminal routes only exist on the local surface set, so the launcher is
+      // absent on remote tiers instead of opening a window that cannot work.
+      if (app.id === "terminal" && !includeTerminal) continue;
       const state = windowStates[app.id];
       entries.push({
         id: app.id,

--- a/web/src/systems/os/hooks/use-desktop-shell-scoped-body.ts
+++ b/web/src/systems/os/hooks/use-desktop-shell-scoped-body.ts
@@ -1,0 +1,38 @@
+import { useGatewayLoopbackOnly } from "@/systems/gateway";
+import {
+  useSessionCreateActions,
+  useSessionLifecycleActions,
+  useSessionListView,
+} from "@/systems/session";
+
+import { useProfileAutomationEnablement } from "./use-profile-automation-enablement";
+
+/**
+ * Scoped shell actions and signals for the desktop body, in one hook so the
+ * body component stays under the component-complexity budget.
+ */
+type DesktopShellScopedWorkspaceId = NonNullable<
+  Parameters<typeof useSessionLifecycleActions>[0]
+>["workspaceId"];
+
+export function useDesktopShellScopedBody({
+  runtimeWorkspaceId,
+}: {
+  runtimeWorkspaceId: DesktopShellScopedWorkspaceId;
+}) {
+  const sessionCreate = useSessionCreateActions();
+  const sessionLifecycle = useSessionLifecycleActions({ workspaceId: runtimeWorkspaceId });
+  const setAutomationEnabled = useProfileAutomationEnablement();
+  // The 403 backstop (US-002): any loopback-only refusal the daemon still
+  // returns — stale UI, deep link — lands here as the truthful loopback-only
+  // strip, never a generic error toast. It persists until the tier latches
+  // `local` again, so a retry cannot silently swallow the explanation.
+  const loopbackOnly = useGatewayLoopbackOnly();
+  // Scope and order are the operator's, persisted by the daemon; the modal
+  // renders them rather than fetching its own.
+  const sessionListView = useSessionListView();
+  const openNewSession = () => {
+    sessionCreate.openForAgent("");
+  };
+  return { loopbackOnly, openNewSession, sessionLifecycle, sessionListView, setAutomationEnabled };
+}

--- a/web/src/systems/os/hooks/use-menubar-actions.ts
+++ b/web/src/systems/os/hooks/use-menubar-actions.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
 
-import { OS_COMPACT_BREAKPOINT, type OsAppId } from "../lib/os-types";
+import { OS_COMPACT_BREAKPOINT, OS_TOUCH_BREAKPOINT, type OsAppId } from "../lib/os-types";
 import { useOsShell } from "./use-os-shell";
 import { useOsWindowCommands, type OsWindowCommandsModel } from "./use-os-window-commands";
 import { useAgentCreateHost } from "@/systems/agent";
@@ -8,24 +8,33 @@ import { settingsSectionPath } from "@/systems/settings";
 
 /** Below the compact breakpoint the app menus collapse (US-019.EC-3). */
 const COMPACT_QUERY = `(max-width: ${OS_COMPACT_BREAKPOINT - 0.02}px)`;
+/** At or below the touch tier, chrome targets reach the 44px floor (S6/T1). */
+const TOUCH_QUERY = `(max-width: ${OS_TOUCH_BREAKPOINT}px)`;
 
-function subscribeCompact(callback: () => void): () => void {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-    return () => undefined;
-  }
-  const mql = window.matchMedia(COMPACT_QUERY);
-  if (typeof mql.addEventListener === "function") {
-    mql.addEventListener("change", callback);
-    return () => mql.removeEventListener("change", callback);
-  }
-  mql.addListener(callback);
-  return () => mql.removeListener(callback);
+function subscribeQuery(query: string): (callback: () => void) => () => void {
+  return callback => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return () => undefined;
+    }
+    const mql = window.matchMedia(query);
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", callback);
+      return () => mql.removeEventListener("change", callback);
+    }
+    mql.addListener(callback);
+    return () => mql.removeListener(callback);
+  };
 }
 
-function getCompact(): boolean {
+function readQuery(query: string): boolean {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
-  return window.matchMedia(COMPACT_QUERY).matches;
+  return window.matchMedia(query).matches;
 }
+
+const subscribeCompact = subscribeQuery(COMPACT_QUERY);
+const getCompact = () => readQuery(COMPACT_QUERY);
+const subscribeTouch = subscribeQuery(TOUCH_QUERY);
+const getTouch = () => readQuery(TOUCH_QUERY);
 
 export interface MenubarActionsModel {
   /**
@@ -34,6 +43,11 @@ export interface MenubarActionsModel {
    * item; the palette still carries every action.
    */
   menusVisible: boolean;
+  /**
+   * Touch tier (S6/T1): at or below `OS_TOUCH_BREAKPOINT` menubar chrome grows
+   * to the 44px floor and the identity chip compresses.
+   */
+  touchViewport: boolean;
   /** The window-manager fence the ⌘K palette uses for the same decisions. */
   canOpenApps: boolean;
   windowCommands: OsWindowCommandsModel;
@@ -54,6 +68,7 @@ export function useMenubarActions(): MenubarActionsModel {
   const agentCreate = useAgentCreateHost();
   const windowCommands = useOsWindowCommands();
   const compact = useSyncExternalStore(subscribeCompact, getCompact, () => false);
+  const touchViewport = useSyncExternalStore(subscribeTouch, getTouch, () => false);
   const canOpenApps = windowCommands.commandsAvailable;
 
   const openApp = (app: OsAppId) => {
@@ -62,6 +77,7 @@ export function useMenubarActions(): MenubarActionsModel {
 
   return {
     menusVisible: !compact,
+    touchViewport,
     canOpenApps,
     windowCommands,
     openApp,

--- a/web/src/systems/os/hooks/use-os-attention.ts
+++ b/web/src/systems/os/hooks/use-os-attention.ts
@@ -1,6 +1,7 @@
 import { useDocumentVisible } from "@/hooks/use-document-visible";
 import { useQuery } from "@tanstack/react-query";
 
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useLoopNodeExists, useLoopRequestAttention } from "@/systems/loops";
 import { useProfileReadScope } from "@/systems/profiles";
 import {
@@ -238,7 +239,10 @@ function useTerminalAttentionSources({
   workspaceId: string | null;
 }) {
   const profile = useProfileReadScope();
-  const enabled = workspaceId !== null;
+  // Remote tiers register no terminal routes: no badge, no rows, no queries
+  // that could only ever refuse.
+  const { localTaskLifecycle } = useGatewayCapabilities();
+  const enabled = workspaceId !== null && localTaskLifecycle;
   const terminalReadScope = terminalScope(workspaceId ?? "", profile.destination);
   const terminalRequests = useQuery({
     ...terminalInputRequestsQuery(terminalReadScope),

--- a/web/src/systems/os/hooks/use-os-palette-terminal-search.ts
+++ b/web/src/systems/os/hooks/use-os-palette-terminal-search.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { terminalCatalogQuery, terminalScope, type TerminalInfo } from "@/systems/terminal/parts";
 
 import type { CmdPaletteRankSignals } from "../lib/cmd-palette-types";
@@ -24,7 +25,9 @@ export interface UseOsPaletteTerminalSearchOptions {
  * Live terminal jump rows for palette domain search.
  *
  * Each row is a real catalog terminal with its id, title, and state.
- * Create/open lives on `app.open.terminal`, not here.
+ * Create/open lives on `app.open.terminal`, not here. Remote tiers register
+ * no terminal routes, so the section is empty there and the catalog is never
+ * queried (BR-1).
  */
 export function useOsPaletteTerminalSection({
   enabled,
@@ -35,11 +38,12 @@ export function useOsPaletteTerminalSection({
   workspaceLabel,
   limit,
 }: UseOsPaletteTerminalSearchOptions): OsPaletteDomainSection {
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const catalog = useQuery({
     ...terminalCatalogQuery(terminalScope(workspaceId ?? "", profile)),
-    enabled: enabled && workspaceId !== null && workspaceId !== "",
+    enabled: enabled && localTaskLifecycle && workspaceId !== null && workspaceId !== "",
   });
-  if (signals === null) {
+  if (signals === null || !localTaskLifecycle) {
     return { title: "Terminals", rows: [], total: 0, loading: false, error: null };
   }
   return section(

--- a/web/src/systems/os/hooks/use-terminal-dock-running.ts
+++ b/web/src/systems/os/hooks/use-terminal-dock-running.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useProfileReadScope } from "@/systems/profiles";
 import { terminalCatalogQuery, terminalScope, terminalsRunning } from "@/systems/terminal";
 import { useActiveWorkspace } from "@/systems/workspace";
@@ -11,16 +12,18 @@ import { useActiveWorkspace } from "@/systems/workspace";
  *
  * The dock's live mark is catalog truth, not "a Terminal window is open".
  * An empty query or a project that is not ready is idle — never a guess
- * from window state.
+ * from window state. Remote tiers register no terminal routes, so the
+ * catalog is never queried there and the mark stays idle.
  */
 export function useTerminalDockRunning(): boolean {
   const workspace = useActiveWorkspace();
   const profile = useProfileReadScope();
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const workspaceId = workspace.runtimeWorkspaceId ?? "";
   const catalogScope = terminalScope(workspaceId, profile.destination, profile.aggregate);
   const catalog = useQuery({
     ...terminalCatalogQuery(catalogScope),
-    enabled: workspaceId !== "",
+    enabled: workspaceId !== "" && localTaskLifecycle,
   });
   if (workspaceId === "" || catalog.data === undefined) return false;
   return terminalsRunning(catalog.data);

--- a/web/src/systems/os/lib/os-types.ts
+++ b/web/src/systems/os/lib/os-types.ts
@@ -249,5 +249,12 @@ export interface WindowManagerController extends OsDesktopRuntime {
 }
 
 export const OS_COMPACT_BREAKPOINT = 960;
+/**
+ * Touch-tier floor (S6/T1): at this width and below, interactive chrome
+ * reaches the 44px floor (`--height-button-cta-lg`), the same tier the
+ * dialog shell and help tips already use. Below the compact breakpoint,
+ * above it chrome keeps desktop target sizes.
+ */
+export const OS_TOUCH_BREAKPOINT = 760;
 export const OS_WINDOW_MIN_WIDTH = 280;
 export const OS_WINDOW_MIN_HEIGHT = 180;

--- a/web/src/systems/os/lib/palette-view-inset.ts
+++ b/web/src/systems/os/lib/palette-view-inset.ts
@@ -11,21 +11,40 @@
  * height is compact; the chrome around the list is not.
  */
 
-export const paletteInputRailClass = "[&_[data-slot=command-input-group]]:px-3";
+export const paletteInputRailClass =
+  "[&_[data-slot=command-input-group]]:px-3 " +
+  // Touch tier (S6/T5): the query field reaches the 44px floor so the palette
+  // input is a full thumb target and stays legible above the keyboard.
+  "max-[760px]:[&_[data-slot=command-input-group]]:h-auto " +
+  "max-[760px]:[&_[data-slot=command-input-group]]:min-h-(--height-button-cta-lg)";
 
 /** Query head: breadcrumb + field, closed by the same hairline as the footer. */
 export const paletteHeadClass = "border-b border-line pb-2";
 
-export const paletteListClass = "max-h-[46vh] px-1 pt-3 pb-3";
+/**
+ * Results well: desktop caps at 46vh; the touch tier grows to
+ * min(52dvh, 440px) — the palette stays top-anchored at 390×844 (T5), and the
+ * well scrolls under the keyboard instead of pushing the input off-screen.
+ */
+export const paletteListClass = "max-h-[46vh] px-1 pt-3 pb-3 max-[760px]:max-h-[min(52dvh,440px)]";
 
 export const paletteGroupClass =
   "p-0 **:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:py-1 **:[[cmdk-group-heading]]:text-faint";
 
 export const paletteGroupFollowClass = "mt-2 border-t border-line pt-2";
 
-export const paletteRowClass = "mt-0.5 h-control-compact gap-2 px-3 py-0 leading-none first:mt-0";
+/**
+ * Palette rows (S6/T1): desktop rows sit at the 32px compact control height;
+ * at the ≤760px touch tier every row reaches the shared 44px floor, so the
+ * ⌘K palette is thumb-navigable at 390×844.
+ */
+export const paletteRowClass =
+  "mt-0.5 h-control-compact gap-2 px-3 py-0 leading-none first:mt-0 " +
+  "max-[760px]:h-auto max-[760px]:min-h-(--height-button-cta-lg)";
 
-export const paletteRowTwoLineClass = "mt-0.5 min-h-11 gap-2 px-3 py-1.5 leading-none first:mt-0";
+export const paletteRowTwoLineClass =
+  "mt-0.5 min-h-11 gap-2 px-3 py-1.5 leading-none first:mt-0 " +
+  "max-[760px]:min-h-(--height-button-cta-lg)";
 
 /** Glyphs that sit in the open (back icon, breadcrumb, footer keys). */
 export const paletteViewLeadClass = "px-4";

--- a/web/src/systems/profiles/components/__tests__/profile-switcher.test.tsx
+++ b/web/src/systems/profiles/components/__tests__/profile-switcher.test.tsx
@@ -43,7 +43,7 @@ function renderSwitcher({
   archivedCount = 2,
   manageable = true,
   onSelectProfile = () => {},
-  onSelectAggregate = () => {},
+  onSelectAggregate,
   onCreate = () => {},
   onEditProfile,
   onOpenSettings = () => {},
@@ -58,7 +58,7 @@ function renderSwitcher({
         archivedCount={archivedCount}
         manageable={manageable}
         onSelectProfile={onSelectProfile}
-        onSelectAggregate={onSelectAggregate}
+        {...(onSelectAggregate ? { onSelectAggregate } : {})}
         onCreate={onCreate}
         {...(onEditProfile ? { onEditProfile } : {})}
         onOpenSettings={onOpenSettings}
@@ -159,6 +159,22 @@ describe("ProfileSwitcher", () => {
 
     await user.click(screen.getByTestId("profile-switcher-all"));
     expect(onSelectAggregate).toHaveBeenCalledOnce();
+  });
+
+  // Invariant: the aggregate entry is the same selection write as switching
+  // profiles, so when no handler is offered (remote tier refuses
+  // `PUT /api/profiles/selection`) the entry is absent, never disabled.
+  // Owning layer: the switcher composition (handler presence comes from
+  // `useProfileSwitcher`'s `profileEnablementWrites` gate).
+  // Canonical suite: this ProfileSwitcher interaction suite.
+  it("Should hide the aggregate entry when the tier cannot write the selection", async () => {
+    const user = userEvent.setup();
+    const onSelectAggregate = vi.fn();
+    renderSwitcher({ aggregate: true, onSelectAggregate: undefined });
+
+    await user.click(screen.getByTestId("os-menubar-profile"));
+    expect(screen.queryByTestId("profile-switcher-all")).not.toBeInTheDocument();
+    expect(onSelectAggregate).not.toHaveBeenCalled();
   });
 
   // Invariant: a row's edit affordance raises the canonical identity dialog for

--- a/web/src/systems/profiles/components/profile-switcher-menu.tsx
+++ b/web/src/systems/profiles/components/profile-switcher-menu.tsx
@@ -20,7 +20,11 @@ export interface ProfileSwitcherMenuProps {
   aggregate: boolean;
   archivedCount: number;
   onSelectProfile: (name: string) => void;
-  onSelectAggregate: () => void;
+  /**
+   * Absent when the tier cannot execute the aggregate selection write: the
+   * aggregate entry does not render at all (BR-1 — absent, never disabled).
+   */
+  onSelectAggregate?: () => void;
   onCreate: () => void;
   onEditProfile?: (name: string) => void;
   onOpenSettings: () => void;
@@ -44,7 +48,10 @@ export function ProfileSwitcherMenu({
   error = null,
   onRetry,
 }: ProfileSwitcherMenuProps) {
-  const showAggregate = aggregate || rows.length > 1 || archivedCount > 0;
+  // The aggregate entry is a selection write (PUT /api/profiles/selection):
+  // without a handler the tier cannot execute it, so the entry goes absent.
+  const showAggregate =
+    onSelectAggregate !== undefined && (aggregate || rows.length > 1 || archivedCount > 0);
 
   return (
     <Command className="bg-transparent p-0 shadow-none">

--- a/web/src/systems/profiles/components/profile-switcher-slot.tsx
+++ b/web/src/systems/profiles/components/profile-switcher-slot.tsx
@@ -25,7 +25,7 @@ export function ProfileSwitcherSlot({ onOpenSettings }: ProfileSwitcherSlotProps
       quiet={model.quiet}
       archivedCount={model.archivedCount}
       onSelectProfile={model.selectProfile}
-      onSelectAggregate={model.selectAggregate}
+      {...(model.selectAggregate ? { onSelectAggregate: model.selectAggregate } : {})}
       onCreate={model.create}
       onEditProfile={name => openProfileDialog({ flow: "update", profile: name })}
       onOpenSettings={onOpenSettings}

--- a/web/src/systems/profiles/components/profile-switcher.tsx
+++ b/web/src/systems/profiles/components/profile-switcher.tsx
@@ -16,7 +16,12 @@ export interface ProfileSwitcherProps {
   quiet: boolean;
   archivedCount: number;
   onSelectProfile: (name: string) => void;
-  onSelectAggregate: () => void;
+  /**
+   * Absent when the tier cannot execute the aggregate selection write
+   * (`profile_remote_management_forbidden`): the aggregate entry goes absent
+   * from the menu, never disabled (BR-1).
+   */
+  onSelectAggregate?: () => void;
   onCreate: () => void;
   onEditProfile?: (name: string) => void;
   onOpenSettings: () => void;
@@ -97,7 +102,7 @@ export function ProfileSwitcher({
           aggregate={aggregate}
           archivedCount={archivedCount}
           onSelectProfile={name => close(() => onSelectProfile(name))()}
-          onSelectAggregate={close(onSelectAggregate)}
+          {...(onSelectAggregate ? { onSelectAggregate: close(onSelectAggregate) } : {})}
           onCreate={close(onCreate)}
           {...(onEditProfile
             ? { onEditProfile: (name: string) => close(() => onEditProfile(name))() }

--- a/web/src/systems/profiles/hooks/__tests__/use-profiles-palette-view.test.tsx
+++ b/web/src/systems/profiles/hooks/__tests__/use-profiles-palette-view.test.tsx
@@ -14,7 +14,7 @@ import { OsPaletteViewShell } from "@/systems/os/components/os-palette-view-shel
 import type { PaletteViewDefinition } from "@/systems/os/lib/palette-view-registry";
 
 vi.mock("@/systems/gateway", () => ({
-  useGatewayAccessTier: () => "local",
+  useGatewayCapabilities: () => ({ profileEnablementWrites: true }),
 }));
 
 import { profileKeys } from "../../lib/query-keys";

--- a/web/src/systems/profiles/hooks/__tests__/use-profiles-settings-page.test.tsx
+++ b/web/src/systems/profiles/hooks/__tests__/use-profiles-settings-page.test.tsx
@@ -9,7 +9,8 @@ const state = {
 };
 
 vi.mock("@/systems/gateway", () => ({
-  useGatewayAccessTier: () => state.tier,
+  // The capability flag is the gating truth; the tier values below only drive it.
+  useGatewayCapabilities: () => ({ profileEnablementWrites: state.tier === "local" }),
 }));
 
 vi.mock("@/systems/workspace", () => ({

--- a/web/src/systems/profiles/hooks/use-profile-switcher.ts
+++ b/web/src/systems/profiles/hooks/use-profile-switcher.ts
@@ -16,10 +16,16 @@ export interface ProfileSwitcherModel {
   rows: ProfileRow[];
   activeName: string;
   aggregate: boolean;
+  /**
+   * Switches to the aggregate view. That is the same selection write as
+   * switching profiles (`PUT /api/profiles/selection`), which remote tiers
+   * refuse with `profile_remote_management_forbidden` — so the handler — and
+   * the menu entry it drives — goes absent on those tiers (BR-1).
+   */
+  selectAggregate: (() => void) | undefined;
   quiet: boolean;
   archivedCount: number;
   selectProfile: (name: string) => void;
-  selectAggregate: () => void;
   create: () => void;
   manageable: boolean;
   isLoading: boolean;
@@ -51,7 +57,9 @@ export function useProfileSwitcher(lens: ProfileLens): ProfileSwitcherModel {
     selectProfile: name => {
       if (profileEnablementWrites) switchProfile.mutate({ kind: "profile", profile: name });
     },
-    selectAggregate: () => switchProfile.mutate({ kind: "aggregate" }),
+    selectAggregate: profileEnablementWrites
+      ? () => switchProfile.mutate({ kind: "aggregate" })
+      : undefined,
     create: () => {
       if (profileEnablementWrites) openProfileDialog({ flow: "create" });
     },

--- a/web/src/systems/profiles/hooks/use-profile-switcher.ts
+++ b/web/src/systems/profiles/hooks/use-profile-switcher.ts
@@ -10,7 +10,7 @@ import {
 } from "../lib/profile-rows";
 import { openProfileDialog } from "../stores/profile-dialog-store";
 import type { ProfileLens } from "../types";
-import { useGatewayAccessTier } from "@/systems/gateway";
+import { useGatewayCapabilities } from "@/systems/gateway";
 
 export interface ProfileSwitcherModel {
   rows: ProfileRow[];
@@ -37,8 +37,8 @@ export function useProfileSwitcher(lens: ProfileLens): ProfileSwitcherModel {
   const profiles = useProfiles();
   const view = useActiveProfileView(lens);
   const switchProfile = useSwitchProfile(lens);
-  const tier = useGatewayAccessTier();
 
+  const { profileEnablementWrites } = useGatewayCapabilities();
   const all = profiles.data ?? [];
   const activeName = view.kind === "profile" ? view.profile : PERMANENT_PROFILE;
 
@@ -49,13 +49,15 @@ export function useProfileSwitcher(lens: ProfileLens): ProfileSwitcherModel {
     quiet: isQuiet(all),
     archivedCount: archivedProfiles(all).length,
     selectProfile: name => {
-      if (tier === "local") switchProfile.mutate({ kind: "profile", profile: name });
+      if (profileEnablementWrites) switchProfile.mutate({ kind: "profile", profile: name });
     },
     selectAggregate: () => switchProfile.mutate({ kind: "aggregate" }),
     create: () => {
-      if (tier === "local") openProfileDialog({ flow: "create" });
+      if (profileEnablementWrites) openProfileDialog({ flow: "create" });
     },
-    manageable: tier === "local" && !profiles.isLoading && !profiles.isError,
+    // Profile management is a local-only write surface: on remote tiers the
+    // affordances go absent (manageable=false hides the create/edit entries).
+    manageable: profileEnablementWrites && !profiles.isLoading && !profiles.isError,
     isLoading: profiles.isLoading,
     error: profiles.error instanceof Error ? profiles.error : null,
     retry: () => void profiles.refetch(),

--- a/web/src/systems/profiles/hooks/use-profiles-palette-view.tsx
+++ b/web/src/systems/profiles/hooks/use-profiles-palette-view.tsx
@@ -124,7 +124,7 @@ export function useProfilesPaletteView({
           },
         ]
       : []),
-    ...(showActions
+    ...(showActions && profileEnablementWrites
       ? [
           {
             value: "action:aggregate",
@@ -135,6 +135,9 @@ export function useProfilesPaletteView({
                 <span>Show all profiles</span>
               </span>
             ),
+            // Same refusal class as the switcher: aggregate selection PUTs are
+            // ProfileRemoteWriteForbidden on remote tiers, so the affordance is
+            // absent (not disabled) there.
             onSelect: () => {
               onDismiss();
               switchProfile.mutate({ kind: "aggregate" });

--- a/web/src/systems/profiles/hooks/use-profiles-palette-view.tsx
+++ b/web/src/systems/profiles/hooks/use-profiles-palette-view.tsx
@@ -13,7 +13,7 @@ import { openProfileDialog } from "../stores/profile-dialog-store";
 import type { ProfileLens } from "../types";
 import { useActiveProfileView, useSwitchProfile } from "./use-profile-selection";
 import { useProfiles } from "./use-profiles";
-import { useGatewayAccessTier } from "@/systems/gateway";
+import { useGatewayCapabilities } from "@/systems/gateway";
 
 /**
  * Row contract of the palette view stack, restated structurally.
@@ -71,12 +71,12 @@ export function useProfilesPaletteView({
   const profiles = useProfiles();
   const view = useActiveProfileView(lens);
   const switchProfile = useSwitchProfile(lens);
-  const tier = useGatewayAccessTier();
+  const { profileEnablementWrites } = useGatewayCapabilities();
 
   const all = profiles.data ?? [];
   const currentName = view.kind === "profile" ? view.profile : "";
   const catalogReady = !profiles.isLoading && !profiles.isError;
-  const manageable = tier === "local" && !profiles.isLoading && !profiles.isError;
+  const manageable = profileEnablementWrites && !profiles.isLoading && !profiles.isError;
   const active = catalogReady
     ? toProfileRows(activeProfiles(all), currentName).filter(row => matches(row, query))
     : [];
@@ -164,7 +164,7 @@ export function useProfilesPaletteView({
     ),
     note: null,
     backHint: "Profiles",
-    resetKey: `${currentName}|${all.length}|${archived.length}|${tier ?? "unknown"}|${profiles.status}`,
+    resetKey: `${currentName}|${all.length}|${archived.length}|${profileEnablementWrites ? "writable" : "read-only"}|${profiles.status}`,
     onEmptyQueryBackspace: () => false,
   };
 }

--- a/web/src/systems/profiles/hooks/use-profiles-settings-page.ts
+++ b/web/src/systems/profiles/hooks/use-profiles-settings-page.ts
@@ -1,4 +1,4 @@
-import { useGatewayAccessTier } from "@/systems/gateway";
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useWorkspaces } from "@/systems/workspace";
 
 import { activeProfiles, archivedProfiles } from "../lib/profile-rows";
@@ -35,7 +35,7 @@ export function useProfilesSettingsPage(): ProfilesSettingsPageModel {
   const selections = useProfileSelectionMap();
   const workspaces = useWorkspaces();
   const view = useActiveProfileView(lens);
-  const tier = useGatewayAccessTier();
+  const { profileEnablementWrites } = useGatewayCapabilities();
 
   const all = profiles.data ?? [];
   const names = new Map((workspaces.data ?? []).map(workspace => [workspace.id, workspace.name]));
@@ -45,7 +45,7 @@ export function useProfilesSettingsPage(): ProfilesSettingsPageModel {
     archived: archivedProfiles(all),
     selections: selections.data ?? [],
     currentName: view.kind === "profile" ? view.profile : "",
-    manageable: tier === "local",
+    manageable: profileEnablementWrites,
     isLoading: profiles.isLoading || selections.isLoading || workspaces.isLoading,
     errorMessage:
       [profiles.error, selections.error, workspaces.error].find(

--- a/web/src/systems/session/components/__tests__/session-inspector.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-inspector.test.tsx
@@ -157,7 +157,7 @@ describe("SessionInspector — Usage tab truthful wiring (/ §3.4)", () => {
   });
 
   it("Should format a non-USD cost with its currency code", () => {
-    const expectedCost = new Intl.NumberFormat(undefined, {
+    const expectedCost = new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "EUR",
       minimumFractionDigits: 2,

--- a/web/src/systems/session/components/goal/session-goal-strip.tsx
+++ b/web/src/systems/session/components/goal/session-goal-strip.tsx
@@ -93,7 +93,8 @@ function ContextRow({ context }: { context: SessionGoalSnapshot["context"] }) {
     <StripRow label="Context">
       <span className="font-mono text-badge text-subtle tabular-nums">
         {context.used !== null && context.size !== null
-          ? `${context.used.toLocaleString()} / ${context.size.toLocaleString()} tokens · ${threshold}`
+          ? // Pin en-US: product copy is English, so digits/separators must not vary by host locale.
+            `${context.used.toLocaleString("en-US")} / ${context.size.toLocaleString("en-US")} tokens · ${threshold}`
           : `${ratioLabel} · ${threshold}`}
       </span>
     </StripRow>

--- a/web/src/systems/session/components/session-inspector-sections.tsx
+++ b/web/src/systems/session/components/session-inspector-sections.tsx
@@ -9,7 +9,8 @@ import type { InspectorUsage } from "./session-inspector-types";
 
 function formatNumber(value?: number): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "—";
-  return value.toLocaleString();
+  // Pin en-US: product copy is English, so digits/separators must not vary by host locale.
+  return value.toLocaleString("en-US");
 }
 
 export function SessionInspectorUsageSection({
@@ -59,7 +60,7 @@ export function SessionInspectorUsageSection({
           </div>
           {turnCount > 0 ? (
             <Eyebrow className="text-subtle self-start" data-testid="session-inspector-usage-turns">
-              {`Across ${turnCount.toLocaleString()} turn${turnCount === 1 ? "" : "s"}`}
+              {`Across ${turnCount.toLocaleString("en-US")} turn${turnCount === 1 ? "" : "s"}`}
             </Eyebrow>
           ) : null}
         </>

--- a/web/src/systems/settings/components/__tests__/settings-page-frame.test.tsx
+++ b/web/src/systems/settings/components/__tests__/settings-page-frame.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 import { SettingsPageFrame } from "../settings-page-frame";
 import { SettingsSaveBar } from "../settings-save-bar";
@@ -18,6 +20,14 @@ function renderFrame(saveBar: React.ReactNode) {
 }
 
 describe("SettingsPageFrame", () => {
+  let unlatch: () => void;
+  beforeEach(() => {
+    // The frame gates the save bar and restart notice on the listener tier;
+    // these tests own the local shape (save bar present when dirty).
+    unlatch = latchGatewayTierForTest("local");
+  });
+  afterEach(() => unlatch());
+
   it("renders the subhead sentence, quiet meta, and body content", () => {
     renderFrame(null);
 
@@ -117,5 +127,26 @@ describe("SettingsPageFrame", () => {
     expect(subhead).toHaveTextContent("1 ready");
     expect(subhead).toHaveTextContent("updated now");
     expect(subhead.querySelectorAll('[aria-hidden="true"]')).toHaveLength(1);
+  });
+
+  it("hides the save bar while the tier cannot execute settings writes, keeping the read view", () => {
+    const unlatch = latchGatewayTierForTest("private");
+
+    try {
+      renderFrame(
+        <SettingsSaveBar
+          slug="general"
+          state={{ kind: "dirty", warnings: [] }}
+          onSave={() => {}}
+          onReset={() => {}}
+        />
+      );
+
+      // Reads stay intact; the write affordance is absent, never disabled.
+      expect(screen.getByTestId("frame-body-content")).toBeInTheDocument();
+      expect(screen.queryByTestId("settings-page-general-save-bar")).not.toBeInTheDocument();
+    } finally {
+      unlatch();
+    }
   });
 });

--- a/web/src/systems/settings/components/settings-page-frame.tsx
+++ b/web/src/systems/settings/components/settings-page-frame.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { cn } from "@compozy/ui";
 
+import { useGatewayCapabilities } from "@/systems/gateway";
 import type { SettingsRestartViewState } from "../lib/restart-presentation";
 import type { SettingsSectionSlug } from "../types";
 import { SettingsRestartNotice } from "./settings-restart-notice";
@@ -48,6 +49,10 @@ export function SettingsPageFrame({
   saveBar,
   children,
 }: SettingsPageFrameProps) {
+  // Settings writes (save bar) and daemon restarts are privileged mutations:
+  // on remote tiers their affordances are absent and the read view renders
+  // normally (BR-1).
+  const { privilegedMutations } = useGatewayCapabilities();
   const hasSubhead = Boolean(description || (meta && meta.length > 0));
 
   return (
@@ -80,9 +85,11 @@ export function SettingsPageFrame({
               ))}
             </div>
           ) : null}
-          {restart ? <SettingsRestartNotice restart={restart} slug={slug} /> : null}
+          {privilegedMutations && restart ? (
+            <SettingsRestartNotice restart={restart} slug={slug} />
+          ) : null}
           {children}
-          {saveBar}
+          {privilegedMutations ? saveBar : null}
         </div>
       </div>
     </div>

--- a/web/src/systems/settings/hooks/use-settings-extensions-page.ts
+++ b/web/src/systems/settings/hooks/use-settings-extensions-page.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { useSettingsPage } from "./use-settings-page";
 
+import { useGatewayCapabilities } from "@/systems/gateway";
 import {
   SettingsApiError,
   type SettingsHooksExtensionsSection,
@@ -47,6 +48,8 @@ export function useSettingsExtensionsPage() {
   const query = useSettingsHooksExtensions();
   const mutation = useUpdateSettingsHooksExtensions();
   const page = useSettingsPage({ currentSlug: "extensions" });
+  // Extension policy writes are privileged mutations; absent on remote tiers.
+  const { privilegedMutations } = useGatewayCapabilities();
   const envelope = query.data ?? null;
   const [draftOverride, setDraftOverride] = useState<PolicyConfig | undefined>();
   const draft = draftOverride ?? (envelope ? clonePolicy(envelope.config) : null);
@@ -57,7 +60,7 @@ export function useSettingsExtensionsPage() {
     mutation.mutate(body);
   };
   return {
-    canMutatePolicy: envelope?.transport_parity?.settings_http !== false,
+    canMutatePolicy: envelope?.transport_parity?.settings_http !== false && privilegedMutations,
     draft,
     envelope,
     error: query.error,

--- a/web/src/systems/settings/hooks/use-settings-hooks-page.ts
+++ b/web/src/systems/settings/hooks/use-settings-hooks-page.ts
@@ -120,12 +120,16 @@ export function useSettingsHooksPage() {
     errorMessage(createPreset.error) ??
     errorMessage(setPresetEnablement.error) ??
     errorMessage(deletePreset.error);
-  // Hook enablement and preset writes are local-only (ProfileRemoteWriteForbidden
-  // on remote tiers): the mutation affordances go absent, reads stay intact.
-  const { profileEnablementWrites } = useGatewayCapabilities();
+  // Hook-declaration PUTs hit loopbackMutationGuard (`loopback_mutation_required`,
+  // privilegedMutations); notification-preset enablement hits
+  // ProfileRemoteWriteForbidden (`profile_remote_management_forbidden`,
+  // profileEnablementWrites) — gate the conjunction on both refusal classes.
+  const { privilegedMutations, profileEnablementWrites } = useGatewayCapabilities();
   return {
     canMutateHooks:
-      capabilityQuery.data?.transport_parity?.settings_http !== false && profileEnablementWrites,
+      capabilityQuery.data?.transport_parity?.settings_http !== false &&
+      privilegedMutations &&
+      profileEnablementWrites,
     createNotificationPreset,
     deleteNotificationPreset,
     envelope: query.data ?? null,

--- a/web/src/systems/settings/hooks/use-settings-hooks-page.ts
+++ b/web/src/systems/settings/hooks/use-settings-hooks-page.ts
@@ -19,6 +19,7 @@ import {
   useSettingsHooksExtensions,
 } from "@/systems/settings";
 import { useProfileReadScope } from "@/systems/profiles";
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useActiveWorkspace } from "@/systems/workspace";
 
 function errorMessage(error: unknown): string | null {
@@ -119,8 +120,12 @@ export function useSettingsHooksPage() {
     errorMessage(createPreset.error) ??
     errorMessage(setPresetEnablement.error) ??
     errorMessage(deletePreset.error);
+  // Hook enablement and preset writes are local-only (ProfileRemoteWriteForbidden
+  // on remote tiers): the mutation affordances go absent, reads stay intact.
+  const { profileEnablementWrites } = useGatewayCapabilities();
   return {
-    canMutateHooks: capabilityQuery.data?.transport_parity?.settings_http !== false,
+    canMutateHooks:
+      capabilityQuery.data?.transport_parity?.settings_http !== false && profileEnablementWrites,
     createNotificationPreset,
     deleteNotificationPreset,
     envelope: query.data ?? null,

--- a/web/src/systems/tasks/components/__tests__/task-overview-panel.test.tsx
+++ b/web/src/systems/tasks/components/__tests__/task-overview-panel.test.tsx
@@ -164,6 +164,47 @@ describe("TaskOverviewPanel", () => {
     expect(handlers.onOpenRun).toHaveBeenCalledWith("run_active");
   });
 
+  // Invariant: the Now strip's lifecycle affordances (approve/reject/resume/
+  // recover) register only on the local surface set, so without their handlers
+  // they are absent, never disabled (BR-1); the read bands stay on every tier.
+  // Owning layer: TaskNowAttentionStates composition.
+  // Canonical suite: TaskOverviewPanel component tests.
+  it("Should keep the attention read states while omitting unoffered lifecycle actions", () => {
+    const detail = buildDetailFixture({
+      task: {
+        approval_state: "pending",
+        blocked_reasons: [{ reason: "Paused by operator", source: "paused" }],
+        status: "needs_attention",
+      },
+      summary: { active_run: null, status: "needs_attention" },
+    } as never);
+
+    render(
+      <TaskOverviewPanel
+        detail={detail}
+        isLive={false}
+        nowHandlers={{
+          ...buildHandlers(),
+          onApprove: undefined,
+          onRecover: undefined,
+          onReject: undefined,
+          onResume: undefined,
+        }}
+        onViewAllActivity={vi.fn()}
+        runs={[]}
+        timeline={[]}
+      />
+    );
+
+    expect(screen.getByTestId("tasks-detail-now-approval")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-paused")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-detail-now-stuck")).toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-approve")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-reject")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-resume")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-detail-now-recover")).not.toBeInTheDocument();
+  });
+
   it("Should render the route-owned active-run elapsed value", () => {
     const baseline = buildDetailFixture();
     const detail = buildDetailFixture({

--- a/web/src/systems/tasks/components/__tests__/task-properties-rail.test.tsx
+++ b/web/src/systems/tasks/components/__tests__/task-properties-rail.test.tsx
@@ -46,4 +46,99 @@ describe("TaskPropertiesRail", () => {
     fireEvent.click(approve);
     expect(onApprove).not.toHaveBeenCalled();
   });
+
+  // Invariant: the approval mutation buttons register only on the local
+  // surface set, so without their handlers they are absent, never disabled
+  // (BR-1); the approval read rows stay on every tier.
+  // Owning layer: TaskPropertiesRail composition.
+  // Canonical suite: TaskPropertiesRail component tests.
+  it("Should omit the approval actions when their handlers are not offered", () => {
+    render(
+      <TaskPropertiesRail
+        detail={buildDetailFixture({
+          task: { approval_state: "pending", status: "blocked" },
+          summary: { status: "blocked" },
+        } as never)}
+        onAutoEnqueueChange={vi.fn()}
+        onEditSetup={vi.fn()}
+        onInspect={vi.fn()}
+        onPriorityChange={vi.fn()}
+        runs={[]}
+      />
+    );
+
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-rail-approve")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-rail-reject")).not.toBeInTheDocument();
+  });
+
+  // Invariant: priority/auto-enqueue persist through task PATCH (UpdateTask),
+  // a local-only mutation route, so the inline editors are absent, never
+  // disabled, when their handlers are not offered (BR-1); the read rows keep
+  // the current values on every tier.
+  // Owning layer: TaskPropertiesRail composition.
+  // Canonical suite: TaskPropertiesRail component tests.
+  it("Should keep the priority and auto-enqueue read rows without their editors", () => {
+    render(
+      <TaskPropertiesRail
+        detail={buildDetailFixture()}
+        onEditSetup={vi.fn()}
+        onInspect={vi.fn()}
+        runs={[]}
+      />
+    );
+
+    expect(screen.queryByTestId("tasks-rail-priority")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tasks-rail-auto-enqueue")).not.toBeInTheDocument();
+    expect(screen.getByText("Priority")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("Auto-enqueue")).toBeInTheDocument();
+    expect(screen.getByText("Off")).toBeInTheDocument();
+  });
+
+  it("Should render the priority and auto-enqueue editors when their handlers are offered", () => {
+    render(
+      <TaskPropertiesRail
+        detail={buildDetailFixture()}
+        onAutoEnqueueChange={vi.fn()}
+        onEditSetup={vi.fn()}
+        onInspect={vi.fn()}
+        onPriorityChange={vi.fn()}
+        runs={[]}
+      />
+    );
+
+    expect(screen.getByTestId("tasks-rail-priority")).toBeInTheDocument();
+    expect(screen.getByTestId("tasks-rail-auto-enqueue")).toBeInTheDocument();
+    expect(screen.queryByText("Off")).not.toBeInTheDocument();
+  });
+
+  // Invariant: the setup editor saves through the execution-profile PUT
+  // (SetTaskExecutionProfile), a local-only mutation route, so the "Edit
+  // setup" entry is absent, never disabled, when its handler is not offered
+  // (BR-1); the execution read rows keep the current values on every tier.
+  // Owning layer: TaskPropertiesRail composition.
+  // Canonical suite: TaskPropertiesRail component tests.
+  it("Should omit the Edit setup entry when its handler is not offered", () => {
+    render(<TaskPropertiesRail detail={buildDetailFixture()} onInspect={vi.fn()} runs={[]} />);
+
+    expect(screen.queryByTestId("tasks-rail-edit-setup")).not.toBeInTheDocument();
+    expect(screen.getByText("Attempts")).toBeInTheDocument();
+    expect(screen.getByText("Auto-enqueue")).toBeInTheDocument();
+  });
+
+  it("Should render the Edit setup entry when its handler is offered", () => {
+    const onEditSetup = vi.fn();
+    render(
+      <TaskPropertiesRail
+        detail={buildDetailFixture()}
+        onEditSetup={onEditSetup}
+        onInspect={vi.fn()}
+        runs={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("tasks-rail-edit-setup"));
+    expect(onEditSetup).toHaveBeenCalledTimes(1);
+  });
 });

--- a/web/src/systems/tasks/components/task-external-result.tsx
+++ b/web/src/systems/tasks/components/task-external-result.tsx
@@ -13,7 +13,8 @@ import {
 import type { TaskRunResultPage } from "../types";
 import type { TaskResultPageController } from "./task-result-types";
 
-const NUMBER_FORMATTER = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+// Pin en-US: product copy is English, so digits/separators must not vary by host locale.
+const NUMBER_FORMATTER = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 
 export function TaskExternalResult({
   controller,

--- a/web/src/systems/tasks/components/task-now-attention-states.tsx
+++ b/web/src/systems/tasks/components/task-now-attention-states.tsx
@@ -35,10 +35,12 @@ function TaskApprovalState({
   pending,
 }: Pick<TaskNowAttentionStatesProps, "handlers" | "pending">) {
   const approvalPending = Boolean(pending.approve || pending.reject);
-  return (
-    <TaskStateBand
-      actions={
-        <>
+  // The band is a read state and stays on every tier; only the mutation
+  // affordances go absent when their handlers are not offered (BR-1).
+  const actions =
+    handlers.onApprove || handlers.onReject ? (
+      <>
+        {handlers.onReject ? (
           <Button
             className="min-h-6"
             data-testid="tasks-detail-now-reject"
@@ -50,6 +52,8 @@ function TaskApprovalState({
           >
             Reject
           </Button>
+        ) : null}
+        {handlers.onApprove ? (
           <Button
             className="min-h-6"
             data-testid="tasks-detail-now-approve"
@@ -61,8 +65,12 @@ function TaskApprovalState({
           >
             Approve
           </Button>
-        </>
-      }
+        ) : null}
+      </>
+    ) : undefined;
+  return (
+    <TaskStateBand
+      actions={actions}
       body="A manual check is required before this task can start."
       data-testid="tasks-detail-now-approval"
       title="Waiting for your approval"
@@ -118,17 +126,19 @@ function TaskBlockingState({
     return (
       <TaskStateBand
         actions={
-          <Button
-            className="min-h-6"
-            data-testid="tasks-detail-now-resume"
-            disabled={pending.resume}
-            onClick={handlers.onResume}
-            size="sm"
-            type="button"
-            variant="neutral"
-          >
-            Resume
-          </Button>
+          handlers.onResume ? (
+            <Button
+              className="min-h-6"
+              data-testid="tasks-detail-now-resume"
+              disabled={pending.resume}
+              onClick={handlers.onResume}
+              size="sm"
+              type="button"
+              variant="neutral"
+            >
+              Resume
+            </Button>
+          ) : undefined
         }
         body={detail.task.paused_reason || "New runs stay queued until the task is resumed."}
         data-testid="tasks-detail-now-paused"
@@ -142,12 +152,15 @@ function TaskBlockingState({
   return (
     <TaskStateBand
       actions={
-        blockId ? (
+        // The band is a read state and stays on every tier; the Clear-block
+        // mutation affordance goes absent when its handler is not offered
+        // (BR-1).
+        blockId && handlers.onClearBlock ? (
           <Button
             className="min-h-6"
             data-testid={`tasks-detail-now-clear-block-${key}`}
             disabled={pending.clearBlock}
-            onClick={() => handlers.onClearBlock(blockId)}
+            onClick={() => handlers.onClearBlock?.(blockId)}
             size="sm"
             type="button"
             variant="neutral"
@@ -179,7 +192,7 @@ function TaskNeedsAttentionState({
   return (
     <TaskStateBand
       actions={
-        canRecover ? (
+        canRecover && handlers.onRecover ? (
           <Button
             className="min-h-6"
             data-testid="tasks-detail-now-recover"

--- a/web/src/systems/tasks/components/task-now-contract.ts
+++ b/web/src/systems/tasks/components/task-now-contract.ts
@@ -1,11 +1,18 @@
 export interface TaskNowStripHandlers {
   onOpenRun: (runId: string) => void;
   onOpenTask: (taskId: string) => void;
-  onApprove: () => void;
-  onReject: () => void;
-  onResume: () => void;
-  onRecover: () => void;
-  onClearBlock: (blockId: string) => void;
+  /**
+   * Approve/reject/resume/recover/clear-block hit task lifecycle routes
+   * registered only on the local surface set (`routes.go`
+   * `includeTaskMutations`), so these handlers — and the affordances they
+   * drive — go absent on remote tiers, never disabled (BR-1). Read handlers
+   * below stay on every tier.
+   */
+  onApprove?: () => void;
+  onReject?: () => void;
+  onResume?: () => void;
+  onRecover?: () => void;
+  onClearBlock?: (blockId: string) => void;
   onViewResult: () => void;
 }
 

--- a/web/src/systems/tasks/components/task-properties-rail.tsx
+++ b/web/src/systems/tasks/components/task-properties-rail.tsx
@@ -13,6 +13,7 @@ import {
 } from "../lib/task-formatters";
 import {
   taskExecutionProfileSummary,
+  taskPriorityPresentation,
   taskPropertiesRunSummary,
 } from "../lib/task-properties-presentation";
 import type { TaskDetailView, TaskExecutionProfile, TaskPriority, TaskRun } from "../types";
@@ -20,18 +21,47 @@ import { TaskLoopProvenance } from "./task-loop-provenance";
 import { TaskAutoEnqueueSwitch, TaskPriorityEditor } from "./task-rail-editors";
 import { TaskRailSection as RailSection } from "./task-rail-section";
 
+/** Read-only priority value: the editor trigger's dot + label, no affordance. */
+function PriorityValue({ priority }: { priority: TaskPriority }) {
+  const presentation = taskPriorityPresentation(priority);
+  return (
+    <>
+      <span aria-hidden="true" className={cn("size-1.5 rounded-full", presentation.dotClass)} />
+      {presentation.label}
+    </>
+  );
+}
+
 export interface TaskPropertiesRailProps extends ComponentPropsWithoutRef<"div"> {
   detail: TaskDetailView;
   runs: readonly TaskRun[];
   profile?: TaskExecutionProfile | null;
-  onEditSetup: () => void;
+  /**
+   * The setup editor saves through the execution-profile PUT
+   * (`SetTaskExecutionProfile`), a local-only mutation route (`routes.go`
+   * `includeTaskMutations`): the entry goes absent on remote tiers, never
+   * disabled (BR-1). The execution read rows stay on every tier.
+   */
+  onEditSetup?: () => void;
   onInspect: () => void;
-  onApprove: () => void;
-  onReject: () => void;
+  /**
+   * Approval mutations register only on the local surface set: the handlers —
+   * and the buttons they drive — go absent on remote tiers, never disabled
+   * (BR-1). The approval read rows stay on every tier.
+   */
+  onApprove?: () => void;
+  onReject?: () => void;
   approvalPending?: { approve?: boolean; reject?: boolean };
   updatePending?: boolean;
-  onPriorityChange: (priority: TaskPriority) => void;
-  onAutoEnqueueChange: (enabled: boolean) => void;
+  /**
+   * Priority/auto-enqueue persist through task PATCH (`UpdateTask`), a
+   * local-only mutation route (`routes.go` `includeTaskMutations`): the
+   * handlers — and the inline editors they drive — go absent on remote tiers,
+   * never disabled (BR-1). The read rows with the current values stay on
+   * every tier.
+   */
+  onPriorityChange?: (priority: TaskPriority) => void;
+  onAutoEnqueueChange?: (enabled: boolean) => void;
 }
 
 /**
@@ -58,6 +88,7 @@ export function TaskPropertiesRail({
 }: TaskPropertiesRailProps) {
   const record = detail.task;
   const activeRun = detail.summary?.active_run ?? null;
+  const priority = record.priority ?? "medium";
   const owner = record.owner ?? null;
   const ownerName = owner ? taskOwnerLabel(owner) : "Unassigned";
   const { worker, model, sandbox, channel } = taskExecutionProfileSummary(profile);
@@ -80,34 +111,44 @@ export function TaskPropertiesRail({
             Pending
           </PropertyRow>
           <PropertyRow label="Requested by">{record.created_by?.ref ?? "unknown"}</PropertyRow>
-          <div className="mt-2 flex items-center justify-end gap-2">
-            <Button
-              aria-busy={approvalPending.reject || undefined}
-              className="min-h-6"
-              data-testid="tasks-rail-reject"
-              disabled={approvalBusy}
-              onClick={onReject}
-              size="sm"
-              type="button"
-              variant="ghost"
-            >
-              {approvalPending.reject ? <Spinner aria-hidden="true" className="size-3" /> : null}
-              {approvalPending.reject ? "Rejecting…" : "Reject"}
-            </Button>
-            <Button
-              aria-busy={approvalPending.approve || undefined}
-              className="min-h-6"
-              data-testid="tasks-rail-approve"
-              disabled={approvalBusy}
-              onClick={onApprove}
-              size="sm"
-              type="button"
-              variant="neutral"
-            >
-              {approvalPending.approve ? <Spinner aria-hidden="true" className="size-3" /> : null}
-              {approvalPending.approve ? "Approving…" : "Approve"}
-            </Button>
-          </div>
+          {onApprove || onReject ? (
+            <div className="mt-2 flex items-center justify-end gap-2">
+              {onReject ? (
+                <Button
+                  aria-busy={approvalPending.reject || undefined}
+                  className="min-h-6"
+                  data-testid="tasks-rail-reject"
+                  disabled={approvalBusy}
+                  onClick={onReject}
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                >
+                  {approvalPending.reject ? (
+                    <Spinner aria-hidden="true" className="size-3" />
+                  ) : null}
+                  {approvalPending.reject ? "Rejecting…" : "Reject"}
+                </Button>
+              ) : null}
+              {onApprove ? (
+                <Button
+                  aria-busy={approvalPending.approve || undefined}
+                  className="min-h-6"
+                  data-testid="tasks-rail-approve"
+                  disabled={approvalBusy}
+                  onClick={onApprove}
+                  size="sm"
+                  type="button"
+                  variant="neutral"
+                >
+                  {approvalPending.approve ? (
+                    <Spinner aria-hidden="true" className="size-3" />
+                  ) : null}
+                  {approvalPending.approve ? "Approving…" : "Approve"}
+                </Button>
+              ) : null}
+            </div>
+          ) : null}
         </RailSection>
       ) : null}
 
@@ -157,14 +198,18 @@ export function TaskPropertiesRail({
       <RailSection label="Properties">
         <PropertyRow
           editor={
-            <TaskPriorityEditor
-              onChange={onPriorityChange}
-              pending={updatePending}
-              priority={record.priority ?? "medium"}
-            />
+            onPriorityChange ? (
+              <TaskPriorityEditor
+                onChange={onPriorityChange}
+                pending={updatePending}
+                priority={priority}
+              />
+            ) : undefined
           }
           label="Priority"
-        />
+        >
+          {onPriorityChange ? undefined : <PriorityValue priority={priority} />}
+        </PropertyRow>
         <PropertyRow label="Owner">
           {owner ? (
             <>
@@ -202,16 +247,18 @@ export function TaskPropertiesRail({
 
       <RailSection
         action={
-          <Button
-            className="-mr-1.5 min-h-6 px-1.5 py-0.5 text-eyebrow font-medium text-muted"
-            data-testid="tasks-rail-edit-setup"
-            onClick={onEditSetup}
-            size="sm"
-            type="button"
-            variant="ghost"
-          >
-            Edit setup
-          </Button>
+          onEditSetup ? (
+            <Button
+              className="-mr-1.5 min-h-6 px-1.5 py-0.5 text-eyebrow font-medium text-muted"
+              data-testid="tasks-rail-edit-setup"
+              onClick={onEditSetup}
+              size="sm"
+              type="button"
+              variant="ghost"
+            >
+              Edit setup
+            </Button>
+          ) : undefined
         }
         label="Execution"
       >
@@ -225,14 +272,18 @@ export function TaskPropertiesRail({
         <PropertyRow label="Attempts">{attemptsLabel}</PropertyRow>
         <PropertyRow
           editor={
-            <TaskAutoEnqueueSwitch
-              enabled={Boolean(record.auto_enqueue_on_ready)}
-              onChange={onAutoEnqueueChange}
-              pending={updatePending}
-            />
+            onAutoEnqueueChange ? (
+              <TaskAutoEnqueueSwitch
+                enabled={Boolean(record.auto_enqueue_on_ready)}
+                onChange={onAutoEnqueueChange}
+                pending={updatePending}
+              />
+            ) : undefined
           }
           label="Auto-enqueue"
-        />
+        >
+          {onAutoEnqueueChange ? undefined : record.auto_enqueue_on_ready ? "On" : "Off"}
+        </PropertyRow>
         {channel ? (
           <PropertyRow label="Channel" mono>
             {channel}

--- a/web/src/systems/tasks/components/task-run-page-head.tsx
+++ b/web/src/systems/tasks/components/task-run-page-head.tsx
@@ -48,7 +48,12 @@ export interface TaskRunPageActionsProps {
   maxAttempts?: number | null;
   isRetryPending?: boolean;
   onOpenSession: (sessionId: string) => void;
-  onRetry: () => void;
+  /**
+   * Absent when the tier cannot execute the run-retry write (a local-only
+   * lifecycle route): the Retry button does not render and the head falls
+   * back to the read affordances (BR-1 — absent, never disabled).
+   */
+  onRetry?: () => void;
 }
 
 /** Opens the live session or retries a failed run when another attempt is available. */
@@ -64,7 +69,7 @@ export function TaskRunPageActions({
   const attemptsRemain =
     maxAttempts !== undefined && (maxAttempts === null || record.attempt < maxAttempts);
 
-  if (record.status === "failed" && attemptsRemain) {
+  if (onRetry && record.status === "failed" && attemptsRemain) {
     return (
       <Button
         data-testid="tasks-run-retry"
@@ -101,6 +106,13 @@ export function TaskRunPageActions({
 export interface TaskRunPageOverflowProps {
   run: TaskRunDetailView;
   canRecover: boolean;
+  /**
+   * Whether the tier's route matrix registers the run-mutation routes
+   * (`registerRunMutationRoutes`, local surface set only). False drops the
+   * cancel/recover/release/force-fail entries while the copy read stays
+   * (BR-1 — absent, never disabled).
+   */
+  lifecycleEnabled?: boolean;
   pending: {
     cancel?: boolean;
     release?: boolean;
@@ -117,6 +129,7 @@ export interface TaskRunPageOverflowProps {
 export function TaskRunPageOverflow({
   run,
   canRecover,
+  lifecycleEnabled = true,
   pending,
   onCancel,
   onRelease,
@@ -125,9 +138,9 @@ export function TaskRunPageOverflow({
   onCopyRunId,
 }: TaskRunPageOverflowProps) {
   const status = run.run.status;
-  const isCancelable = CANCELABLE_STATUSES.has(status);
-  const canRelease = status === "claimed";
-  const canForceFail = status === "queued" || status === "claimed";
+  const isCancelable = lifecycleEnabled && CANCELABLE_STATUSES.has(status);
+  const canRelease = lifecycleEnabled && status === "claimed";
+  const canForceFail = lifecycleEnabled && (status === "queued" || status === "claimed");
 
   return (
     <DropdownMenu>
@@ -139,7 +152,7 @@ export function TaskRunPageOverflow({
         <TopbarOverflowIcon aria-hidden="true" className="size-3" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" data-testid="tasks-run-overflow-menu">
-        {canRecover ? (
+        {lifecycleEnabled && canRecover ? (
           <DropdownMenuItem
             data-testid="tasks-run-recover"
             disabled={pending.recover}

--- a/web/src/systems/tasks/components/tasks-dashboard-view.tsx
+++ b/web/src/systems/tasks/components/tasks-dashboard-view.tsx
@@ -18,6 +18,8 @@ export interface TasksDashboardViewProps {
   dashboard: TaskDashboardView | null;
   dashboardStatus?: "loading" | "ready";
   errorMessage?: string | null;
+  /** False on remote tiers: the scheduler routes do not exist there, so the panel is absent. */
+  schedulerAvailable?: boolean;
   scheduler?: SchedulerStatus | null;
   schedulerBacklog?: SchedulerBacklog | null;
   schedulerStatus?: "loading" | "ready";
@@ -40,6 +42,7 @@ export function TasksDashboardView({
   dashboard,
   dashboardStatus = "ready",
   errorMessage = null,
+  schedulerAvailable = true,
   scheduler = null,
   schedulerBacklog = null,
   schedulerStatus = "ready",
@@ -82,22 +85,24 @@ export function TasksDashboardView({
       className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-5"
       data-testid="tasks-dashboard-view"
     >
-      <SchedulerControlsPanel
-        backlog={schedulerBacklog}
-        backlogErrorMessage={schedulerBacklogErrorMessage}
-        errorMessage={schedulerErrorMessage}
-        isBacklogLoading={schedulerBacklogStatus === "loading"}
-        isLoading={schedulerStatus === "loading"}
-        onDrain={onDrainScheduler ? () => onDrainScheduler({ timeoutSeconds: 60 }) : undefined}
-        onPause={onPauseScheduler}
-        onResume={onResumeScheduler}
-        pending={{
-          drain: schedulerPendingActions?.has("drain") ?? false,
-          pause: schedulerPendingActions?.has("pause") ?? false,
-          resume: schedulerPendingActions?.has("resume") ?? false,
-        }}
-        status={scheduler}
-      />
+      {schedulerAvailable ? (
+        <SchedulerControlsPanel
+          backlog={schedulerBacklog}
+          backlogErrorMessage={schedulerBacklogErrorMessage}
+          errorMessage={schedulerErrorMessage}
+          isBacklogLoading={schedulerBacklogStatus === "loading"}
+          isLoading={schedulerStatus === "loading"}
+          onDrain={onDrainScheduler ? () => onDrainScheduler({ timeoutSeconds: 60 }) : undefined}
+          onPause={onPauseScheduler}
+          onResume={onResumeScheduler}
+          pending={{
+            drain: schedulerPendingActions?.has("drain") ?? false,
+            pause: schedulerPendingActions?.has("pause") ?? false,
+            resume: schedulerPendingActions?.has("resume") ?? false,
+          }}
+          status={scheduler}
+        />
+      ) : null}
 
       <TasksDashboardCards dashboard={dashboard} />
 

--- a/web/src/systems/tasks/hooks/__tests__/use-task-detail-page.test.tsx
+++ b/web/src/systems/tasks/hooks/__tests__/use-task-detail-page.test.tsx
@@ -34,7 +34,9 @@ vi.mock("@/systems/tasks/adapters/tasks-api", () => ({
   recoverTaskRun: vi.fn(),
   approveTask: vi.fn(),
   rejectTask: vi.fn(),
+  resumeTask: vi.fn(),
   retryTaskRun: vi.fn(),
+  enqueueTaskRun: vi.fn(),
   clearTaskBlock: vi.fn(),
   fanOutTaskRuns: vi.fn(),
   publishTask: vi.fn(),
@@ -48,6 +50,7 @@ import {
   approveTask,
   cancelTask,
   clearTaskBlock,
+  enqueueTaskRun,
   fanOutTaskRuns,
   getTask,
   getTaskExecutionProfile,
@@ -59,6 +62,7 @@ import {
   recoverTask,
   recoverTaskRun,
   rejectTask,
+  resumeTask,
   retryTaskRun,
 } from "@/systems/tasks/adapters/tasks-api";
 import { toast } from "sonner";
@@ -479,6 +483,9 @@ describe("useTaskDetailPage", () => {
 
     expect(approveTask).not.toHaveBeenCalled();
     expect(rejectTask).not.toHaveBeenCalled();
+    expect(resumeTask).not.toHaveBeenCalled();
+    expect(recoverTask).not.toHaveBeenCalled();
+    expect(enqueueTaskRun).not.toHaveBeenCalled();
     expect(clearTaskBlock).not.toHaveBeenCalled();
     expect(publishTask).not.toHaveBeenCalled();
     expect(cancelTask).not.toHaveBeenCalled();

--- a/web/src/systems/tasks/hooks/__tests__/use-task-detail-page.test.tsx
+++ b/web/src/systems/tasks/hooks/__tests__/use-task-detail-page.test.tsx
@@ -7,6 +7,7 @@ import {
   taskExecutionProfileFixture,
   taskRunReviewListFixture,
 } from "@/systems/tasks/mocks/fixtures";
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 const hooks = vi.hoisted(() => ({ stream: vi.fn() }));
 
@@ -36,12 +37,16 @@ vi.mock("@/systems/tasks/adapters/tasks-api", () => ({
   retryTaskRun: vi.fn(),
   clearTaskBlock: vi.fn(),
   fanOutTaskRuns: vi.fn(),
+  publishTask: vi.fn(),
+  cancelTask: vi.fn(),
+  pauseTask: vi.fn(),
 }));
 
 vi.mock("../use-task-stream", () => ({ useTaskStream: hooks.stream }));
 
 import {
   approveTask,
+  cancelTask,
   clearTaskBlock,
   fanOutTaskRuns,
   getTask,
@@ -49,6 +54,8 @@ import {
   getTaskTimeline,
   listTaskReviews,
   listTaskRuns,
+  pauseTask,
+  publishTask,
   recoverTask,
   recoverTaskRun,
   rejectTask,
@@ -78,8 +85,14 @@ const detailFixture = {
   },
 };
 
+let unlatch: () => void;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // The lifecycle verbs (approve/reject/resume/recover/start run) gate on the
+  // latched tier at the origin: latch `local` so the suite's default shape
+  // keeps firing them, and unlatch so each case starts from a clean store.
+  unlatch = latchGatewayTierForTest("local");
   vi.mocked(getTask).mockResolvedValue(detailFixture as never);
   vi.mocked(getTaskTimeline).mockResolvedValue([{ event_id: "evt_1", sequence: 1 }] as never);
   vi.mocked(listTaskRuns).mockResolvedValue([{ id: "run_1", status: "running" }] as never);
@@ -88,6 +101,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  unlatch();
   vi.restoreAllMocks();
 });
 
@@ -422,5 +436,54 @@ describe("useTaskDetailPage", () => {
 
     expect(recoverTaskRun).not.toHaveBeenCalled();
     expect(recoverTask).not.toHaveBeenCalled();
+  });
+
+  // Invariant: the lifecycle verbs (approve/reject/resume/recover/clear-block/
+  // start run/publish/cancel/pause/fan-out/run-retry) hit task/run mutation
+  // routes registered only on the local surface set, so at the origin they
+  // no-op on a remote tier — a wiring regression cannot fire a doomed request
+  // (BR-1).
+  // Owning layer: task detail page view model.
+  // Canonical suite: useTaskDetailPage hook tests.
+  it("Should not fire task lifecycle mutations when the tier cannot execute them", async () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    vi.mocked(approveTask).mockResolvedValue({ id: "task_001" } as never);
+    vi.mocked(rejectTask).mockResolvedValue({ id: "task_001" } as never);
+    vi.mocked(publishTask).mockResolvedValue({ id: "task_001" } as never);
+    vi.mocked(cancelTask).mockResolvedValue({ id: "task_001" } as never);
+    const fanOutRequest = {
+      designations: [{ brief: "Investigate checkout" }],
+      network_participation: { mode: "local" as const },
+    };
+
+    const { result } = renderHook(() => useTaskDetailPage("task_001"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.detail?.task.id).toBe("task_001"));
+
+    await act(async () => {
+      await result.current.handleApproveTask();
+      await result.current.handleRejectTask();
+      await result.current.handleResumeTask();
+      await result.current.handleRecoverTask();
+      await result.current.handleEnqueueRun();
+      await result.current.handleClearBlock("block_007");
+      await result.current.handlePublishTask();
+      await result.current.handleCancelTask();
+      await result.current.handlePauseTask("Investigating flakiness");
+      await result.current.handleRetryRun("run_failed");
+      await expect(result.current.handleFanOutRuns(fanOutRequest)).resolves.toBeUndefined();
+    });
+
+    expect(approveTask).not.toHaveBeenCalled();
+    expect(rejectTask).not.toHaveBeenCalled();
+    expect(clearTaskBlock).not.toHaveBeenCalled();
+    expect(publishTask).not.toHaveBeenCalled();
+    expect(cancelTask).not.toHaveBeenCalled();
+    expect(pauseTask).not.toHaveBeenCalled();
+    expect(retryTaskRun).not.toHaveBeenCalled();
+    expect(fanOutTaskRuns).not.toHaveBeenCalled();
   });
 });

--- a/web/src/systems/tasks/hooks/__tests__/use-task-editor-state.test.tsx
+++ b/web/src/systems/tasks/hooks/__tests__/use-task-editor-state.test.tsx
@@ -1,12 +1,17 @@
 // Suite: task editor local draft identity
 // Invariant: one source identity preserves edits, a new task/workspace source is visible in every
-// render, and each editor admits only one concurrent submission across source changes.
-// Boundary IN: task/profile Query projections, active workspace, and template route search.
+// render, each editor admits only one concurrent submission across source changes, and the submit
+// path no-ops at the origin when the latched tier cannot execute the local-only task create/PATCH
+// routes (BR-1).
+// Boundary IN: task/profile Query projections, active workspace, template route search, and the
+// latched gateway tier.
 // Boundary OUT: mutations and the presentational editor surface.
 import { act, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
 
 const editorMocks = vi.hoisted(() => ({
   activeWorkspaceId: "ws_alpha" as string | null,
@@ -82,8 +87,14 @@ function buildEditorDetail(id: string, title: string, updatedAt: string) {
   });
 }
 
+let unlatch: () => void;
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // The editors' submit paths gate on the latched tier at the origin: latch
+  // `local` so the suite's default shape keeps submitting, and unlatch so
+  // each case starts from a clean store.
+  unlatch = latchGatewayTierForTest("local");
   editorMocks.activeWorkspaceId = "ws_alpha";
   editorMocks.scope = "workspace";
   editorMocks.detail = buildEditorDetail("task_alpha", "Alpha source", "2026-07-25T10:00:00Z");
@@ -94,6 +105,10 @@ beforeEach(() => {
   editorMocks.detailOptions = undefined;
   editorMocks.profileOptions = undefined;
   editorMocks.activeWorkspaceOptions = undefined;
+});
+
+afterEach(() => {
+  unlatch();
 });
 
 /** The create flow resolves the acting profile, which is a server read. */
@@ -312,5 +327,43 @@ describe("task editor state identity", () => {
     expect(renderedTitles.length).toBeGreaterThan(0);
     expect(renderedTitles.every(title => title === "Beta source")).toBe(true);
     expect(result.current.draft.title).toBe("Beta source");
+  });
+
+  // Invariant: task create (POST /api/tasks and the child-task variant) and
+  // task PATCH register only on the local surface set (`routes.go`
+  // `includeTaskMutations`), so the editors' submit paths no-op at the origin
+  // on a remote tier — a wiring regression cannot fire a doomed request (BR-1).
+  // Owning layer: task editor state hooks.
+  // Canonical suite: useTaskCreateState / useTaskEditState hook tests.
+  it("Should no-op the edit submission when the tier cannot execute task mutations", async () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    const { result } = renderHook(() => useTaskEditState("task_alpha", vi.fn()), {
+      wrapper: createWrapper(),
+    });
+    const draft = { ...result.current.draft, title: "Doomed remote edit" };
+
+    await act(async () => {
+      await expect(result.current.handleSubmit(draft)).resolves.toBeNull();
+    });
+
+    expect(editorMocks.update).not.toHaveBeenCalled();
+  });
+
+  it("Should no-op the create submission when the tier cannot execute task mutations", async () => {
+    unlatch();
+    unlatch = latchGatewayTierForTest("private");
+    const { result } = renderHook(() => useTaskCreateState({}, vi.fn()), {
+      wrapper: createWrapper(),
+    });
+    const draft = { ...result.current.draft, title: "Doomed remote create" };
+
+    await act(async () => {
+      await expect(result.current.handleSubmit(draft, true)).resolves.toBeNull();
+    });
+
+    expect(editorMocks.create).not.toHaveBeenCalled();
+    expect(editorMocks.createChild).not.toHaveBeenCalled();
+    expect(editorMocks.enqueue).not.toHaveBeenCalled();
   });
 });

--- a/web/src/systems/tasks/hooks/__tests__/use-tasks-page.test.tsx
+++ b/web/src/systems/tasks/hooks/__tests__/use-tasks-page.test.tsx
@@ -3,6 +3,8 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { createElement, useState, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { latchGatewayTierForTest } from "@/test/gateway-tier";
+
 vi.mock("@/systems/tasks/adapters/tasks-api", () => ({
   listTasks: vi.fn(),
   getTask: vi.fn(),
@@ -226,7 +228,11 @@ function taskListPage(tasks = taskFixtures, total = 21): TaskListPage {
   };
 }
 
+let unlatchGatewayTier: () => void;
+
 beforeEach(() => {
+  // Scheduler reads exist only on the local surface set.
+  unlatchGatewayTier = latchGatewayTierForTest("local");
   vi.clearAllMocks();
   workspaceMockState.error = null;
   workspaceMockState.hasHydrated = true;
@@ -261,6 +267,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  unlatchGatewayTier();
 });
 
 describe("useTasksPage", () => {

--- a/web/src/systems/tasks/hooks/use-task-create-state.ts
+++ b/web/src/systems/tasks/hooks/use-task-create-state.ts
@@ -3,6 +3,7 @@ import { useSelector, useStore } from "@xstate/store-react";
 import { toast } from "sonner";
 
 import { useStoreBinding } from "@/hooks/use-store-binding";
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useCreateChildTask, useCreateTask, useEnqueueTaskRun } from "./use-task-actions";
 import { taskEditorDraftLogic } from "./task-editor-draft-store";
 import {
@@ -54,6 +55,14 @@ export function useTaskCreateState(
   const createMutation = useCreateTask();
   const createChildMutation = useCreateChildTask();
   const enqueueMutation = useEnqueueTaskRun();
+  // Origin gate for the submit path below: task create (POST /api/tasks and
+  // the child-task variant) and the first-run enqueue register only on the
+  // local surface set (`routes.go` `includeTaskMutations`), with no 403 code
+  // for the truthful loopback-only state to render (BR-3). The create dialog
+  // goes absent at the composition layer (BR-1); this gate is the backstop
+  // that keeps a wiring regression from firing a doomed POST on a remote tier
+  // (mirrors the task-detail lifecycle verbs).
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const submissionStore = useStore(taskEditorSubmissionLogic);
 
   const templateId = search.template ?? DEFAULT_TASK_TEMPLATE_ID;
@@ -102,7 +111,7 @@ export function useTaskCreateState(
   };
 
   const handleSubmit = (nextDraft: TaskEditorDraft, asDraft: boolean) => {
-    if (isScopeResolving) return Promise.resolve(null);
+    if (!localTaskLifecycle || isScopeResolving) return Promise.resolve(null);
     return requestTaskEditorSubmission(
       submissionStore,
       async () => {

--- a/web/src/systems/tasks/hooks/use-task-detail-page.ts
+++ b/web/src/systems/tasks/hooks/use-task-detail-page.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useSelector } from "@xstate/store-react";
 
 import { useStoreBinding } from "@/hooks/use-store-binding";
+import { useGatewayCapabilities } from "@/systems/gateway";
 
 import {
   useApproveTask,
@@ -47,6 +48,13 @@ const TIMELINE_PAGE_SIZE = 50;
  * every task-level verb handler.
  */
 function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {}) {
+  // Origin gate for the lifecycle verbs below: approve/reject/resume/recover/
+  // clear-block/start-run/publish/cancel/pause/fan-out/run-retry hit task/run
+  // mutation routes registered only on the local surface set (`routes.go`
+  // `includeTaskMutations`). The affordances go absent at the composition
+  // layer (BR-1); this capability gate is the backstop that keeps a wiring
+  // regression from firing a doomed request on a remote tier.
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const [timelineLimit, setTimelineLimit] = useState<number>(
     options.initialTimelineLimit ?? DEFAULT_TIMELINE_LIMIT
   );
@@ -142,7 +150,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
   };
 
   const handlePublishTask = () =>
-    hasTaskId
+    hasTaskId && localTaskLifecycle
       ? notifyTaskMutation(
           () => publishMutation.mutateAsync({ id: taskId }),
           "Task published.",
@@ -151,7 +159,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
       : Promise.resolve();
 
   const handleCancelTask = () =>
-    hasTaskId
+    hasTaskId && localTaskLifecycle
       ? notifyTaskMutation(
           () => cancelMutation.mutateAsync({ id: taskId }),
           "Task canceled.",
@@ -160,7 +168,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
       : Promise.resolve();
 
   const handleEnqueueRun = () =>
-    hasTaskId
+    hasTaskId && localTaskLifecycle
       ? notifyTaskMutation(
           () => enqueueMutation.mutateAsync({ id: taskId }),
           "Run queued.",
@@ -169,7 +177,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
       : Promise.resolve();
 
   const handleApproveTask = () =>
-    hasTaskId
+    hasTaskId && localTaskLifecycle
       ? notifyTaskMutation(
           () => approveMutation.mutateAsync({ id: taskId }),
           "Task approved.",
@@ -178,7 +186,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
       : Promise.resolve();
 
   const handleRejectTask = () =>
-    hasTaskId
+    hasTaskId && localTaskLifecycle
       ? notifyTaskMutation(
           () => rejectMutation.mutateAsync({ id: taskId }),
           "Task rejected.",
@@ -187,14 +195,16 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
       : Promise.resolve();
 
   const handleRetryRun = (runId: string) =>
-    notifyTaskMutation(
-      () => retryRunMutation.mutateAsync({ runId }),
-      "Retry queued.",
-      "Failed to retry run"
-    );
+    localTaskLifecycle
+      ? notifyTaskMutation(
+          () => retryRunMutation.mutateAsync({ runId }),
+          "Retry queued.",
+          "Failed to retry run"
+        )
+      : Promise.resolve();
 
   const handleClearBlock = (blockId: string) =>
-    hasTaskId
+    hasTaskId && localTaskLifecycle
       ? notifyTaskMutation(
           () => clearBlockMutation.mutateAsync({ id: taskId, blockId }),
           "Block cleared.",
@@ -203,7 +213,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
       : Promise.resolve();
 
   const handleFanOutRuns = async (data: FanOutTaskRunsRequest) => {
-    if (!hasTaskId) return undefined;
+    if (!hasTaskId || !localTaskLifecycle) return undefined;
     return submitTaskMutation(
       () => fanOutMutation.mutateAsync({ id: taskId, data }),
       result => {
@@ -215,7 +225,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
   };
 
   const handlePauseTask = async (reason: string) => {
-    if (!hasTaskId) return;
+    if (!hasTaskId || !localTaskLifecycle) return;
     await submitTaskMutation(
       () => pauseMutation.mutateAsync({ id: taskId, data: { reason } }),
       "Task paused.",
@@ -224,7 +234,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
   };
 
   const handleResumeTask = async () => {
-    if (!hasTaskId) return;
+    if (!hasTaskId || !localTaskLifecycle) return;
     await notifyTaskMutation(
       () => resumeMutation.mutateAsync({ id: taskId }),
       "Task resumed.",
@@ -235,6 +245,7 @@ function useTaskDetailPage(taskId: string, options: UseTaskDetailPageOptions = {
   const handleRecoverTask = async () => {
     if (
       !hasTaskId ||
+      !localTaskLifecycle ||
       (activeRunNeedsAttention && !recoverableRunId) ||
       recoverTaskMutation.isPending ||
       recoverRunMutation.isPending

--- a/web/src/systems/tasks/hooks/use-task-edit-state.ts
+++ b/web/src/systems/tasks/hooks/use-task-edit-state.ts
@@ -3,6 +3,7 @@ import { useSelector, useStore } from "@xstate/store-react";
 import { toast } from "sonner";
 
 import { useStoreBinding } from "@/hooks/use-store-binding";
+import { useGatewayCapabilities } from "@/systems/gateway";
 import { useUpdateTask } from "./use-task-actions";
 import { useTaskExecutionProfile } from "./use-task-profile";
 import { useTask } from "./use-tasks";
@@ -39,6 +40,13 @@ export function useTaskEditState(
     refetchIntervalMs,
   });
   const updateMutation = useUpdateTask();
+  // Origin gate for the submit path below: task PATCH (`UpdateTask`) registers
+  // only on the local surface set (`routes.go` `includeTaskMutations`), with no
+  // 403 code for the truthful loopback-only state to render (BR-3). The editor
+  // goes absent at the composition layer (BR-1); this gate is the backstop that
+  // keeps a wiring regression from firing a doomed PATCH on a remote tier
+  // (mirrors the task-detail lifecycle verbs).
+  const { localTaskLifecycle } = useGatewayCapabilities();
   const submissionStore = useStore(taskEditorSubmissionLogic);
   const detail = detailQuery.data ?? null;
   const task = detail?.task ?? null;
@@ -61,26 +69,28 @@ export function useTaskEditState(
   };
 
   const handleSubmit = (nextDraft: TaskEditorDraft) =>
-    requestTaskEditorSubmission(
-      submissionStore,
-      async () => {
-        if (!id || !task || !profile) return null;
-        try {
-          await updateMutation.mutateAsync({ id, data: buildUpdateTaskRequest(nextDraft) });
-          toast.success("Task updated.");
-          onSaved();
-          return true;
-        } catch (error) {
-          console.error("Failed to update task", error);
-          toast.error("Couldn't save your changes.");
-          return null;
-        }
-      },
-      error => {
-        console.error("Failed to update task", error);
-        toast.error("Couldn't save your changes.");
-      }
-    );
+    localTaskLifecycle
+      ? requestTaskEditorSubmission(
+          submissionStore,
+          async () => {
+            if (!id || !task || !profile) return null;
+            try {
+              await updateMutation.mutateAsync({ id, data: buildUpdateTaskRequest(nextDraft) });
+              toast.success("Task updated.");
+              onSaved();
+              return true;
+            } catch (error) {
+              console.error("Failed to update task", error);
+              toast.error("Couldn't save your changes.");
+              return null;
+            }
+          },
+          error => {
+            console.error("Failed to update task", error);
+            toast.error("Couldn't save your changes.");
+          }
+        )
+      : Promise.resolve(null);
 
   return {
     draft,

--- a/web/src/systems/tasks/hooks/use-tasks-dashboard-page.ts
+++ b/web/src/systems/tasks/hooks/use-tasks-dashboard-page.ts
@@ -1,5 +1,7 @@
 import { toast } from "sonner";
 
+import { useGatewayCapabilities } from "@/systems/gateway";
+
 import { useTaskDashboard } from "./use-task-dashboard";
 import type { TaskDashboardFilter } from "../types";
 import {
@@ -11,20 +13,28 @@ import {
 } from "@/systems/scheduler";
 
 export function useTasksDashboardPage(filters: TaskDashboardFilter, enabled: boolean) {
+  // The scheduler routes register only on the local surface set, so remote
+  // tiers neither query them nor receive their handlers; the dashboard view
+  // then skips the scheduler panel entirely.
+  const { localTaskLifecycle } = useGatewayCapabilities();
+  const schedulerEnabled = enabled && localTaskLifecycle;
   const dashboardQuery = useTaskDashboard(filters, { enabled });
-  const schedulerStatusQuery = useSchedulerStatus({ enabled });
+  const schedulerStatusQuery = useSchedulerStatus({ enabled: schedulerEnabled });
   const schedulerBacklogFilters = {
     scope: filters.scope,
     limit: 5,
     workspace: filters.workspace,
     include_paused: true,
   };
-  const schedulerBacklogQuery = useSchedulerBacklog(schedulerBacklogFilters, { enabled });
+  const schedulerBacklogQuery = useSchedulerBacklog(schedulerBacklogFilters, {
+    enabled: schedulerEnabled,
+  });
   const pauseMutation = usePauseScheduler();
   const resumeMutation = useResumeScheduler();
   const drainMutation = useDrainScheduler();
 
   const handlePauseScheduler = async (reason: string) => {
+    if (!localTaskLifecycle) return;
     try {
       const normalizedReason = reason.trim();
       await pauseMutation.mutateAsync(normalizedReason ? { reason: normalizedReason } : {});
@@ -36,6 +46,7 @@ export function useTasksDashboardPage(filters: TaskDashboardFilter, enabled: boo
     }
   };
   const handleResumeScheduler = async (reason?: string) => {
+    if (!localTaskLifecycle) return;
     try {
       const normalizedReason = reason?.trim();
       await resumeMutation.mutateAsync(normalizedReason ? { reason: normalizedReason } : {});
@@ -53,6 +64,7 @@ export function useTasksDashboardPage(filters: TaskDashboardFilter, enabled: boo
     reason?: string;
     timeoutSeconds?: number;
   }) => {
+    if (!localTaskLifecycle) return;
     try {
       const normalizedReason = reason?.trim();
       await drainMutation.mutateAsync({
@@ -77,6 +89,7 @@ export function useTasksDashboardPage(filters: TaskDashboardFilter, enabled: boo
     isSchedulerDrainPending: drainMutation.isPending,
     isSchedulerPausePending: pauseMutation.isPending,
     isSchedulerResumePending: resumeMutation.isPending,
+    schedulerAvailable: localTaskLifecycle,
     schedulerBacklog: schedulerBacklogQuery.data ?? null,
     schedulerBacklogError: schedulerBacklogQuery.error ?? null,
     schedulerBacklogLoading: schedulerBacklogQuery.isLoading && !schedulerBacklogQuery.data,

--- a/web/src/test/gateway-tier.ts
+++ b/web/src/test/gateway-tier.ts
@@ -1,0 +1,18 @@
+// Imported from the store module, not the barrel: test files that mock other
+// systems' modules must not pull the full gateway module graph into the file,
+// or the barrel's transitive imports race with the file's `vi.mock` factories.
+import { gatewayCapabilityStore } from "@/systems/gateway/stores/gateway-capability-store";
+import type { GatewayListenerTier } from "@/lib/gateway-access-signal";
+
+/**
+ * Latches the app-wide capability store for a test and returns the reset.
+ *
+ * Production latches the tier from every `/api` response; component tests that
+ * render tier-gated consumers without the transport latch `local` here so the
+ * suite keeps asserting the local shape. Tests asserting remote behavior latch
+ * a remote tier (or nothing — the unlatched default is the all-false set).
+ */
+export function latchGatewayTierForTest(tier: GatewayListenerTier = "local"): () => void {
+  gatewayCapabilityStore.trigger.tierSignalled({ tier });
+  return () => gatewayCapabilityStore.trigger.capabilitiesReset();
+}


### PR DESCRIPTION
## Summary

Spec-driven delivery of workflow `mobile-surface-truth`: the operator UI now shows only what the connected gateway tier can execute, the two loopback-guard 403 envelopes gained stable wire codes, and the shell gains a mobile touch-tier ergonomics pass frozen in a T1–T11 artboard (`docs/design/opendesign/mobile-surface-truth/`).

- **Backend (additive):** loopback sentinels re-homed to `internal/api/core`; error payload emits `loopback_mutation_required` / `loopback_api_required`. Remote tiers now enforce the mutation policy by listener surface set (the bind-host-keyed guard was inert on loopback-bound tier listeners — paired devices could execute guarded mutations remotely). tsnet tier forwarder is now an HTTP-aware reverse proxy (fixes SPA boot through the forwarded tier: X-Forwarded-Proto/Host forced, client forwarding headers stripped). No routes, storage, or config changes.
- **Web:** tier-keyed capability model + store (`systems/gateway`); loopback-only affordances absent (never disabled) on remote tiers across os/terminal/settings/extensions/tasks/notifications/profiles; truthful loopback-only state; touch-tier ergonomics per the frozen artboard (44px floor, dock pager, window-control identification without hover, menubar scope truncation, session rail overlay, keyboard/viewport contract).
- **QA:** 3 walks (2 lab, 1 real-device on the user's phone) — `docs/qa/reports/2026-09-11-mobile-surface-truth.md`. 3 product defects found, fixed, and verified in-product (forwarded-tier origin rejection; inert remote mutation guard; touch-tier rail/menubar/dock findings). Scenarios settled: `APP-mobile-touch-tier` pass, `RT-gateway-paired-device` pass, `RT-gateway-operator-surface-truth` pass. Public tier/Funnel out of scope (owned elsewhere).
- **Review:** 4 deep-review rounds (3× FIX_BEFORE_SHIP fully remediated, round 4 SHIP, 0 defects). Full BR-1 class converged across the task-detail surface with origin-gate backstops on all lifecycle verbs.

## Delivery evidence

- `make gate` PASS at HEAD (all affected lanes; web 782 files / 7262 tests; go suites `-race` green)
- Cross-surface impact: `docs/_memory/change-impact.md` (additive wire codes, no delete targets, SD-013 ladder)
- Known gap (separate follow-up): `make build` embeds the published web-assets module pin, not local `web/dist` — local builds need `COMPOZY_WEB_DIST_DIR` or the publish flow; staleness guard not wired into `make build`.