### PR TITLE
fix: recover owned task work after supervised silence stops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,22 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  supervised-recovery:
+    name: Supervised work recovery (integration)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-go
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Verify disposable frozen executor recovery
+        env:
+          CGO_ENABLED: "1"
+        run: go test -race -tags=integration -count=1 -timeout=5m -v ./internal/session -run '^TestManagerIntegrationSupervisedWorkRecovery$'
+
   sdk-go-test:
     name: Go SDK (race test)
     runs-on: ubuntu-latest
@@ -496,6 +512,7 @@ jobs:
         frontend,
         go-static,
         go-test,
+        supervised-recovery,
         sdk-go-test,
         go-build,
         go-peer-darwin,
@@ -510,6 +527,7 @@ jobs:
           FRONTEND_RESULT: ${{ needs.frontend.result }}
           GO_STATIC_RESULT: ${{ needs.go-static.result }}
           GO_TEST_RESULT: ${{ needs.go-test.result }}
+          SUPERVISED_RECOVERY_RESULT: ${{ needs.supervised-recovery.result }}
           SDK_GO_TEST_RESULT: ${{ needs.sdk-go-test.result }}
           GO_BUILD_RESULT: ${{ needs.go-build.result }}
           GO_PEER_DARWIN_RESULT: ${{ needs.go-peer-darwin.result }}
@@ -517,7 +535,7 @@ jobs:
           DESKTOP_RESULT: ${{ needs.desktop.result }}
         run: |
           set -euo pipefail
-          for result in "$PREFLIGHT_RESULT" "$FRONTEND_RESULT" "$GO_STATIC_RESULT" "$GO_TEST_RESULT" "$SDK_GO_TEST_RESULT" "$GO_BUILD_RESULT" "$GO_PEER_DARWIN_RESULT" "$GO_TERMINAL_WINDOWS_RESULT" "$DESKTOP_RESULT"; do
+          for result in "$PREFLIGHT_RESULT" "$FRONTEND_RESULT" "$GO_STATIC_RESULT" "$GO_TEST_RESULT" "$SUPERVISED_RECOVERY_RESULT" "$SDK_GO_TEST_RESULT" "$GO_BUILD_RESULT" "$GO_PEER_DARWIN_RESULT" "$GO_TERMINAL_WINDOWS_RESULT" "$DESKTOP_RESULT"; do
             if [[ "$result" != "success" ]]; then
               echo "Verification lane finished with result: $result"
               exit 1

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -1,5 +1,29 @@
 # Compozy Change Impact
 
+## Issue 616 — Supervised work recovery
+
+- **Native tools:** existing session stop, task inspection/recovery and Loop status IDs and schemas
+  stay unchanged. Only verified inactivity settlement queues a bounded linked task attempt.
+  `task.run_recovered` carries `reason=supervised_silence`, stop identity and attempt counters;
+  its existing `requeue` action contributes to the existing Requeued projection.
+- **Extensibility/hooks/config:** no new configuration, hook family, SDK or permission. Existing
+  `quiet_after`, `stop_grace` and `max_attempts` own policy. The task enqueue hook observes the
+  committed successor. Zero grace remains warning-only. No general session auto-restart.
+- **Workspace data isolation:** session/profile/workspace ownership and the exact task lease fence
+  gate the atomic write. Success, cancellation, deletion, a pending terminal command or a new owner
+  wins over stale recovery. The successor preserves worktree, participation and capability selectors;
+  Loop recovery validates the node epoch and owned binding. Borrowed Goals retain their controls.
+- **Compatibility:** no database shape change, migration, user-file rollback or public removal.
+  The existing verified stop receipt remains until task settlement succeeds, including after restart.
+  Prior lease recoveries remain charged; exhausted work is parked for attention. Committed outputs
+  remain intact; external partial effects require application-specific reconciliation/idempotency.
+- **Official skill:** runtime, tasks and Loop references distinguish Loop silence attention from
+  configured session inactivity stop and document retry limits and side-effect boundaries.
+- **Web/Docs/QA:** existing Tasks/Loop history and attention consume corrected durable state;
+  no Web layout or controls change. Session health docs and `TA-action-run-liveness` are updated.
+  Existing store/lifecycle suites plus the CI-only disposable ACP integration own verification.
+  Local gates, builds and runtime labs are deferred under the explicit delivery instruction.
+
 Use for changed runtime behavior, public contracts, config, or feature documentation. Record this analysis once in the owning spec/task/PR and link it from implementation slices; update only the affected entries. A small change needs only concise findings. Editorial changes with no runtime contract may state `not applicable — editorial only`.
 
 - **Native tools:** changed `compozy__*` IDs, toolsets, descriptors, schemas/digests, risk flags, capability gates, diagnostics, and CLI/API fallbacks.

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -15,6 +15,8 @@
   Loop recovery validates the node epoch and owned binding. Borrowed Goals retain their controls.
 - **Compatibility:** no database shape change, migration, user-file rollback or public removal.
   The existing verified stop receipt remains until task settlement succeeds, including after restart.
+  Multiple owned runs settle independently; a failed candidate does not roll back recovered work,
+  and replay selects only the remaining active bindings.
   Prior lease recoveries remain charged; exhausted work is parked for attention. Committed outputs
   remain intact; external partial effects require application-specific reconciliation/idempotency.
 - **Official skill:** runtime, tasks and Loop references distinguish Loop silence attention from

--- a/docs/qa/scenarios/TA-action-run-liveness.md
+++ b/docs/qa/scenarios/TA-action-run-liveness.md
@@ -37,7 +37,10 @@ Issue 616 verification slice (CI only): `TestManagerIntegrationSupervisedWorkRec
 disposable ACP process group with bounded supervision timings and requires process-tree exit before
 a linked task attempt appears. `TestGlobalDBSupervisedRecovery` owns attempt exhaustion, prior lease
 recovery accounting and the Loop cell/binding transition. `TestSharedSessionStopOperation` owns
-receipt replay and explicit-stop exclusion. Run the integration through the required
+receipt replay and explicit-stop exclusion. Store coverage also checks independent recovery after
+one candidate fails, shared designation budgets and cross-profile/workspace exclusion. Integration
+requires cleared source lease timestamps and rejects a heartbeat using the old claim token.
+Run the integration through the required
 `Supervised work recovery (integration)` CI lane; no host sessions or local QA labs are used.
 The original reporter's 41-minute measurements remain unverified. A successful bounded fixture does
 not establish exactly-once external effects or remeasure the production default timers.

--- a/docs/qa/scenarios/TA-action-run-liveness.md
+++ b/docs/qa/scenarios/TA-action-run-liveness.md
@@ -4,7 +4,7 @@ area: TA
 title: Keep long-running Loop nodes alive without a hidden clock
 persona: Ada
 journey: J-bound-runaway-work
-expected: A Loop node runs for days when the definition has no timeout, fresh ACP activity, an in-flight tool, or a present transport counts as life, silence only raises a self-clearing attention flag, and only an authored node timeout may end the work by duration.
+expected: A Loop node without an authored timeout stays live while fresh work evidence remains. The Loop silence window raises attention. Separately, configured session supervision can stop expired work after stop_grace; only verified process-tree exit permits bounded recovery of an authoritative task binding, preserving committed files and consuming max_attempts.
 entry_points: `compozy loop status --run-id <run-id> -o json`; Loop node inventory and event history over CLI/HTTP/UDS; `loops.defaults.delivery.liveness.silence_window`
 qa_status: blocked-verify
 bug_ids:
@@ -30,4 +30,14 @@ Forensic evidence contract (SD-006) — each item cites timestamp, exact command
   synthetic heartbeat becoming progress.
 - Silence raises one attention flag, new evidence clears it, and neither transition interrupts
   the prompt or frees its lease.
-- An explicitly authored node timeout remains the only duration-based terminal path.
+- An authored node timeout bounds that node; session supervision is independently controlled by
+  fresh work evidence, `quiet_after` and `stop_grace`.
+
+Issue 616 verification slice (CI only): `TestManagerIntegrationSupervisedWorkRecovery` freezes a
+disposable ACP process group with bounded supervision timings and requires process-tree exit before
+a linked task attempt appears. `TestGlobalDBSupervisedRecovery` owns attempt exhaustion, prior lease
+recovery accounting and the Loop cell/binding transition. `TestSharedSessionStopOperation` owns
+receipt replay and explicit-stop exclusion. Run the integration through the required
+`Supervised work recovery (integration)` CI lane; no host sessions or local QA labs are used.
+The original reporter's 41-minute measurements remain unverified. A successful bounded fixture does
+not establish exactly-once external effects or remeasure the production default timers.

--- a/internal/daemon/boot_session_repair.go
+++ b/internal/daemon/boot_session_repair.go
@@ -39,6 +39,9 @@ func (d *Daemon) bootSessionRepair(ctx context.Context, state *bootState) error 
 	if err := d.prepareServerDependencies(ctx, state); err != nil {
 		return err
 	}
+	if err := d.installBootSupervisedWorkRecovery(state); err != nil {
+		return err
+	}
 	if recoverer, ok := state.sessions.(sessionPendingStopRecoverer); ok {
 		if err := recoverer.RecoverPendingStops(ctx); err != nil {
 			return fmt.Errorf("daemon: recover pending session stops: %w", err)

--- a/internal/daemon/loop_action_death_resume.go
+++ b/internal/daemon/loop_action_death_resume.go
@@ -11,6 +11,7 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
+// resumeConfirmedDeadAction leaves supervised stops to their receipt owner and resumes only confirmed crash deaths.
 func (r *loopActionRuntime) resumeConfirmedDeadAction(
 	ctx context.Context,
 	run taskpkg.Run,

--- a/internal/daemon/loop_action_death_resume.go
+++ b/internal/daemon/loop_action_death_resume.go
@@ -32,6 +32,11 @@ func (r *loopActionRuntime) resumeConfirmedDeadAction(
 		)
 		return false, nil
 	}
+	if info != nil && (info.StopCause == session.CauseInactivity ||
+		(info.StopReason == storepkg.StopTimeout && info.StopDetail == "inactivity")) {
+		// The durable stop receipt owns recovery and fences this attempt's late result.
+		return true, nil
+	}
 	if !confirmedLoopActionSessionDeath(info) {
 		return false, nil
 	}

--- a/internal/daemon/session_work_recovery.go
+++ b/internal/daemon/session_work_recovery.go
@@ -7,6 +7,7 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
+// installSupervisedWorkRecovery passes verified session identity to the authoritative task service.
 func installSupervisedWorkRecovery(state *bootState, tasks *taskpkg.Service) {
 	manager, ok := state.sessions.(*session.Manager)
 	if !ok {
@@ -19,6 +20,7 @@ func installSupervisedWorkRecovery(state *bootState, tasks *taskpkg.Service) {
 	})
 }
 
+// installBootSupervisedWorkRecovery makes task settlement available before pending stop receipts are replayed.
 func (d *Daemon) installBootSupervisedWorkRecovery(state *bootState) error {
 	store, ok := taskStoreForBoot(state)
 	if !ok {

--- a/internal/daemon/session_work_recovery.go
+++ b/internal/daemon/session_work_recovery.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"context"
+
+	"github.com/compozy/compozy/internal/session"
+	taskpkg "github.com/compozy/compozy/internal/task"
+)
+
+func installSupervisedWorkRecovery(state *bootState, tasks *taskpkg.Service) {
+	manager, ok := state.sessions.(*session.Manager)
+	if !ok {
+		return
+	}
+	manager.SetSupervisedWorkRecovery(func(ctx context.Context, info *session.Info, eventID string) error {
+		return tasks.RecoverSupervisedWork(ctx, taskpkg.SupervisedStop{
+			SessionID: info.ID, WorkspaceID: info.WorkspaceID, ProfileID: info.ProfileID, EventID: eventID,
+		})
+	})
+}
+
+func (d *Daemon) installBootSupervisedWorkRecovery(state *bootState) error {
+	store, ok := taskStoreForBoot(state)
+	if !ok {
+		return nil
+	}
+	manager, err := taskpkg.NewManager(taskpkg.WithStore(store), taskpkg.WithManagerNow(d.now))
+	if err != nil {
+		return err
+	}
+	installSupervisedWorkRecovery(state, manager)
+	return nil
+}

--- a/internal/daemon/task_runtime_boot.go
+++ b/internal/daemon/task_runtime_boot.go
@@ -43,6 +43,7 @@ func (d *Daemon) bootTasks(ctx context.Context, state *bootState, cleanup *bootC
 	if err := bootSubprocessHealthEscalator(state, store, manager); err != nil {
 		return err
 	}
+	installSupervisedWorkRecovery(state, manager)
 	coordinatorBackstop := newLoopCoordinatorBootGate(schedulerTaskSource{manager: manager, store: store})
 	if err := installLoopTaskObservers(ctx, state, manager, store, coordinatorBackstop, d.now); err != nil {
 		return err

--- a/internal/daemon/task_runtime_boot.go
+++ b/internal/daemon/task_runtime_boot.go
@@ -11,6 +11,7 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
+// bootTasks installs the configured task service, recovery hook and scheduler after durable session stop replay.
 func (d *Daemon) bootTasks(ctx context.Context, state *bootState, cleanup *bootCleanup) error {
 	if state == nil || state.registry == nil || state.sessions == nil {
 		return nil

--- a/internal/session/manager_lifecycle_contract_test.go
+++ b/internal/session/manager_lifecycle_contract_test.go
@@ -809,6 +809,66 @@ func TestStopRequiresVerifiedProcessExit(t *testing.T) {
 }
 
 func TestSharedSessionStopOperation(t *testing.T) {
+	t.Run("Should replay supervised work recovery from the same verified stop receipt", func(t *testing.T) {
+		t.Parallel()
+		h := newHarness(t)
+		active := createSession(t, h)
+		failure := errors.New("task recovery unavailable")
+		var stopEventID string
+		h.manager.SetSupervisedWorkRecovery(func(_ context.Context, info *Info, eventID string) error {
+			if info.State != StateStopped || info.StopCause != CauseInactivity {
+				t.Errorf("stop identity = %#v", info)
+			}
+			stopEventID = eventID
+			return failure
+		})
+		active.mu.Lock()
+		active.supervisionStopAt = h.manager.now().Add(-time.Second)
+		active.mu.Unlock()
+		if err := h.manager.StopWithCause(
+			t.Context(),
+			active.ID,
+			CauseInactivity,
+			"inactivity",
+		); !errors.Is(err, failure) ||
+			!errors.Is(err, ErrRecoveryPersistence) {
+			t.Fatalf("stop = %v", err)
+		}
+		if stopEventID == "" {
+			t.Fatal("recovery did not receive the durable stop identity")
+		}
+		h.manager.removeActive(active.ID)
+		manager := newManagerWithHarness(t, h)
+		cleanupTestManager(t, manager)
+		var replayed bool
+		manager.SetSupervisedWorkRecovery(func(_ context.Context, info *Info, eventID string) error {
+			replayed = true
+			if info.StopCause != CauseInactivity || eventID != stopEventID {
+				t.Errorf("replayed identity = %v/%q", info.StopCause, eventID)
+			}
+			return nil
+		})
+		if err := manager.RecoverPendingStops(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+		if !replayed || manager.hasPendingStopSettlement(active.ID) {
+			t.Fatal("supervised recovery did not settle")
+		}
+		if countEventType(readStoredEvents(t, active), EventTypeSessionStopped) != 1 {
+			t.Fatal("replay duplicated terminal stop")
+		}
+	})
+	t.Run("Should never recover work after an explicit session cancellation", func(t *testing.T) {
+		t.Parallel()
+		h := newHarness(t)
+		active := createSession(t, h)
+		h.manager.SetSupervisedWorkRecovery(func(context.Context, *Info, string) error {
+			return errors.New("explicit cancellation entered supervised recovery")
+		})
+		if err := h.manager.Stop(t.Context(), active.ID); err != nil {
+			t.Fatal(err)
+		}
+	})
 	for _, restart := range []bool{false, true} {
 		t.Run(fmt.Sprintf("Should retry Goal cancellation settlement with restart %t", restart), func(t *testing.T) {
 			t.Parallel()

--- a/internal/session/manager_stop_finalization.go
+++ b/internal/session/manager_stop_finalization.go
@@ -79,7 +79,8 @@ func (m *Manager) finalizeStoppedOwned(
 	return m.finishStoppedPersistence(ctx, session)
 }
 
-// finishStoppedPersistence retains the recovery receipt until stop history and Goal cancellation settle.
+// finishStoppedPersistence retains the receipt until stop history, Goal cancellation
+// and supervised task recovery settle.
 func (m *Manager) finishStoppedPersistence(ctx context.Context, session *Session) error {
 	if err := m.markSessionStopped(ctx, session); err != nil {
 		m.dispatchSessionPostStop(ctx, session)

--- a/internal/session/manager_stop_finalization.go
+++ b/internal/session/manager_stop_finalization.go
@@ -90,6 +90,14 @@ func (m *Manager) finishStoppedPersistence(ctx context.Context, session *Session
 		m.dispatchSessionPostStop(ctx, session)
 		return errors.Join(session.stopFinalizationErr, ErrRecoveryPersistence, err)
 	}
+	turnID, err := m.sessionStopTurnID(session)
+	if err == nil {
+		err = m.recoverSupervisedWork(ctx, session.Info(), turnID)
+	}
+	if err != nil {
+		session.setPendingStopState(true, true)
+		return errors.Join(session.stopFinalizationErr, ErrRecoveryPersistence, err)
+	}
 	if err := m.removeRecoveredStopReceipt(session.ID); err != nil {
 		session.setPendingStopState(true, true)
 		m.dispatchSessionPostStop(ctx, session)

--- a/internal/session/manager_stop_integration_test.go
+++ b/internal/session/manager_stop_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -25,6 +27,8 @@ import (
 	"github.com/compozy/compozy/internal/providers"
 	"github.com/compozy/compozy/internal/sandbox/local"
 	"github.com/compozy/compozy/internal/store"
+	"github.com/compozy/compozy/internal/store/globaldb"
+	taskpkg "github.com/compozy/compozy/internal/task"
 	"github.com/compozy/compozy/internal/testutil"
 	"github.com/compozy/compozy/internal/testutil/acpmock"
 	toolspkg "github.com/compozy/compozy/internal/tools"
@@ -138,6 +142,117 @@ func TestManagerIntegrationStopFinalizesWrappedACPProcess(t *testing.T) {
 	if *meta.StopReason != store.StopUserCanceled {
 		t.Fatalf("meta.StopReason = %q, want %q", *meta.StopReason, store.StopUserCanceled)
 	}
+}
+
+func TestManagerIntegrationSupervisedWorkRecovery(t *testing.T) {
+	t.Parallel()
+	t.Run("Should recover owned work only after the frozen process tree exits", func(t *testing.T) {
+		t.Parallel()
+		base := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+		var clock atomic.Int64
+		clock.Store(base.UnixNano())
+		pidFile := filepath.Join(t.TempDir(), "child.pid")
+		h := newRealACPIntegrationHarness(t, sessionStopWrapperCommand(t, pidFile))
+		config := testSupervisionConfig()
+		config.QuietAfter, config.StopGrace = time.Second, time.Second
+		h.manager = newManagerWithHarness(t, h, WithDriver(h.manager.driver),
+			WithNow(func() time.Time { return time.Unix(0, clock.Load()).UTC() }),
+			WithSessionSupervision(config),
+			WithSessionStopConfig(compozyconfig.SessionStopConfig{CooperativeGrace: 20 * time.Millisecond}))
+		db := openManagerInputQueueStore(t)
+		registerManagerInputQueueWorkspace(t, db, h)
+		sess := createSession(t, h)
+		registerManagerInputQueueSession(t, db, h, sess)
+		proc := sess.processHandle()
+		childPID := waitForSessionStopWrapperChildPID(t, pidFile)
+		t.Cleanup(func() {
+			if err := h.manager.Stop(context.Background(), sess.ID); err != nil {
+				t.Errorf("cleanup Stop: %v", err)
+			}
+		})
+		tasks, source := seedSupervisedTaskForSession(t, db, sess, base)
+		artifact := filepath.Join(h.workspace, "committed-output.txt")
+		if err := os.WriteFile(artifact, []byte("part-1\npart-2\npart-3\npart-4\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		h.manager.SetSupervisedWorkRecovery(func(ctx context.Context, info *Info, eventID string) error {
+			if sessionStopProcessAlive(proc.PID) || sessionStopProcessAlive(childPID) {
+				return fmt.Errorf("recovery ran before process tree exit")
+			}
+			return tasks.RecoverSupervisedWork(ctx, taskpkg.SupervisedStop{
+				SessionID: info.ID, WorkspaceID: info.WorkspaceID, ProfileID: info.ProfileID, EventID: eventID,
+			})
+		})
+		installAbsentWorkSources(h.manager)
+		if err := syscall.Kill(-proc.PID, syscall.SIGSTOP); err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+		for tick := range 3 {
+			at := base.Add(time.Duration(10+tick) * time.Second)
+			clock.Store(at.UnixNano())
+			if err := h.manager.Supervise(ctx, at); err != nil {
+				t.Fatal(err)
+			}
+		}
+		outcome, err := h.manager.AwaitStopped(ctx, sess.ID)
+		if err != nil || !outcome.Verified || outcome.Cause != CauseInactivity {
+			t.Fatalf("supervised stop = %#v, %v", outcome, err)
+		}
+		runs, err := db.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: source.TaskID})
+		if err != nil || len(runs) != 2 {
+			t.Fatalf("recovered runs = %#v, %v", runs, err)
+		}
+		for _, run := range runs {
+			if run.ID != source.ID && (run.PreviousRunID != source.ID || run.Attempt != 2 ||
+				run.Status != taskpkg.TaskRunStatusQueued || run.SessionID != "") {
+				t.Fatalf("successor = %#v", run)
+			}
+		}
+		content, err := os.ReadFile(artifact)
+		if err != nil || string(content) != "part-1\npart-2\npart-3\npart-4\n" {
+			t.Fatalf("committed output = %q, %v", content, err)
+		}
+		assertSupervisionEventCorrelation(t, h.manager, sess, "session.supervision_stopped")
+	})
+}
+
+func seedSupervisedTaskForSession(
+	t *testing.T, db *globaldb.GlobalDB, sess *Session, at time.Time,
+) (*taskpkg.Service, taskpkg.Run) {
+	t.Helper()
+	tasks, err := taskpkg.NewManager(taskpkg.WithStore(db), taskpkg.WithManagerNow(func() time.Time { return at }))
+	if err != nil {
+		t.Fatal(err)
+	}
+	actor, err := taskpkg.DeriveHumanActorContext("operator", taskpkg.OriginKindCLI, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := tasks.CreateTask(t.Context(), taskpkg.CreateTask{
+		ProfileID: sess.Info().ProfileID, Scope: taskpkg.ScopeWorkspace, WorkspaceID: sess.WorkspaceID,
+		Title: "Recover committed work", MaxAttempts: new(3),
+	}, actor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := tasks.EnqueueRun(t.Context(), taskpkg.EnqueueRun{TaskID: record.ID}, actor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent, err := taskpkg.DeriveAgentSessionActorContext(sess.ID, sess.WorkspaceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := tasks.ClaimNextRun(t.Context(), taskpkg.ClaimCriteria{
+		RunID: run.ID, Scope: taskpkg.ScopeWorkspace, WorkspaceID: sess.WorkspaceID,
+		ClaimerSessionID: sess.ID, LeaseDuration: time.Second, Now: at.Add(-time.Minute),
+	}, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tasks, claim.Run
 }
 
 func TestManagerIntegrationAllowedToolsOverrideNarrowsAcpmockSession(t *testing.T) {

--- a/internal/session/manager_stop_integration_test.go
+++ b/internal/session/manager_stop_integration_test.go
@@ -170,7 +170,8 @@ func TestManagerIntegrationSupervisedWorkRecovery(t *testing.T) {
 				t.Errorf("cleanup Stop: %v", err)
 			}
 		})
-		tasks, source := seedSupervisedTaskForSession(t, db, sess, base)
+		tasks, claim := seedSupervisedTaskForSession(t, db, sess, base)
+		source := claim.Run
 		artifact := filepath.Join(h.workspace, "committed-output.txt")
 		if err := os.WriteFile(artifact, []byte("part-1\npart-2\npart-3\npart-4\n"), 0o600); err != nil {
 			t.Fatal(err)
@@ -205,6 +206,12 @@ func TestManagerIntegrationSupervisedWorkRecovery(t *testing.T) {
 			t.Fatalf("recovered runs = %#v, %v", runs, err)
 		}
 		for _, run := range runs {
+			if run.ID == source.ID {
+				if run.Status != taskpkg.TaskRunStatusFailed || run.Error != taskpkg.SupervisedSilenceReason ||
+					!run.LeaseUntil.IsZero() || !run.HeartbeatAt.IsZero() {
+					t.Fatalf("source retained a live lease after recovery: %#v", run)
+				}
+			}
 			if run.ID != source.ID && (run.PreviousRunID != source.ID || run.Attempt != 2 ||
 				run.Status != taskpkg.TaskRunStatusQueued || run.SessionID != "") {
 				t.Fatalf("successor = %#v", run)
@@ -214,13 +221,23 @@ func TestManagerIntegrationSupervisedWorkRecovery(t *testing.T) {
 		if err != nil || string(content) != "part-1\npart-2\npart-3\npart-4\n" {
 			t.Fatalf("committed output = %q, %v", content, err)
 		}
+		agent, err := taskpkg.DeriveAgentSessionActorContext(sess.ID, sess.WorkspaceID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tasks.HeartbeatRunLease(ctx, taskpkg.LeaseHeartbeat{
+			RunID: source.ID, ClaimToken: claim.ClaimToken, LeaseDuration: time.Minute,
+			Now: base.Add(time.Minute),
+		}, agent); !errors.Is(err, taskpkg.ErrInvalidStatusTransition) {
+			t.Fatalf("old lease retained write authority: %v", err)
+		}
 		assertSupervisionEventCorrelation(t, h.manager, sess, "session.supervision_stopped")
 	})
 }
 
 func seedSupervisedTaskForSession(
 	t *testing.T, db *globaldb.GlobalDB, sess *Session, at time.Time,
-) (*taskpkg.Service, taskpkg.Run) {
+) (*taskpkg.Service, *taskpkg.ClaimResult) {
 	t.Helper()
 	tasks, err := taskpkg.NewManager(taskpkg.WithStore(db), taskpkg.WithManagerNow(func() time.Time { return at }))
 	if err != nil {
@@ -252,7 +269,7 @@ func seedSupervisedTaskForSession(
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tasks, claim.Run
+	return tasks, claim
 }
 
 func TestManagerIntegrationAllowedToolsOverrideNarrowsAcpmockSession(t *testing.T) {

--- a/internal/session/manager_types.go
+++ b/internal/session/manager_types.go
@@ -152,6 +152,8 @@ type Manager struct {
 	managedInputMu             sync.Mutex
 	managedInputLeases         map[string]managedInputLease
 	goalCommandMu              sync.RWMutex
+	supervisedRecoveryMu       sync.RWMutex
+	supervisedWorkRecovery     SupervisedWorkRecovery
 	promptAdmissionMu          sync.Mutex
 	promptAdmissionLocks       map[string]*promptAdmissionLock
 	resumeReplayMu             sync.Mutex

--- a/internal/session/stop_recovered_finalization.go
+++ b/internal/session/stop_recovered_finalization.go
@@ -72,6 +72,9 @@ func (m *Manager) settleRecoveredStop(
 	if err := m.stopSessionGoals(settleCtx, info); err != nil {
 		return errors.Join(ErrRecoveryPersistence, err)
 	}
+	if err := m.recoverSupervisedWork(settleCtx, info, settlement.turnID); err != nil {
+		return err
+	}
 	if err := m.removeRecoveredStopReceipt(run.recoveredID); err != nil {
 		return err
 	}

--- a/internal/session/stop_recovered_finalization.go
+++ b/internal/session/stop_recovered_finalization.go
@@ -36,7 +36,8 @@ func (m *Manager) finishRecoveredStop(ctx context.Context, id string, cause Stop
 	return errors.Join(sandboxErr, ledgerErr, networkErr)
 }
 
-// settleRecoveredStop replays persistence and Goal cancellation before releasing the durable stop receipt.
+// settleRecoveredStop replays persistence, Goal cancellation and task recovery
+// before releasing the durable stop receipt.
 func (m *Manager) settleRecoveredStop(
 	ctx context.Context,
 	run *sessionStopRun,

--- a/internal/session/supervised_work_recovery.go
+++ b/internal/session/supervised_work_recovery.go
@@ -1,0 +1,33 @@
+package session
+
+import (
+	"context"
+	"errors"
+)
+
+type SupervisedWorkRecovery func(context.Context, *Info, string) error
+
+func (m *Manager) SetSupervisedWorkRecovery(recoverWork SupervisedWorkRecovery) {
+	m.supervisedRecoveryMu.Lock()
+	defer m.supervisedRecoveryMu.Unlock()
+	m.supervisedWorkRecovery = recoverWork
+}
+
+func (m *Manager) recoverSupervisedWork(ctx context.Context, info *Info, turnID string) error {
+	if info.StopCause != CauseInactivity {
+		return nil
+	}
+	m.supervisedRecoveryMu.RLock()
+	recoverWork := m.supervisedWorkRecovery
+	m.supervisedRecoveryMu.RUnlock()
+	if recoverWork == nil {
+		return nil
+	}
+	if turnID == "" {
+		return errors.Join(ErrRecoveryPersistence, errors.New("session: supervised stop has no durable turn"))
+	}
+	if err := recoverWork(ctx, info, "session-stop:"+turnID); err != nil {
+		return errors.Join(ErrRecoveryPersistence, err)
+	}
+	return nil
+}

--- a/internal/session/supervised_work_recovery.go
+++ b/internal/session/supervised_work_recovery.go
@@ -5,14 +5,17 @@ import (
 	"errors"
 )
 
+// SupervisedWorkRecovery settles task ownership while the verified inactivity stop receipt still fences session reuse.
 type SupervisedWorkRecovery func(context.Context, *Info, string) error
 
+// SetSupervisedWorkRecovery installs the task settlement hook before stop replay or live supervision begins.
 func (m *Manager) SetSupervisedWorkRecovery(recoverWork SupervisedWorkRecovery) {
 	m.supervisedRecoveryMu.Lock()
 	defer m.supervisedRecoveryMu.Unlock()
 	m.supervisedWorkRecovery = recoverWork
 }
 
+// recoverSupervisedWork admits only inactivity stops and retains the receipt on task settlement failure.
 func (m *Manager) recoverSupervisedWork(ctx context.Context, info *Info, turnID string) error {
 	if info.StopCause != CauseInactivity {
 		return nil

--- a/internal/store/globaldb/global_db_loop_supervised_recovery.go
+++ b/internal/store/globaldb/global_db_loop_supervised_recovery.go
@@ -3,6 +3,7 @@ package globaldb
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	looppkg "github.com/compozy/compozy/internal/loop"
@@ -11,6 +12,25 @@ import (
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
+// loadSupervisedLoopRecovery admits ordinary task work or an unchanged, recoverable Loop cell and binding.
+func loadSupervisedLoopRecovery(
+	ctx context.Context, exec taskSQLExecutor, source taskpkg.Run,
+) (loopNodeRunMetadata, looppkg.Run, bool, error) {
+	if !source.IsLoopWorker() {
+		return loopNodeRunMetadata{}, looppkg.Run{}, true, nil
+	}
+	metadata, run, err := loadBoundLoopTaskRunCell(ctx, exec, source)
+	if errors.Is(err, looppkg.ErrTransitionConflict) {
+		return metadata, run, false, nil
+	}
+	if err != nil || run.Status != looppkg.StatusRunning {
+		return metadata, run, false, err
+	}
+	allowed, err := supervisedLoopRecoveryAllowed(ctx, exec, source, metadata)
+	return metadata, run, allowed, err
+}
+
+// supervisedLoopRecoveryAllowed honors durable controls and requires the current run-owned session-binding epoch.
 func supervisedLoopRecoveryAllowed(
 	ctx context.Context, exec taskSQLExecutor, source taskpkg.Run, metadata loopNodeRunMetadata,
 ) (bool, error) {

--- a/internal/store/globaldb/global_db_loop_supervised_recovery.go
+++ b/internal/store/globaldb/global_db_loop_supervised_recovery.go
@@ -1,0 +1,48 @@
+package globaldb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/loop/goal"
+	"github.com/compozy/compozy/internal/store/globaldb/sqlcgen"
+	taskpkg "github.com/compozy/compozy/internal/task"
+)
+
+func supervisedLoopRecoveryAllowed(
+	ctx context.Context, exec taskSQLExecutor, source taskpkg.Run, metadata loopNodeRunMetadata,
+) (bool, error) {
+	controls, err := sqlcgen.New(exec).ListLoopNodeControls(ctx, sqlcgen.ListLoopNodeControlsParams{
+		WorkspaceID: source.WorkspaceID, LoopRunID: source.LoopRunID,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, control := range controls {
+		if control.NodeID == metadata.NodeID && (control.Paused != 0 || control.Quarantined != 0 ||
+			control.CancelState != "" ||
+			(control.AttentionFlag != "" && control.AttentionFlag != looppkg.AttentionSilence)) {
+			return false, nil
+		}
+	}
+	var bindingMetadata runAgentBindingMetadata
+	if err := json.Unmarshal(source.Metadata, &bindingMetadata); err != nil {
+		return false, err
+	}
+	if bindingMetadata.NodeKind != "run-agent" {
+		return false, nil
+	}
+	binding, found, err := findSessionBindingAttemptWithExecutor(ctx, exec, goal.BindingKey{
+		WorkspaceID: looppkg.WorkspaceID(source.WorkspaceID), LoopRunID: looppkg.RunID(source.LoopRunID),
+		Handle: bindingMetadata.SessionHandle,
+	}, metadata.Epoch+1)
+	if err != nil {
+		return false, err
+	}
+	if !found || binding.SessionID != source.SessionID {
+		return false, fmt.Errorf("%w: supervised Loop session binding changed", looppkg.ErrTransitionConflict)
+	}
+	return binding.Ownership == goal.BindingOwnershipRunOwned && binding.State == goal.BindingStateActive, nil
+}

--- a/internal/store/globaldb/global_db_loop_task_recovery.go
+++ b/internal/store/globaldb/global_db_loop_task_recovery.go
@@ -142,6 +142,8 @@ func loadBoundLoopTaskRunCell(
 	}
 }
 
+// applyLoopTaskRecovery advances the owned cell and records its new attempt
+// and cleared attention in the same transaction.
 func applyLoopTaskRecovery(
 	ctx context.Context,
 	exec taskSQLExecutor,
@@ -238,6 +240,7 @@ func clearLoopTaskRecoveryAttention(
 	return attentionFlag, nil
 }
 
+// appendLoopTaskRecoveryAttempt records the stopped cell attempt with its actual operator or supervision cause.
 func appendLoopTaskRecoveryAttempt(
 	ctx context.Context,
 	exec taskSQLExecutor,
@@ -264,6 +267,7 @@ func appendLoopTaskRecoveryAttempt(
 	return nil
 }
 
+// loopTaskRecoveryCause preserves operator history while distinguishing automatic supervised recovery.
 func loopTaskRecoveryCause(args retryTaskRunArgs) string {
 	if args.reason == taskpkg.SupervisedSilenceReason {
 		return taskpkg.SupervisedSilenceReason
@@ -271,6 +275,7 @@ func loopTaskRecoveryCause(args retryTaskRunArgs) string {
 	return "operator_recovery"
 }
 
+// appendLoopTaskRecoveryAttentionClearedEvent attributes cleared attention to the action that advanced the cell.
 func appendLoopTaskRecoveryAttentionClearedEvent(
 	ctx context.Context,
 	exec taskSQLExecutor,

--- a/internal/store/globaldb/global_db_loop_task_recovery.go
+++ b/internal/store/globaldb/global_db_loop_task_recovery.go
@@ -168,7 +168,7 @@ func applyLoopTaskRecovery(
 			loopRun,
 			continuation.ID,
 			metadata,
-			args.queuedAt,
+			args,
 		); err != nil {
 			return err
 		}
@@ -248,12 +248,13 @@ func appendLoopTaskRecoveryAttempt(
 	if _, err := exec.ExecContext(ctx, `INSERT INTO loop_node_attempts (
 		loop_run_id, generation, node_id, item_index, attempt, failure_code,
 		cause, disposition, started_at, ended_at
-	) VALUES (?, ?, ?, ?, ?, 'operator_recovery', ?, 'resumed', ?, ?)`,
+	) VALUES (?, ?, ?, ?, ?, ?, ?, 'resumed', ?, ?)`,
 		source.LoopRunID,
 		metadata.Generation,
 		metadata.NodeID,
 		metadata.ItemIndex,
 		metadata.Attempt,
+		loopTaskRecoveryCause(args),
 		args.reason,
 		args.queuedAt,
 		args.queuedAt,
@@ -263,13 +264,20 @@ func appendLoopTaskRecoveryAttempt(
 	return nil
 }
 
+func loopTaskRecoveryCause(args retryTaskRunArgs) string {
+	if args.reason == taskpkg.SupervisedSilenceReason {
+		return taskpkg.SupervisedSilenceReason
+	}
+	return "operator_recovery"
+}
+
 func appendLoopTaskRecoveryAttentionClearedEvent(
 	ctx context.Context,
 	exec taskSQLExecutor,
 	loopRun looppkg.Run,
 	continuationID string,
 	metadata loopNodeRunMetadata,
-	at time.Time,
+	args retryTaskRunArgs,
 ) error {
 	return appendLoopRunEventWithExecutor(
 		ctx,
@@ -282,9 +290,9 @@ func appendLoopTaskRecoveryAttentionClearedEvent(
 			loopRunEventPayloadKeyNodeID:     metadata.NodeID,
 			loopRunEventPayloadKeyItemIndex:  metadata.ItemIndex,
 			loopRunEventPayloadKeyTaskRunID:  continuationID,
-			loopRunEventPayloadKeyReason:     "operator_recovery",
+			loopRunEventPayloadKeyReason:     loopTaskRecoveryCause(args),
 		},
-		at,
+		args.queuedAt,
 	)
 }
 

--- a/internal/store/globaldb/global_db_task_supervised_recovery.go
+++ b/internal/store/globaldb/global_db_task_supervised_recovery.go
@@ -7,14 +7,20 @@ import (
 	"fmt"
 	"time"
 
-	looppkg "github.com/compozy/compozy/internal/loop"
 	"github.com/compozy/compozy/internal/store/globaldb/sqlcgen"
 	taskpkg "github.com/compozy/compozy/internal/task"
 )
 
+// RecoverSupervisedRun rechecks ownership and terminal intent inside the task transaction before spending an attempt.
 func (s *taskMutationTxStore) RecoverSupervisedRun(
-	ctx context.Context, mutation taskpkg.SupervisedRunRecoveryMutation,
+	ctx context.Context, mutation *taskpkg.SupervisedRunRecoveryMutation,
 ) (taskpkg.SupervisedRunRecoveryResult, error) {
+	if mutation == nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, fmt.Errorf(
+			"%w: supervised recovery mutation is required",
+			taskpkg.ErrValidation,
+		)
+	}
 	source, err := s.tasks.getTaskRunWithExecutor(ctx, s.exec, mutation.Source.ID)
 	if errors.Is(err, taskpkg.ErrTaskRunNotFound) {
 		return taskpkg.SupervisedRunRecoveryResult{}, nil
@@ -32,7 +38,6 @@ func (s *taskMutationTxStore) RecoverSupervisedRun(
 	}
 	if source.SessionID != mutation.Stop.SessionID ||
 		(source.WorkspaceID != "" && source.WorkspaceID != mutation.Stop.WorkspaceID) ||
-		source.ProfileID != mutation.Stop.ProfileID ||
 		mutation.Stop.EventID == "" {
 		return taskpkg.SupervisedRunRecoveryResult{}, fmt.Errorf(
 			"%w: supervised recovery scope mismatch",
@@ -52,6 +57,10 @@ func (s *taskMutationTxStore) RecoverSupervisedRun(
 	if err != nil {
 		return taskpkg.SupervisedRunRecoveryResult{}, err
 	}
+	// Task profiles are authoritative; task-run projections do not hydrate ProfileID.
+	if taskRecord.ProfileID != mutation.Stop.ProfileID {
+		return taskpkg.SupervisedRunRecoveryResult{}, nil
+	}
 	if taskRecord.Status == taskpkg.TaskStatusCompleted {
 		return taskpkg.SupervisedRunRecoveryResult{}, nil
 	}
@@ -61,30 +70,20 @@ func (s *taskMutationTxStore) RecoverSupervisedRun(
 	return s.recoverSupervisedRun(ctx, source, taskRecord, mutation)
 }
 
+// recoverSupervisedRun atomically settles the stopped attempt and its successor, including any owned Loop cell.
 func (s *taskMutationTxStore) recoverSupervisedRun(
-	ctx context.Context, source taskpkg.Run, taskRecord taskpkg.Task, mutation taskpkg.SupervisedRunRecoveryMutation,
+	ctx context.Context, source taskpkg.Run, taskRecord taskpkg.Task, mutation *taskpkg.SupervisedRunRecoveryMutation,
 ) (taskpkg.SupervisedRunRecoveryResult, error) {
-	var metadata loopNodeRunMetadata
-	var loopRun looppkg.Run
-	var err error
-	if source.IsLoopWorker() {
-		metadata, loopRun, err = loadBoundLoopTaskRunCell(ctx, s.exec, source)
-		if errors.Is(err, looppkg.ErrTransitionConflict) {
-			return taskpkg.SupervisedRunRecoveryResult{}, nil
-		}
-		if err != nil {
-			return taskpkg.SupervisedRunRecoveryResult{}, err
-		}
-		if loopRun.Status != looppkg.StatusRunning {
-			return taskpkg.SupervisedRunRecoveryResult{}, nil
-		}
-		allowed, controlErr := supervisedLoopRecoveryAllowed(ctx, s.exec, source, metadata)
-		if controlErr != nil || !allowed {
-			return taskpkg.SupervisedRunRecoveryResult{}, controlErr
-		}
+	metadata, loopRun, allowed, err := loadSupervisedLoopRecovery(ctx, s.exec, source)
+	if err != nil || !allowed {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
 	}
-	consumed := int64(source.Attempt) + int64(source.RecoveryCount)
-	if consumed >= int64(normalizeStoredTaskMaxAttempts(taskRecord.MaxAttempts)) {
+	nextAttempt, err := nextTaskRunAttemptNumberWithExecutor(ctx, s.exec, taskRecord)
+	if err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	consumed := int64(nextAttempt) + int64(source.RecoveryCount)
+	if consumed > int64(normalizeStoredTaskMaxAttempts(taskRecord.MaxAttempts)) {
 		attention, attentionErr := s.MarkRunNeedsAttentionMutation(ctx,
 			taskpkg.NewRunNeedsAttentionCommand(source, taskpkg.SupervisedSilenceExhaustedReason, mutation.At))
 		return taskpkg.SupervisedRunRecoveryResult{
@@ -106,13 +105,25 @@ func (s *taskMutationTxStore) recoverSupervisedRun(
 	if err := updateTaskCurrentRunProjectionForRunUpdate(ctx, s.exec, source, failed); err != nil {
 		return taskpkg.SupervisedRunRecoveryResult{}, err
 	}
-	if _, err := s.tasks.runs.retryTaskRunTask(ctx, s.exec, source.TaskID); err != nil {
+	openRunID, err := s.tasks.findOpenRunIDForQueuedRunReservation(
+		ctx,
+		s.exec,
+		source.TaskID,
+		source.DesignationGroupID,
+	)
+	if err != nil {
 		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	if openRunID != "" {
+		return taskpkg.SupervisedRunRecoveryResult{}, fmt.Errorf(
+			"%w: task has another open run",
+			taskpkg.ErrInvalidStatusTransition,
+		)
 	}
 	if err := requireNoRetryChildWithExecutor(ctx, s.exec, source.ID); err != nil {
 		return taskpkg.SupervisedRunRecoveryResult{}, err
 	}
-	continuation, err := s.insertSupervisedContinuation(ctx, source, taskRecord, metadata, mutation)
+	continuation, err := s.insertSupervisedContinuation(ctx, source, metadata, mutation, nextAttempt)
 	if err != nil {
 		return taskpkg.SupervisedRunRecoveryResult{}, err
 	}
@@ -128,16 +139,15 @@ func (s *taskMutationTxStore) recoverSupervisedRun(
 	return taskpkg.SupervisedRunRecoveryResult{Previous: source, Run: continuation, Applied: true, Requeued: true}, nil
 }
 
+// insertSupervisedContinuation preserves execution context while issuing a fresh run
+// without live session or lease state.
 func (s *taskMutationTxStore) insertSupervisedContinuation(
-	ctx context.Context, source taskpkg.Run, taskRecord taskpkg.Task,
-	metadata loopNodeRunMetadata, mutation taskpkg.SupervisedRunRecoveryMutation,
+	ctx context.Context, source taskpkg.Run, metadata loopNodeRunMetadata,
+	mutation *taskpkg.SupervisedRunRecoveryMutation, attempt int,
 ) (taskpkg.Run, error) {
-	attempt, err := nextTaskRunAttemptWithExecutor(ctx, s.exec, taskRecord)
-	if err != nil {
-		return taskpkg.Run{}, err
-	}
 	continuation := source
 	continuation.ID, continuation.PreviousRunID = mutation.NewRunID, source.ID
+	var err error
 	continuation.Attempt, err = taskRunAttemptFromInt(attempt)
 	if err != nil {
 		return taskpkg.Run{}, err

--- a/internal/store/globaldb/global_db_task_supervised_recovery.go
+++ b/internal/store/globaldb/global_db_task_supervised_recovery.go
@@ -1,0 +1,168 @@
+package globaldb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	looppkg "github.com/compozy/compozy/internal/loop"
+	"github.com/compozy/compozy/internal/store/globaldb/sqlcgen"
+	taskpkg "github.com/compozy/compozy/internal/task"
+)
+
+func (s *taskMutationTxStore) RecoverSupervisedRun(
+	ctx context.Context, mutation taskpkg.SupervisedRunRecoveryMutation,
+) (taskpkg.SupervisedRunRecoveryResult, error) {
+	source, err := s.tasks.getTaskRunWithExecutor(ctx, s.exec, mutation.Source.ID)
+	if errors.Is(err, taskpkg.ErrTaskRunNotFound) {
+		return taskpkg.SupervisedRunRecoveryResult{}, nil
+	}
+	if err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	if !taskpkg.NewRunMutationFence(mutation.Source).Matches(source) {
+		return taskpkg.SupervisedRunRecoveryResult{}, nil
+	}
+	switch source.Status {
+	case taskpkg.TaskRunStatusClaimed, taskpkg.TaskRunStatusStarting, taskpkg.TaskRunStatusRunning:
+	default:
+		return taskpkg.SupervisedRunRecoveryResult{}, nil
+	}
+	if source.SessionID != mutation.Stop.SessionID ||
+		(source.WorkspaceID != "" && source.WorkspaceID != mutation.Stop.WorkspaceID) ||
+		source.ProfileID != mutation.Stop.ProfileID ||
+		mutation.Stop.EventID == "" {
+		return taskpkg.SupervisedRunRecoveryResult{}, fmt.Errorf(
+			"%w: supervised recovery scope mismatch",
+			taskpkg.ErrValidation,
+		)
+	}
+	_, err = sqlcgen.New(s.exec).GetTaskRunTerminalCommandByScope(ctx, sqlcgen.GetTaskRunTerminalCommandByScopeParams{
+		RunID: source.ID, TaskID: source.TaskID, WorkspaceID: source.WorkspaceID,
+	})
+	if err == nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	taskRecord, err := s.tasks.getTaskWithExecutor(ctx, s.exec, source.TaskID)
+	if err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	if taskRecord.Status == taskpkg.TaskStatusCompleted {
+		return taskpkg.SupervisedRunRecoveryResult{}, nil
+	}
+	if err := validateTaskForQueuedRunReservation(taskRecord); err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, nil
+	}
+	return s.recoverSupervisedRun(ctx, source, taskRecord, mutation)
+}
+
+func (s *taskMutationTxStore) recoverSupervisedRun(
+	ctx context.Context, source taskpkg.Run, taskRecord taskpkg.Task, mutation taskpkg.SupervisedRunRecoveryMutation,
+) (taskpkg.SupervisedRunRecoveryResult, error) {
+	var metadata loopNodeRunMetadata
+	var loopRun looppkg.Run
+	var err error
+	if source.IsLoopWorker() {
+		metadata, loopRun, err = loadBoundLoopTaskRunCell(ctx, s.exec, source)
+		if errors.Is(err, looppkg.ErrTransitionConflict) {
+			return taskpkg.SupervisedRunRecoveryResult{}, nil
+		}
+		if err != nil {
+			return taskpkg.SupervisedRunRecoveryResult{}, err
+		}
+		if loopRun.Status != looppkg.StatusRunning {
+			return taskpkg.SupervisedRunRecoveryResult{}, nil
+		}
+		allowed, controlErr := supervisedLoopRecoveryAllowed(ctx, s.exec, source, metadata)
+		if controlErr != nil || !allowed {
+			return taskpkg.SupervisedRunRecoveryResult{}, controlErr
+		}
+	}
+	consumed := int64(source.Attempt) + int64(source.RecoveryCount)
+	if consumed >= int64(normalizeStoredTaskMaxAttempts(taskRecord.MaxAttempts)) {
+		attention, attentionErr := s.MarkRunNeedsAttentionMutation(ctx,
+			taskpkg.NewRunNeedsAttentionCommand(source, taskpkg.SupervisedSilenceExhaustedReason, mutation.At))
+		return taskpkg.SupervisedRunRecoveryResult{
+			Previous: source,
+			Run:      attention.Run,
+			Applied:  attention.Applied,
+		}, attentionErr
+	}
+	failed := source
+	failed.Status, failed.Error, failed.EndedAt = taskpkg.TaskRunStatusFailed, taskpkg.SupervisedSilenceReason, mutation.At
+	if err := transitionTerminalRunRecordWithExecutor(
+		ctx,
+		s.exec,
+		&failed,
+		taskpkg.NewRunMutationFence(source),
+	); err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	if err := updateTaskCurrentRunProjectionForRunUpdate(ctx, s.exec, source, failed); err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	if _, err := s.tasks.runs.retryTaskRunTask(ctx, s.exec, source.TaskID); err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	if err := requireNoRetryChildWithExecutor(ctx, s.exec, source.ID); err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	continuation, err := s.insertSupervisedContinuation(ctx, source, taskRecord, metadata, mutation)
+	if err != nil {
+		return taskpkg.SupervisedRunRecoveryResult{}, err
+	}
+	if source.IsLoopWorker() {
+		if err := closeTerminalRunAgentBinding(ctx, s.exec, source, mutation.At); err != nil {
+			return taskpkg.SupervisedRunRecoveryResult{}, err
+		}
+		args := retryTaskRunArgs{origin: source.Origin, queuedAt: mutation.At, reason: taskpkg.SupervisedSilenceReason}
+		if err := applyLoopTaskRecovery(ctx, s.exec, loopRun, source, continuation, metadata, args); err != nil {
+			return taskpkg.SupervisedRunRecoveryResult{}, err
+		}
+	}
+	return taskpkg.SupervisedRunRecoveryResult{Previous: source, Run: continuation, Applied: true, Requeued: true}, nil
+}
+
+func (s *taskMutationTxStore) insertSupervisedContinuation(
+	ctx context.Context, source taskpkg.Run, taskRecord taskpkg.Task,
+	metadata loopNodeRunMetadata, mutation taskpkg.SupervisedRunRecoveryMutation,
+) (taskpkg.Run, error) {
+	attempt, err := nextTaskRunAttemptWithExecutor(ctx, s.exec, taskRecord)
+	if err != nil {
+		return taskpkg.Run{}, err
+	}
+	continuation := source
+	continuation.ID, continuation.PreviousRunID = mutation.NewRunID, source.ID
+	continuation.Attempt, err = taskRunAttemptFromInt(attempt)
+	if err != nil {
+		return taskpkg.Run{}, err
+	}
+	continuation.Status = taskpkg.TaskRunStatusQueued
+	continuation.SessionID, continuation.ClaimTokenHash, continuation.IdempotencyKey = "", "", ""
+	continuation.ClaimedBy = nil
+	continuation.ClaimedAt, continuation.StartedAt, continuation.EndedAt = time.Time{}, time.Time{}, time.Time{}
+	continuation.LeaseUntil, continuation.HeartbeatAt = time.Time{}, time.Time{}
+	continuation.QueuedAt, continuation.TokensUsed = mutation.At, 0
+	continuation.Error, continuation.FailureKind = "", ""
+	continuation.RunResultState = nil
+	continuation.SetNetworkState(source.NetworkSpecSnapshot(), "", "", "")
+	if source.IsLoopWorker() {
+		continuation.Metadata, err = loopTaskRecoveryMetadata(source.Metadata, nil, metadata)
+		if err != nil {
+			return taskpkg.Run{}, err
+		}
+	}
+	continuation, err = s.tasks.normalizeTaskRunForCreate(continuation)
+	if err != nil {
+		return taskpkg.Run{}, err
+	}
+	if err := insertQueuedTaskRun(ctx, s.exec, continuation); err != nil {
+		return taskpkg.Run{}, err
+	}
+	return continuation, nil
+}

--- a/internal/store/globaldb/global_db_task_test.go
+++ b/internal/store/globaldb/global_db_task_test.go
@@ -5197,11 +5197,161 @@ func TestGlobalDBRecoverTaskRun(t *testing.T) {
 
 func TestGlobalDBSupervisedRecovery(t *testing.T) {
 	t.Parallel()
+	t.Run("Should preserve a shared designation and account for every linked attempt", func(t *testing.T) {
+		t.Parallel()
+		db := openLoopTestGlobalDB(t)
+		ctx := t.Context()
+		record := taskRecordForTest("task-supervised-designation")
+		record.MaxAttempts = 4
+		if err := db.CreateTask(ctx, record); err != nil {
+			t.Fatal(err)
+		}
+		for attempt := range int32(2) {
+			source := taskRunForTest(fmt.Sprintf("run-supervised-%d", attempt), record.ID)
+			source.Attempt, source.Status, source.SessionID = attempt+1, taskpkg.TaskRunStatusRunning, "sess-supervised"
+			source.DesignationGroupID = "designation-supervised"
+			if err := db.CreateTaskRun(ctx, source); err != nil {
+				t.Fatal(err)
+			}
+		}
+		manager, err := taskpkg.NewManager(taskpkg.WithStore(db))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for range 2 {
+			if err := manager.RecoverSupervisedWork(ctx, taskpkg.SupervisedStop{
+				SessionID: "sess-supervised", WorkspaceID: "ws-1", ProfileID: store.DefaultProfileID,
+				EventID: "session-stop:turn-designation",
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		runs, err := db.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: record.ID})
+		if err != nil || len(runs) != 4 {
+			t.Fatalf("runs = %#v, %v", runs, err)
+		}
+		children := make(map[string]int32)
+		for _, run := range runs {
+			if run.PreviousRunID == "" {
+				continue
+			}
+			if run.Status != taskpkg.TaskRunStatusQueued || run.DesignationGroupID != "designation-supervised" ||
+				run.Attempt < 3 || run.Attempt > 4 {
+				t.Fatalf("successor = %#v", run)
+			}
+			children[run.PreviousRunID] = run.Attempt
+		}
+		if len(children) != 2 || children["run-supervised-0"]+children["run-supervised-1"] != 7 {
+			t.Fatalf("linked attempts = %#v, want two distinct successors at attempts 3 and 4", children)
+		}
+	})
+	t.Run("Should recover remaining owned runs after one candidate fails", func(t *testing.T) {
+		t.Parallel()
+		db := openLoopTestGlobalDB(t)
+		ctx := t.Context()
+		for _, suffix := range []string{"a", "b"} {
+			record := taskRecordForTest("task-supervised-" + suffix)
+			if err := db.CreateTask(ctx, record); err != nil {
+				t.Fatal(err)
+			}
+			source := taskRunForTest("run-supervised-"+suffix, record.ID)
+			source.Status, source.SessionID = taskpkg.TaskRunStatusRunning, "sess-supervised"
+			if err := db.CreateTaskRun(ctx, source); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if _, err := db.db.ExecContext(ctx, `CREATE TRIGGER reject_supervised_b BEFORE UPDATE OF status ON task_runs
+			WHEN OLD.id = 'run-supervised-b' AND NEW.status = 'failed'
+			BEGIN SELECT RAISE(ABORT, 'recovery temporarily unavailable'); END`); err != nil {
+			t.Fatal(err)
+		}
+		manager, err := taskpkg.NewManager(taskpkg.WithStore(db))
+		if err != nil {
+			t.Fatal(err)
+		}
+		stop := taskpkg.SupervisedStop{SessionID: "sess-supervised", WorkspaceID: "ws-1",
+			ProfileID: store.DefaultProfileID, EventID: "session-stop:turn-multiple"}
+		if err := manager.RecoverSupervisedWork(ctx, stop); err == nil {
+			t.Fatal("partial failure must retain the stop receipt")
+		}
+		recovered, err := db.GetTaskRun(ctx, "run-supervised-a")
+		if err != nil || recovered.Status != taskpkg.TaskRunStatusFailed {
+			t.Fatalf("independent candidate did not settle: %#v, %v", recovered, err)
+		}
+		if _, err := db.db.ExecContext(ctx, "DROP TRIGGER reject_supervised_b"); err != nil {
+			t.Fatal(err)
+		}
+		for range 2 {
+			if err := manager.RecoverSupervisedWork(ctx, stop); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, suffix := range []string{"a", "b"} {
+			runs, err := db.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: "task-supervised-" + suffix})
+			if err != nil || len(runs) != 2 {
+				t.Fatalf("runs = %#v, %v", runs, err)
+			}
+			for _, run := range runs {
+				if run.ID != "run-supervised-"+suffix &&
+					(run.PreviousRunID != "run-supervised-"+suffix || run.Status != taskpkg.TaskRunStatusQueued || run.Attempt != 2) {
+					t.Fatalf("unexpected successor: %#v", run)
+				}
+			}
+			events, err := db.ListTaskEvents(ctx, taskpkg.EventQuery{
+				TaskID: "task-supervised-" + suffix, EventType: "task.run_recovered",
+			})
+			if err != nil || len(events) != 1 {
+				t.Fatalf("recovery history duplicated: %#v, %v", events, err)
+			}
+		}
+	})
+	for _, tc := range []struct {
+		name        string
+		sessionID   string
+		workspaceID string
+		profileID   string
+	}{
+		{"Should ignore a session without owned task work", "sess-unbound", "ws-1", store.DefaultProfileID},
+		{"Should preserve another workspace's work", "sess-supervised", "ws-other", store.DefaultProfileID},
+		{"Should preserve another profile's work", "sess-supervised", "ws-1", "profile-other"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			db := openLoopTestGlobalDB(t)
+			ctx := t.Context()
+			record := taskRecordForTest("task-supervised-scope")
+			record.Scope, record.WorkspaceID = taskpkg.ScopeWorkspace, "ws-1"
+			if err := db.CreateTask(ctx, record); err != nil {
+				t.Fatal(err)
+			}
+			source := taskRunForTest("run-supervised-scope", record.ID)
+			source.Status, source.SessionID = taskpkg.TaskRunStatusRunning, "sess-supervised"
+			if err := db.CreateTaskRun(ctx, source); err != nil {
+				t.Fatal(err)
+			}
+			manager, err := taskpkg.NewManager(taskpkg.WithStore(db))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := manager.RecoverSupervisedWork(ctx, taskpkg.SupervisedStop{
+				SessionID:   tc.sessionID,
+				WorkspaceID: tc.workspaceID,
+				ProfileID:   tc.profileID,
+				EventID:     "session-stop:turn-scope",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			runs, err := db.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: record.ID})
+			if err != nil || len(runs) != 1 || runs[0].Status != taskpkg.TaskRunStatusRunning {
+				t.Fatalf("foreign recovery changed work: %#v, %v", runs, err)
+			}
+		})
+	}
 	for _, tc := range []struct {
 		name   string
 		change string
 	}{
-		{"Should preserve a winning success", "UPDATE task_runs SET status = 'succeeded' WHERE id = ?"},
+		{"Should preserve a winning success", "UPDATE task_runs SET status = 'completed' WHERE id = ?"},
 		{"Should preserve a winning cancellation", "UPDATE task_runs SET status = 'canceled' WHERE id = ?"},
 		{"Should reject ownership transferred to another session", "UPDATE task_runs SET session_id = 'sess-new-owner' WHERE id = ?"},
 		{"Should preserve completed task intent", "UPDATE tasks SET status = 'completed' WHERE id = (SELECT task_id FROM task_runs WHERE id = ?)"},
@@ -5228,7 +5378,7 @@ func TestGlobalDBSupervisedRecovery(t *testing.T) {
 				ctx,
 				"test supervised race",
 				func(tx *taskMutationTxStore) error {
-					result, err := tx.RecoverSupervisedRun(ctx, taskpkg.SupervisedRunRecoveryMutation{
+					result, err := tx.RecoverSupervisedRun(ctx, &taskpkg.SupervisedRunRecoveryMutation{
 						Source: source, NewRunID: "run-unwanted", At: time.Now().UTC(),
 						Stop: taskpkg.SupervisedStop{SessionID: source.SessionID, WorkspaceID: "ws-loop-test",
 							ProfileID: source.ProfileID, EventID: "session-stop:turn-fence"},
@@ -5276,7 +5426,7 @@ func TestGlobalDBSupervisedRecovery(t *testing.T) {
 			t.Fatal(err)
 		}
 		stop := taskpkg.SupervisedStop{SessionID: source.SessionID, WorkspaceID: source.WorkspaceID,
-			ProfileID: source.ProfileID, EventID: "session-stop:turn-loop"}
+			ProfileID: store.DefaultProfileID, EventID: "session-stop:turn-loop"}
 		for range 2 {
 			if err := manager.RecoverSupervisedWork(ctx, stop); err != nil {
 				t.Fatal(err)
@@ -5369,6 +5519,10 @@ func TestGlobalDBSupervisedRecovery(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			persistedTask, err := db.GetTask(ctx, record.ID)
+			if err != nil || persistedTask.ProfileID != record.ProfileID {
+				t.Fatalf("task profile changed: %q, %v", persistedTask.ProfileID, err)
+			}
 			if !tc.wantRetry {
 				if len(runs) != 1 || previous.Status != taskpkg.TaskRunStatusNeedsAttention ||
 					previous.Error != taskpkg.SupervisedSilenceExhaustedReason {
@@ -5385,7 +5539,7 @@ func TestGlobalDBSupervisedRecovery(t *testing.T) {
 					continue
 				}
 				if run.PreviousRunID != source.ID || run.Attempt != 2 || run.RecoveryCount != tc.recoveries ||
-					run.Status != taskpkg.TaskRunStatusQueued || run.SessionID != "" || run.ProfileID != source.ProfileID ||
+					run.Status != taskpkg.TaskRunStatusQueued || run.SessionID != "" || run.TaskID != source.TaskID ||
 					string(run.Metadata) != string(source.Metadata) {
 					t.Fatalf("successor = %#v", run)
 				}

--- a/internal/store/globaldb/global_db_task_test.go
+++ b/internal/store/globaldb/global_db_task_test.go
@@ -5195,6 +5195,212 @@ func TestGlobalDBRecoverTaskRun(t *testing.T) {
 	})
 }
 
+func TestGlobalDBSupervisedRecovery(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name   string
+		change string
+	}{
+		{"Should preserve a winning success", "UPDATE task_runs SET status = 'succeeded' WHERE id = ?"},
+		{"Should preserve a winning cancellation", "UPDATE task_runs SET status = 'canceled' WHERE id = ?"},
+		{"Should reject ownership transferred to another session", "UPDATE task_runs SET session_id = 'sess-new-owner' WHERE id = ?"},
+		{"Should preserve completed task intent", "UPDATE tasks SET status = 'completed' WHERE id = (SELECT task_id FROM task_runs WHERE id = ?)"},
+		{"Should preserve canceled task intent", "UPDATE tasks SET status = 'canceled' WHERE id = (SELECT task_id FROM task_runs WHERE id = ?)"},
+		{"Should ignore a deleted run", "DELETE FROM task_runs WHERE id = ?"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			db := openLoopTestGlobalDB(t)
+			ctx := t.Context()
+			record := taskRecordForTest("task-supervised-fence")
+			if err := db.CreateTask(ctx, record); err != nil {
+				t.Fatal(err)
+			}
+			source := taskRunForTest("run-supervised-fence", record.ID)
+			source.Status, source.SessionID = taskpkg.TaskRunStatusRunning, "sess-supervised"
+			if err := db.CreateTaskRun(ctx, source); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.db.ExecContext(ctx, tc.change, source.ID); err != nil {
+				t.Fatal(err)
+			}
+			err := db.withTaskMutationTransactionForTest(
+				ctx,
+				"test supervised race",
+				func(tx *taskMutationTxStore) error {
+					result, err := tx.RecoverSupervisedRun(ctx, taskpkg.SupervisedRunRecoveryMutation{
+						Source: source, NewRunID: "run-unwanted", At: time.Now().UTC(),
+						Stop: taskpkg.SupervisedStop{SessionID: source.SessionID, WorkspaceID: "ws-loop-test",
+							ProfileID: source.ProfileID, EventID: "session-stop:turn-fence"},
+					})
+					if result.Applied || result.Requeued {
+						t.Errorf("stale recovery applied: %#v", result)
+					}
+					return err
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := db.GetTaskRun(ctx, "run-unwanted"); !errors.Is(err, taskpkg.ErrTaskRunNotFound) {
+				t.Fatalf("unexpected successor: %v", err)
+			}
+		})
+	}
+	t.Run("Should atomically advance the owned Loop cell and close its old binding", func(t *testing.T) {
+		t.Parallel()
+		db := openLoopTestGlobalDB(t)
+		ctx := t.Context()
+		at := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+		loopRun, sourceID := seedLiveLoopLivenessCellForTest(t, db, at)
+		seedLoopCancellationBindingForTest(
+			t,
+			db,
+			string(loopRun.ID),
+			string(loopRun.WorkspaceID),
+			"main",
+			5,
+			"sess-supervised",
+			at,
+		)
+		if _, err := db.db.ExecContext(ctx, `UPDATE task_runs SET status = 'running', session_id = ?,
+			metadata_json = json_set(metadata_json, '$.node_kind', 'run-agent') WHERE id = ?`, "sess-supervised", sourceID); err != nil {
+			t.Fatal(err)
+		}
+		source, err := db.GetTaskRun(ctx, sourceID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		manager, err := taskpkg.NewManager(taskpkg.WithStore(db))
+		if err != nil {
+			t.Fatal(err)
+		}
+		stop := taskpkg.SupervisedStop{SessionID: source.SessionID, WorkspaceID: source.WorkspaceID,
+			ProfileID: source.ProfileID, EventID: "session-stop:turn-loop"}
+		for range 2 {
+			if err := manager.RecoverSupervisedWork(ctx, stop); err != nil {
+				t.Fatal(err)
+			}
+		}
+		runs, err := db.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: source.TaskID})
+		if err != nil || len(runs) != 2 {
+			t.Fatalf("runs = %#v, %v", runs, err)
+		}
+		var child taskpkg.Run
+		for _, run := range runs {
+			if run.ID != source.ID {
+				child = run
+			}
+		}
+		if child.PreviousRunID != source.ID || child.LoopRunID != source.LoopRunID ||
+			child.DesignationGroupID != source.DesignationGroupID || !reflect.DeepEqual(child.RunWorktreeState, source.RunWorktreeState) ||
+			!reflect.DeepEqual(child.RequiredCapabilities, source.RequiredCapabilities) {
+			t.Fatalf("child = %#v", child)
+		}
+		var cellRun, bindingState, failureCode string
+		var epoch, attempt int
+		if err := db.db.QueryRowContext(ctx, `SELECT task_run_id, epoch, attempt FROM loop_generation_outputs
+			WHERE loop_run_id = ? AND node_id = 'work'`, loopRun.ID).Scan(&cellRun, &epoch, &attempt); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.db.QueryRowContext(ctx, `SELECT state FROM loop_session_bindings WHERE loop_run_id = ? AND handle = 'main'`, loopRun.ID).
+			Scan(&bindingState); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.db.QueryRowContext(ctx, `SELECT failure_code FROM loop_node_attempts WHERE loop_run_id = ? AND node_id = 'work'`, loopRun.ID).
+			Scan(&failureCode); err != nil {
+			t.Fatal(err)
+		}
+		if cellRun != child.ID || epoch != 5 || attempt != 2 || bindingState != "closed" ||
+			failureCode != taskpkg.SupervisedSilenceReason {
+			t.Fatalf("cell=%s/%d/%d binding=%s cause=%s", cellRun, epoch, attempt, bindingState, failureCode)
+		}
+	})
+	for _, tc := range []struct {
+		name        string
+		status      taskpkg.RunStatus
+		maxAttempts int
+		recoveries  int32
+		wantRetry   bool
+	}{
+		{"Should retry running work with a linked attempt", taskpkg.TaskRunStatusRunning, 3, 0, true},
+		{"Should retry claimed work with a linked attempt", taskpkg.TaskRunStatusClaimed, 3, 0, true},
+		{"Should disable retry with one allowed attempt", taskpkg.TaskRunStatusRunning, 1, 0, false},
+		{"Should count previous lease recoveries against the budget", taskpkg.TaskRunStatusClaimed, 2, 1, false},
+		{"Should retain consumed lease recoveries in the successor", taskpkg.TaskRunStatusRunning, 3, 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			db := openLoopTestGlobalDB(t)
+			ctx := t.Context()
+			record := taskRecordForTest("task-supervised")
+			record.MaxAttempts = tc.maxAttempts
+			if err := db.CreateTask(ctx, record); err != nil {
+				t.Fatal(err)
+			}
+			source := taskRunForTest("run-supervised", record.ID)
+			source.Status, source.SessionID, source.RecoveryCount = tc.status, "sess-supervised", tc.recoveries
+			source.ClaimedBy = &taskpkg.ActorIdentity{Kind: taskpkg.ActorKindAgentSession, Ref: source.SessionID}
+			source.ClaimedAt = source.QueuedAt
+			source.Metadata = json.RawMessage(`{"checkpoint":"committed-part-4"}`)
+			if err := db.CreateTaskRun(ctx, source); err != nil {
+				t.Fatal(err)
+			}
+			manager, err := taskpkg.NewManager(taskpkg.WithStore(db))
+			if err != nil {
+				t.Fatal(err)
+			}
+			stop := taskpkg.SupervisedStop{SessionID: source.SessionID, WorkspaceID: "ws-loop-test",
+				ProfileID: store.DefaultProfileID, EventID: "session-stop:turn-supervised"}
+			var recoveryWG sync.WaitGroup
+			for range 2 {
+				recoveryWG.Go(func() {
+					if err := manager.RecoverSupervisedWork(ctx, stop); err != nil {
+						t.Error(err)
+					}
+				})
+			}
+			recoveryWG.Wait()
+			runs, err := db.ListTaskRuns(ctx, taskpkg.RunQuery{TaskID: record.ID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			previous, err := db.GetTaskRun(ctx, source.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !tc.wantRetry {
+				if len(runs) != 1 || previous.Status != taskpkg.TaskRunStatusNeedsAttention ||
+					previous.Error != taskpkg.SupervisedSilenceExhaustedReason {
+					t.Fatalf("exhausted recovery: runs=%#v previous=%#v", runs, previous)
+				}
+				return
+			}
+			if len(runs) != 2 || previous.Status != taskpkg.TaskRunStatusFailed ||
+				previous.Error != taskpkg.SupervisedSilenceReason {
+				t.Fatalf("recovery: runs=%#v previous=%#v", runs, previous)
+			}
+			for _, run := range runs {
+				if run.ID == source.ID {
+					continue
+				}
+				if run.PreviousRunID != source.ID || run.Attempt != 2 || run.RecoveryCount != tc.recoveries ||
+					run.Status != taskpkg.TaskRunStatusQueued || run.SessionID != "" || run.ProfileID != source.ProfileID ||
+					string(run.Metadata) != string(source.Metadata) {
+					t.Fatalf("successor = %#v", run)
+				}
+			}
+			events, err := db.ListTaskEvents(
+				ctx,
+				taskpkg.EventQuery{TaskID: record.ID, EventType: "task.run_recovered"},
+			)
+			if err != nil || len(events) != 1 {
+				t.Fatalf("recovery events = %#v, %v", events, err)
+			}
+		})
+	}
+}
+
 func forceReleaseTaskRunForTest(
 	ctx context.Context,
 	globalDB *GlobalDB,

--- a/internal/task/supervised_recovery.go
+++ b/internal/task/supervised_recovery.go
@@ -35,7 +35,7 @@ type SupervisedRunRecoveryResult struct {
 }
 
 type supervisedRunRecoveryStore interface {
-	RecoverSupervisedRun(context.Context, SupervisedRunRecoveryMutation) (SupervisedRunRecoveryResult, error)
+	RecoverSupervisedRun(context.Context, *SupervisedRunRecoveryMutation) (SupervisedRunRecoveryResult, error)
 }
 
 // RecoverSupervisedWork is called only while the verified stop receipt still fences session reuse.
@@ -50,12 +50,17 @@ func (m *Service) RecoverSupervisedWork(ctx context.Context, stop SupervisedStop
 		return err
 	}
 	candidates := supervisedWorkCandidates(runs, stop)
-	if len(candidates) == 0 {
-		return nil
+	var errs []error
+	for _, candidate := range candidates {
+		if err := m.recoverSupervisedRun(ctx, candidate, stop); err != nil {
+			errs = append(errs, fmt.Errorf("recover supervised run %s: %w", candidate.ID, err))
+		}
 	}
-	if len(candidates) != 1 {
-		return fmt.Errorf("task: supervised session has ambiguous work ownership")
-	}
+	return errors.Join(errs...)
+}
+
+// recoverSupervisedRun commits one owned attempt so another candidate's failure cannot roll it back.
+func (m *Service) recoverSupervisedRun(ctx context.Context, source Run, stop SupervisedStop) error {
 	actor, err := DeriveDaemonActorContext("session-supervision", SupervisedSilenceReason)
 	if err != nil {
 		return err
@@ -75,8 +80,8 @@ func (m *Service) RecoverSupervisedWork(ctx context.Context, stop SupervisedStop
 			return errors.New("task: supervised recovery store is unavailable")
 		}
 		var mutationErr error
-		result, mutationErr = recoverer.RecoverSupervisedRun(ctx, SupervisedRunRecoveryMutation{
-			Source: candidates[0], Stop: stop, NewRunID: newRunID, At: at,
+		result, mutationErr = recoverer.RecoverSupervisedRun(ctx, &SupervisedRunRecoveryMutation{
+			Source: source, Stop: stop, NewRunID: newRunID, At: at,
 		})
 		if mutationErr != nil || !result.Applied {
 			return mutationErr
@@ -97,7 +102,7 @@ func (m *Service) RecoverSupervisedWork(ctx context.Context, stop SupervisedStop
 			taskEventRunRecovered,
 			actor,
 			at,
-			supervisedRecoveryPayload(result, stop),
+			supervisedRecoveryPayload(&result, stop),
 		)
 		if mutationErr != nil {
 			return mutationErr
@@ -114,7 +119,8 @@ func (m *Service) RecoverSupervisedWork(ctx context.Context, stop SupervisedStop
 	return nil
 }
 
-func supervisedRecoveryPayload(result SupervisedRunRecoveryResult, stop SupervisedStop) map[string]any {
+// supervisedRecoveryPayload correlates task history with the stable session stop without exposing lease credentials.
+func supervisedRecoveryPayload(result *SupervisedRunRecoveryResult, stop SupervisedStop) map[string]any {
 	action := "needs_attention"
 	if result.Requeued {
 		action = "requeue"
@@ -127,11 +133,12 @@ func supervisedRecoveryPayload(result SupervisedRunRecoveryResult, stop Supervis
 	}
 }
 
+// supervisedWorkCandidates keeps task workers from the profile-scoped query that still belong to the stopped session.
 func supervisedWorkCandidates(runs []Run, stop SupervisedStop) []Run {
 	var candidates []Run
 	for _, run := range runs {
 		if run.SessionID != stop.SessionID || (run.WorkspaceID != "" && run.WorkspaceID != stop.WorkspaceID) ||
-			run.ProfileID != stop.ProfileID || !run.IsTaskAnchored() || run.RunKind.Normalize() != RunKindWorker {
+			!run.IsTaskAnchored() || run.RunKind.Normalize() != RunKindWorker {
 			continue
 		}
 		switch run.Status.Normalize() {

--- a/internal/task/supervised_recovery.go
+++ b/internal/task/supervised_recovery.go
@@ -1,0 +1,143 @@
+package task
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/compozy/compozy/internal/store"
+)
+
+const SupervisedSilenceReason = "supervised_silence"
+const SupervisedSilenceExhaustedReason = "supervised_silence_exhausted"
+
+// SupervisedStop identifies a durable, verified session stop owned by the session manager.
+type SupervisedStop struct {
+	SessionID   string
+	WorkspaceID string
+	ProfileID   string
+	EventID     string
+}
+
+type SupervisedRunRecoveryMutation struct {
+	Source   Run
+	Stop     SupervisedStop
+	NewRunID string
+	At       time.Time
+}
+
+type SupervisedRunRecoveryResult struct {
+	Previous Run
+	Run      Run
+	Applied  bool
+	Requeued bool
+}
+
+type supervisedRunRecoveryStore interface {
+	RecoverSupervisedRun(context.Context, SupervisedRunRecoveryMutation) (SupervisedRunRecoveryResult, error)
+}
+
+// RecoverSupervisedWork is called only while the verified stop receipt still fences session reuse.
+func (m *Service) RecoverSupervisedWork(ctx context.Context, stop SupervisedStop) error {
+	if stop.SessionID == "" || stop.WorkspaceID == "" || stop.ProfileID == "" || stop.EventID == "" {
+		return fmt.Errorf("%w: supervised stop identity is required", ErrValidation)
+	}
+	runs, err := m.store.ListTaskRuns(ctx, RunQuery{
+		SessionID: stop.SessionID, ReadScope: store.ReadScope{ProfileID: stop.ProfileID},
+	})
+	if err != nil {
+		return err
+	}
+	candidates := supervisedWorkCandidates(runs, stop)
+	if len(candidates) == 0 {
+		return nil
+	}
+	if len(candidates) != 1 {
+		return fmt.Errorf("task: supervised session has ambiguous work ownership")
+	}
+	actor, err := DeriveDaemonActorContext("session-supervision", SupervisedSilenceReason)
+	if err != nil {
+		return err
+	}
+	newRunID, err := m.newID("run")
+	if err != nil {
+		return err
+	}
+	var result SupervisedRunRecoveryResult
+	var event Event
+	var taskRecord Task
+	var transitions []StatusTransition
+	at := m.now().UTC()
+	err = m.store.WithTaskMutationTransaction(ctx, "recover supervised task work", func(tx runMutationStore) error {
+		recoverer, ok := tx.(supervisedRunRecoveryStore)
+		if !ok {
+			return errors.New("task: supervised recovery store is unavailable")
+		}
+		var mutationErr error
+		result, mutationErr = recoverer.RecoverSupervisedRun(ctx, SupervisedRunRecoveryMutation{
+			Source: candidates[0], Stop: stop, NewRunID: newRunID, At: at,
+		})
+		if mutationErr != nil || !result.Applied {
+			return mutationErr
+		}
+		taskRecord, transitions, mutationErr = m.reconcileTaskSettlementCascadeWithStore(
+			ctx,
+			tx,
+			result.Run.TaskID,
+			actor,
+			at,
+		)
+		if mutationErr != nil {
+			return mutationErr
+		}
+		event, mutationErr = m.newTaskEventAt(
+			result.Run.TaskID,
+			result.Run.ID,
+			taskEventRunRecovered,
+			actor,
+			at,
+			supervisedRecoveryPayload(result, stop),
+		)
+		if mutationErr != nil {
+			return mutationErr
+		}
+		return tx.CreateTaskEvent(ctx, event)
+	})
+	if err != nil || !result.Applied {
+		return err
+	}
+	m.publishLeaseSettlement(ctx, []Event{event}, transitions, actor)
+	if result.Requeued {
+		m.dispatchTaskRunEnqueued(ctx, result.Run, taskRecord, actor, "")
+	}
+	return nil
+}
+
+func supervisedRecoveryPayload(result SupervisedRunRecoveryResult, stop SupervisedStop) map[string]any {
+	action := "needs_attention"
+	if result.Requeued {
+		action = "requeue"
+	}
+	return map[string]any{
+		"reason": SupervisedSilenceReason, "action": action, "stop_event_id": stop.EventID,
+		"previous_run_id": result.Previous.ID, "previous_session_id": stop.SessionID,
+		"previous_status": result.Previous.Status, "status": result.Run.Status,
+		"attempt": result.Run.Attempt, "recovery_count": result.Run.RecoveryCount,
+	}
+}
+
+func supervisedWorkCandidates(runs []Run, stop SupervisedStop) []Run {
+	var candidates []Run
+	for _, run := range runs {
+		if run.SessionID != stop.SessionID || (run.WorkspaceID != "" && run.WorkspaceID != stop.WorkspaceID) ||
+			run.ProfileID != stop.ProfileID || !run.IsTaskAnchored() || run.RunKind.Normalize() != RunKindWorker {
+			continue
+		}
+		switch run.Status.Normalize() {
+		case TaskRunStatusClaimed, TaskRunStatusStarting, TaskRunStatusRunning:
+			candidates = append(candidates, run)
+		}
+	}
+	return candidates
+}

--- a/packages/site/content/docs/sessions/health.mdx
+++ b/packages/site/content/docs/sessions/health.mdx
@@ -18,6 +18,25 @@ answers four questions without ever calling the model:
   /api/workspaces/:workspace_id/sessions/:session_id/health|status|inspect`.
 </OperatorNote>
 
+## Recovering supervised work
+
+Session supervision warns after `session.supervision.quiet_after` (30 minutes by default) when no
+fresh work evidence remains. A positive `stop_grace` (10 minutes by default) then permits a verified
+process-tree stop. Valid work signals and unknown signal sources prevent this stop.
+
+After a verified stop, an authoritative task binding can recover through one linked queued attempt.
+The existing `max_attempts` budget includes previous lease recoveries; setting it to `1` disables
+automatic retry. Exhausted work remains visible as `needs_attention` with
+`supervised_silence_exhausted`. Explicit cancellation and sessions without task ownership never
+create a retry. Recovery history uses `task.run_recovered`, reason `supervised_silence`, and action
+`requeue`; the existing Requeued total includes it.
+
+The replacement keeps the task, profile, workspace, worktree and participation. Owned Loop
+`run-agent` work advances its node epoch; paused, quarantined and borrowed Goal bindings retain
+their existing control requirements. Committed files remain available. Workers must inspect partial
+external effects before repeating them and use the destination's idempotency mechanism where
+available; automatic recovery does not make external effects exactly once.
+
 ## What health describes
 
 Health is stored alongside the session and maintained by the daemon. The wake service reads it,

--- a/skills/compozy/references/loops.md
+++ b/skills/compozy/references/loops.md
@@ -377,7 +377,12 @@ run or addressed node. A missing managed session is already stopped. Failed stop
 and retry after transient failures or daemon restart; origin-borrowed sessions are excluded. A
 canceled run cannot resume; use rerun to start a new generation.
 
-Silence raises attention and never auto-kills or auto-pauses. Confirmed process/transport death may
+The Loop silence window raises attention and never auto-kills or auto-pauses. Separately, configured
+session supervision can stop a session after all work evidence expires and `stop_grace` elapses.
+A verified supervised stop recovers its authoritative task work within `max_attempts`; an owned
+`run-agent` cell advances to the linked task attempt and next epoch. Explicit cancellation,
+paused/quarantined cells, and borrowed Goal bindings are not automatically requeued.
+Confirmed process/transport death may
 resume from progress through the bounded death-streak authority; parked nodes are never
 death-resumed. Paused nodes, durable waits, approval waits, and quarantined cells suspend node
 clocks and the run wall-clock work budget; token spend still counts.

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -873,7 +873,9 @@ Canonical events are `session.supervision_warning`, `session.supervision_stopped
 `session.supervision_source_error`. Persisted inactivity stop metadata remains timeout/inactivity.
 
 After verified process-tree exit, the durable stop receipt settles authoritative task work before
-session reuse. A remaining task attempt queues one linked run with `previous_run_id`, preserving
+session reuse. Each owned run settles independently, so replay can finish remaining candidates
+without duplicating successors already committed. A remaining task attempt queues one linked run
+with `previous_run_id`, preserving
 profile, workspace, worktree, participation, capabilities, and metadata. Existing lease recovery
 counts remain charged. `max_attempts = 1` disables retry; exhaustion leaves `needs_attention` with
 `supervised_silence_exhausted`. Recovery emits `task.run_recovered` with reason `supervised_silence`

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -872,6 +872,16 @@ the warning. Zero quiet disables both actions; zero grace keeps warning only. A 
 Canonical events are `session.supervision_warning`, `session.supervision_stopped`, and
 `session.supervision_source_error`. Persisted inactivity stop metadata remains timeout/inactivity.
 
+After verified process-tree exit, the durable stop receipt settles authoritative task work before
+session reuse. A remaining task attempt queues one linked run with `previous_run_id`, preserving
+profile, workspace, worktree, participation, capabilities, and metadata. Existing lease recovery
+counts remain charged. `max_attempts = 1` disables retry; exhaustion leaves `needs_attention` with
+`supervised_silence_exhausted`. Recovery emits `task.run_recovered` with reason `supervised_silence`
+and action `requeue`, contributing to the existing Requeued total without a daemon-boot label.
+Explicit cancellation and sessions without authoritative task ownership never create retry work.
+Committed files remain in place. A replacement worker must reconcile partial external effects and
+use operation-specific idempotency; recovery does not guarantee exactly-once side effects.
+
 Expiryless event waits use the pinned admission horizon (default 168h), including upgrade from
 their original creation time. Live's aggregate wall budget defaults to zero; per-wake, count,
 token and depth limits remain independent. Old inactivity config keys remain deprecated through

--- a/skills/compozy/references/tasks-and-orchestration.md
+++ b/skills/compozy/references/tasks-and-orchestration.md
@@ -181,7 +181,11 @@ Wait for the next runtime wake instead of releasing
 an unrelated lease. Global task runs and Network wake runs do not consume this workspace limit.
 
 Action nodes have no inherited duration limit. Only `timeout` or lifecycle deadlines written on the
-node bound execution time; silence can raise attention but never fails or cancels the work. Recovered expired leases
+node bound execution time; the Loop silence window raises attention without canceling work.
+Session supervision independently stops sessions whose evidence has expired when configured
+`stop_grace` elapses. After verified exit, owned task work consumes the next available attempt,
+preserving its task identity and linking the new run. Exhaustion becomes `needs_attention` with
+`supervised_silence_exhausted`; explicit cancellation is never retried. Recovered expired leases
 increment the run's `recovery_count`; once `attempt + recovery_count` reaches `max_attempts`, the run
 and task move to `needs_attention` with `lease_recovery_exhausted` instead of reclaiming forever.
 Inspect the run before retrying.


### PR DESCRIPTION
## Problem and behavior

Closes #616.

When session supervision stops an executor after a verified quiet episode, the session stop previously left its task work behind. The daemon-boot recovery path only handles claimed runs and requeues the same run, so invoking that path would neither cover running work nor create the required linked attempt.

This change recovers an authoritative task worker binding only after the session manager verifies process-tree exit and persists the stop. It creates one linked queued attempt within the existing `max_attempts` budget, including previously consumed lease recoveries. `max_attempts=1` does not retry; exhaustion leaves visible `needs_attention` work with `supervised_silence_exhausted`.

## Implementation and safety boundaries

- The durable stop receipt remains until task settlement succeeds. Normal stop finalization and restart replay use the same stop identity. The recovery callback is installed before boot stop replay and replaced with the configured task service during normal boot.
- A transaction fences the exact task run, session, profile and workspace. Terminal results, pending terminal commands, cancellation, deletion and changed ownership take precedence. Concurrent calls and receipt replay cannot create another child from the same source. Multiple owned runs settle independently, so a failed candidate does not roll back other recovered work; replay finishes only the remaining active bindings.
- The successor retains task identity, participation, worktree binding, capabilities and task metadata, with fresh session/lease/result state and `previous_run_id` linkage. Existing committed files are preserved. External partial effects still require worker reconciliation and destination idempotency; this does not provide exactly-once side effects.
- Owned Loop `run-agent` recovery also checks the current cell and session-binding epoch, closes the old binding, and atomically advances the cell to its new attempt. Paused, quarantined, canceled and borrowed Goal bindings retain their existing controls. Late ACP failure does not override receipt-owned recovery.
- Existing `task.run_recovered` history records `supervised_silence`, the stop identity, attempt and recovery count. Its `requeue` action participates in existing recovery totals; silence is not labeled daemon boot.

## Validation

[All current-head CI lanes passed](https://github.com/compozy/compozy/actions/runs/34642778517) on `8e168d912d0a90918d30c477e7f38f42068a17e4`, including both aggregate verification and E2E gates. The [disposable frozen-executor integration](https://github.com/compozy/compozy/actions/runs/34642778517/job/103406539141) passed with the race detector (bounded scenario: 2.35 seconds). Per the requested delivery contract, heavy gates, builds, tests and disposable runtime reproduction run exclusively in GitHub CI; local hooks/gates were deferred for this commit without changing repository gate policy or weakening CI. Scoped formatting and diff inspection were performed locally.

- Extended the existing GlobalDB task suite for running/claimed work, budget exhaustion, inherited recovery counts, concurrent and partial-failure replay, terminal intent/ownership/profile fences, shared designation budgets and atomic Loop cell/binding recovery.
- Extended the existing session lifecycle suite for durable receipt replay after recovery failure and exclusion of explicit cancellation.
- Added a case to the existing session integration suite using a disposable real ACP process tree, bounded supervision timings and `SIGSTOP`. It asserts verified tree exit before recovery, a linked queued successor, correlated supervision history, preserved committed output, settled source lease timestamps and rejection of the old token. A dedicated required-by-aggregate CI lane runs this case with the race detector.
- Reporter timing estimates are not treated as reproduced measurements. The fixture uses bounded test timings; it does not access a user's provider/account/session or claim live-provider continuation coverage.

## Cross-surface and compatibility impact

No schema, configuration key, public DTO, route, native tool ID or extension contract changes. Existing task/history surfaces expose the linked attempt and reason. No migration is required. Official session/Loop/task runtime manuals, site session-health documentation and the affected QA scenario distinguish Loop silence attention from session `stop_grace` and describe recovery/side-effect boundaries. The issue-specific audit is recorded in `docs/_memory/change-impact.md`.

The first complete CodeRabbit review identified two actionable comments and a docstring warning; all are addressed in consolidated remediation commit 8e168d912 with linked dispositions in the PR discussion. Greptile explicitly completed its first 22-file review with zero findings. A later unsolicited action-pinning suggestion was addressed with an evidence-backed disposition: the new job retains the existing first-party action tag convention used throughout this workflow, as required by repository instructions. All three threads are resolved; no re-review was requested. Initial CI exposed an unhydrated Run profile assumption; recovery now checks the authoritative Task profile inside the transaction while retaining the profile-scoped candidate query. All required current-head CI is green. The release/nightly-only jobs were intentionally skipped by their existing PR conditions; no relevant CI lane is missing or pending. No second review or post-remediation approval is requested or awaited. This PR must remain open.
