### PR TITLE
fix: preserve nested raw terminal input visibility

### DIFF
--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -340,3 +340,25 @@ No additional public, config, persistence, or Web contracts change.
 - **Web/Docs/QA:** Web Terminal uses the corrected daemon PTY path without renderer changes.
   `ET-terminal-shell-config-fidelity` includes startup redirection, plugin loading and nested shells.
   The real-zsh PTY replay and platform limits are recorded in the linked QA report.
+
+## Issue 628 — Nested raw terminal input
+
+- **Native tools:** `compozy__terminal_write`, `compozy__terminal_request_input`, CLI respond,
+  and HTTP/UDS/WebSocket input retain their schemas and authorization. Unix ordinary raw input
+  no longer emits automatic hidden-input markers. Explicit redaction remains accepted for no-echo
+  canonical and raw readers, and rejects echo-enabled input at admission and delivery.
+- **Extensibility/hooks/config:** no new configuration, hook, SDK, or capability. Existing input
+  events retain trusted redaction/length metadata. Process identity no longer guesses secrecy.
+- **Workspace data isolation:** no database or layout migration; existing session/profile/workspace
+  checks and journal reservation remain authoritative. Previously redacted recordings stay intact.
+  Ordinary raw input is now journaled as ordinary input; raw secrets require explicit redaction.
+- **Compatibility:** public shapes and error codes remain; the internal PTY interface adds an echo
+  query to separate automatic classification from explicit hidden-input admission. Windows retains
+  console echo behavior. No public removal or deprecation shim is needed.
+- **Official skill:** terminal input-request guidance documents canonical detection, explicit raw
+  secret entry, and the limit that application-rendered input cannot be hidden by termios.
+- **Web/Docs/QA:** existing Terminal rendering consumes the corrected stream without component or
+  layout changes. Terminal safety and recording docs explain the same limits. The affected
+  `ET-terminal-redaction-boundaries` and `ET-terminal-agent-handoff-input` scenarios gain raw-mode
+  cases. Canonical PTY, session input/recording, and real HTTP/WebSocket integration suites own
+  regression evidence; changes do not affect Unicode counting or shell environment setup.

--- a/docs/qa/scenarios/ET-terminal-agent-handoff-input.md
+++ b/docs/qa/scenarios/ET-terminal-agent-handoff-input.md
@@ -36,3 +36,16 @@ Walk:
 2026-09-02 re-walk: passed after remediation. A fresh managed agent routed private input through a
 running terminal, the runtime refused ordinary visible-shell input, and a hidden foreground reader
 accepted one answer and one decline without exposing the value to chat, screen, journal, or quote.
+
+2026-09-12 issue 628: repeat the hidden-answer step for a foreground raw no-echo reader as well as
+canonical input. Explicit redaction must remain accepted in both modes and must fail if terminal
+echo is enabled before delivery. Ordinary nested-shell typing must remain readable without hidden
+markers. See `ET-terminal-redaction-boundaries` steps 9–11 for the owning verification slice.
+
+Issue 628 targeted replay passed on macOS: `TestUnixPTYHardening` exercised real nested bash and
+canonical/raw no-echo readers; `TestSessionTypingGrantAndInputRequestLifecycle` verified explicit
+raw answers, length-only journal/stream data, and echo-enabled rejection. The existing real
+`TestTerminalWireShouldCompleteRealLifecycle` HTTP/WebSocket run typed `abc` one character at a
+time in nested bash without a redaction opcode. Existing secret-output-sink tests passed with
+`-race`. This slice changes no Web layout or hostile-output filtering behavior. Linux and Windows
+runtime parity is owned by the PR CI lanes.

--- a/docs/qa/scenarios/ET-terminal-redaction-boundaries.md
+++ b/docs/qa/scenarios/ET-terminal-redaction-boundaries.md
@@ -48,3 +48,25 @@ canaries were absent from live and durable surfaces. Hostile OSC title, OSC52, a
 removed while visible text survived consistently. The saved recording and spill artifact were
 scrubbed, mode `0600`, workspace-contained, and the artifact endpoint refused a forged external
 symbolic link.
+
+2026-09-12 issue 628 verification slice:
+
+9. Start `bash --noprofile --norc` inside the Terminal and type `abc` one character at a time.
+   Each character appears without a trusted hidden-input marker. Editors and pagers using the
+   same raw no-echo mode have the same automatic classification, regardless of foreground group.
+10. Run a canonical no-echo reader and confirm automatic length-only redaction still applies.
+11. Run a raw no-echo reader that never prints its input. Submit an explicitly redacted request;
+    confirm one delivery and length-only journal/stream metadata. Re-enable echo before answering
+    another request and confirm rejection with zero bytes delivered. Echo must remain program-owned.
+
+Raw mode alone cannot identify secrets. Ordinary typing into raw programs is retained as ordinary
+input; use explicit redaction for a trusted secret reader. Program-rendered text is output and is
+not made private by marking its input redacted.
+
+Issue 628 targeted replay passed on macOS: `TestUnixPTYHardening` exercised real nested bash and
+canonical/raw no-echo readers; `TestSessionTypingGrantAndInputRequestLifecycle` verified explicit
+raw answers, length-only journal/stream data, and echo-enabled rejection. The existing real
+`TestTerminalWireShouldCompleteRealLifecycle` HTTP/WebSocket run typed `abc` one character at a
+time in nested bash without a redaction opcode. Existing secret-output-sink tests passed with
+`-race`. This slice changes no Web layout or hostile-output filtering behavior. Linux and Windows
+runtime parity is owned by the PR CI lanes.

--- a/internal/api/core/terminal_wire_integration_test.go
+++ b/internal/api/core/terminal_wire_integration_test.go
@@ -104,7 +104,7 @@ func TestTerminalWireShouldCompleteRealLifecycle(t *testing.T) {
 		t.Cleanup(server.Close)
 
 		created := terminalTestJSONRequest(t, server.Client(), http.MethodPost,
-			server.URL+"/api/workspaces/"+registered.ID+"/terminals", `{"cols":80,"rows":24}`)
+			server.URL+"/api/workspaces/"+registered.ID+"/terminals", `{"shell":"sh","cols":80,"rows":24}`)
 		var createResponse struct {
 			Terminal struct {
 				ID string `json:"id"`
@@ -196,6 +196,7 @@ func TestTerminalWireShouldCompleteRealLifecycle(t *testing.T) {
 		if !foundEcho {
 			t.Fatal("terminal stream did not echo input")
 		}
+		terminalCheckNestedRawInput(t, conn)
 		resize, err := terminalwire.EncodeClient(
 			terminalwire.Frame{Op: terminalwire.ClientOpResize, Payload: json.RawMessage(`{"cols":100,"rows":30}`)},
 		)
@@ -332,4 +333,40 @@ func terminalReadServerFrame(t *testing.T, conn *websocket.Conn) terminalwire.Fr
 		t.Fatalf("DecodeServer() error = %v, encoded=%s", err, fmt.Sprintf("%x", encoded))
 	}
 	return frame
+}
+
+func terminalCheckNestedRawInput(t *testing.T, conn *websocket.Conn) {
+	t.Helper()
+	write := func(input string) {
+		t.Helper()
+		encoded, err := terminalwire.EncodeClient(
+			terminalwire.Frame{Op: terminalwire.ClientOpInput, Payload: []byte(input)},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := conn.WriteMessage(websocket.BinaryMessage, encoded); err != nil {
+			t.Fatal(err)
+		}
+	}
+	readUntil := func(want string) {
+		t.Helper()
+		var output strings.Builder
+		for !strings.Contains(output.String(), want) {
+			frame := terminalReadServerFrame(t, conn)
+			if frame.Op == terminalwire.ServerOpRedactedInput {
+				t.Fatal("nested raw shell emitted a hidden-input marker")
+			}
+			if frame.Op == terminalwire.ServerOpOutput {
+				output.Write(frame.Payload)
+			}
+		}
+	}
+	write("PS1=nested-$((620+8))'> ' bash --noprofile --norc -i\n")
+	readUntil("nested-628> ")
+	for _, character := range []string{"a", "b", "c"} {
+		write(character)
+		readUntil(character)
+	}
+	write("\x15exit\n")
 }

--- a/internal/terminal/input_requests.go
+++ b/internal/terminal/input_requests.go
@@ -36,19 +36,13 @@ func (s *session) RequestInput(ctx context.Context, actor Actor, request InputRe
 		return nil, err
 	}
 	info := s.Info()
-	visibilityProc, err := requireInputVisibilityProc(s.proc)
+	if _, err := requireInputVisibilityProc(s.proc); err != nil {
+		return nil, err
+	}
+	_, redacted, err := s.inputWriter(request.Redact)
 	if err != nil {
 		return nil, err
 	}
-	redacted := request.Redact
-	inputVisible, err := visibilityProc.InputVisible()
-	if err != nil {
-		return nil, err
-	}
-	if request.Redact && inputVisible {
-		return nil, inputRequiresHiddenError(nil)
-	}
-	redacted = redacted || !inputVisible
 	pending, err := s.manager.inputs.create(s, request, redacted, actor, func() (InputRequestID, error) {
 		return newInputRequestID(s.manager.entropy)
 	})

--- a/internal/terminal/manager_test.go
+++ b/internal/terminal/manager_test.go
@@ -3053,75 +3053,86 @@ func TestSessionTypingGrantAndInputRequestLifecycle(t *testing.T) {
 		}
 	})
 
-	t.Run("Should resolve delivered redacted input once while foreground input stays hidden", func(t *testing.T) {
-		t.Parallel()
-		journal := &fakeRecordingJournal{}
-		manager, starter, _ := newTestManager(t, DefaultSettings(), WithJournal(journal))
-		handle, err := manager.Open(t.Context(), OpenRequest{
-			WS: "workspace-a", Shell: "sh", Actor: agent, Capabilities: Capabilities{Interactive: true},
+	for _, tc := range []struct {
+		name        string
+		lineEditing bool
+	}{
+		{name: "Should resolve delivered redacted input once while foreground input stays hidden"},
+		{name: "Should resolve explicitly redacted raw input without recording its contents", lineEditing: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			journal := &fakeRecordingJournal{}
+			manager, starter, _ := newTestManager(t, DefaultSettings(), WithJournal(journal))
+			handle, err := manager.Open(t.Context(), OpenRequest{
+				WS: "workspace-a", Shell: "sh", Actor: agent, Capabilities: Capabilities{Interactive: true},
+			})
+			if err != nil {
+				t.Fatalf("Open(agent) error = %v", err)
+			}
+			proc := receiveStartedProc(t, starter)
+			proc.hideInputEcho()
+			proc.mu.Lock()
+			proc.lineEditing = tc.lineEditing
+			proc.mu.Unlock()
+			type requestResult struct {
+				outcome *InputOutcome
+				err     error
+			}
+			requestDone := make(chan requestResult, 1)
+			go func() {
+				outcome, requestErr := handle.RequestInput(
+					t.Context(),
+					agent,
+					InputRequest{Reason: "password", Redact: true},
+				)
+				requestDone <- requestResult{outcome: outcome, err: requestErr}
+			}()
+			pending := waitForInputRequests(t, manager, "workspace-a", store.ReadScope{ProfileID: "profile-a"}, 1)
+			human := Actor{Kind: ActorKindHuman, ID: "operator", ProfileID: "profile-a"}
+			answer, answerErr := handle.AnswerInput(
+				t.Context(), human, pending[0].ID, InputAnswer{Input: []byte("secret")},
+			)
+			if answerErr != nil || answer == nil || answer.Outcome != "answered" || answer.Length != len("secret") {
+				t.Fatalf(
+					"AnswerInput(hidden foreground) = %#v error=%v, want answered",
+					answer,
+					answerErr,
+				)
+			}
+			request := <-requestDone
+			if request.err != nil || request.outcome == nil || request.outcome.Outcome != "answered" {
+				t.Fatalf("RequestInput() = %#v error=%v, want answered", request.outcome, request.err)
+			}
+			if got := proc.inputString(); got != "secret\n" {
+				t.Fatalf("delivered input = %q, want one secret delivery", got)
+			}
+			read, err := handle.Screen(t.Context(), ReadOptions{View: "tail"})
+			if err != nil {
+				t.Fatalf("Screen() error = %v", err)
+			}
+			if len(read.Segments) != 1 || read.Segments[0].Kind != OutputSegmentRedactedInput ||
+				read.Segments[0].Characters != len("secret") {
+				t.Fatalf("redacted segments = %#v, want one trusted length-only marker", read.Segments)
+			}
+			journal.mu.Lock()
+			journalInputs := slices.Clone(journal.inputs)
+			journal.mu.Unlock()
+			if len(journalInputs) != 1 || !journalInputs[0].Redacted ||
+				journalInputs[0].Characters != len("secret") || len(journalInputs[0].Content) != 0 {
+				t.Fatalf("journal inputs = %#v, want one length-only redacted input", journalInputs)
+			}
+			if _, retryErr := handle.AnswerInput(
+				t.Context(), human, pending[0].ID, InputAnswer{Input: []byte("secret")},
+			); !errors.Is(retryErr, ErrInputAnswered) ||
+				terminalErrorCode(retryErr) != string(ErrorCodeInputRequestAnswered) {
+				t.Fatalf("AnswerInput(retry) error = %v, want already answered", retryErr)
+			}
+			if got := proc.inputString(); got != "secret\n" {
+				t.Fatalf("delivered input after retry = %q, want no duplicate", got)
+			}
 		})
-		if err != nil {
-			t.Fatalf("Open(agent) error = %v", err)
-		}
-		proc := receiveStartedProc(t, starter)
-		proc.hideInputEcho()
-		type requestResult struct {
-			outcome *InputOutcome
-			err     error
-		}
-		requestDone := make(chan requestResult, 1)
-		go func() {
-			outcome, requestErr := handle.RequestInput(
-				t.Context(),
-				agent,
-				InputRequest{Reason: "password", Redact: true},
-			)
-			requestDone <- requestResult{outcome: outcome, err: requestErr}
-		}()
-		pending := waitForInputRequests(t, manager, "workspace-a", store.ReadScope{ProfileID: "profile-a"}, 1)
-		human := Actor{Kind: ActorKindHuman, ID: "operator", ProfileID: "profile-a"}
-		answer, answerErr := handle.AnswerInput(
-			t.Context(), human, pending[0].ID, InputAnswer{Input: []byte("secret")},
-		)
-		if answerErr != nil || answer == nil || answer.Outcome != "answered" || answer.Length != len("secret") {
-			t.Fatalf(
-				"AnswerInput(hidden foreground) = %#v error=%v, want answered",
-				answer,
-				answerErr,
-			)
-		}
-		request := <-requestDone
-		if request.err != nil || request.outcome == nil || request.outcome.Outcome != "answered" {
-			t.Fatalf("RequestInput() = %#v error=%v, want answered", request.outcome, request.err)
-		}
-		if got := proc.inputString(); got != "secret\n" {
-			t.Fatalf("delivered input = %q, want one secret delivery", got)
-		}
-		read, err := handle.Screen(t.Context(), ReadOptions{View: "tail"})
-		if err != nil {
-			t.Fatalf("Screen() error = %v", err)
-		}
-		if len(read.Segments) != 1 || read.Segments[0].Kind != OutputSegmentRedactedInput ||
-			read.Segments[0].Characters != len("secret") {
-			t.Fatalf("redacted segments = %#v, want one trusted length-only marker", read.Segments)
-		}
-		journal.mu.Lock()
-		journalInputs := slices.Clone(journal.inputs)
-		journal.mu.Unlock()
-		if len(journalInputs) != 1 || !journalInputs[0].Redacted ||
-			journalInputs[0].Characters != len("secret") || len(journalInputs[0].Content) != 0 {
-			t.Fatalf("journal inputs = %#v, want one length-only redacted input", journalInputs)
-		}
-		if _, retryErr := handle.AnswerInput(
-			t.Context(), human, pending[0].ID, InputAnswer{Input: []byte("secret")},
-		); !errors.Is(retryErr, ErrInputAnswered) ||
-			terminalErrorCode(retryErr) != string(ErrorCodeInputRequestAnswered) {
-			t.Fatalf("AnswerInput(retry) error = %v, want already answered", retryErr)
-		}
-		if got := proc.inputString(); got != "secret\n" {
-			t.Fatalf("delivered input after retry = %q, want no duplicate", got)
-		}
-	})
+	}
 
 	t.Run(
 		"Should supersede a redacted request when foreground input becomes visible before delivery",

--- a/internal/terminal/pty/echo_unix_common.go
+++ b/internal/terminal/pty/echo_unix_common.go
@@ -23,17 +23,22 @@ func (p *unixProc) inputVisibleLocked() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if state.Lflag&unix.ECHO != 0 {
-		return true, nil
+	// Raw line editors render their own input regardless of foreground process group.
+	return state.Lflag&unix.ECHO != 0 || state.Lflag&unix.ICANON == 0, nil
+}
+
+func (p *unixProc) InputEchoEnabled() (bool, error) {
+	if err := p.io.begin(); err != nil {
+		return false, err
 	}
-	if state.Lflag&unix.ICANON != 0 {
-		return false, nil
-	}
-	foregroundGroup, err := p.foregroundProcessGroup()
+	defer p.io.end()
+	p.inputMu.Lock()
+	defer p.inputMu.Unlock()
+	state, err := p.readTermios()
 	if err != nil {
 		return false, err
 	}
-	return foregroundGroup == p.ProcessGroupID(), nil
+	return state.Lflag&unix.ECHO != 0, nil
 }
 
 func (p *unixProc) WriteRedacted(input []byte) (RedactedWriteResult, error) {
@@ -43,11 +48,11 @@ func (p *unixProc) WriteRedacted(input []byte) (RedactedWriteResult, error) {
 	defer p.io.end()
 	p.inputMu.Lock()
 	defer p.inputMu.Unlock()
-	visible, err := p.inputVisibleLocked()
+	state, err := p.readTermios()
 	if err != nil {
 		return RedactedWriteResult{}, err
 	}
-	if visible {
+	if state.Lflag&unix.ECHO != 0 {
 		return RedactedWriteResult{}, ErrInputVisible
 	}
 	written, writeErr := writeAllRedactedBytes(input, p.write)
@@ -75,18 +80,6 @@ func (p *unixProc) writeTermios(state *unix.Termios, action string) error {
 		return fmt.Errorf("terminal pty: %s echo: %w", action, err)
 	}
 	return nil
-}
-
-func (p *unixProc) foregroundProcessGroup() (int, error) {
-	foregroundGroup := 0
-	if err := p.controlTerminal(func(fd int) error {
-		var err error
-		foregroundGroup, err = unix.IoctlGetInt(fd, unix.TIOCGPGRP)
-		return err
-	}); err != nil {
-		return 0, fmt.Errorf("terminal pty: inspect foreground process group: %w", err)
-	}
-	return foregroundGroup, nil
 }
 
 func (p *unixProc) controlTerminal(operation func(int) error) error {

--- a/internal/terminal/pty/echo_windows.go
+++ b/internal/terminal/pty/echo_windows.go
@@ -56,6 +56,10 @@ func windowsErrorCode(err error) uint32 {
 }
 
 func (p *windowsProc) InputVisible() (bool, error) {
+	return p.InputEchoEnabled()
+}
+
+func (p *windowsProc) InputEchoEnabled() (bool, error) {
 	p.inputMu.Lock()
 	defer p.inputMu.Unlock()
 	if err := p.io.begin(); err != nil {

--- a/internal/terminal/pty/pty_test.go
+++ b/internal/terminal/pty/pty_test.go
@@ -101,6 +101,47 @@ func TestUnixPTYHardening(t *testing.T) {
 		}
 	})
 
+	t.Run("Should keep nested raw shell editing visible", func(t *testing.T) {
+		t.Parallel()
+		proc := startTestProc(t, ProcSpec{
+			Argv: []string{
+				"/bin/bash",
+				"--noprofile",
+				"--norc",
+				"-c",
+				"set -m; PS1='nested-ready> ' bash --noprofile --norc -i; exit $?",
+			},
+			Env:  map[string]string{"PS1": "nested-ready> ", "TERM": "xterm"},
+			Mode: ModePTY,
+			Cols: 80,
+			Rows: 24,
+		})
+		defer stopTestProc(t, proc)
+		unixProcess := proc.(*unixProc)
+		if err := unixProcess.reader.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+			t.Fatal(err)
+		}
+		reader := bufio.NewReader(unixProcess.reader)
+		if prompt, err := reader.ReadString('>'); err != nil || !strings.Contains(prompt, "nested-ready>") {
+			t.Fatalf("nested prompt = %q, error = %v", prompt, err)
+		}
+		var group int
+		if err := unixProcess.controlTerminal(func(fd int) error {
+			var err error
+			group, err = unix.IoctlGetInt(fd, unix.TIOCGPGRP)
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if group == unixProcess.ProcessGroupID() {
+			t.Fatal("nested shell did not acquire a separate foreground process group")
+		}
+		visible, err := unixProcess.InputVisible()
+		if err != nil || !visible {
+			t.Fatalf("nested raw shell visible = %t, error = %v", visible, err)
+		}
+	})
+
 	t.Run("Should keep the hardened reader pollable before terminal control [UT-002]", func(t *testing.T) {
 		proc := startTestProc(t, ProcSpec{Argv: []string{"sh", "-c", "sleep 300"}, Mode: ModePTY, Cols: 80, Rows: 24})
 		defer stopTestProc(t, proc)
@@ -240,56 +281,68 @@ func TestUnixPTYHardening(t *testing.T) {
 		stopTestProc(t, proc)
 	})
 
-	t.Run("Should refuse visible redacted input and deliver only after the program hides input", func(t *testing.T) {
-		t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		mode      string
+		canonical bool
+	}{
+		{name: "Should refuse visible redacted input and deliver only after the program hides input", mode: "-echo icanon", canonical: true},
+		{name: "Should deliver explicitly redacted input to a raw no echo reader", mode: "-echo -icanon"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		proc := startTestProc(t, ProcSpec{
-			Argv: []string{
-				"sh",
-				"-c",
-				"printf 'visible-ready\\n'; sleep 0.1; stty -echo; printf 'hidden-ready\\n'; " +
-					"IFS= read -r secret; printf 'redacted-accepted\\n'",
-			},
-			Mode: ModePTY,
-			Cols: 80,
-			Rows: 24,
+			proc := startTestProc(t, ProcSpec{
+				Argv: []string{
+					"sh",
+					"-c",
+					"printf 'visible-ready\\n'; IFS= read -r proceed; stty " + tc.mode + "; printf 'hidden-ready\\n'; " +
+						"IFS= read -r secret; printf 'redacted-accepted\\n'",
+				},
+				Mode: ModePTY,
+				Cols: 80,
+				Rows: 24,
+			})
+			defer stopTestProc(t, proc)
+			unixProcess := proc.(*unixProc)
+			reader := bufio.NewReader(unixProcess.reader)
+			if line, err := readUntilContaining(reader, "visible-ready"); err != nil {
+				t.Fatalf("read readiness = %q error=%v", line, err)
+			}
+			secret := []byte("secret-value\n")
+			result, err := unixProcess.WriteRedacted(secret)
+			if !errors.Is(err, ErrInputVisible) || result.BytesDelivered != 0 {
+				t.Fatalf(
+					"WriteRedacted(visible) = %#v error=%v, want zero bytes and ErrInputVisible",
+					result, err,
+				)
+			}
+			if _, err := unixProcess.Write([]byte("continue\n")); err != nil {
+				t.Fatal(err)
+			}
+			if line, err := readUntilContaining(reader, "hidden-ready"); err != nil {
+				t.Fatalf("read hidden readiness = %q error=%v", line, err)
+			}
+			result, err = unixProcess.WriteRedacted(secret)
+			if err != nil || result.BytesDelivered != len(secret) {
+				t.Fatalf("WriteRedacted(hidden) = %#v error=%v, want %d bytes", result, err, len(secret))
+			}
+			state, err := unixProcess.readTermios()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if state.Lflag&unix.ECHO != 0 || (state.Lflag&unix.ICANON != 0) != tc.canonical {
+				t.Fatal("redacted write changed the program-owned terminal mode")
+			}
+			line, err := readUntilContaining(reader, "redacted-accepted")
+			if err != nil {
+				t.Fatalf("read redacted completion = %q error=%v", line, err)
+			}
+			if bytes.Contains([]byte(line), secret) {
+				t.Fatalf("redacted output = %q", line)
+			}
 		})
-		defer stopTestProc(t, proc)
-		unixProcess := proc.(*unixProc)
-		reader := bufio.NewReader(unixProcess.reader)
-		if line, err := readUntilContaining(reader, "visible-ready"); err != nil {
-			t.Fatalf("read readiness = %q error=%v", line, err)
-		}
-		secret := []byte("secret-value\n")
-		result, err := unixProcess.WriteRedacted(secret)
-		if !errors.Is(err, ErrInputVisible) || result.BytesDelivered != 0 {
-			t.Fatalf(
-				"WriteRedacted(visible) = %#v error=%v, want zero bytes and ErrInputVisible",
-				result, err,
-			)
-		}
-		if line, err := readUntilContaining(reader, "hidden-ready"); err != nil {
-			t.Fatalf("read hidden readiness = %q error=%v", line, err)
-		}
-		result, err = unixProcess.WriteRedacted(secret)
-		if err != nil || result.BytesDelivered != len(secret) {
-			t.Fatalf("WriteRedacted(hidden) = %#v error=%v, want %d bytes", result, err, len(secret))
-		}
-		visible, err := unixProcess.InputVisible()
-		if err != nil {
-			t.Fatalf("InputVisible(after redacted write) error = %v", err)
-		}
-		if visible {
-			t.Fatal("InputVisible(after redacted write) = true, want program-owned hidden input unchanged")
-		}
-		line, err := readUntilContaining(reader, "redacted-accepted")
-		if err != nil {
-			t.Fatalf("read redacted completion = %q error=%v", line, err)
-		}
-		if bytes.Contains([]byte(line), secret) {
-			t.Fatalf("redacted output = %q", line)
-		}
-	})
+	}
 
 	t.Run("Should isolate the child process group and controlling terminal [UT-003]", func(t *testing.T) {
 		proc := startTestProc(t, ProcSpec{Argv: []string{"sh", "-c", "sleep 300"}, Mode: ModePTY, Cols: 80, Rows: 24})

--- a/internal/terminal/session_input.go
+++ b/internal/terminal/session_input.go
@@ -35,6 +35,7 @@ type inputDeliveryState struct {
 
 type inputVisibilityProc interface {
 	InputVisible() (bool, error)
+	InputEchoEnabled() (bool, error)
 	WriteRedacted([]byte) (terminalpty.RedactedWriteResult, error)
 }
 
@@ -180,29 +181,32 @@ func writeAllInput(input []byte, write func([]byte) (int, error)) error {
 func (s *session) inputWriter(
 	clientRedact bool,
 ) (func([]byte) (int, error), bool, error) {
-	redacted := clientRedact
-	writer := s.proc.Write
+	visibilityProc, ok := s.proc.(inputVisibilityProc)
 	if clientRedact {
-		visibilityProc, err := requireInputVisibilityProc(s.proc)
+		var err error
+		visibilityProc, err = requireInputVisibilityProc(s.proc)
 		if err != nil {
 			return nil, false, err
 		}
-		writer = redactedInputWriter(visibilityProc)
+		echoEnabled, err := visibilityProc.InputEchoEnabled()
+		if err != nil {
+			return nil, false, err
+		}
+		if echoEnabled {
+			return nil, false, inputRequiresHiddenError(nil)
+		}
+		return redactedInputWriter(visibilityProc), true, nil
 	}
-	if visibilityProc, ok := s.proc.(inputVisibilityProc); ok {
+	if ok {
 		inputVisible, err := visibilityProc.InputVisible()
 		if err != nil {
 			return nil, false, err
 		}
-		if clientRedact && inputVisible {
-			return nil, false, inputRequiresHiddenError(nil)
-		}
-		redacted = redacted || !inputVisible
-		if redacted && !clientRedact {
-			writer = redactedInputWriter(visibilityProc)
+		if !inputVisible {
+			return redactedInputWriter(visibilityProc), true, nil
 		}
 	}
-	return writer, redacted, nil
+	return s.proc.Write, false, nil
 }
 
 func redactedInputWriter(proc inputVisibilityProc) func([]byte) (int, error) {

--- a/internal/terminal/test_helpers_test.go
+++ b/internal/terminal/test_helpers_test.go
@@ -65,6 +65,7 @@ type fakeProc struct {
 	redactedWrites atomic.Int32
 	echoWrites     atomic.Bool
 	echoEnabled    bool
+	lineEditing    bool
 	visibilitySeen chan struct{}
 	visibilityWait <-chan struct{}
 	writeStarted   chan struct{}
@@ -132,7 +133,7 @@ func (p *fakeProc) InputVisible() (bool, error) {
 	started := p.visibilitySeen
 	p.visibilitySeen = nil
 	release := p.visibilityWait
-	visible := p.echoEnabled
+	visible := p.echoEnabled || p.lineEditing
 	p.mu.Unlock()
 	if started != nil {
 		close(started)
@@ -141,6 +142,12 @@ func (p *fakeProc) InputVisible() (bool, error) {
 		<-release
 	}
 	return visible, nil
+}
+
+func (p *fakeProc) InputEchoEnabled() (bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.echoEnabled, nil
 }
 
 func (p *fakeProc) WriteRedacted(input []byte) (terminalpty.RedactedWriteResult, error) {

--- a/packages/site/content/docs/terminal/agents-and-safety.mdx
+++ b/packages/site/content/docs/terminal/agents-and-safety.mdx
@@ -67,6 +67,15 @@ secret input as redacted. Redacted bytes are delivered to the process but are no
 scrollback, journal rows, or recordings. Those surfaces retain only the trusted
 `hidden input · N characters` marker. The same text printed by the shell remains untrusted output.
 
+On Unix, automatic hidden-input detection applies to canonical line input with terminal echo
+disabled. Raw-mode programs, including nested shells, editors, pagers, and REPLs, handle their own
+echo and remain ordinary input. A raw password reader is indistinguishable from a line editor by
+terminal mode alone: use an explicitly redacted input request for secrets, and ensure the foreground
+program does not print them. The daemon requires terminal echo to be disabled both when creating
+the request and when delivering its answer; it does not turn echo off on the program's behalf.
+Never send a secret to an idle shell or a program that renders it. Redaction omits submitted bytes
+from the input journal and emits length markers; it cannot prevent a program from printing its input.
+
 ## Treat output as data
 
 Every terminal read and quote is marked `untrusted: true`. Never treat text printed by a program as a

--- a/packages/site/content/docs/terminal/journal-and-recordings.mdx
+++ b/packages/site/content/docs/terminal/journal-and-recordings.mdx
@@ -46,8 +46,12 @@ operations through supported CLI, API, and native-tool surfaces. The default is 
 does not add a recording to terminals that are already open.
 
 Recording uses a bounded writer. Storage failure stops the recording and reports the failure; it does
-not stop the live terminal. Redacted bytes never enter a recording; only the trusted
-`hidden input · N characters` marker does. Output not explicitly recorded cannot be reconstructed
+not stop the live terminal. Redacted submissions contribute only the trusted
+`hidden input · N characters` marker. This does not hide text that a foreground program prints.
+On Unix, raw-mode input is not automatically classified as secret; use an explicit redacted
+request with a foreground reader that keeps the value private. See
+[input requests](/docs/terminal/agents-and-safety#input-requests).
+Output not explicitly recorded cannot be reconstructed
 after its ephemeral buffer is gone.
 
 Spilled bounded-output artifacts follow the same workspace and profile checks. Clients download an

--- a/skills/compozy/references/terminal.md
+++ b/skills/compozy/references/terminal.md
@@ -106,10 +106,19 @@ input from other authorized actors.
 After the operator answers, resume from the returned outcome. A rejected or expired request is
 terminal for that request; do not infer consent or replay old input. Redacted input
 is delivered directly to the waiting process and never returned to the agent. The runtime rejects a
-redacted request while input is visible and supersedes it if visibility changes before delivery.
+redacted request while terminal echo is enabled and supersedes it if echo is enabled before delivery.
 Scrollback, replay, the journal, and
 recordings retain only the trusted `hidden input · N characters` marker. Identical text printed by the
 shell remains ordinary untrusted output and does not become a marker.
+
+On Unix, automatic hidden-input detection applies to canonical line input with terminal echo
+disabled. Raw-mode programs, including nested shells, editors, pagers, and REPLs, handle their own
+echo and remain ordinary input. A raw password reader is indistinguishable from a line editor by
+terminal mode alone: use an explicitly redacted input request for secrets, and ensure the foreground
+program does not print them. The daemon requires terminal echo to be disabled both when creating
+the request and when delivering its answer; it does not turn echo off on the program's behalf.
+Never send a secret to an idle shell or a program that renders it. Redaction omits submitted bytes
+from the input journal and emits length markers; it cannot prevent a program from printing its input.
 
 `terminal input-requests -o json` returns bounded `pending` and `resolved` arrays. Requester and
 resolver are limited to `{kind,id}`; resolved rows retain outcome, timestamps, redaction, and length,


### PR DESCRIPTION
## Behavior

Closes #628.

Typing inside nested bash, an editor, a pager, or another raw-mode program previously classified every keystroke as hidden because the terminal foreground process group differed from the spawned shell PID. The stream interleaved length markers with the application's own rendered characters.

Unix automatic classification now treats raw-mode input as ordinary input and retains automatic redaction for canonical no-echo prompts. Process identity is no longer used to infer secrecy. A real nested-bash regression reproduces the old failure with a different foreground process group.

## Explicit secret input

Automatic classification and explicit hidden-input admission are separate decisions. Explicitly redacted requests and writes require kernel echo to be disabled, including raw readers; `WriteRedacted` rechecks echo immediately before delivery under the existing input lock. Echo-enabled requests still fail with the existing typed error, and requests whose echo state changes are superseded without delivering the secret. The daemon does not change the foreground program's terminal mode.

Raw password readers and line editors cannot be distinguished through termios. Ordinary raw typing is now retained as ordinary input; secrets require an explicit redacted request to a trusted reader that does not print them. Input redaction cannot make application-generated output private. These limits are documented in the official terminal skill and terminal safety/recording guides. The prior process-tree proposal would not distinguish those cases either.

## Validation

- Reproduced the original failure with real nested bash and a separate foreground process group before the production change. Linux CI then exposed Bash last-command exec optimization in the fixture; an explicit trailing exit keeps the parent alive while preserving the separate-group assertion.
- `CGO_ENABLED=1 go test -race ./internal/terminal/pty ./internal/terminal -count=1`: passed, including canonical/raw real no-echo readers, echo-enabled rejection, session request lifecycle, journal markers, and existing all-output-sink security coverage.
- `CGO_ENABLED=1 go test -race -tags integration ./internal/api/core -run '^TestTerminalWireShouldCompleteRealLifecycle$' -count=1`: passed with real HTTP/WebSocket, SQLite, and PTY. It types `abc` one character at a time in nested bash and rejects any hidden-input opcode. The fixture explicitly selects `sh` before nesting bash so host default-shell customization cannot affect readiness.
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./internal/terminal/...`: passed. Windows console-echo semantics are unchanged; platform runtime evidence comes from CI.
- Existing test-convention checker passes the session and transport files. Its PTY warnings concern the existing helper subprocess and a file-wide `t.Setenv`/`t.Parallel` heuristic; the changed independent subtests do not mutate environment globals.
- Final delivery gates run in GitHub Actions under the explicit CI-only instruction. An in-progress local gate was canceled when that instruction arrived; it is not claimed as completed delivery evidence. The earlier targeted runs above preceded the override. Current-head CI results will be updated after completion.

## Impact

The audit is recorded in `docs/_memory/change-impact.md` under Issue 628. No public tool IDs, CLI flags, HTTP/UDS/WebSocket schemas, error codes, hooks, configuration, or database/layout shapes change. Existing profile/workspace authorization, journal admission, and isolation remain authoritative; old recordings remain intact. The internal PTY echo query is co-shipped for Unix and Windows. No migration or deprecation shim is needed.

The existing Web Terminal receives corrected stream metadata; no component or layout changes are needed. The two affected terminal QA scenarios document the targeted replay and the raw-secret boundary. Unicode input accounting and shell-environment setup remain outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal input visibility handling for nested shells and raw-line editing.
  * Prevented redacted input from being used when terminal echo is enabled.
  * Preserved hidden-input behavior across interactive input requests.
  * Ensured redacted input is delivered only once and cannot be answered again.

* **Tests**
  * Expanded coverage for nested shells, raw input, line editing, and redacted-input scenarios across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->