### PR TITLE
fix: recognize structured Claude authentication status

### DIFF
--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -261,3 +261,28 @@ public replay. No Web, hook, config, persistence, or official skill surface chan
 The following linter-only continuation preserves custom-property importance and recognizes icon
 containers with delimiter-aware names across non-void tags. The same tool/schema/isolation audit
 and ET-open-design scenario apply; no additional surface contract is introduced.
+
+## Issue 623 — Structured native authentication probes
+
+- **Native tools / CLI / HTTP / UDS:** existing provider status/probe and pre-start
+  admission share the top-level JSON `loggedIn` verdict. False requests native
+  login; invalid/missing/non-boolean/duplicate verdicts remain unknown. Exit zero
+  and absence of a classified error are required for success. Unknown admission
+  remains fail-closed. No native IDs, routes, or DTO shapes change.
+- **Extensibility / hooks / config:** no new configuration or hook contracts.
+  Existing text probes retain their vocabulary, with negative/error evidence
+  preceding positive text. Structured output retains only its boolean verdict;
+  unrecognized structured output is represented as an empty object, avoiding
+  identity-derived substring classifications and disclosure. Local and prepared
+  sandbox runners sanitize before bounding; API/CLI projection also sanitizes
+  injected runner results. Native login execution is unchanged.
+- **Workspace / profile isolation:** native credential ownership, operator-home
+  policy, prepared executable identity, pre-start cache keys, and workspace/profile
+  resolution remain unchanged. No schema, persisted-state migration, or host
+  credential change. Previously collected support bundles are not rewritten.
+- **Official skill / Web / Docs:** the agent definition reference and provider
+  configuration guide document direct JSON support. Web consumes the same state
+  and safe probe payload without UI changes. RT-026 owns the targeted replay;
+  [the QA report](../qa/reports/2026-09-12-issue-623-claude-auth.md) records evidence
+  and platform boundaries. Cursor/Codex output shapes and overlay discovery remain
+  outside this fix.

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -286,3 +286,8 @@ and ET-open-design scenario apply; no additional surface contract is introduced.
   [the QA report](../qa/reports/2026-09-12-issue-623-claude-auth.md) records evidence
   and platform boundaries. Cursor/Codex output shapes and overlay discovery remain
   outside this fix.
+
+PR #632 prefix remediation remains within the same projection boundary: bracket
+log labels retain text compatibility; warning-prefixed JSON is reduced to its
+verdict, and recognized prefix errors retain their safe recovery classification.
+No additional public, config, persistence, or Web contracts change.

--- a/docs/qa/reports/2026-09-12-issue-623-claude-auth.md
+++ b/docs/qa/reports/2026-09-12-issue-623-claude-auth.md
@@ -50,3 +50,14 @@ Final delivery is pending the current-head GitHub CI and both external reviewers
 The historical Daytona leg of RT-026 remains outside this local-provider slice.
 No first-prompt replay was performed because the assignment prohibits creating
 Compozy sessions; existing integration/E2E workflows own broader session evidence.
+
+PR #632 review remediation: Greptile finding 3995000662 exposed two untested
+prefix cases. The shared projection now preserves bracket-labeled text probes
+and locates a JSON object after a warning. It suppresses the surrounding identity
+payload, preserves classified prefix errors, and keeps malformed mixed output
+unknown. The existing classifier table covers both reported forms and adjacent
+true/malformed/error-prefixed variants. These cases run in GitHub CI under the
+execution override; the unchanged native true response retains the earlier live
+probe evidence. CodeRabbit completed the initial source review without actionable
+comments; its generic docstring-coverage warning conflicts with the repository's
+explicit rule against restating obvious private helper behavior in comments.

--- a/docs/qa/reports/2026-09-12-issue-623-claude-auth.md
+++ b/docs/qa/reports/2026-09-12-issue-623-claude-auth.md
@@ -61,3 +61,10 @@ execution override; the unchanged native true response retains the earlier live
 probe evidence. CodeRabbit completed the initial source review without actionable
 comments; its generic docstring-coverage warning conflicts with the repository's
 explicit rule against restating obvious private helper behavior in comments.
+
+Greptile follow-up 3995018821 narrows candidate detection so ordinary text such as
+`logged in {region=us-east}` remains text. JSON-like object starts and malformed
+`loggedIn` payloads still take the safe structured path; the scan continues past
+ordinary brace metadata to find a later JSON verdict. Both cases extend the same
+canonical classifier table and await GitHub CI. No additional live-provider or
+surface contract changes are introduced.

--- a/docs/qa/reports/2026-09-12-issue-623-claude-auth.md
+++ b/docs/qa/reports/2026-09-12-issue-623-claude-auth.md
@@ -1,0 +1,52 @@
+# Issue 623: Claude structured authentication probe
+
+Scope: Dora administers provider authentication through the existing
+CH-provider-auth-surfaces-dora charter, restricted to RT-026 and its local CLI
+equivalent. Existing operator credentials remain unchanged. No Compozy sessions,
+worktrees, or Goals are created by this execution assignment.
+
+| Journey | Status | Evidence |
+| --- | --- | --- |
+| Native Claude JSON status through local CLI | Pass | `local-claude.json`: authenticated, exit 0, verdict only |
+| Native Claude JSON status through daemon HTTP/UDS | Pass | `http-claude.json`, `remote-claude.json`: authenticated, exit 0, verdict only |
+| Unknown provider adjacent canary | Pass | Unconfigured acpmock returned provider_not_installed without probing |
+
+The canonical classifier suite reproduces the reported unknown state and an
+identity-bearing diagnostic before the fix. It also exposes false authentication
+from incidental JSON text and negative text on exit zero. The provider suite now
+passes with the race detector. Classification belongs to `classify_test.go`;
+subprocess output minimization belongs to `runner_test.go`; the existing API
+failure case owns privacy at the injected-runner response boundary.
+
+Platform boundary: the available native Claude CLI is 2.1.266 on macOS; the
+reporter's exact Linux/2.1.269 environment is unavailable. Malformed and logged-out
+cases are deterministic canonical tests, without logging out the operator.
+
+Dora's local and daemon reads agree without a translation shim. A fresh native
+status read confirmed the same true boolean. The generated support bundle included
+11 artifacts, including providers and diagnostics; scanning each artifact for the
+current native email, organization ID, and organization name found zero matches.
+Only the field names and zero-match summary were retained as evidence; no raw
+native identity payload was captured. Lab teardown finished with `clean: true` and
+no survivors.
+
+The isolated lab's scratch evidence includes `provider-attempt.json`,
+`journey-log.jsonl`, `support-privacy-summary.json`, and `teardown.json`. The
+executor's private report retains their exact paths. The structured-error rejection
+added after this walk affects an unobserved error case, covered by the canonical
+classifier suite in CI; it does not invalidate the unchanged successful native
+response path. The operator's login state was never modified.
+
+Validation boundary: initial provider race tests, focused API tests, and the real
+app build passed before the user changed the execution policy. Earlier local gate
+attempts exposed formatting and constant-lint findings; those were repaired. The
+user then explicitly required GitHub CI-only delivery gates. The executor cancelled
+its own remaining local gate and used per-command `HUSKY=0` for commit hooks. No
+local gate completion is claimed. The QA metadata auditor's local-gate requirement
+(C14) is superseded by that explicit user instruction; its missing report finding
+(C12) is resolved by this report and the lab-side copy.
+
+Final delivery is pending the current-head GitHub CI and both external reviewers.
+The historical Daytona leg of RT-026 remains outside this local-provider slice.
+No first-prompt replay was performed because the assignment prohibits creating
+Compozy sessions; existing integration/E2E workflows own broader session evidence.

--- a/docs/qa/scenarios/RT-026.md
+++ b/docs/qa/scenarios/RT-026.md
@@ -33,3 +33,19 @@ src: docs/qa/_seeds/feature-stories/01_analysis_runtime-sessions.md
 inventory: Needs QA
 
 QA rewalk 2026-08-03: the controlled local runtime passed the pre-login, authenticated, restart-survival, `auth_mode=none`, missing-status-command, HTTP, and UDS/CLI branches without exposing login command material. The original disclosure bug is verified fixed. The scenario remains `blocked-verify` only because this isolated lab has no configured Daytona backend or Daytona CLI, so the required real remote final-environment probe cannot be walked honestly.
+
+Issue 623 impact (2026-09-12): replay native Claude JSON status through local CLI
+and daemon HTTP/UDS without a shim or `--text`. A valid top-level boolean true
+requires exit zero and no classified error; false requests login. Invalid,
+missing, non-boolean, nested, and duplicate verdicts remain unknown. Account and
+organization payloads must be absent from probe responses and diagnostics, even
+for malformed output. Canonical provider suites own destructive/logged-out edge
+cases; never log out a working operator account to test them. The targeted replay
+is recorded in `docs/qa/reports/2026-09-12-issue-623-claude-auth.md`; it does not
+replace the outstanding historical Daytona verification.
+
+Issue 623 targeted replay: local Claude 2.1.266 and daemon HTTP/UDS all returned
+`authenticated` with only `loggedIn` in probe stdout. A real support bundle had no
+native email/org ID/org name values across its 11 artifacts. The lab teardown was
+clean. The scenario's historical `blocked-verify` status remains for Daytona;
+GitHub CI owns final delivery gates under the user's explicit execution override.

--- a/internal/api/core/providers.go
+++ b/internal/api/core/providers.go
@@ -119,8 +119,8 @@ func (h *BaseHandlers) ProbeProviderAuth(c *gin.Context) {
 		AuthStatus: authStatus,
 		Probe: &contract.ProviderAuthProbeResult{
 			ExitCode:   result.ExitCode,
-			Stdout:     diagnostics.RedactAndBound(result.Stdout, maxDiagnosticPayloadBytes),
-			Stderr:     diagnostics.RedactAndBound(result.Stderr, maxDiagnosticPayloadBytes),
+			Stdout:     authproviders.RedactAuthProbeOutput(result.Stdout, maxDiagnosticPayloadBytes),
+			Stderr:     authproviders.RedactAuthProbeOutput(result.Stderr, maxDiagnosticPayloadBytes),
 			DurationMs: result.DurationMs,
 		},
 	})

--- a/internal/api/core/providers_test.go
+++ b/internal/api/core/providers_test.go
@@ -201,7 +201,7 @@ func TestProviderAuthHandlers(t *testing.T) {
 			}
 			return authproviders.ProviderAuthCommandResult{
 				ExitCode: 1,
-				Stdout:   "access_token=stdout-secret",
+				Stdout:   `{"loggedIn":false,"email":"private@example.test","orgId":"private-org-id","orgName":"Private Organization","access_token":"stdout-secret"}`,
 				Stderr:   "HTTP 401 unauthorized token=stderr-secret compozy_claim_sensitive",
 			}, nil
 		}
@@ -233,7 +233,7 @@ func TestProviderAuthHandlers(t *testing.T) {
 			t.Fatal("Probe = nil, want redacted probe output")
 		}
 		probeOutput := payload.Probe.Stdout + payload.Probe.Stderr
-		for _, leaked := range []string{"stdout-secret", "stderr-secret", "compozy_claim_sensitive"} {
+		for _, leaked := range []string{"stdout-secret", "stderr-secret", "compozy_claim_sensitive", "private@example.test", "private-org-id", "Private Organization"} {
 			if strings.Contains(probeOutput, leaked) {
 				t.Fatalf("probe output = %#v leaked %q", payload.Probe, leaked)
 			}

--- a/internal/cli/provider_status.go
+++ b/internal/cli/provider_status.go
@@ -196,6 +196,8 @@ func populateProviderAuthProbe(
 	if err != nil {
 		return err
 	}
+	result.Stdout = authproviders.RedactAuthProbeOutput(result.Stdout, 4096)
+	result.Stderr = authproviders.RedactAuthProbeOutput(result.Stderr, 4096)
 	record.Probe = &result
 	if provider.EffectiveAuthMode() == compozyconfig.ProviderAuthModeNativeCLI {
 		classification := authproviders.ClassifyProbeResultContext(ctx, provider, authproviders.ProbeOutcome{

--- a/internal/providers/classify.go
+++ b/internal/providers/classify.go
@@ -176,19 +176,30 @@ func ClassifyProbeResultContext(
 			Message: ProviderAuthNoAuthRequiredMessage,
 		}
 	}
+	outcome.Stdout = RedactAuthProbeOutput(outcome.Stdout, 4096)
+	outcome.Stderr = RedactAuthProbeOutput(outcome.Stderr, 4096)
 	combined := strings.ToLower(outcome.Stdout + "\n" + outcome.Stderr)
 	nativeCLI, classification, classified := classifyNativeCLIProbePrecondition(ctx, provider, env, authMode)
 	if classified {
 		return classification
+	}
+	if classification, classified := classifyProbeOutput(combined); classified {
+		return classification
+	}
+	if outcome.Stdout == probeJSONNeedsLogin || outcome.Stderr == probeJSONNeedsLogin {
+		return Classification{
+			State:   ProviderAuthStateNeedsLogin,
+			Code:    diagcontract.CodeProviderNotAuthenticated,
+			Message: loginGuidance(),
+			Kind:    ProviderFailureNotAuthenticated,
+			Action:  ProviderFailureActionLogin,
+		}
 	}
 	if outcome.ExitCode == 0 && outputLooksAuthenticated(outcome) {
 		return Classification{
 			State:   ProviderAuthStateAuthenticated,
 			Message: "Provider status command completed successfully.",
 		}
-	}
-	if classification, classified := classifyProbeOutput(combined); classified {
-		return classification
 	}
 	if nativeCLI != nil && nativeCLI.Command != "" && !nativeCLI.Present &&
 		hasAny(combined, "not found on path", "not found", "not installed") {
@@ -328,6 +339,12 @@ func ClassifyError(err error) Classification {
 }
 
 func outputLooksAuthenticated(outcome ProbeOutcome) bool {
+	if outcome.Stdout == probeJSONUnknown || outcome.Stderr == probeJSONUnknown {
+		return false
+	}
+	if outcome.Stdout == probeJSONAuthenticated || outcome.Stderr == probeJSONAuthenticated {
+		return true
+	}
 	combined := strings.ToLower(strings.TrimSpace(outcome.Stdout + "\n" + outcome.Stderr))
 	return combined == "" || hasAny(
 		combined,

--- a/internal/providers/classify_test.go
+++ b/internal/providers/classify_test.go
@@ -139,6 +139,32 @@ func TestClassifyProviderAuth(t *testing.T) {
 				stdout: "not logged in",
 				state:  ProviderAuthStateNeedsLogin,
 			},
+			{
+				name:   "Should retain bracket-prefixed text probes",
+				stdout: "[INFO] logged in",
+				state:  ProviderAuthStateAuthenticated,
+			},
+			{
+				name: "Should parse a warning-prefixed false verdict without exposing identity",
+				stdout: "warning\n" +
+					`{"loggedIn":false,"orgName":"Authenticated Labs","email":"private@example.test"}`,
+				state: ProviderAuthStateNeedsLogin,
+			},
+			{
+				name:   "Should parse a warning-prefixed true verdict",
+				stdout: "[INFO] account status\n" + `{"loggedIn":true}`,
+				state:  ProviderAuthStateAuthenticated,
+			},
+			{
+				name:   "Should suppress malformed warning-prefixed identity",
+				stdout: "warning\n" + `{"loggedIn":true,"email":"private@example.test"`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{
+				name:   "Should preserve a classified error before JSON",
+				stdout: "HTTP 403 forbidden\n" + `{"loggedIn":true,"email":"private@example.test"}`,
+				state:  ProviderAuthStatePermissionDenied,
+			},
 		}
 		for _, tt := range cases {
 			t.Run(tt.name, func(t *testing.T) {

--- a/internal/providers/classify_test.go
+++ b/internal/providers/classify_test.go
@@ -29,6 +29,141 @@ func TestClassifyProviderAuth(t *testing.T) {
 		}
 	})
 
+	t.Run("Should classify structured login verdicts without trusting identity text", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			name     string
+			stdout   string
+			stderr   string
+			exitCode int
+			state    ProviderAuthState
+		}{
+			{
+				name:   "Should accept a true boolean",
+				stdout: `{"loggedIn":true,"email":"private@example.test","orgId":"org-429","orgName":"Unauthorized Labs"}`,
+				state:  ProviderAuthStateAuthenticated,
+			},
+			{
+				name:   "Should reject a false boolean on success",
+				stdout: `{"loggedIn":false,"orgName":"Authenticated Labs"}`,
+				state:  ProviderAuthStateNeedsLogin,
+			},
+			{
+				name:     "Should reject a false boolean on failure",
+				stdout:   `{"loggedIn":false}`,
+				exitCode: 1,
+				state:    ProviderAuthStateNeedsLogin,
+			},
+			{
+				name:   "Should reject a missing boolean",
+				stdout: `{"orgName":"Authenticated Labs"}`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{
+				name:   "Should reject a string boolean",
+				stdout: `{"loggedIn":"true","orgName":"Authenticated Labs"}`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{name: "Should reject a null boolean", stdout: `{"loggedIn":null}`, state: ProviderAuthStateUnknown},
+			{name: "Should reject a numeric boolean", stdout: `{"loggedIn":1}`, state: ProviderAuthStateUnknown},
+			{
+				name:   "Should reject malformed JSON",
+				stdout: `{"loggedIn":true,"email":"private@example.test"`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{
+				name:   "Should reject trailing content",
+				stdout: `{"loggedIn":true} authenticated`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{
+				name:   "Should reject duplicate verdicts",
+				stdout: `{"loggedIn":false,"loggedIn":true}`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{
+				name:   "Should reject nested verdicts",
+				stdout: `{"status":{"loggedIn":true}}`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{name: "Should reject array verdicts", stdout: `[{"loggedIn":true}]`, state: ProviderAuthStateUnknown},
+			{
+				name:   "Should reject a verdict accompanied by a structured error",
+				stdout: `{"loggedIn":true,"error":"private provider failure"}`,
+				state:  ProviderAuthStateUnknown,
+			},
+			{
+				name:     "Should keep nonzero true verdict unknown",
+				stdout:   `{"loggedIn":true}`,
+				exitCode: 1,
+				state:    ProviderAuthStateUnknown,
+			},
+			{
+				name:   "Should prioritize permission errors",
+				stdout: `{"loggedIn":true}`,
+				stderr: "HTTP 403 forbidden",
+				state:  ProviderAuthStatePermissionDenied,
+			},
+			{
+				name:   "Should prioritize rate limits",
+				stdout: `{"loggedIn":true}`,
+				stderr: "HTTP 429 rate limit",
+				state:  ProviderAuthStateRateLimited,
+			},
+			{
+				name:   "Should prioritize transport errors",
+				stdout: `{"loggedIn":true}`,
+				stderr: "connection refused",
+				state:  ProviderAuthStateTransient,
+			},
+			{
+				name:   "Should prioritize login errors",
+				stdout: `{"loggedIn":true}`,
+				stderr: "not authenticated",
+				state:  ProviderAuthStateNeedsLogin,
+			},
+			{
+				name:   "Should reject conflicting stream verdicts",
+				stdout: `{"loggedIn":true}`,
+				stderr: `{"loggedIn":false}`,
+				state:  ProviderAuthStateNeedsLogin,
+			},
+			{
+				name:   "Should not let success text override invalid JSON",
+				stdout: `{"loggedIn":"true"}`,
+				stderr: "authenticated",
+				state:  ProviderAuthStateUnknown,
+			},
+			{
+				name:   "Should prioritize negative text even on success",
+				stdout: "not logged in",
+				state:  ProviderAuthStateNeedsLogin,
+			},
+		}
+		for _, tt := range cases {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				got := ClassifyProbeResult(
+					nativeProvider(),
+					ProbeOutcome{ExitCode: tt.exitCode, Stdout: tt.stdout, Stderr: tt.stderr},
+					presentEnv(),
+				)
+				if got.State != tt.state {
+					t.Fatalf("State = %q, want %q", got.State, tt.state)
+				}
+				encoded, err := json.Marshal(DiagnosticItem("native", got))
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, identity := range []string{"private@example.test", "org-429", "Unauthorized Labs", "Authenticated Labs"} {
+					if strings.Contains(string(encoded), identity) {
+						t.Fatalf("diagnostic leaked %q: %s", identity, encoded)
+					}
+				}
+			})
+		}
+	})
+
 	t.Run("Should treat the Hermes ACP import check as preflight success", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/providers/classify_test.go
+++ b/internal/providers/classify_test.go
@@ -140,6 +140,16 @@ func TestClassifyProviderAuth(t *testing.T) {
 				state:  ProviderAuthStateNeedsLogin,
 			},
 			{
+				name:   "Should retain successful text with brace-delimited metadata",
+				stdout: "logged in {region=us-east}",
+				state:  ProviderAuthStateAuthenticated,
+			},
+			{
+				name:   "Should not let brace metadata hide a later JSON verdict",
+				stdout: "[INFO] {region=us-east}\n" + `{"loggedIn":false,"email":"private@example.test"}`,
+				state:  ProviderAuthStateNeedsLogin,
+			},
+			{
 				name:   "Should retain bracket-prefixed text probes",
 				stdout: "[INFO] logged in",
 				state:  ProviderAuthStateAuthenticated,

--- a/internal/providers/probe_output.go
+++ b/internal/providers/probe_output.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/compozy/compozy/internal/diagnostics"
+)
+
+const (
+	probeJSONAuthenticated = `{"loggedIn":true}`
+	probeJSONNeedsLogin    = `{"loggedIn":false}`
+	probeJSONUnknown       = "{}"
+)
+
+// RedactAuthProbeOutput retains only the authentication verdict from structured status output.
+func RedactAuthProbeOutput(output string, limit int) string {
+	trimmed := strings.TrimSpace(output)
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		return diagnostics.RedactAndBound(output, limit)
+	}
+	loggedIn, valid := probeLoggedIn(trimmed)
+	if !valid {
+		return probeJSONUnknown
+	}
+	if loggedIn {
+		return probeJSONAuthenticated
+	}
+	return probeJSONNeedsLogin
+}
+
+func probeLoggedIn(output string) (bool, bool) {
+	if !json.Valid([]byte(output)) {
+		return false, false
+	}
+	decoder := json.NewDecoder(strings.NewReader(output))
+	opening, err := decoder.Token()
+	if err != nil || opening != json.Delim('{') {
+		return false, false
+	}
+	var loggedIn bool
+	found := false
+	for decoder.More() {
+		key, err := decoder.Token()
+		if err != nil {
+			return false, false
+		}
+		var value json.RawMessage
+		if err := decoder.Decode(&value); err != nil {
+			return false, false
+		}
+		if key == "error" && string(value) != "null" && string(value) != `""` {
+			return false, false
+		}
+		if key != "loggedIn" {
+			continue
+		}
+		if found {
+			return false, false
+		}
+		found = true
+		switch string(value) {
+		case "true":
+			loggedIn = true
+		case "false":
+			loggedIn = false
+		default:
+			return false, false
+		}
+	}
+	return loggedIn, found
+}

--- a/internal/providers/probe_output.go
+++ b/internal/providers/probe_output.go
@@ -48,8 +48,15 @@ func structuredProbeOutput(output string) (string, string, bool) {
 	if strings.HasPrefix(trimmed, "[") && !probeTextLabel(trimmed) {
 		return trimmed, "", true
 	}
-	if start := strings.IndexByte(trimmed, '{'); start >= 0 {
-		return trimmed[start:], trimmed[:start], true
+	for start, char := range trimmed {
+		if char != '{' {
+			continue
+		}
+		body := strings.TrimSpace(trimmed[start+1:])
+		if body == "" || strings.HasPrefix(body, `"`) || strings.HasPrefix(body, "}") ||
+			strings.HasPrefix(body, "loggedIn") {
+			return trimmed[start:], trimmed[:start], true
+		}
 	}
 	if strings.Contains(trimmed, `"loggedIn"`) {
 		return trimmed, "", true

--- a/internal/providers/probe_output.go
+++ b/internal/providers/probe_output.go
@@ -11,15 +11,29 @@ const (
 	probeJSONAuthenticated = `{"loggedIn":true}`
 	probeJSONNeedsLogin    = `{"loggedIn":false}`
 	probeJSONUnknown       = "{}"
+	probeJSONTrueLiteral   = "true"
+	probeJSONFalseLiteral  = "false"
 )
 
 // RedactAuthProbeOutput retains only the authentication verdict from structured status output.
 func RedactAuthProbeOutput(output string, limit int) string {
-	trimmed := strings.TrimSpace(output)
-	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+	payload, prefix, structured := structuredProbeOutput(output)
+	if !structured {
 		return diagnostics.RedactAndBound(output, limit)
 	}
-	loggedIn, valid := probeLoggedIn(trimmed)
+	if failure, classified := classifyProbeOutput(strings.ToLower(prefix)); classified {
+		switch failure.State {
+		case ProviderAuthStateRateLimited:
+			return "rate limit"
+		case ProviderAuthStatePermissionDenied:
+			return "permission denied"
+		case ProviderAuthStateTransient:
+			return "temporary failure"
+		case ProviderAuthStateNeedsLogin:
+			return "not authenticated"
+		}
+	}
+	loggedIn, valid := probeLoggedIn(payload)
 	if !valid {
 		return probeJSONUnknown
 	}
@@ -27,6 +41,37 @@ func RedactAuthProbeOutput(output string, limit int) string {
 		return probeJSONAuthenticated
 	}
 	return probeJSONNeedsLogin
+}
+
+func structuredProbeOutput(output string) (string, string, bool) {
+	trimmed := strings.TrimSpace(output)
+	if strings.HasPrefix(trimmed, "[") && !probeTextLabel(trimmed) {
+		return trimmed, "", true
+	}
+	if start := strings.IndexByte(trimmed, '{'); start >= 0 {
+		return trimmed[start:], trimmed[:start], true
+	}
+	if strings.Contains(trimmed, `"loggedIn"`) {
+		return trimmed, "", true
+	}
+	return "", "", false
+}
+
+func probeTextLabel(output string) bool {
+	end := strings.IndexByte(output, ']')
+	if end <= 1 {
+		return false
+	}
+	label := output[1:end]
+	if label == probeJSONTrueLiteral || label == probeJSONFalseLiteral || label == "null" {
+		return false
+	}
+	for _, char := range label {
+		if (char < 'a' || char > 'z') && (char < 'A' || char > 'Z') && char != ' ' && char != '_' && char != '-' {
+			return false
+		}
+	}
+	return true
 }
 
 func probeLoggedIn(output string) (bool, bool) {
@@ -60,9 +105,9 @@ func probeLoggedIn(output string) (bool, bool) {
 		}
 		found = true
 		switch string(value) {
-		case "true":
+		case probeJSONTrueLiteral:
 			loggedIn = true
-		case "false":
+		case probeJSONFalseLiteral:
 			loggedIn = false
 		default:
 			return false, false

--- a/internal/providers/runner.go
+++ b/internal/providers/runner.go
@@ -70,8 +70,8 @@ func DefaultProviderAuthCommandRunner(
 	err = execCmd.Run()
 	result := ProviderAuthCommandResult{
 		ExitCode:   commandExitCode(execCmd, err),
-		Stdout:     diagnostics.RedactAndBound(stdout.String(), 4096),
-		Stderr:     diagnostics.RedactAndBound(stderr.String(), 4096),
+		Stdout:     RedactAuthProbeOutput(stdout.String(), 4096),
+		Stderr:     RedactAuthProbeOutput(stderr.String(), 4096),
 		DurationMs: time.Since(startedAt).Milliseconds(),
 	}
 	if commandCtx.Err() != nil {

--- a/internal/providers/runner_test.go
+++ b/internal/providers/runner_test.go
@@ -1,9 +1,11 @@
 package providers
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,6 +52,38 @@ func TestProviderAuthCommandEnvironmentPrefix(t *testing.T) {
 
 func TestDefaultProviderAuthCommandRunner(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Should remove structured identity before bounding subprocess output", func(t *testing.T) {
+		t.Parallel()
+		shell, err := exec.LookPath("sh")
+		if err != nil {
+			t.Skipf("POSIX shell unavailable: %v", err)
+		}
+		payload := `{"email":"private@example.test","orgId":"private-org-id","orgName":"` + strings.Repeat(
+			"Private Organization ",
+			300,
+		) + `","loggedIn":true}`
+		result, err := DefaultProviderAuthCommandRunner(t.Context(), ProviderAuthCommandSpec{
+			Command: "sh", Executable: shell,
+			Args:  []string{"-c", `printf '%s' "$1"; printf '%s' "$1" >&2`, "probe", payload},
+			NoTTY: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.ExitCode != 0 {
+			t.Fatalf("ExitCode = %d, want 0", result.ExitCode)
+		}
+		for _, output := range []string{result.Stdout, result.Stderr} {
+			var verdict map[string]bool
+			if err := json.Unmarshal([]byte(output), &verdict); err != nil {
+				t.Fatal(err)
+			}
+			if len(verdict) != 1 || !verdict["loggedIn"] {
+				t.Fatalf("output = %q, want only loggedIn true", output)
+			}
+		}
+	})
 
 	t.Run("Should return when a lingering child keeps the output pipe open", func(t *testing.T) {
 		t.Parallel()

--- a/internal/session/provider_runtime_command.go
+++ b/internal/session/provider_runtime_command.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/compozy/compozy/internal/diagnostics"
 	authproviders "github.com/compozy/compozy/internal/providers"
 	"github.com/compozy/compozy/internal/sandbox"
 )
@@ -88,8 +87,8 @@ func providerRuntimeCommandRunner(
 		}
 		return authproviders.ProviderAuthCommandResult{
 			ExitCode:   result.ExitCode,
-			Stdout:     diagnostics.RedactAndBound(result.Stdout, 4096),
-			Stderr:     diagnostics.RedactAndBound(result.Stderr, 4096),
+			Stdout:     authproviders.RedactAuthProbeOutput(result.Stdout, 4096),
+			Stderr:     authproviders.RedactAuthProbeOutput(result.Stderr, 4096),
 			DurationMs: duration.Milliseconds(),
 		}, nil
 	}

--- a/packages/site/content/docs/agents/providers.mdx
+++ b/packages/site/content/docs/agents/providers.mdx
@@ -281,6 +281,14 @@ a replacement process starts a new count. Older events may omit this object.
 Use this when you need to pin a different adapter command or change the default model used by
 agents that omit `model`.
 
+Keep `claude auth status` in its default JSON mode. CompozyOS reads the top-level
+`loggedIn` boolean: `true` requires exit code zero, and `false` requests native
+login. Missing, malformed, or non-boolean verdicts remain unknown; reported
+permission, rate-limit, transport, and login errors take precedence over success.
+Structured probe output exposes only the verdict, omitting account and
+organization details from status responses and diagnostics. No translation shim
+or `--text` override is needed.
+
 ```toml
 [providers.claude]
 auth_mode = "native_cli"

--- a/skills/compozy/references/agent-definitions.md
+++ b/skills/compozy/references/agent-definitions.md
@@ -155,3 +155,9 @@ Provider aliases are small built-in conveniences, not user-configured compatibil
 Settings writes are governed by the config apply lifecycle. Provider model-only changes are live; provider command/auth changes remain restart-required. After config edits, inspect `lifecycle`, `applied`, `next_action`, `active_generation`, and `apply_record_id` in the command response or `compozy config apply-history -o json`.
 
 After native provider login, run `compozy provider auth status <provider> --remote` to probe through the daemon (`POST /api/providers/:provider_id/auth/probe` over HTTP/UDS). An `authenticated` result clears cached pre-start verdicts; retry session creation immediately. Each workspace/profile still probes its own credentials. HTTP and UDS never execute the login command.
+
+Claude's default `claude auth status` JSON is supported directly: only a valid
+`loggedIn: true` with exit zero permits authentication, while `false` requires
+native login. Invalid or missing verdicts remain unknown and error classifications
+retain precedence. Structured status output retains only the verdict, excluding
+account and organization details from probe responses and diagnostics.


### PR DESCRIPTION
Closes #623

Claude Code defaults `claude auth status` to JSON. A healthy account returned `loggedIn: true` with exit zero, but Compozy only recognized text such as `logged in`, classified it as unknown, and refused session admission. The unknown diagnostic also copied account and organization details into public status/support output.

## Behavior and implementation

- Parse the exact top-level `loggedIn` boolean. True requires exit zero; false requests native login. Missing, malformed, wrong-type, nested, duplicate, and explicit-error responses remain unknown. Error evidence from the other stream takes precedence over success, and unknown authentication still blocks admission.
- Minimize structured probe output to the verdict before bounding it. Incidental identity fields cannot influence classification or leak into diagnostics. Unrecognized structured output becomes `{}`. Native local and prepared sandbox runners share this boundary; API and CLI response projection also sanitize injected runner results.
- Preserve bracket-labeled text probes and sanitize JSON after warning prefixes. Recognized prefix errors keep their safe recovery classification; malformed mixed payloads remain unknown. Greptile finding 3995000662 is covered by the canonical classifier table.
- Preserve text probes, native credential ownership, configured executable/environment/home policies, and existing routes/DTOs/cache isolation. Negative text is now classified before positive substrings, so `not logged in` cannot authenticate on exit zero. Native login itself is unchanged.

## Verification

- Canonical provider classifier regressions reproduced the reported failure and diagnostic identity disclosure before the fix; they cover boolean/shape/exit/error precedence. The existing subprocess runner suite covers stripping identity before the output limit, and the existing API failure case covers public response privacy.
- Before the CI-only execution override, `CGO_ENABLED=1 go test -race ./internal/providers -count=1`, focused provider API race tests, and an app build passed. The final classifier cases, including structured errors and review regressions, passed in the provider race shard. Initial local gate attempts identified formatting/constants and were repaired; no completed local delivery gate is claimed.
- Real Claude CLI 2.1.266 on macOS reported boolean true/exit zero. The built app's local CLI, daemon UDS, and HTTP probes all returned authenticated with only `{"loggedIn":true}`. No login/logout or credential replacement was performed.
- A real support bundle contained 11 artifacts, including provider and diagnostic snapshots. Inspection found no current native email, organization ID, or organization name values. The isolated lab was torn down with `clean: true` and no survivors.
- Final gates ran exclusively in GitHub Actions under the user's explicit instruction. [CI run 34671837606](https://github.com/compozy/compozy/actions/runs/34671837606) passed for `1533aafeee4ae5341118b989cdcf5bc76551e335`: all eight Go race shards, static/build/platform lanes, frontend, supervised integration, runtime/desktop E2E, all four web E2E shards, and both aggregate gates. All 33 applicable PR checks are green; 17 release-only checks are correctly skipped.

## Impact and limitations

The cross-surface audit is recorded in `docs/_memory/change-impact.md`; the provider guide, official skill reference, RT-026 scenario, and dated QA report are updated. No migration, public shape replacement, or workspace/profile state change is needed. Previously created bundles are not rewritten. Web consumes the existing safe state/payload without UI changes.

The reporter's exact Linux/Claude 2.1.269 environment was unavailable. Logged-out/malformed cases use the owning deterministic tests; host credentials were preserved. No first-prompt replay was performed because this assignment prohibits creating Compozy sessions; existing integration/E2E workflows own broader session evidence. Historical Daytona QA, unverified Cursor/Codex response shapes, and overlay discovery (#627) are outside this fix.

## Final review disposition

- Greptile reviewed `1533aafee`, [confirmed both findings resolved](https://github.com/compozy/compozy/pull/632#issuecomment-5643277868), and reports no outstanding actionable findings. Both review threads are resolved.
- CodeRabbit reviewed and approved the same head. Its outside-diff suggestion to select a later JSON document was [explicitly withdrawn](https://github.com/compozy/compozy/pull/632#issuecomment-5643352898): multi-document output remains intentionally unknown to avoid ignoring an earlier logged-out/error verdict.
- CodeRabbit [accepted the repository comment convention](https://github.com/compozy/compozy/pull/632#issuecomment-5643380465); the generic private-helper docstring percentage is not actionable. The exported API contract remains documented.
- All pages of reviews, inline threads, and general comments were refreshed after CI. No actionable findings remain. The PR is open, non-draft, and mergeable; it has not been merged.
