### PR TITLE
fix: preserve zsh startup directory semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,12 @@ jobs:
           sudo apt-get "${apt_sources[@]}" install --no-install-recommends --yes zsh
           zsh --version
 
+      - name: Verify zsh startup contracts
+        if: matrix.shard_index == '0'
+        env:
+          CGO_ENABLED: "1"
+        run: go test -race -count=1 -timeout=2m -v ./internal/terminal/pty -run '^TestShellIntegrationContract$'
+
       - name: Run Go runtime verification
         run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,14 @@ jobs:
         with:
           install-playwright: "false"
 
+      - name: Install zsh for shell integration contracts
+        run: |
+          test -f /etc/apt/sources.list.d/ubuntu.sources
+          apt_sources=(-o Dir::Etc::sourcelist=sources.list.d/ubuntu.sources -o Dir::Etc::sourceparts=-)
+          sudo apt-get "${apt_sources[@]}" update
+          sudo apt-get "${apt_sources[@]}" install --no-install-recommends --yes zsh
+          zsh --version
+
       - name: Run Go runtime verification
         run: make test
 

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -185,7 +185,6 @@ The [integration report](../qa/reports/2026-09-10-pr-607-611-integration.md) rec
 
 PR #619 review remediation preserves the same surface and isolation contracts: editable controls retain text-editing shortcuts, a one-session bulk failure exposes its daemon error and retry, failed targets beyond the five-row preview remain named with their errors, and selection derives from current catalog membership before catalog/selection-store-driven pruning. The existing list/dialog/lifecycle suites own regression coverage; CI owns the final integration run.
 
-
 ## QA workspace hook dispatch identity — 2026-09-11
 
 BUG-20260911-workspace-hooks-not-dispatched: workspace declaration scoping now uses the registered workspace ID, matching actual session, task-run and window hook payloads. The durable directory identity is not changed. The owning canonical daemon integration fixtures distinguish both IDs, dispatch real hook subprocesses and verify a foreign task workspace does not execute the hook.
@@ -261,3 +260,22 @@ public replay. No Web, hook, config, persistence, or official skill surface chan
 The following linter-only continuation preserves custom-property importance and recognizes icon
 containers with delimiter-aware names across non-void tags. The same tool/schema/isolation audit
 and ET-open-design scenario apply; no additional surface contract is introduced.
+
+## Issue 626 — Zsh startup directory fidelity
+
+- **Native tools:** terminal open/write/wait/read retain their IDs and schemas. Zsh user startup
+  files see the original ZDOTDIR state and subsequent startup-file changes; authenticated markers
+  still load after the interactive rc. No daemon authority or journal grammar change.
+- **Extensibility/hooks/config:** existing `terminal.shell_integration` controls injection. No new
+  key or hook. User `.zshenv`, `.zprofile`, `.zshrc`, `.zlogin` and `.zlogout` retain their ordering;
+  unset versus set ZDOTDIR and its export attribute survive the temporary startup routing.
+- **Workspace data isolation:** private per-process shim files remain ephemeral and cleanup-owned.
+  User startup files are sourced without rewriting them. Child shells inherit the user's environment,
+  not the shim directory or marker nonce. Profile/workspace ownership is unchanged.
+- **Compatibility:** internal startup fix with no database, wire, CLI, or config shape change;
+  no migration or recovery command. Bash, fish and disabled-integration paths are unchanged.
+- **Official skill:** terminal operation guidance and structured interfaces remain valid; no skill
+  resource edit is required for this transparent configuration fidelity fix.
+- **Web/Docs/QA:** Web Terminal uses the corrected daemon PTY path without renderer changes.
+  `ET-terminal-shell-config-fidelity` includes startup redirection, plugin loading and nested shells.
+  The real-zsh PTY replay and platform limits are recorded in the linked QA report.

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -271,7 +271,9 @@ and ET-open-design scenario apply; no additional surface contract is introduced.
   unset versus set ZDOTDIR and its export attribute survive the temporary startup routing.
 - **Workspace data isolation:** private per-process shim files remain ephemeral and cleanup-owned.
   User startup files are sourced without rewriting them. Child shells inherit the user's environment,
-  not the shim directory or marker nonce. Profile/workspace ownership is unchanged.
+  not the marker nonce. An early child entering the shim from a global startup file restores the
+  user directory/export state and bypasses parent marker injection. Temporary directory metadata
+  is removed before user files run; profile/workspace ownership is unchanged.
 - **Compatibility:** internal startup fix with no database, wire, CLI, or config shape change;
   no migration or recovery command. Bash, fish and disabled-integration paths are unchanged.
 - **Official skill:** terminal operation guidance and structured interfaces remain valid; no skill

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -273,7 +273,8 @@ and ET-open-design scenario apply; no additional surface contract is introduced.
   User startup files are sourced without rewriting them. Child shells inherit the user's environment,
   not the marker nonce. An early child entering the shim from a global startup file restores the
   user directory/export state and bypasses parent marker injection. Temporary directory metadata
-  is removed before user files run; profile/workspace ownership is unchanged.
+  is bound to the current private shim and removed before user files run; stale daemon metadata
+  cannot select child routing. Profile/workspace ownership is unchanged.
 - **Compatibility:** internal startup fix with no database, wire, CLI, or config shape change;
   no migration or recovery command. Bash, fish and disabled-integration paths are unchanged.
 - **Official skill:** terminal operation guidance and structured interfaces remain valid; no skill

--- a/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
+++ b/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
@@ -34,7 +34,6 @@ rendered Web, packaged-desktop, or Linux run. Linux validation belongs to the PR
 checks; a skipped zsh case does not establish Linux zsh coverage. Global system startup files
 continue to run under zsh's native startup mechanism; this replay exercises user startup files.
 
-
 ## Review follow-up: children between startup bridges
 
 CodeRabbit identified an additional interval: a global startup file can launch a child after the
@@ -49,7 +48,13 @@ and custom ZDOTDIR. It compares native/integrated child output and verifies the 
 nonce. This follow-up is validated exclusively by GitHub CI under the later user instruction;
 the earlier local results above apply to the initial implementation only.
 
-
 The initial Linux CI logs exposed missing zsh, so the Go race-test workflow now installs zsh
 before executing its existing sharded suite. Linux evidence must include the real shell cases in
 the gotestsum JSON artifact; package success with skipped shell cases is insufficient.
+
+
+Greptile's inherited-state follow-up binds the child restoration metadata to the current private
+shim directory and clears stale metadata before top-level user startup. The existing inherited
+daemon-environment case now includes stale bridge variables and still requires authenticated
+parent markers and native startup trace equality. This prevents an unrelated inherited variable
+from silently selecting the marker-free child path.

--- a/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
+++ b/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
@@ -48,3 +48,8 @@ The existing canonical suite now explicitly launches children in both bridge int
 and custom ZDOTDIR. It compares native/integrated child output and verifies the child has no parent
 nonce. This follow-up is validated exclusively by GitHub CI under the later user instruction;
 the earlier local results above apply to the initial implementation only.
+
+
+The initial Linux CI logs exposed missing zsh, so the Go race-test workflow now installs zsh
+before executing its existing sharded suite. Linux evidence must include the real shell cases in
+the gotestsum JSON artifact; package success with skipped shell cases is insufficient.

--- a/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
+++ b/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
@@ -33,3 +33,18 @@ The changed startup slice is verified at the real PTY boundary. This does not cl
 rendered Web, packaged-desktop, or Linux run. Linux validation belongs to the PR's current-head
 checks; a skipped zsh case does not establish Linux zsh coverage. Global system startup files
 continue to run under zsh's native startup mechanism; this replay exercises user startup files.
+
+
+## Review follow-up: children between startup bridges
+
+CodeRabbit identified an additional interval: a global startup file can launch a child after the
+user env/profile file returns and before the next user-file bridge restores ZDOTDIR. The bridge
+now carries only the user's directory value and export metadata for that interval. A child entering
+the shim restores the environment it would normally inherit, removes the temporary metadata, and
+sources its own `.zshenv` without continuing the parent's marker injection. A nonexported parent
+ZDOTDIR remains absent in the child. The parent still retains routing to its injected rc.
+
+The existing canonical suite now explicitly launches children in both bridge intervals with unset
+and custom ZDOTDIR. It compares native/integrated child output and verifies the child has no parent
+nonce. This follow-up is validated exclusively by GitHub CI under the later user instruction;
+the earlier local results above apply to the initial implementation only.

--- a/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
+++ b/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
@@ -1,0 +1,35 @@
+# Zsh startup fidelity — issue 626
+
+The Unix PTY `TestShellIntegrationContract` suite reproduces the missing plugin bundle using a
+real zsh and `${ZDOTDIR:-$HOME}/.zsh_plugins.txt`. Before the fix, the integrated shell resolves
+that bundle inside the temporary shim directory; `.zshenv` redirection also skips the marker rc.
+The reproduction log is retained in the issue executor's local evidence packet.
+
+The corrected startup restores the original environment before user configuration executes,
+retains temporary routing between interactive startup stages, and follows subsequent ZDOTDIR
+changes. `typeset -p` preserves unset/set state and export attributes between those stages.
+User files are not rewritten. The native shell continues to own `.zlogin` and `.zlogout`.
+
+## Changed-slice replay
+
+- Command: `CGO_ENABLED=1 go test -race ./internal/terminal/pty -run TestShellIntegrationContract -count=1 -timeout=60s`.
+- Local platform: macOS arm64, zsh 5.9. All cases pass against real OS PTYs.
+- Twelve native/integrated comparisons: interactive and interactive-login shells, with unset
+  ZDOTDIR, custom directories containing spaces/quotes, `.zshenv` redirection, `.zshenv` unsetting,
+  `.zprofile` redirection, and `.zshrc` redirection.
+- Additional cases compare inherited daemon ZDOTDIR and noninteractive login startup, including an
+  explicitly empty ZDOTDIR.
+- Exact startup traces match native zsh, including startup phase order and ZDOTDIR attributes.
+  Parent and nested interactive shells both load their plugin bundle. The child does not load
+  the parent's nonce, and the integrated parent emits authenticated start/finish markers.
+- Existing bash marker, disabled-integration, private-shim cleanup and fish configuration
+  assertions also pass in the canonical suite.
+- Each case owns temporary fixture homes and its PTYs; suite cleanup waits/kills only those
+  processes and closes them. No daemon or persistent QA lab is started.
+
+## Limits
+
+The changed startup slice is verified at the real PTY boundary. This does not claim a new
+rendered Web, packaged-desktop, or Linux run. Linux validation belongs to the PR's current-head
+checks; a skipped zsh case does not establish Linux zsh coverage. Global system startup files
+continue to run under zsh's native startup mechanism; this replay exercises user startup files.

--- a/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
+++ b/docs/qa/reports/2026-09-12-zsh-startup-fidelity.md
@@ -58,3 +58,8 @@ shim directory and clears stale metadata before top-level user startup. The exis
 daemon-environment case now includes stale bridge variables and still requires authenticated
 parent markers and native startup trace equality. This prevents an unrelated inherited variable
 from silently selecting the marker-free child path.
+
+
+The workflow also runs the canonical shell suite once with a two-minute timeout and verbose output
+before the full race suite. This provides direct real-shell evidence and a bounded diagnostic if
+startup hangs, rather than waiting for the full package shard's much longer timeout.

--- a/docs/qa/scenarios/ET-terminal-shell-config-fidelity.md
+++ b/docs/qa/scenarios/ET-terminal-shell-config-fidelity.md
@@ -28,7 +28,8 @@ Walk:
 4. Open interactive and login zsh terminals with ZDOTDIR unset and with a custom directory containing spaces and quotes. Compare with a standalone zsh: `.zshenv`, `.zprofile`, `.zshrc`, `.zlogin` and `.zlogout` run in the same order with the same ZDOTDIR state. Load a bundle through `${ZDOTDIR:-$HOME}/.zsh_plugins.txt` and confirm it loads.
 5. Repeat with `.zshenv` setting or unsetting ZDOTDIR, and with `.zprofile` or `.zshrc` redirecting it. Confirm later files follow the changed directory and commands still emit authenticated start/finish markers.
 6. Start a nested interactive zsh. Confirm its bundle loads from the user directory and it receives neither the shim path nor the parent's marker nonce.
-7. Set `[terminal] shell_integration = false`; confirm the shell starts with no shim environment and journal rows degrade to `idle` detection.
+7. In an isolated startup harness, launch a child between the env/profile and rc bridges, as a global startup file can do. Confirm it restores the user directory/export state and never installs the parent nonce.
+8. Set `[terminal] shell_integration = false`; confirm the shell starts with no shim environment and journal rows degrade to `idle` detection.
 
 2026-09-12: Issue #626's real-zsh PTY replay covers the changed startup slice, including
 native/integrated trace equality and authenticated command markers. See

--- a/docs/qa/scenarios/ET-terminal-shell-config-fidelity.md
+++ b/docs/qa/scenarios/ET-terminal-shell-config-fidelity.md
@@ -4,7 +4,7 @@ area: ET
 title: A terminal shell keeps the user's own configuration
 persona: Marina
 journey: J-operate-integrated-terminal
-expected: fish opens with the user's themes, functions, completions, and universal variables intact while journal markers still record commands; zsh sources the user's .zshenv and .zshrc; disabling shell_integration removes the shim entirely.
+expected: fish opens with the user's themes, functions, completions, and universal variables intact while journal markers still record commands; zsh preserves native ZDOTDIR semantics and startup ordering while loading plugins and authenticated markers; disabling shell_integration removes the shim entirely.
 entry_points: Web dock Terminal app; compozy terminal open --shell; [terminal] shell_integration
 qa_status: pass
 bug_ids:
@@ -25,5 +25,12 @@ Walk:
 1. With a fish config that sets a theme (for example rose-pine), open a terminal with fish; confirm the theme applies and `fish_config theme show` finds it.
 2. Confirm user functions, completions, and universal variables behave exactly as in a stand-alone fish.
 3. Run a command and confirm the journal records it with `detected_by: "marker"`.
-4. Open a zsh terminal; confirm values exported from the user's `.zshenv` are present and `.zshrc` ran.
-5. Set `[terminal] shell_integration = false`; confirm the shell starts with no shim environment and journal rows degrade to `idle` detection.
+4. Open interactive and login zsh terminals with ZDOTDIR unset and with a custom directory containing spaces and quotes. Compare with a standalone zsh: `.zshenv`, `.zprofile`, `.zshrc`, `.zlogin` and `.zlogout` run in the same order with the same ZDOTDIR state. Load a bundle through `${ZDOTDIR:-$HOME}/.zsh_plugins.txt` and confirm it loads.
+5. Repeat with `.zshenv` setting or unsetting ZDOTDIR, and with `.zprofile` or `.zshrc` redirecting it. Confirm later files follow the changed directory and commands still emit authenticated start/finish markers.
+6. Start a nested interactive zsh. Confirm its bundle loads from the user directory and it receives neither the shim path nor the parent's marker nonce.
+7. Set `[terminal] shell_integration = false`; confirm the shell starts with no shim environment and journal rows degrade to `idle` detection.
+
+2026-09-12: Issue #626's real-zsh PTY replay covers the changed startup slice, including
+native/integrated trace equality and authenticated command markers. See
+[Zsh startup fidelity](../reports/2026-09-12-zsh-startup-fidelity.md). Prior fish and Web evidence
+is unchanged; this replay does not claim a new rendered Web or packaged-desktop walk.

--- a/internal/terminal/pty/pty_test.go
+++ b/internal/terminal/pty/pty_test.go
@@ -706,7 +706,7 @@ source "${ZDOTDIR-$HOME}/.zshenv"
 		}
 	})
 
-	t.Run("Should preserve inherited ZDOTDIR for zsh startup", func(t *testing.T) {
+	t.Run("Should ignore stale bridge state while preserving inherited ZDOTDIR", func(t *testing.T) {
 		// not parallel: this case exercises the inherited daemon environment.
 		zshPath, err := exec.LookPath("zsh")
 		if err != nil {
@@ -714,6 +714,9 @@ source "${ZDOTDIR-$HOME}/.zshenv"
 		}
 		env := zshStartupFixture(t, false, "")
 		t.Setenv("ZDOTDIR", env["HOME"])
+		t.Setenv("__compozy_zdotdir_child", "/stale-user-directory")
+		t.Setenv("__compozy_zdotdir_child_attributes", "scalar-export")
+		t.Setenv("__compozy_zdotdir_child_root", "/stale-shim-directory")
 		argv := []string{zshPath, "-i"}
 		native := runZshStartup(t, argv, env, false)
 		if integrated := runZshStartup(t, argv, env, true); integrated != native {

--- a/internal/terminal/pty/pty_test.go
+++ b/internal/terminal/pty/pty_test.go
@@ -690,7 +690,8 @@ func TestShellIntegrationContract(t *testing.T) {
 			t.Run(fmt.Sprintf("Should preserve early children with custom directory %t", custom), func(t *testing.T) {
 				t.Parallel()
 				env := zshStartupFixture(t, custom, "")
-				child := shellQuote(zshPath) + ` -i -c 'print -r -- "child|${ZDOTDIR-unset}|${__compozy_nonce-unset}"'` + "\n"
+				child := shellQuote(zshPath) +
+					` -i -c 'print -r -- "child|${ZDOTDIR-unset}|${__compozy_nonce-unset}"'` + "\n"
 				script := `setopt rcs
 source "${ZDOTDIR-$HOME}/.zshenv"
 ` + child + `source "${ZDOTDIR-$HOME}/.zprofile"

--- a/internal/terminal/pty/pty_test.go
+++ b/internal/terminal/pty/pty_test.go
@@ -680,6 +680,84 @@ func TestShellIntegrationContract(t *testing.T) {
 		}
 	})
 
+	t.Run("Should preserve inherited ZDOTDIR for zsh startup", func(t *testing.T) {
+		// not parallel: this case exercises the inherited daemon environment.
+		zshPath, err := exec.LookPath("zsh")
+		if err != nil {
+			t.Skipf("zsh is not available: %v", err)
+		}
+		env := zshStartupFixture(t, false, "")
+		t.Setenv("ZDOTDIR", env["HOME"])
+		argv := []string{zshPath, "-i"}
+		native := runZshStartup(t, argv, env, false)
+		if integrated := runZshStartup(t, argv, env, true); integrated != native {
+			t.Fatalf("inherited startup differs: integrated=%q native=%q", integrated, native)
+		}
+	})
+
+	t.Run("Should preserve noninteractive and empty ZDOTDIR semantics", func(t *testing.T) {
+		t.Parallel()
+		zshPath, err := exec.LookPath("zsh")
+		if err != nil {
+			t.Skipf("zsh is not available: %v", err)
+		}
+		for _, empty := range []bool{false, true} {
+			t.Run(
+				fmt.Sprintf("Should match native noninteractive startup with empty directory %t", empty),
+				func(t *testing.T) {
+					t.Parallel()
+					env := zshStartupFixture(t, true, "env")
+					if empty {
+						env["ZDOTDIR"] = ""
+					}
+					argv := []string{zshPath, "-l", "-c", `print -r -- "${ZDOTDIR-unset}|${parameters[ZDOTDIR]-unset}"`}
+					native := runZshStartupCommand(t, argv, env, false)
+					if integrated := runZshStartupCommand(t, argv, env, true); integrated != native {
+						t.Fatalf("noninteractive startup differs: integrated=%q native=%q", integrated, native)
+					}
+				},
+			)
+		}
+	})
+
+	t.Run("Should preserve native zsh startup and plugin paths with authenticated markers", func(t *testing.T) {
+		zshPath, err := exec.LookPath("zsh")
+		if err != nil {
+			t.Skipf("zsh is not available: %v", err)
+		}
+		for _, test := range []struct {
+			name   string
+			custom bool
+			change string
+		}{
+			{name: "Should preserve unset ZDOTDIR"},
+			{name: "Should preserve custom quoted ZDOTDIR", custom: true},
+			{name: "Should follow zshenv redirection", change: "env"},
+			{name: "Should follow zprofile redirection", change: "profile"},
+			{name: "Should follow zshrc redirection", change: "rc"},
+			{name: "Should preserve zshenv unsetting ZDOTDIR", custom: true, change: "unset"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+				for _, login := range []bool{false, true} {
+					t.Run(fmt.Sprintf("Should match native startup with login %t", login), func(t *testing.T) {
+						t.Parallel()
+						env := zshStartupFixture(t, test.custom, test.change)
+						argv := []string{zshPath, "-i"}
+						if login {
+							argv = append(argv, "-l")
+						}
+						native := runZshStartup(t, argv, env, false)
+						integrated := runZshStartup(t, argv, env, true)
+						if integrated != native {
+							t.Fatalf("startup differs from native zsh: integrated=%q native=%q", integrated, native)
+						}
+					})
+				}
+			})
+		}
+	})
+
 	t.Run("Should emit clean start and finish markers for one human zsh command [UT-123]", func(t *testing.T) {
 		zshPath, err := exec.LookPath("zsh")
 		if err != nil {
@@ -852,4 +930,108 @@ func TestPTYWinsizeHelperProcess(_ *testing.T) {
 		os.Exit(4)
 	}
 	os.Exit(0)
+}
+
+func zshStartupFixture(t *testing.T, custom bool, change string) map[string]string {
+	t.Helper()
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	config := filepath.Join(root, " config 'quoted' ")
+	moved := filepath.Join(root, " moved 'quoted' ")
+	for _, dir := range []string{home, config, moved} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		for _, phase := range []string{"zshenv", "zprofile", "zshrc", "zlogin", "zlogout"} {
+			script := `print -r -- "` + phase + `|${ZDOTDIR-unset}|${parameters[ZDOTDIR]-unset}" >> "$STARTUP_TRACE"` + "\n"
+			if phase == "zshenv" && change == "env" || phase == "zprofile" && change == "profile" ||
+				phase == "zshrc" && change == "rc" {
+				script += "ZDOTDIR=" + shellQuote(moved) + "\n"
+			}
+			if phase == "zshenv" && change == "unset" {
+				script += "unset ZDOTDIR\n"
+			}
+			if phase == "zshrc" {
+				script += `source "${ZDOTDIR:-$HOME}/.zsh_plugins.txt"` + "\n"
+			}
+			if err := os.WriteFile(filepath.Join(dir, "."+phase), []byte(script), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := os.WriteFile(
+			filepath.Join(dir, ".zsh_plugins.txt"),
+			[]byte("print -r -- PLUGIN_LOADED >> \"$STARTUP_TRACE\"\n"),
+			0o600,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	env := map[string]string{"HOME": home, "STARTUP_TRACE": filepath.Join(root, "trace")}
+	if custom {
+		env["ZDOTDIR"] = config
+	}
+	return env
+}
+
+func runZshStartup(t *testing.T, argv []string, env map[string]string, integration bool) string {
+	t.Helper()
+	if err := os.WriteFile(env["STARTUP_TRACE"], nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	proc := startTestProc(t, ProcSpec{
+		Argv: argv, Env: env, MarkerNonce: "nonce-startup", ShellIntegration: integration,
+		Mode: ModePTY, Cols: 80, Rows: 24,
+	})
+	t.Cleanup(func() { stopTestProc(t, proc) })
+	// A child must inherit the user's directory without inheriting the shim or nonce.
+	command := shellQuote(argv[0]) + ` -i -c 'print -r -- "child|${__compozy_nonce-unset}" >> "$STARTUP_TRACE"'` + "\n"
+	if _, err := proc.Write([]byte(command + "echo startup-done\nexit\n")); err != nil {
+		t.Fatal(err)
+	}
+	output, err := io.ReadAll(proc.Reader())
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	exit, err := proc.Wait(waitCtx)
+	if err != nil || exit.Code == nil || *exit.Code != 0 {
+		t.Fatalf("Wait()=%#v error=%v output=%q", exit, err, output)
+	}
+	if integration && (!bytes.Contains(output, []byte("7113;v1;nonce-startup;S;cmd=echo%20startup-done;")) ||
+		!bytes.Contains(output, []byte("7113;v1;nonce-startup;F;exit=0"))) {
+		t.Fatalf("authenticated markers missing: %q", output)
+	}
+	trace, err := os.ReadFile(env["STARTUP_TRACE"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(trace), "PLUGIN_LOADED\n") != 2 || !strings.Contains(string(trace), "child|unset\n") {
+		t.Fatalf("parent/child plugin or nonce isolation failed: trace=%q output=%q", trace, output)
+	}
+	return string(trace)
+}
+
+func runZshStartupCommand(t *testing.T, argv []string, env map[string]string, integration bool) string {
+	t.Helper()
+	setup, err := prepareShellIntegration(ProcSpec{
+		Argv: argv, Env: env, MarkerNonce: "nonce-command", ShellIntegration: integration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := setup.cleanup(); err != nil {
+			t.Error(err)
+		}
+	})
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, setup.argv[0], setup.argv[1:]...)
+	cmd.Env = environment(setup.env)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("zsh command failed: %v output=%q", err, output)
+	}
+	return string(output)
 }

--- a/internal/terminal/pty/pty_test.go
+++ b/internal/terminal/pty/pty_test.go
@@ -680,6 +680,32 @@ func TestShellIntegrationContract(t *testing.T) {
 		}
 	})
 
+	t.Run("Should isolate children launched between zsh startup bridges", func(t *testing.T) {
+		t.Parallel()
+		zshPath, err := exec.LookPath("zsh")
+		if err != nil {
+			t.Skipf("zsh is not available: %v", err)
+		}
+		for _, custom := range []bool{false, true} {
+			t.Run(fmt.Sprintf("Should preserve early children with custom directory %t", custom), func(t *testing.T) {
+				t.Parallel()
+				env := zshStartupFixture(t, custom, "")
+				child := shellQuote(zshPath) + ` -i -c 'print -r -- "child|${ZDOTDIR-unset}|${__compozy_nonce-unset}"'` + "\n"
+				script := `setopt rcs
+source "${ZDOTDIR-$HOME}/.zshenv"
+` + child + `source "${ZDOTDIR-$HOME}/.zprofile"
+` + child + `source "${ZDOTDIR-$HOME}/.zshrc"
+`
+				argv := []string{zshPath, "-i", "-f", "-c", script}
+				native := runZshStartupCommand(t, argv, env, false)
+				integrated := runZshStartupCommand(t, argv, env, true)
+				if integrated != native || strings.Count(integrated, "|unset\n") != 2 {
+					t.Fatalf("early child environment differs: integrated=%q native=%q", integrated, native)
+				}
+			})
+		}
+	})
+
 	t.Run("Should preserve inherited ZDOTDIR for zsh startup", func(t *testing.T) {
 		// not parallel: this case exercises the inherited daemon environment.
 		zshPath, err := exec.LookPath("zsh")

--- a/internal/terminal/pty/shell_integration.go
+++ b/internal/terminal/pty/shell_integration.go
@@ -77,20 +77,50 @@ func prepareZshIntegration(setup *shellSetup, root, nonce string) error {
 	if err != nil {
 		return fmt.Errorf("terminal pty: resolve zsh home: %w", err)
 	}
-	originalRoot := strings.TrimSpace(setup.env["ZDOTDIR"])
-	if originalRoot == "" {
+	originalRoot, hasZdotdir := setup.env["ZDOTDIR"]
+	if !hasZdotdir {
+		originalRoot, hasZdotdir = os.LookupEnv("ZDOTDIR")
+	}
+	restore := "unset ZDOTDIR\n"
+	if hasZdotdir {
+		restore = "export ZDOTDIR=" + shellQuote(originalRoot) + "\n"
+	} else {
 		originalRoot = home
 	}
-	envScript := zshSourceIfExists(filepath.Join(originalRoot, ".zshenv"))
-	if err := os.WriteFile(filepath.Join(root, ".zshenv"), []byte(envScript), 0o600); err != nil {
-		return fmt.Errorf("terminal pty: write zsh env integration: %w", err)
-	}
-	rcScript := zshSourceIfExists(filepath.Join(originalRoot, ".zshrc")) + zshMarkerScript(nonce)
-	if err := os.WriteFile(filepath.Join(root, ".zshrc"), []byte(rcScript), 0o600); err != nil {
-		return fmt.Errorf("terminal pty: write zsh integration: %w", err)
+	envScript := restore + zshSourceIfExists(originalRoot+"/.zshenv") + zshContinueIntegration(root)
+	profileScript := zshRestoreDirectory() + zshSourceUserFile(".zprofile") + zshContinueIntegration(root)
+	rcScript := zshRestoreDirectory() + zshSourceUserFile(".zshrc") + zshMarkerScript(nonce)
+	for _, file := range []struct{ name, script string }{
+		{".zshenv", envScript}, {".zprofile", profileScript}, {".zshrc", rcScript},
+	} {
+		if err := os.WriteFile(filepath.Join(root, file.name), []byte(file.script), 0o600); err != nil {
+			return fmt.Errorf("terminal pty: write zsh %s integration: %w", file.name, err)
+		}
 	}
 	setup.env["ZDOTDIR"] = root
 	return nil
+}
+
+func zshContinueIntegration(root string) string {
+	// Keep zsh on the shim route only until its next interactive startup stage.
+	return `if [[ -o interactive && -o rcs ]]; then
+  __compozy_zdotdir=$(typeset -p ZDOTDIR 2>/dev/null) || __compozy_zdotdir=''
+  export ZDOTDIR=` + shellQuote(root) + `
+fi
+`
+}
+
+func zshRestoreDirectory() string {
+	// typeset emits shell-quoted declarations, preserving unset and export attributes.
+	return `unset ZDOTDIR
+if [[ -n $__compozy_zdotdir ]]; then eval "$__compozy_zdotdir"; fi
+unset __compozy_zdotdir
+`
+}
+
+func zshSourceUserFile(name string) string {
+	return `if [[ -f "${ZDOTDIR-$HOME}/` + name + `" ]]; then source "${ZDOTDIR-$HOME}/` + name + `"; fi
+`
 }
 
 func zshSourceIfExists(path string) string {

--- a/internal/terminal/pty/shell_integration.go
+++ b/internal/terminal/pty/shell_integration.go
@@ -72,6 +72,9 @@ func prepareBashIntegration(setup *shellSetup, root, nonce string) error {
 	return nil
 }
 
+const zshClearDirectoryState = "unset __compozy_zdotdir __compozy_zdotdir_child " +
+	"__compozy_zdotdir_child_attributes __compozy_zdotdir_child_root\n"
+
 func prepareZshIntegration(setup *shellSetup, root, nonce string) error {
 	home, err := shellHome(setup.env)
 	if err != nil {
@@ -87,9 +90,10 @@ func prepareZshIntegration(setup *shellSetup, root, nonce string) error {
 	} else {
 		originalRoot = home
 	}
-	envScript := "if (( ${+__compozy_zdotdir_child} )); then\n" +
+	envScript := "if [[ ${__compozy_zdotdir_child_root-} == " + shellQuote(root) + " ]]; then\n" +
 		zshRestoreChildDirectory() + zshSourceUserFile(".zshenv") + "else\n" +
-		restore + zshSourceIfExists(originalRoot+"/.zshenv") + zshContinueIntegration(root) + "fi\n"
+		zshClearDirectoryState + restore + zshSourceIfExists(originalRoot+"/.zshenv") +
+		zshContinueIntegration(root) + "fi\n"
 	profileScript := zshRestoreDirectory() + zshSourceUserFile(".zprofile") + zshContinueIntegration(root)
 	rcScript := zshRestoreDirectory() + zshSourceUserFile(".zshrc") + zshMarkerScript(nonce)
 	for _, file := range []struct{ name, script string }{
@@ -109,6 +113,7 @@ func zshContinueIntegration(root string) string {
   __compozy_zdotdir=$(typeset -p ZDOTDIR 2>/dev/null) || __compozy_zdotdir=''
   export __compozy_zdotdir_child="${ZDOTDIR-}"
   export __compozy_zdotdir_child_attributes="${parameters[ZDOTDIR]-}"
+  export __compozy_zdotdir_child_root=` + shellQuote(root) + `
   export ZDOTDIR=` + shellQuote(root) + `
 fi
 `
@@ -118,8 +123,7 @@ func zshRestoreDirectory() string {
 	// typeset emits shell-quoted declarations, preserving unset and export attributes.
 	return `unset ZDOTDIR
 if [[ -n $__compozy_zdotdir ]]; then eval "$__compozy_zdotdir"; fi
-unset __compozy_zdotdir __compozy_zdotdir_child __compozy_zdotdir_child_attributes
-`
+` + zshClearDirectoryState
 }
 
 func zshRestoreChildDirectory() string {
@@ -128,8 +132,7 @@ func zshRestoreChildDirectory() string {
 if [[ ${__compozy_zdotdir_child_attributes-} == *-export* ]]; then
   export ZDOTDIR="$__compozy_zdotdir_child"
 fi
-unset __compozy_zdotdir_child __compozy_zdotdir_child_attributes
-`
+` + zshClearDirectoryState
 }
 
 func zshSourceUserFile(name string) string {

--- a/internal/terminal/pty/shell_integration.go
+++ b/internal/terminal/pty/shell_integration.go
@@ -87,7 +87,9 @@ func prepareZshIntegration(setup *shellSetup, root, nonce string) error {
 	} else {
 		originalRoot = home
 	}
-	envScript := restore + zshSourceIfExists(originalRoot+"/.zshenv") + zshContinueIntegration(root)
+	envScript := "if (( ${+__compozy_zdotdir_child} )); then\n" +
+		zshRestoreChildDirectory() + zshSourceUserFile(".zshenv") + "else\n" +
+		restore + zshSourceIfExists(originalRoot+"/.zshenv") + zshContinueIntegration(root) + "fi\n"
 	profileScript := zshRestoreDirectory() + zshSourceUserFile(".zprofile") + zshContinueIntegration(root)
 	rcScript := zshRestoreDirectory() + zshSourceUserFile(".zshrc") + zshMarkerScript(nonce)
 	for _, file := range []struct{ name, script string }{
@@ -105,6 +107,8 @@ func zshContinueIntegration(root string) string {
 	// Keep zsh on the shim route only until its next interactive startup stage.
 	return `if [[ -o interactive && -o rcs ]]; then
   __compozy_zdotdir=$(typeset -p ZDOTDIR 2>/dev/null) || __compozy_zdotdir=''
+  export __compozy_zdotdir_child="${ZDOTDIR-}"
+  export __compozy_zdotdir_child_attributes="${parameters[ZDOTDIR]-}"
   export ZDOTDIR=` + shellQuote(root) + `
 fi
 `
@@ -114,7 +118,17 @@ func zshRestoreDirectory() string {
 	// typeset emits shell-quoted declarations, preserving unset and export attributes.
 	return `unset ZDOTDIR
 if [[ -n $__compozy_zdotdir ]]; then eval "$__compozy_zdotdir"; fi
-unset __compozy_zdotdir
+unset __compozy_zdotdir __compozy_zdotdir_child __compozy_zdotdir_child_attributes
+`
+}
+
+func zshRestoreChildDirectory() string {
+	// Children launched by global startup files must not install the parent's markers.
+	return `unset ZDOTDIR
+if [[ ${__compozy_zdotdir_child_attributes-} == *-export* ]]; then
+  export ZDOTDIR="$__compozy_zdotdir_child"
+fi
+unset __compozy_zdotdir_child __compozy_zdotdir_child_attributes
 `
 }
 


### PR DESCRIPTION
## What & why

Closes #626.

Opening an integrated zsh with a plugin manager that reads `${ZDOTDIR:-$HOME}/.zsh_plugins.txt`
previously looked for the bundle inside CompozyOS's private shim directory. The shim sourced the
user's files without restoring their environment. A `.zshenv` that changed ZDOTDIR could also
cause zsh to bypass the injected `.zshrc`, losing authenticated command markers.

The shim now restores the original ZDOTDIR before user `.zshenv` executes, including inherited,
unset, explicitly empty, and quoted values. It temporarily resumes shim routing between
interactive startup stages, adding a `.zprofile` bridge for login shells. Each bridge preserves
ZDOTDIR's declaration and export attribute, restores it before user code, and follows any user
redirection when locating the next file. The final `.zshrc` restores the user's environment and
installs the existing markers after user configuration. Native zsh handles `.zlogin` and `.zlogout`.
Noninteractive shells restore their environment without continuing interactive shim routing.

This preserves the [zsh user-startup ordering](https://zsh.sourceforge.io/Doc/Release/Files.html)
without rewriting user configuration. Nested shells inherit user configuration rather than
installing the parent's nonce. Early children launched by global startup files restore the user
directory/export state before sourcing their own configuration and bypass parent marker injection.
Child metadata is bound to the current private shim; stale inherited metadata cannot disable
authenticated markers in a new terminal. Global system startup remains owned by zsh; the behavioral
regressions exercise user configuration.

## How you verified it

Implemented and checked by Codex (GPT-6 Astra).

- Reproduced the failure before the production change in the existing real-PTY
  `TestShellIntegrationContract` suite: missing plugin bundle, marker loss after `.zshenv`
  redirection, and nested shim inheritance.
- `CGO_ENABLED=1 go test -race ./internal/terminal/pty -run TestShellIntegrationContract -count=1 -timeout=60s` passes on macOS arm64 with zsh 5.9.
- Twelve native/integrated real-PTY comparisons cover interactive and login startup with unset
  and custom quoted directories, `.zshenv` redirection/unsetting, and `.zprofile`/`.zshrc`
  redirection. Exact traces match startup ordering and environment attributes. Both parent and
  child load their bundles; the parent emits authenticated start/finish markers and the child
  does not inherit its nonce.
- The existing GitHub Go race-test workflow now installs zsh. Initial Linux logs showed the
  shell cases were skipped without that runtime dependency.
- Additional real-shell cases cover inherited daemon ZDOTDIR and noninteractive login startup
  with custom and explicitly empty values. Existing bash, fish setup, disabled-integration,
  private-shim and cleanup checks remain in the canonical suite.
- The initial `make gate` passed before a subsequent user override. All review follow-up validation
  runs exclusively through GitHub Actions; no later local gate is used as delivery evidence.
- [QA replay and limits](docs/qa/reports/2026-09-12-zsh-startup-fidelity.md) records the real-shell
  evidence. No new rendered Web or packaged-desktop walk is claimed. Linux zsh coverage requires
  an actual non-skipped run; current-head CI and reviewer completion are tracked separately.

## Impact

The [cross-surface audit](docs/_memory/change-impact.md#issue-626--zsh-startup-directory-fidelity)
covers native terminal tools, config/hooks, workspace isolation, compatibility, official skill,
Web and Docs. Public tool IDs, HTTP/UDS/CLI schemas, journal markers and `terminal.shell_integration`
are unchanged. No persistence migration or recovery action is required. Bash/fish behavior and
disabled integration are unchanged. The affected `ET-terminal-shell-config-fidelity` QA scenario
now includes user directory redirection and nested shell behavior. The existing official terminal
skill and site interfaces require no resource or API update.

- [x] `make gate` passes locally; this PR is delivered only after its required CI checks are green
- [x] New or changed behavior is covered by tests
- [x] Agent authorship and verification are identified above
