### PR TITLE
fix: discover and bind models in provider overlays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,15 @@ jobs:
       - name: Run Go runtime verification
         run: make test
 
+      - name: Verify overlay catalog with ACP subprocesses and SQLite
+        if: matrix.shard_index == '0'
+        env:
+          CGO_ENABLED: "1"
+          COMPOZY_TEST_ACPMOCK_DRIVER_BIN: ${{ runner.temp }}/acpmock-driver
+        run: |
+          go build -o "$COMPOZY_TEST_ACPMOCK_DRIVER_BIN" ./internal/testutil/acpmock/cmd/acpmock-driver
+          go test -race -tags=integration -count=1 -timeout=5m ./internal/modelcatalog
+
       - name: Upload gotestsum timing data
         uses: actions/upload-artifact@v7
         with:

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -8,9 +8,13 @@
   registered adapter when the overlay ID has none. The overlay's command, auth mode, credential
   slots and home/environment policies remain authoritative. Settings reconciliation adds/removes
   live sources together with the durable catalog generation; no daemon restart is needed.
+  Removing an overlay deletes only its derived live cache across all execution contexts in that
+  transaction, so recreating it offline cannot revive the removed account observations.
 - **Workspace data isolation:** account observations keep the overlay provider/source IDs and
   profile/workspace execution contexts. Command/runtime changes invalidate discovery identity.
   Session binding reads the overlay source, never the runtime family's account observations.
+  Active and stopped runtime-selection admission resolve the configured runtime family while
+  retaining the overlay ID for catalog membership.
 - **Compatibility:** existing config, model IDs, database shapes and public DTOs remain unchanged.
   Built-in model identities are mapping hints for advertised Claude aliases only; they create no
   overlay rows and confer no account availability. Existing short curated aliases remain valid.

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -1,5 +1,29 @@
 # Compozy Change Impact
 
+## Issue 627 — Overlay model discovery and binding
+
+- **Native tools:** existing provider model list/status/refresh/curate and session-create tools keep
+  their IDs and schemas. CLI, HTTP, UDS and Extension Host consume the same corrected catalog rows.
+- **Extensibility/hooks/config:** no new key, hook, SDK or permission. `runtime_provider` selects a
+  registered adapter when the overlay ID has none. The overlay's command, auth mode, credential
+  slots and home/environment policies remain authoritative. Settings reconciliation adds/removes
+  live sources together with the durable catalog generation; no daemon restart is needed.
+- **Workspace data isolation:** account observations keep the overlay provider/source IDs and
+  profile/workspace execution contexts. Command/runtime changes invalidate discovery identity.
+  Session binding reads the overlay source, never the runtime family's account observations.
+- **Compatibility:** existing config, model IDs, database shapes and public DTOs remain unchanged.
+  Built-in model identities are mapping hints for advertised Claude aliases only; they create no
+  overlay rows and confer no account availability. Existing short curated aliases remain valid.
+- **Official skill:** runtime operations now explain overlay-scoped discovery and binding.
+- **Web/Docs/QA:** no Web component or layout changes; Settings and runtime selectors receive the
+  shared corrected projection. Model catalog docs and `RT-model-catalog-cold-open` cover overlays.
+  Owning checks: live-source and session suites, daemon reconciliation suite, and the SQLite/ACP
+  subprocess catalog integration suite. Real provider authentication is not inferred from fixtures.
+- **Related work:** PR #550 owns curated-merge semantics and broader picker/startability changes.
+  This fix is based independently on main and changes only overlay discovery/binding plus necessary
+  source lifecycle handling. Its overlapping Claude binding code must preserve overlay ownership
+  when that PR is integrated. Issue #623 owns auth classification; it is excluded here.
+
 ## Issue 616 — Supervised work recovery
 
 - **Native tools:** existing session stop, task inspection/recovery and Loop status IDs and schemas

--- a/docs/qa/scenarios/RT-model-catalog-cold-open.md
+++ b/docs/qa/scenarios/RT-model-catalog-cold-open.md
@@ -50,3 +50,8 @@ continues to cover unchanged selector interactions.
 5. Change the overlay command and refresh; prior account rows must not remain live under the new
    execution identity. Remove the overlay through Settings and confirm it leaves scheduled discovery
    and catalog projections without restarting the daemon.
+
+6. Recreate the removed overlay with the same command while its discovery is unavailable. No
+   previously removed live models may reappear, including stale entries from other profiles/workspaces.
+7. For a Cursor-family overlay with an explicit discovery command, set an advertised logical runtime
+   model on active and stopped sessions. Reject raw aliases before persisting a selection revision.

--- a/docs/qa/scenarios/RT-model-catalog-cold-open.md
+++ b/docs/qa/scenarios/RT-model-catalog-cold-open.md
@@ -35,3 +35,18 @@ QA 2026-08-28: pass. A fresh isolated onboarding opened the model picker once an
 showed Cursor Agent, Grok 4.5, Grok 4.6, and GPT-5.6 Terra without pressing catalog refresh.
 
 QA 2026-09-09: pass for the changed catalog/reasoning journey. Fresh native discovery exposed Astra through Ultra, Luna through Max, Grok 4.5 through High and Grok 4.6 through Extra high. Saved runtime survived reload/restart. Native Cursor and Codex prompts completed; unsupported Cursor combinations returned 400 without changing the selection. See the current report for captures, exact runtime evidence and limits.
+
+QA impact 2026-09-12, issue #627: overlay discovery must remain account-scoped. The added checks
+below are pending until the issue delivery report records their evidence; earlier evidence above
+continues to cover unchanged selector interactions.
+
+1. Create a provider overlay with `runtime_provider = "claude"` and its own account command.
+2. Refresh/list that provider and inspect `provider_live:<overlay-id>` status. Only its advertised
+   models should appear; a runtime-family seed alone must not create a live model.
+3. Curate a returned logical ID and start a session. The overlay command must receive its advertised
+   transport alias while the persisted session keeps the overlay provider and logical model ID.
+4. With two accounts advertising different models, verify that neither catalog or session admission
+   accepts the other account's live bindings.
+5. Change the overlay command and refresh; prior account rows must not remain live under the new
+   execution identity. Remove the overlay through Settings and confirm it leaves scheduled discovery
+   and catalog projections without restarting the daemon.

--- a/internal/daemon/model_catalog.go
+++ b/internal/daemon/model_catalog.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	compozyconfig "github.com/compozy/compozy/internal/config"
 	extensionpkg "github.com/compozy/compozy/internal/extension"
 	"github.com/compozy/compozy/internal/modelcatalog"
 )
@@ -27,6 +28,8 @@ type modelCatalogRuntime struct {
 	timeout            time.Duration
 	configSource       *modelcatalog.ProviderConfigSource
 	liveSources        map[string]*modelcatalog.LiveProviderSource
+	liveSourcesMu      sync.RWMutex
+	liveSourceFactory  func(map[string]compozyconfig.ProviderConfig) ([]modelcatalog.Source, error)
 	dynamicSources     map[string]modelcatalog.Source
 	executionContextMu sync.RWMutex
 	executionContexts  map[string]modelcatalog.CatalogExecutionContext
@@ -396,6 +399,12 @@ func (d *Daemon) bootModelCatalog(ctx context.Context, state *bootState, cleanup
 			}
 			runtime.liveSources[typed.ProviderIDs()[0]] = typed
 		}
+	}
+	runtime.liveSourceFactory = func(providers map[string]compozyconfig.ProviderConfig) ([]modelcatalog.Source, error) {
+		return modelcatalog.NewLiveProviderSources(&modelcatalog.LiveProviderSourcesConfig{
+			Providers: providers, HomePaths: d.homePaths, BaseEnv: os.Environ(),
+			SecretResolver: d.modelCatalogSecretResolver(state), HTTPClient: httpClient, DefaultTimeout: sourceTimeout,
+		})
 	}
 	state.modelCatalog = runtime
 	runtime.startDynamicRefreshLoop()

--- a/internal/daemon/model_catalog_refresh_loop.go
+++ b/internal/daemon/model_catalog_refresh_loop.go
@@ -76,6 +76,8 @@ func (r *modelCatalogRuntime) dynamicRefreshTargets() []modelCatalogRefreshTarge
 	if r == nil {
 		return nil
 	}
+	r.liveSourcesMu.RLock()
+	defer r.liveSourcesMu.RUnlock()
 	sources := make(map[string]modelcatalog.Source, len(r.dynamicSources)+len(r.liveSources))
 	maps.Copy(sources, r.dynamicSources)
 	for _, source := range r.liveSources {

--- a/internal/daemon/model_catalog_staging.go
+++ b/internal/daemon/model_catalog_staging.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"time"
 
@@ -54,6 +56,9 @@ func (r *modelCatalogRuntime) stageModelCatalogGeneration(
 			"daemon: create model catalog refresh plan: %w",
 			err,
 		)
+	}
+	if err := plan.SetLiveSources(slices.Collect(maps.Values(live.sources))); err != nil {
+		return stagedModelCatalogGeneration{}, fmt.Errorf("daemon: stage live model catalog sources: %w", err)
 	}
 	now := time.Now().UTC()
 	if r.now != nil {
@@ -142,9 +147,14 @@ func (r *modelCatalogRuntime) publishModelCatalogGeneration(generation stagedMod
 	if updater, ok := r.service.(modelCatalogMergeOptionsUpdater); ok {
 		updater.UpdateMergeOptions(modelcatalog.MergeOptions{ReasoningApply: generation.reasoningApply})
 	}
-	for providerID, source := range r.liveSources {
-		source.ReplaceProvider(generation.live.effective[providerID])
+	r.liveSourcesMu.Lock()
+	for id, source := range r.dynamicSources {
+		if source.Kind() == modelcatalog.SourceKindProviderLive {
+			delete(r.dynamicSources, id)
+		}
 	}
+	r.liveSources = generation.live.sources
+	r.liveSourcesMu.Unlock()
 }
 
 func reconcileProviderIDs(
@@ -171,7 +181,22 @@ func (r *modelCatalogRuntime) stageLiveProviderConfigs(
 ) (stagedLiveProviderConfigs, error) {
 	resolver := &compozyconfig.Config{Providers: providers}
 	effective := make(map[string]compozyconfig.ProviderConfig, len(r.liveSources))
-	for providerID := range r.liveSources {
+	candidates := maps.Clone(r.liveSources)
+	if r.liveSourceFactory != nil {
+		sources, err := r.liveSourceFactory(providers)
+		if err != nil {
+			return stagedLiveProviderConfigs{}, err
+		}
+		candidates = make(map[string]*modelcatalog.LiveProviderSource, len(sources))
+		for _, source := range sources {
+			live, ok := source.(*modelcatalog.LiveProviderSource)
+			if !ok {
+				return stagedLiveProviderConfigs{}, fmt.Errorf("daemon: unexpected live source type %T", source)
+			}
+			candidates[live.ProviderIDs()[0]] = live
+		}
+	}
+	for providerID := range candidates {
 		provider, err := resolver.ResolveProvider(providerID)
 		if err != nil {
 			return stagedLiveProviderConfigs{}, fmt.Errorf(
@@ -188,7 +213,13 @@ func (r *modelCatalogRuntime) stageLiveProviderConfigs(
 		previous:  make(map[string]*modelcatalog.LiveProviderSource, len(r.liveSources)),
 		changed:   make([]string, 0, len(r.liveSources)),
 	}
-	for providerID, source := range r.liveSources {
+	for providerID, candidate := range candidates {
+		source := r.liveSources[providerID]
+		if source == nil {
+			staged.sources[providerID] = candidate
+			staged.changed = append(staged.changed, providerID)
+			continue
+		}
 		clone, changed, err := source.CloneWithProvider(effective[providerID])
 		if err != nil {
 			return stagedLiveProviderConfigs{}, fmt.Errorf(
@@ -212,9 +243,7 @@ func previousLiveExecutionContext(
 	executionContext modelcatalog.CatalogExecutionContext,
 ) (modelcatalog.CatalogExecutionContext, error) {
 	if source == nil {
-		return modelcatalog.CatalogExecutionContext{}, errors.New(
-			"daemon: previous live model catalog source is required",
-		)
+		return modelcatalog.CatalogExecutionContext{}, nil
 	}
 	fingerprint, err := source.CatalogExecutionFingerprint()
 	if err != nil {

--- a/internal/daemon/model_catalog_test.go
+++ b/internal/daemon/model_catalog_test.go
@@ -99,6 +99,23 @@ func TestDaemonModelCatalogWiring(t *testing.T) {
 				t.Fatal("removed overlay still scheduled")
 			}
 		}
+
+		probe.mu.Lock()
+		probe.err = errors.New("overlay discovery offline")
+		probe.mu.Unlock()
+		if err := runtime.ReconcileConfig(ctx, cfg); err != nil {
+			t.Fatal(err)
+		}
+		models, err = runtime.ListModels(
+			ctx,
+			modelcatalog.ListOptions{ProviderID: overlay, View: modelcatalog.CatalogViewAll},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(models) != 0 {
+			t.Fatalf("recreated offline overlay revived deleted account models: %#v", models)
+		}
 	})
 
 	t.Run("Should preserve builtin model mappings while staging a partial provider override", func(t *testing.T) {
@@ -1860,6 +1877,7 @@ func (s *catalogReadRefreshService) waitForRefresh(
 }
 
 type configReloadACPProbe struct {
+	err      error
 	mu       sync.Mutex
 	requests []modelcatalog.DiscoveryCommandRequest
 }
@@ -1991,7 +2009,11 @@ func (e *configReloadACPProbe) RunDiscoveryCommand(
 ) (modelcatalog.DiscoveryCommandResult, error) {
 	e.mu.Lock()
 	e.requests = append(e.requests, req)
+	err := e.err
 	e.mu.Unlock()
+	if err != nil {
+		return modelcatalog.DiscoveryCommandResult{}, err
+	}
 	if req.Command == "cursor-offline" {
 		return modelcatalog.DiscoveryCommandResult{Stderr: "cursor discovery offline"},
 			errors.New("cursor discovery offline")

--- a/internal/daemon/model_catalog_test.go
+++ b/internal/daemon/model_catalog_test.go
@@ -22,6 +22,85 @@ import (
 func TestDaemonModelCatalogWiring(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should register and remove overlay discovery during config reconciliation", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		home := testHomePaths(t)
+		db, err := openDaemonTestGlobalDBAtPath(ctx, home.DatabaseFile)
+		if err != nil {
+			t.Fatal(err)
+		}
+		configSource := modelcatalog.NewConfigSource(nil)
+		service, err := modelcatalog.NewService(db, []modelcatalog.Source{configSource}, modelcatalog.MergeOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		runtime, err := newModelCatalogRuntime(ctx, service, discardLogger(), nil, 5*time.Second)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := runtime.Shutdown(context.Background()); err != nil {
+				t.Error(err)
+			}
+			if err := db.Close(context.Background()); err != nil {
+				t.Error(err)
+			}
+		})
+		runtime.configSource = configSource
+		probe := &configReloadACPProbe{}
+		runtime.liveSourceFactory = func(providers map[string]compozyconfig.ProviderConfig) ([]modelcatalog.Source, error) {
+			sources := make([]modelcatalog.Source, 0, len(providers))
+			for id, provider := range providers {
+				source, err := modelcatalog.NewLiveProviderSource(id, provider, &modelcatalog.LiveProviderSourcesConfig{
+					HomePaths: home, CommandExecutor: probe,
+				})
+				if err != nil {
+					return nil, err
+				}
+				sources = append(sources, source)
+			}
+			return sources, nil
+		}
+		const overlay = "cursor-secondary"
+		cfg := &compozyconfig.Config{Providers: map[string]compozyconfig.ProviderConfig{overlay: {
+			RuntimeProvider: "cursor",
+			Command:         "cursor-agent acp",
+			AuthMode:        compozyconfig.ProviderAuthModeNativeCLI,
+			Models: compozyconfig.ProviderModelsConfig{
+				Discovery: compozyconfig.ProviderModelsDiscoveryConfig{Command: "cursor-new"},
+			},
+		}}}
+		if err := runtime.ReconcileConfig(ctx, cfg); err != nil {
+			t.Fatal(err)
+		}
+		models, err := runtime.ListModels(ctx, modelcatalog.ListOptions{ProviderID: overlay})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(models) != 1 || models[0].ProviderID != overlay || models[0].ModelID != "new-model" {
+			t.Fatalf("overlay models = %#v", models)
+		}
+		if request := probe.LastRequest(t); request.ProviderID != overlay {
+			t.Fatalf("probe provider = %q", request.ProviderID)
+		}
+		if err := runtime.ReconcileConfig(ctx, &compozyconfig.Config{}); err != nil {
+			t.Fatal(err)
+		}
+		models, err = runtime.ListModels(ctx, modelcatalog.ListOptions{ProviderID: overlay})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(models) != 0 {
+			t.Fatalf("removed overlay leaked rows: %#v", models)
+		}
+		for _, target := range runtime.dynamicRefreshTargets() {
+			if target.providerID == overlay {
+				t.Fatal("removed overlay still scheduled")
+			}
+		}
+	})
+
 	t.Run("Should preserve builtin model mappings while staging a partial provider override", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/modelcatalog/live_sources.go
+++ b/internal/modelcatalog/live_sources.go
@@ -127,9 +127,9 @@ func NewLiveProviderSources(cfg *LiveProviderSourcesConfig) ([]Source, error) {
 			providerSet[providerID] = struct{}{}
 		}
 	}
-	for providerID := range cfg.Providers {
+	for providerID, provider := range cfg.Providers {
 		providerID = compozyconfig.CanonicalProviderName(providerID)
-		if _, registered := liveProviderAdapters[providerID]; registered {
+		if _, registered := liveProviderAdapterFor(providerID, provider); registered {
 			providerSet[providerID] = struct{}{}
 		}
 	}
@@ -156,7 +156,7 @@ func NewLiveProviderSource(
 	cfg *LiveProviderSourcesConfig,
 ) (*LiveProviderSource, error) {
 	trimmedProviderID := strings.TrimSpace(providerID)
-	adapter, ok := liveProviderAdapters[trimmedProviderID]
+	adapter, ok := liveProviderAdapterFor(trimmedProviderID, provider)
 	if !ok {
 		return nil, fmt.Errorf(
 			"model catalog: live discovery adapter for provider %q is not registered",
@@ -330,7 +330,9 @@ func liveDiscoveryConfigChanged(
 	current compozyconfig.ProviderConfig,
 	next compozyconfig.ProviderConfig,
 ) bool {
-	return !reflect.DeepEqual(current.Models.Discovery, next.Models.Discovery) ||
+	return strings.TrimSpace(current.Command) != strings.TrimSpace(next.Command) ||
+		current.RuntimeProviderName("") != next.RuntimeProviderName("") ||
+		!reflect.DeepEqual(current.Models.Discovery, next.Models.Discovery) ||
 		strings.TrimSpace(current.BaseURL) != strings.TrimSpace(next.BaseURL) ||
 		current.EffectiveHarness() != next.EffectiveHarness() ||
 		current.EffectiveAuthMode() != next.EffectiveAuthMode() ||

--- a/internal/modelcatalog/live_sources_acp.go
+++ b/internal/modelcatalog/live_sources_acp.go
@@ -89,7 +89,13 @@ func (s *LiveProviderSource) listACP(
 			s.providerID,
 		)
 	}
-	rows := acpModelRows(s.providerID, provider.Models, s.adapter.parseACPModelRows, modelOption, now)
+	rows := acpModelRows(
+		s.providerID,
+		liveModelMappings(s.providerID, provider),
+		s.adapter.parseACPModelRows,
+		modelOption,
+		now,
+	)
 	if len(rows) == 0 {
 		return nil, fmt.Errorf(
 			"model catalog: %s ACP model option did not advertise model values",
@@ -168,4 +174,29 @@ func acpModelRows(
 func (s *LiveProviderSource) usesNativeCodexDiscovery(provider compozyconfig.ProviderConfig) bool {
 	return s.providerID == liveSourcesCodexKey && strings.TrimSpace(provider.Models.Discovery.Command) == "" &&
 		providerexec.StrategyFor(provider).NativeCLI.Command == "codex"
+}
+
+func liveModelMappings(providerID string, provider compozyconfig.ProviderConfig) compozyconfig.ProviderModelsConfig {
+	models := provider.Models
+	builtins := compozyconfig.BuiltinProviders()
+	if _, builtin := builtins[providerID]; builtin {
+		return models
+	}
+	runtimeProvider := compozyconfig.CanonicalProviderName(provider.RuntimeProvider)
+	builtin, ok := builtins[runtimeProvider]
+	if !ok {
+		return models
+	}
+	// Seed identities only; the live response remains the sole source of advertised rows.
+	seen := make(map[string]bool, len(models.Curated))
+	for _, model := range models.Curated {
+		seen[model.ID] = true
+	}
+	models.Curated = append([]compozyconfig.ProviderModelConfig(nil), models.Curated...)
+	for _, model := range builtin.Models.Curated {
+		if !seen[model.ID] {
+			models.Curated = append(models.Curated, model)
+		}
+	}
+	return models
 }

--- a/internal/modelcatalog/live_sources_adapters.go
+++ b/internal/modelcatalog/live_sources_adapters.go
@@ -143,6 +143,15 @@ var liveProviderAdapters = map[string]liveProviderAdapter{
 	},
 }
 
+func liveProviderAdapterFor(providerID string, provider compozyconfig.ProviderConfig) (liveProviderAdapter, bool) {
+	adapter, ok := liveProviderAdapters[compozyconfig.CanonicalProviderName(providerID)]
+	if ok {
+		return adapter, true
+	}
+	adapter, ok = liveProviderAdapters[compozyconfig.CanonicalProviderName(provider.RuntimeProvider)]
+	return adapter, ok
+}
+
 func (s *LiveProviderSource) discoveryTarget(
 	provider compozyconfig.ProviderConfig,
 ) (liveDiscoveryTarget, error) {
@@ -190,6 +199,12 @@ func (s *LiveProviderSource) discoveryTarget(
 			timeout:  timeout,
 		}, nil
 	case liveDiscoveryCommand:
+		if _, registered := liveProviderAdapters[s.providerID]; !registered {
+			return liveDiscoveryTarget{}, fmt.Errorf(
+				"model catalog: provider overlay %q requires models.discovery.command for command discovery",
+				s.providerID,
+			)
+		}
 		return liveDiscoveryTarget{
 			kind:    liveDiscoveryCommand,
 			command: s.adapter.defaultCommand,
@@ -263,10 +278,14 @@ func (s *LiveProviderSource) CatalogExecutionFingerprint() (string, error) {
 	}
 	modelMappings := ""
 	if s.adapter.parseACPModelRows != nil {
-		modelMappings = providerModelMappingFingerprint(provider.Models)
+		modelMappings = providerModelMappingFingerprint(liveModelMappings(s.providerID, provider))
+	}
+	providerIdentity := s.providerID
+	if _, registered := liveProviderAdapters[s.providerID]; !registered {
+		providerIdentity += "\x1f" + provider.RuntimeProviderName(s.providerID)
 	}
 	return CatalogExecutionFingerprint(
-		s.providerID,
+		providerIdentity,
 		string(target.kind),
 		strings.TrimSpace(target.endpoint),
 		command,

--- a/internal/modelcatalog/live_sources_test.go
+++ b/internal/modelcatalog/live_sources_test.go
@@ -897,6 +897,71 @@ func TestLiveProviderRefreshCoalescing(t *testing.T) {
 func TestLiveProviderSourceRegistration(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should discover overlay models with its own execution and transport identity", func(t *testing.T) {
+		t.Parallel()
+		const overlay = "claude-secondary"
+		command := "env CLAUDE_CONFIG_DIR=/account-secondary claude-acp"
+		probe := &fakeACPModelProbe{options: []acp.SessionConfigOption{{
+			ID: "model", Category: "model", Kind: acp.SessionConfigOptionKindSelect,
+			Values: []acp.SessionConfigOptionValue{{Value: "haiku", Label: "Haiku"}},
+		}}}
+		providers := map[string]compozyconfig.ProviderConfig{overlay: {
+			RuntimeProvider: "claude", Command: command, AuthMode: compozyconfig.ProviderAuthModeNativeCLI,
+			Harness: compozyconfig.ProviderHarnessACP,
+		}}
+		sources, err := NewLiveProviderSources(&LiveProviderSourcesConfig{
+			Providers: providers, ACPProbe: probe, BaseEnv: []string{"PATH=/bin", "ANTHROPIC_API_KEY=ambient-secret"},
+			WorkingDir: t.TempDir(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var source *LiveProviderSource
+		for _, candidate := range sources {
+			if candidate.ID() == SourceKindProviderLiveID(overlay) {
+				source = candidate.(*LiveProviderSource)
+			}
+		}
+		if source == nil {
+			t.Fatal("overlay live source is missing")
+		}
+		rows, err := source.ListModels(t.Context(), ListOptions{ProviderID: overlay, Now: testTime(0)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		row := requireSingleRow(t, rows)
+		if row.ProviderID != overlay || row.SourceID != SourceKindProviderLiveID(overlay) ||
+			row.ModelID != "claude-haiku-4-5-20251001" {
+			t.Fatalf("overlay row = %#v", row)
+		}
+		assertClaudeTransportBinding(t, row, "haiku")
+		request := probe.singleRequest(t)
+		if request.ProviderID != overlay || request.Command != command || request.Cwd != source.workingDir {
+			t.Fatalf("overlay execution = %#v", request)
+		}
+		if firstEnvValue(request.Env, "COMPOZY_PROVIDER") != overlay ||
+			firstEnvValue(request.Env, "ANTHROPIC_API_KEY") != "" {
+			t.Fatalf("overlay environment = %#v", request.Env)
+		}
+		fingerprint, err := source.CatalogExecutionFingerprint()
+		if err != nil {
+			t.Fatal(err)
+		}
+		changedProvider := providers[overlay]
+		changedProvider.Command = "env CLAUDE_CONFIG_DIR=/account-other claude-acp"
+		clone, changed, err := source.CloneWithProvider(changedProvider)
+		if err != nil {
+			t.Fatal(err)
+		}
+		nextFingerprint, err := clone.CatalogExecutionFingerprint()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !changed || fingerprint == nextFingerprint {
+			t.Fatal("account command change reused discovery identity")
+		}
+	})
+
 	t.Run("Should preserve builtin model mappings under a partial provider override", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/modelcatalog/service.go
+++ b/internal/modelcatalog/service.go
@@ -20,6 +20,7 @@ type sourceTTLProvider interface {
 // CatalogService refreshes sources and projects stored model catalog rows.
 type CatalogService struct {
 	store                   Store
+	sourcesMu               sync.RWMutex
 	sources                 []Source
 	sourceByID              map[string]Source
 	mergeMu                 sync.RWMutex
@@ -99,7 +100,7 @@ func (s *CatalogService) ListModels(ctx context.Context, opts ListOptions) ([]Mo
 	opts.ExecutionContext = s.requestExecutionContext(opts.ExecutionContext)
 	listOpts := opts
 	listOpts.Now = now
-	sourceContexts, err := resolveReadSourceExecutionContexts(s.sources, listOpts.ExecutionContext)
+	sourceContexts, err := resolveReadSourceExecutionContexts(s.sourcesSnapshot(), listOpts.ExecutionContext)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +121,7 @@ func (s *CatalogService) ListModels(ctx context.Context, opts ListOptions) ([]Mo
 		needsRefresh = len(sourceRows) == 0 && !bootstrapHandled
 	}
 
-	if opts.Refresh || (needsRefresh && !opts.SkipRefreshIfEmpty && len(s.sources) > 0) {
+	if opts.Refresh || (needsRefresh && !opts.SkipRefreshIfEmpty && len(s.sourcesSnapshot()) > 0) {
 		statuses, err := s.Refresh(ctx, RefreshOptions{
 			ProviderID:       opts.ProviderID,
 			SourceID:         opts.SourceID,
@@ -210,7 +211,7 @@ func (s *CatalogService) ListSourceStatus(ctx context.Context, opts StatusOption
 		return nil, fmt.Errorf("model catalog status context is required")
 	}
 	opts.ExecutionContext = s.requestExecutionContext(opts.ExecutionContext)
-	sourceContexts, err := resolveReadSourceExecutionContexts(s.sources, opts.ExecutionContext)
+	sourceContexts, err := resolveReadSourceExecutionContexts(s.sourcesSnapshot(), opts.ExecutionContext)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +221,9 @@ func (s *CatalogService) ListSourceStatus(ctx context.Context, opts StatusOption
 	if err != nil {
 		return nil, fmt.Errorf("model catalog: list source status: %w", err)
 	}
+	s.sourcesMu.RLock()
 	statuses = filterStatusesByProviderOwnership(statuses, s.sourceByID, opts.ProviderID)
+	s.sourcesMu.RUnlock()
 	for index := range statuses {
 		statuses[index].LastError = RedactString(statuses[index].LastError)
 	}
@@ -376,6 +379,8 @@ func (s *CatalogService) storedProvidersForSource(
 }
 
 func (s *CatalogService) selectSources(sourceID string) ([]Source, error) {
+	s.sourcesMu.RLock()
+	defer s.sourcesMu.RUnlock()
 	trimmed := strings.TrimSpace(sourceID)
 	if trimmed == "" {
 		return s.sources, nil

--- a/internal/modelcatalog/service_integration_test.go
+++ b/internal/modelcatalog/service_integration_test.go
@@ -5,9 +5,11 @@ package modelcatalog_test
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -19,11 +21,96 @@ import (
 	storepkg "github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/store/globaldb"
 	"github.com/compozy/compozy/internal/testutil"
+	"github.com/compozy/compozy/internal/testutil/acpmock"
 	_ "modernc.org/sqlite"
 )
 
 func TestCatalogServiceGlobalDBIntegration(t *testing.T) {
 	t.Parallel()
+
+	t.Run("Should discover account scoped Claude overlays through ACP subprocesses and SQLite", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		driver := acpmock.RequireDriver(t)
+		fixture := acpmock.Fixture{Version: acpmock.FixtureVersion}
+		for _, name := range []string{"haiku", "sonnet"} {
+			fixture.Agents = append(fixture.Agents, acpmock.AgentFixture{
+				Name:     name,
+				Provider: "claude",
+				Model:    name,
+				ConfigOptions: []acpmock.SessionConfigOptionFixture{{
+					ID: "model", Name: "Model", Category: "model", Current: name,
+					Values: []acpmock.SessionConfigOptionValueFixture{{Value: name, Label: name}},
+				}},
+				Turns: []acpmock.TurnFixture{
+					{
+						Match: acpmock.TurnMatch{UserText: "noop"},
+						Steps: []acpmock.Step{{Kind: acpmock.StepKindAssistant, Chunks: []string{"noop"}}},
+					},
+				},
+			})
+		}
+		data, err := json.Marshal(fixture)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fixturePath := filepath.Join(t.TempDir(), "overlay-fixture.json")
+		if err := os.WriteFile(fixturePath, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		store, _ := openCatalogGlobalDB(t)
+		var sources []modelcatalog.Source
+		for _, name := range []string{"haiku", "sonnet"} {
+			providerID := "claude-" + name
+			provider := compozyconfig.ProviderConfig{
+				RuntimeProvider: "claude", Command: acpmock.BuildCommand(driver, fixturePath, name, ""),
+				Harness: compozyconfig.ProviderHarnessACP, AuthMode: compozyconfig.ProviderAuthModeNativeCLI,
+			}
+			source, err := modelcatalog.NewLiveProviderSource(
+				providerID,
+				provider,
+				&modelcatalog.LiveProviderSourcesConfig{
+					BaseEnv: os.Environ(), WorkingDir: t.TempDir(),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			sources = append(sources, source)
+		}
+		service, err := modelcatalog.NewService(store, sources, modelcatalog.MergeOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		execution := modelcatalog.CatalogExecutionContext{
+			Scope:     modelcatalog.ExecutionScopeProfile,
+			ProfileID: "overlay-test",
+		}
+		for _, test := range []struct{ provider, model, transport string }{
+			{"claude-haiku", "claude-haiku-4-5-20251001", "haiku"},
+			{"claude-sonnet", "claude-sonnet-5", "sonnet"},
+		} {
+			models, err := service.ListModels(
+				ctx,
+				modelcatalog.ListOptions{
+					ProviderID:       test.provider,
+					ExecutionContext: execution,
+					Now:              integrationTime(0),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(models) != 1 || models[0].ProviderID != test.provider || models[0].ModelID != test.model ||
+				models[0].AvailabilityState != modelcatalog.AvailabilityStateAvailableLive {
+				t.Fatalf("account catalog = %#v", models)
+			}
+			if len(models[0].TransportBindings) != 1 ||
+				models[0].TransportBindings[0].TransportModelID != test.transport {
+				t.Fatalf("transport bindings = %#v", models[0].TransportBindings)
+			}
+		}
+	})
 
 	t.Run("Should refresh and list rows by provider with global DB store", func(t *testing.T) {
 		t.Parallel()

--- a/internal/modelcatalog/service_refresh_plan.go
+++ b/internal/modelcatalog/service_refresh_plan.go
@@ -10,8 +10,9 @@ import (
 
 // RefreshPlan buffers source replacements until a whole catalog generation is ready.
 type RefreshPlan struct {
-	owner *CatalogService
-	store *refreshPlanStore
+	owner   *CatalogService
+	store   *refreshPlanStore
+	sources *CatalogService
 }
 
 // NewRefreshPlan creates an isolated, read-through refresh generation.
@@ -62,7 +63,47 @@ func (s *CatalogService) CommitRefreshPlan(ctx context.Context, plan *RefreshPla
 	if plan == nil || plan.store == nil || plan.owner != s {
 		return errors.New("model catalog: refresh plan does not belong to service")
 	}
-	return s.store.ReplaceSourceRowsBatch(ctx, plan.store.snapshot())
+	if err := s.store.ReplaceSourceRowsBatch(ctx, plan.store.snapshot()); err != nil {
+		return err
+	}
+	if plan.sources != nil {
+		s.sourcesMu.Lock()
+		s.sources = plan.sources.sources
+		s.sourceByID = plan.sources.sourceByID
+		s.sourcesMu.Unlock()
+	}
+	return nil
+}
+
+// SetLiveSources stages the complete live source registry with its durable generation.
+func (p *RefreshPlan) SetLiveSources(live []*LiveProviderSource) error {
+	if p == nil || p.owner == nil {
+		return errors.New("model catalog: refresh plan is required")
+	}
+	sources := make([]Source, 0)
+	for _, source := range p.owner.sourcesSnapshot() {
+		if source.Kind() != SourceKindProviderLive {
+			sources = append(sources, source)
+		}
+	}
+	for _, source := range live {
+		if source == nil {
+			return errors.New("model catalog: live source is required")
+		}
+		sources = append(sources, source)
+	}
+	staged, err := NewService(p.owner.store, sources, MergeOptions{})
+	if err != nil {
+		return err
+	}
+	p.sources = staged
+	return nil
+}
+
+func (s *CatalogService) sourcesSnapshot() []Source {
+	s.sourcesMu.RLock()
+	defer s.sourcesMu.RUnlock()
+	return s.sources
 }
 
 type refreshPlanStore struct {

--- a/internal/modelcatalog/service_refresh_plan.go
+++ b/internal/modelcatalog/service_refresh_plan.go
@@ -97,6 +97,26 @@ func (p *RefreshPlan) SetLiveSources(live []*LiveProviderSource) error {
 		return err
 	}
 	p.sources = staged
+	for _, source := range p.owner.sourcesSnapshot() {
+		if source.Kind() != SourceKindProviderLive {
+			continue
+		}
+		if _, exists := staged.sourceByID[source.ID()]; exists {
+			continue
+		}
+		owned, ok := source.(sourceProviderLister)
+		if !ok {
+			return errors.New("model catalog: live source provider ownership is required")
+		}
+		for _, providerID := range owned.ProviderIDs() {
+			key := removedSourceKey(source.ID(), providerID)
+			p.store.replacements[key] = SourceRowsReplacement{
+				SourceID:     source.ID(),
+				ProviderID:   providerID,
+				RemoveSource: true,
+			}
+		}
+	}
 	return nil
 }
 
@@ -154,11 +174,7 @@ func (s *refreshPlanStore) ReplaceSourceRowsBatch(
 	next := make(map[string]SourceRowsReplacement, len(s.replacements)+len(replacements))
 	maps.Copy(next, s.replacements)
 	for _, replacement := range replacements {
-		key, err := refreshPlanSourceProviderKey(
-			replacement.ExecutionContext,
-			replacement.SourceID,
-			replacement.ProviderID,
-		)
+		key, err := replacementKey(replacement)
 		if err != nil {
 			return err
 		}
@@ -281,12 +297,26 @@ func replacementMatchesStatus(
 	return replacementMatchesSourceProvider(replacements, opts.SourceContexts, status.SourceID, status.ProviderID)
 }
 
+func removedSourceKey(sourceID, providerID string) string {
+	return "removed\x00" + sourceID + "\x00" + providerID
+}
+
+func replacementKey(replacement SourceRowsReplacement) (string, error) {
+	if replacement.RemoveSource {
+		return removedSourceKey(replacement.SourceID, replacement.ProviderID), nil
+	}
+	return refreshPlanSourceProviderKey(replacement.ExecutionContext, replacement.SourceID, replacement.ProviderID)
+}
+
 func replacementMatchesSourceProvider(
 	replacements map[string]SourceRowsReplacement,
 	contexts map[string]CatalogExecutionContext,
 	sourceID string,
 	providerID string,
 ) bool {
+	if _, removed := replacements[removedSourceKey(sourceID, providerID)]; removed {
+		return true
+	}
 	executionContext, ok := contexts[sourceID]
 	if !ok {
 		return false
@@ -303,6 +333,9 @@ func replacementContextSelected(
 	replacement SourceRowsReplacement,
 	contexts map[string]CatalogExecutionContext,
 ) bool {
+	if replacement.RemoveSource {
+		return false
+	}
 	selected, ok := contexts[replacement.SourceID]
 	if !ok {
 		return false

--- a/internal/modelcatalog/service_test.go
+++ b/internal/modelcatalog/service_test.go
@@ -3158,6 +3158,15 @@ func (s *memoryStore) ReplaceSourceRowsBatch(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, replacement := range replacements {
+		if replacement.RemoveSource {
+			for key, status := range s.statuses {
+				if status.SourceID == replacement.SourceID && status.ProviderID == replacement.ProviderID {
+					delete(s.statuses, key)
+					delete(s.rows, key)
+				}
+			}
+			continue
+		}
 		s.replaceCount++
 		key, err := sourceProviderContextKey(
 			replacement.ExecutionContext,

--- a/internal/modelcatalog/types.go
+++ b/internal/modelcatalog/types.go
@@ -229,6 +229,8 @@ type Source interface {
 
 // SourceRowsReplacement is one provider-scoped source publication.
 type SourceRowsReplacement struct {
+	// RemoveSource deletes the live source for this provider across all execution contexts.
+	RemoveSource     bool
 	ExecutionContext CatalogExecutionContext
 	SourceID         string
 	ProviderID       string

--- a/internal/session/manager_busy_input.go
+++ b/internal/session/manager_busy_input.go
@@ -104,7 +104,7 @@ func (m *Manager) resolvePromptRuntimeAtAdmission(
 	if err != nil {
 		return nil, err
 	}
-	if err := m.validateRuntimeModelAtAdmission(ctx, session, *selection); err != nil {
+	if err := m.validateRuntimeModelAtAdmission(ctx, session, *selection, session.Meta()); err != nil {
 		return nil, err
 	}
 	return selection, nil

--- a/internal/session/manager_prompt_admission.go
+++ b/internal/session/manager_prompt_admission.go
@@ -80,7 +80,7 @@ func (m *Manager) submitAdmittedGoalByTarget(
 			return SendPromptResult{}, err
 		}
 	}
-	if err := m.validateRuntimeModelAtAdmission(ctx, target.session, *target.runtime); err != nil {
+	if err := m.validateRuntimeModelAtAdmission(ctx, target.session, *target.runtime, target.meta); err != nil {
 		return SendPromptResult{}, err
 	}
 	return m.submitAdmittedGoalPrompt(ctx, target.session, preparation, opts, admissionReq)
@@ -124,7 +124,7 @@ func (m *Manager) submitAdmittedPromptByTarget(
 			return SendPromptResult{}, err
 		}
 	}
-	if err := m.validateRuntimeModelAtAdmission(ctx, target.session, *target.runtime); err != nil {
+	if err := m.validateRuntimeModelAtAdmission(ctx, target.session, *target.runtime, target.meta); err != nil {
 		return SendPromptResult{}, err
 	}
 	session := target.session

--- a/internal/session/manager_prompt_admission_target.go
+++ b/internal/session/manager_prompt_admission_target.go
@@ -11,6 +11,7 @@ type promptAdmissionTarget struct {
 	session     *Session
 	workspaceID string
 	runtime     *RuntimeSelection
+	meta        store.SessionMeta
 }
 
 func (m *Manager) canonicalizeAdmissionPromptAttachments(
@@ -44,7 +45,12 @@ func (m *Manager) resolvePromptAdmissionTarget(
 		if err != nil {
 			return promptAdmissionTarget{}, err
 		}
-		return promptAdmissionTarget{session: active, workspaceID: workspaceID, runtime: resolved}, nil
+		return promptAdmissionTarget{
+			session:     active,
+			workspaceID: workspaceID,
+			runtime:     resolved,
+			meta:        active.Meta(),
+		}, nil
 	}
 
 	meta, err := m.readMetaWithContext(ctx, target)
@@ -58,5 +64,5 @@ func (m *Manager) resolvePromptAdmissionTarget(
 	if err != nil {
 		return promptAdmissionTarget{}, err
 	}
-	return promptAdmissionTarget{workspaceID: meta.WorkspaceID, runtime: resolved}, nil
+	return promptAdmissionTarget{workspaceID: meta.WorkspaceID, runtime: resolved, meta: meta}, nil
 }

--- a/internal/session/manager_runtime_model_validation.go
+++ b/internal/session/manager_runtime_model_validation.go
@@ -20,11 +20,9 @@ func (m *Manager) validateRuntimeModelAtAdmission(
 	ctx context.Context,
 	session *Session,
 	selection RuntimeSelection,
+	meta store.SessionMeta,
 ) error {
 	providerID := strings.TrimSpace(selection.Provider)
-	if providerID != cursorRuntimeProvider {
-		return nil
-	}
 	if session != nil {
 		snapshot := session.runtimeBindingSnapshot()
 		if snapshot.process != nil &&
@@ -33,11 +31,20 @@ func (m *Manager) validateRuntimeModelAtAdmission(
 			return nil
 		}
 	}
-	_, err := m.resolveCatalogTransportModel(
-		ctx,
-		providerID,
-		selection,
-		modelCatalogExecutionContextForSession(session),
+	workspace, err := m.resolveResumeWorkspace(ctx, meta)
+	if err != nil {
+		return err
+	}
+	provider, err := workspace.Config.ResolveProvider(providerID)
+	if err != nil {
+		return err
+	}
+	runtimeProvider := provider.RuntimeProviderName(providerID)
+	if runtimeProvider != cursorRuntimeProvider {
+		return nil
+	}
+	_, err = m.resolveCatalogTransportModel(
+		ctx, runtimeProvider, selection, modelCatalogExecutionContext(meta.ProfileID, meta.WorkspaceID),
 	)
 	return err
 }
@@ -417,13 +424,6 @@ func (m *Manager) validateExplicitStartModel(
 	return nil
 }
 
-func modelCatalogExecutionContextForSession(session *Session) modelcatalog.CatalogExecutionContext {
-	if session == nil {
-		return modelCatalogExecutionContext("", "")
-	}
-	return modelCatalogExecutionContext(session.ProfileID, session.WorkspaceID)
-}
-
 func modelCatalogExecutionContext(profileID string, workspaceID string) modelcatalog.CatalogExecutionContext {
 	profileID = strings.TrimSpace(profileID)
 	if profileID == "" {
@@ -441,11 +441,6 @@ func modelCatalogExecutionContext(profileID string, workspaceID string) modelcat
 		ProfileID:   profileID,
 		WorkspaceID: workspaceID,
 	}
-}
-
-func isCursorRuntimeSelection(selection RuntimeSelection) bool {
-	return strings.TrimSpace(selection.Provider) == cursorRuntimeProvider &&
-		strings.TrimSpace(selection.Model) != ""
 }
 
 func providerLiveSourcePresent(model modelcatalog.Model, providerID string) bool {

--- a/internal/session/manager_runtime_model_validation.go
+++ b/internal/session/manager_runtime_model_validation.go
@@ -35,6 +35,7 @@ func (m *Manager) validateRuntimeModelAtAdmission(
 	}
 	_, err := m.resolveCatalogTransportModel(
 		ctx,
+		providerID,
 		selection,
 		modelCatalogExecutionContextForSession(session),
 	)
@@ -46,7 +47,7 @@ func (m *Manager) resolveCursorCatalogBinding(
 	selection RuntimeSelection,
 	executionContext modelcatalog.CatalogExecutionContext,
 ) (string, error) {
-	models, err := m.listLiveProviderModels(ctx, cursorRuntimeProvider, executionContext)
+	models, err := m.listLiveProviderModels(ctx, selection.Provider, executionContext)
 	if err != nil {
 		return "", err
 	}
@@ -80,7 +81,7 @@ func (m *Manager) resolveClaudeCatalogBinding(
 	executionContext modelcatalog.CatalogExecutionContext,
 ) (string, error) {
 	modelID := strings.TrimSpace(selection.Model)
-	models, err := m.listLiveProviderModels(ctx, runtimeProviderClaude, executionContext)
+	models, err := m.listLiveProviderModels(ctx, selection.Provider, executionContext)
 	if err != nil {
 		if !claudeLogicalModelRequiresCatalogBinding(modelID) {
 			return modelID, nil
@@ -127,10 +128,11 @@ func claudeLogicalModelRequiresCatalogBinding(modelID string) bool {
 
 func (m *Manager) resolveCatalogTransportModel(
 	ctx context.Context,
+	runtimeProvider string,
 	selection RuntimeSelection,
 	executionContext modelcatalog.CatalogExecutionContext,
 ) (string, error) {
-	switch strings.TrimSpace(selection.Provider) {
+	switch strings.TrimSpace(runtimeProvider) {
 	case cursorRuntimeProvider:
 		return m.resolveCursorCatalogBinding(ctx, selection, executionContext)
 	case runtimeProviderClaude:
@@ -401,8 +403,8 @@ func (m *Manager) validateExplicitStartModel(
 	if strings.TrimSpace(modelID) == "" {
 		return nil
 	}
-	transportModel, err := m.resolveCatalogTransportModel(ctx, RuntimeSelection{
-		Provider:        providerID,
+	transportModel, err := m.resolveCatalogTransportModel(ctx, providerID, RuntimeSelection{
+		Provider:        runtime.agent.Provider,
 		Model:           modelID,
 		ReasoningEffort: spec.reasoningEffort,
 		Speed:           spec.speed,

--- a/internal/session/manager_runtime_selection.go
+++ b/internal/session/manager_runtime_selection.go
@@ -55,7 +55,7 @@ func (m *Manager) updateRuntimeSelection(
 	}
 	if active, ok := m.Get(target); ok {
 		if selection != nil {
-			if err := m.validateRuntimeModelAtAdmission(ctx, active, *selection); err != nil {
+			if err := m.validateRuntimeModelAtAdmission(ctx, active, *selection, active.Meta()); err != nil {
 				return nil, err
 			}
 		}
@@ -106,15 +106,12 @@ func (m *Manager) updateStoppedRuntimeSelection(
 	if err != nil {
 		return nil, err
 	}
-	if selection != nil && isCursorRuntimeSelection(*selection) {
-		if _, err := m.resolveCursorCatalogBinding(
-			ctx,
-			*selection,
-			modelCatalogExecutionContext(meta.ProfileID, meta.WorkspaceID),
-		); err != nil {
+	if selection != nil {
+		if err := m.validateRuntimeModelAtAdmission(ctx, nil, *selection, meta); err != nil {
 			return nil, err
 		}
 	}
+
 	_, selectionRevision := store.SessionRuntimeSelectionStateValues(meta.RuntimeSelectionValue())
 	if selectionRevision != expectedRevision {
 		return nil, runtimeSelectionConflict(expectedRevision, selectionRevision)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -799,6 +799,74 @@ func TestCreateAppliesRuntimeModelOverride(t *testing.T) {
 		}
 	})
 
+	t.Run("Should bind a Claude overlay using only its own live catalog", func(t *testing.T) {
+		t.Parallel()
+		const overlay = "claude-secondary"
+		const logical = "claude-haiku-4-5-20251001"
+		for _, available := range []bool{true, false} {
+			name := "Should reject another account live binding"
+			if available {
+				name = "Should launch with the overlay live binding"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				catalogProvider := "claude"
+				if available {
+					catalogProvider = overlay
+				}
+				h := newHarness(t, WithModelCatalog(modelCatalogStub{models: []modelcatalog.Model{
+					{
+						ProviderID:        catalogProvider,
+						ModelID:           logical,
+						AvailabilityState: modelcatalog.AvailabilityStateAvailableLive,
+						TransportBindings: []modelcatalog.ModelTransportBinding{{TransportModelID: "haiku"}},
+						Sources: []modelcatalog.SourceRef{
+							{
+								SourceID:   modelcatalog.SourceKindProviderLiveID(catalogProvider),
+								SourceKind: modelcatalog.SourceKindProviderLive,
+							},
+						},
+					},
+				}}))
+				workspace, err := h.resolver.Resolve(t.Context(), h.workspaceID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				workspace.Config.Providers[overlay] = compozyconfig.ProviderConfig{
+					RuntimeProvider: "claude", Command: "env CLAUDE_CONFIG_DIR=/account-secondary claude-acp",
+					AuthMode: compozyconfig.ProviderAuthModeNativeCLI, Harness: compozyconfig.ProviderHarnessACP,
+				}
+				h.resolver.upsert(&workspace)
+				session, err := h.manager.Create(
+					t.Context(),
+					CreateOpts{AgentName: "coder", Provider: overlay, Model: logical, Workspace: h.workspaceID},
+				)
+				if !available {
+					if err == nil {
+						t.Fatal("overlay accepted another account catalog")
+					}
+					if len(h.driver.startCalls) != 0 {
+						t.Fatal("unavailable model launched")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { reportSessionStop(t, h, session.ID) })
+				if got := h.driver.startCalls[0].PreferredModel; got != "haiku" {
+					t.Fatalf("transport = %q", got)
+				}
+				if info := session.Info(); info.Provider != overlay || info.Model != logical {
+					t.Fatalf("session identity = %#v", info)
+				}
+				if got := readMeta(t, session.MetaPath()).Model; got != logical {
+					t.Fatalf("persisted model = %q", got)
+				}
+			})
+		}
+	})
+
 	t.Run("Should reject an aliased Cursor agent default before session reservation", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -842,8 +842,12 @@ func TestCreateAppliesRuntimeModelOverride(t *testing.T) {
 					CreateOpts{AgentName: "coder", Provider: overlay, Model: logical, Workspace: h.workspaceID},
 				)
 				if !available {
-					if err == nil {
-						t.Fatal("overlay accepted another account catalog")
+					if err == nil ||
+						!strings.Contains(
+							err.Error(),
+							"Claude model \""+logical+"\" is not advertised by the live ACP catalog",
+						) {
+						t.Fatalf("overlay accepted another account catalog or failed for another reason: %v", err)
 					}
 					if len(h.driver.startCalls) != 0 {
 						t.Fatal("unavailable model launched")

--- a/internal/session/manager_transition_test.go
+++ b/internal/session/manager_transition_test.go
@@ -983,9 +983,7 @@ func TestManagerLifecycleCatalogTransitions(t *testing.T) {
 			if !ok || negotiationErr.Code != acp.NegotiationCodeModelUnavailable {
 				t.Fatalf("stopped selection error = %v", err)
 			}
-
 		})
-
 	}
 
 	t.Run("Should update selected runtime while stopped without starting ACP", func(t *testing.T) {

--- a/internal/session/manager_transition_test.go
+++ b/internal/session/manager_transition_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/compozy/compozy/internal/acp"
+	compozyconfig "github.com/compozy/compozy/internal/config"
 	"github.com/compozy/compozy/internal/modelcatalog"
 	speedpkg "github.com/compozy/compozy/internal/speed"
 	"github.com/compozy/compozy/internal/store"
@@ -874,94 +875,118 @@ func TestManagerLifecycleCatalogTransitions(t *testing.T) {
 		}
 	})
 
-	t.Run("Should persist only an advertised Cursor runtime selection", func(t *testing.T) {
-		t.Parallel()
+	for _, providerID := range []string{"cursor", "cursor-secondary"} {
+		t.Run("Should persist only an advertised Cursor runtime selection for "+providerID, func(t *testing.T) {
+			t.Parallel()
 
-		const advertisedModel = "grok-4.5"
-		const transportModel = "cursor-grok-4.5-high"
-		h := newHarness(t, WithModelCatalog(modelCatalogStub{models: []modelcatalog.Model{{
-			ProviderID:             "cursor",
-			ModelID:                advertisedModel,
-			AvailabilityState:      modelcatalog.AvailabilityStateAvailableLive,
-			DefaultReasoningEffort: new(modelcatalog.ReasoningEffortHigh),
-			TransportBindings: []modelcatalog.ModelTransportBinding{{
-				TransportModelID: transportModel,
-				ReasoningEffort:  new(modelcatalog.ReasoningEffortHigh),
-				Fast:             new(false),
-			}},
-			Sources: []modelcatalog.SourceRef{{
-				SourceID:   modelcatalog.SourceKindProviderLiveID("cursor"),
-				SourceKind: modelcatalog.SourceKindProviderLive,
-			}},
-		}}}))
-		resolvedWorkspace, err := h.resolver.Resolve(testutil.Context(t), h.workspaceID)
-		if err != nil {
-			t.Fatalf("Resolve() error = %v", err)
-		}
-		for index := range resolvedWorkspace.Agents {
-			if resolvedWorkspace.Agents[index].Name == "coder" {
-				resolvedWorkspace.Agents[index].Provider = "cursor"
-				resolvedWorkspace.Agents[index].Model = ""
+			const advertisedModel = "grok-4.5"
+			const transportModel = "cursor-grok-4.5-high"
+			h := newHarness(t, WithModelCatalog(modelCatalogStub{models: []modelcatalog.Model{{
+				ProviderID:             providerID,
+				ModelID:                advertisedModel,
+				AvailabilityState:      modelcatalog.AvailabilityStateAvailableLive,
+				DefaultReasoningEffort: new(modelcatalog.ReasoningEffortHigh),
+				TransportBindings: []modelcatalog.ModelTransportBinding{{
+					TransportModelID: transportModel,
+					ReasoningEffort:  new(modelcatalog.ReasoningEffortHigh),
+					Fast:             new(false),
+				}},
+				Sources: []modelcatalog.SourceRef{{
+					SourceID:   modelcatalog.SourceKindProviderLiveID(providerID),
+					SourceKind: modelcatalog.SourceKindProviderLive,
+				}},
+			}}}))
+			resolvedWorkspace, err := h.resolver.Resolve(testutil.Context(t), h.workspaceID)
+			if err != nil {
+				t.Fatalf("Resolve() error = %v", err)
 			}
-		}
-		h.resolver.upsert(&resolvedWorkspace)
-		h.driver.startHook = func(opts acp.StartOpts, _ int) (*fakeProcess, error) {
-			proc := newFakeProcess(opts.AgentName, opts.Command, opts.Cwd, "acp-cursor-runtime-selection")
-			proc.handle.setCaps(acp.Caps{ConfigOptions: []acp.SessionConfigOption{{
-				ID:             "model",
-				Category:       "model",
-				Kind:           acp.SessionConfigOptionKindSelect,
-				CurrentValueID: transportModel,
-				Values:         []acp.SessionConfigOptionValue{{Value: transportModel}},
-			}}})
-			return proc, nil
-		}
-		active := createSession(t, h)
-		t.Cleanup(func() {
-			if err := h.manager.Stop(testutil.Context(t), active.ID); err != nil {
-				t.Errorf("Stop() cleanup error = %v", err)
+			provider := compozyconfig.BuiltinProviders()["cursor"]
+			provider.RuntimeProvider = "cursor"
+			resolvedWorkspace.Config.Providers[providerID] = provider
+			for index := range resolvedWorkspace.Agents {
+				if resolvedWorkspace.Agents[index].Name == "coder" {
+					resolvedWorkspace.Agents[index].Provider = providerID
+					resolvedWorkspace.Agents[index].Model = ""
+				}
 			}
+			h.resolver.upsert(&resolvedWorkspace)
+			h.driver.startHook = func(opts acp.StartOpts, _ int) (*fakeProcess, error) {
+				proc := newFakeProcess(opts.AgentName, opts.Command, opts.Cwd, "acp-cursor-runtime-selection")
+				proc.handle.setCaps(acp.Caps{ConfigOptions: []acp.SessionConfigOption{{
+					ID:             "model",
+					Category:       "model",
+					Kind:           acp.SessionConfigOptionKindSelect,
+					CurrentValueID: transportModel,
+					Values:         []acp.SessionConfigOptionValue{{Value: transportModel}},
+				}}})
+				return proc, nil
+			}
+			active := createSession(t, h)
+			t.Cleanup(func() {
+				if err := h.manager.Stop(
+					testutil.Context(t),
+					active.ID,
+				); err != nil &&
+					!errors.Is(err, ErrSessionNotFound) {
+					t.Errorf("Stop() cleanup error = %v", err)
+				}
+			})
+
+			_, err = h.manager.SetRuntimeSelection(
+				testutil.Context(t),
+				active.ID,
+				RuntimeSelection{Provider: providerID, Model: "cursor-grok-4.5-high"},
+				0,
+			)
+			negotiationErr, ok := errors.AsType[*acp.NegotiationError](err)
+			if !ok || negotiationErr.Code != acp.NegotiationCodeModelUnavailable {
+				t.Fatalf("SetRuntimeSelection(alias) error = %v, want model_unavailable NegotiationError", err)
+			}
+			rejectedMeta := readMeta(t, active.MetaPath())
+			rejectedSelection, rejectedRevision := store.SessionRuntimeSelectionStateValues(
+				rejectedMeta.RuntimeSelectionValue(),
+			)
+			if rejectedSelection != nil || rejectedRevision != 0 {
+				t.Fatalf(
+					"rejected Cursor selection = %#v at revision %d, want no persisted selection",
+					rejectedSelection,
+					rejectedRevision,
+				)
+			}
+
+			updated, err := h.manager.SetRuntimeSelection(
+				testutil.Context(t),
+				active.ID,
+				RuntimeSelection{Provider: providerID, Model: advertisedModel},
+				0,
+			)
+			if err != nil {
+				t.Fatalf("SetRuntimeSelection(advertised model) error = %v", err)
+			}
+			if updated.SelectedRuntime == nil || updated.SelectedRuntime.Model != advertisedModel ||
+				updated.RuntimeSelectionRevision != 1 {
+				t.Fatalf(
+					"SetRuntimeSelection(advertised model) info = %#v, want exact persisted model at revision 1",
+					updated,
+				)
+			}
+			if err := h.manager.Stop(t.Context(), active.ID); err != nil {
+				t.Fatal(err)
+			}
+			_, err = h.manager.SetRuntimeSelection(
+				t.Context(),
+				active.ID,
+				RuntimeSelection{Provider: providerID, Model: transportModel},
+				1,
+			)
+			negotiationErr, ok = errors.AsType[*acp.NegotiationError](err)
+			if !ok || negotiationErr.Code != acp.NegotiationCodeModelUnavailable {
+				t.Fatalf("stopped selection error = %v", err)
+			}
+
 		})
 
-		_, err = h.manager.SetRuntimeSelection(
-			testutil.Context(t),
-			active.ID,
-			RuntimeSelection{Provider: "cursor", Model: "cursor-grok-4.5-high"},
-			0,
-		)
-		negotiationErr, ok := errors.AsType[*acp.NegotiationError](err)
-		if !ok || negotiationErr.Code != acp.NegotiationCodeModelUnavailable {
-			t.Fatalf("SetRuntimeSelection(alias) error = %v, want model_unavailable NegotiationError", err)
-		}
-		rejectedMeta := readMeta(t, active.MetaPath())
-		rejectedSelection, rejectedRevision := store.SessionRuntimeSelectionStateValues(
-			rejectedMeta.RuntimeSelectionValue(),
-		)
-		if rejectedSelection != nil || rejectedRevision != 0 {
-			t.Fatalf(
-				"rejected Cursor selection = %#v at revision %d, want no persisted selection",
-				rejectedSelection,
-				rejectedRevision,
-			)
-		}
-
-		updated, err := h.manager.SetRuntimeSelection(
-			testutil.Context(t),
-			active.ID,
-			RuntimeSelection{Provider: "cursor", Model: advertisedModel},
-			0,
-		)
-		if err != nil {
-			t.Fatalf("SetRuntimeSelection(advertised model) error = %v", err)
-		}
-		if updated.SelectedRuntime == nil || updated.SelectedRuntime.Model != advertisedModel ||
-			updated.RuntimeSelectionRevision != 1 {
-			t.Fatalf(
-				"SetRuntimeSelection(advertised model) info = %#v, want exact persisted model at revision 1",
-				updated,
-			)
-		}
-	})
+	}
 
 	t.Run("Should update selected runtime while stopped without starting ACP", func(t *testing.T) {
 		t.Parallel()

--- a/internal/store/globaldb/global_db_model_catalog_batch.go
+++ b/internal/store/globaldb/global_db_model_catalog_batch.go
@@ -13,6 +13,7 @@ type normalizedModelCatalogReplacement struct {
 	executionContext modelcatalog.CatalogExecutionContext
 	rows             []modelcatalog.ModelRow
 	status           modelcatalog.SourceStatus
+	removeSource     bool
 }
 
 // ReplaceSourceRowsBatch publishes a complete model catalog generation in one transaction.
@@ -30,33 +31,23 @@ func (g *ModelCatalogRepo) ReplaceSourceRowsBatch(
 	normalized := make([]normalizedModelCatalogReplacement, 0, len(replacements))
 	seen := make(map[string]struct{}, len(replacements))
 	for index, replacement := range replacements {
-		executionContext, rows, status, err := normalizeModelCatalogReplacement(
-			replacement.ExecutionContext,
-			replacement.SourceID,
-			replacement.ProviderID,
-			replacement.Rows,
-			replacement.Status,
-		)
+		entry, err := normalizeModelCatalogBatchReplacement(replacement)
 		if err != nil {
 			return fmt.Errorf("store: normalize model catalog replacement %d: %w", index, err)
 		}
-		key, err := modelCatalogReplacementKey(executionContext, status.SourceID, status.ProviderID)
+		key, err := modelCatalogReplacementKey(entry.executionContext, entry.status.SourceID, entry.status.ProviderID)
 		if err != nil {
 			return err
 		}
 		if _, duplicate := seen[key]; duplicate {
 			return fmt.Errorf(
 				"store: model catalog replacement %q/%q is duplicated",
-				status.SourceID,
-				status.ProviderID,
+				entry.status.SourceID,
+				entry.status.ProviderID,
 			)
 		}
 		seen[key] = struct{}{}
-		normalized = append(normalized, normalizedModelCatalogReplacement{
-			executionContext: executionContext,
-			rows:             rows,
-			status:           status,
-		})
+		normalized = append(normalized, entry)
 	}
 
 	return g.withModelCatalogImmediateTransaction(
@@ -64,6 +55,12 @@ func (g *ModelCatalogRepo) ReplaceSourceRowsBatch(
 		"model catalog source replacement batch",
 		func(exec modelCatalogSQLExecutor) error {
 			for _, replacement := range normalized {
+				if replacement.removeSource {
+					if err := deleteModelCatalogSource(ctx, exec, replacement.status); err != nil {
+						return err
+					}
+					continue
+				}
 				if err := replaceModelCatalogSourceRows(
 					ctx,
 					exec,
@@ -172,4 +169,47 @@ func modelCatalogReplacementKey(
 		return "", err
 	}
 	return contextID + "\x00" + strings.TrimSpace(sourceID) + "\x00" + strings.TrimSpace(providerID), nil
+}
+
+func normalizeModelCatalogBatchReplacement(
+	replacement modelcatalog.SourceRowsReplacement,
+) (normalizedModelCatalogReplacement, error) {
+	if replacement.RemoveSource {
+		if len(replacement.Rows) != 0 || replacement.ExecutionContext != (modelcatalog.CatalogExecutionContext{}) {
+			return normalizedModelCatalogReplacement{}, fmt.Errorf(
+				"store: live source removal cannot include rows or an execution context",
+			)
+		}
+		sourceID, providerID := strings.TrimSpace(replacement.SourceID), strings.TrimSpace(replacement.ProviderID)
+		if providerID == "" || sourceID != modelcatalog.SourceKindProviderLiveID(providerID) {
+			return normalizedModelCatalogReplacement{}, fmt.Errorf(
+				"store: live source removal requires matching source and provider IDs",
+			)
+		}
+		return normalizedModelCatalogReplacement{
+			executionContext: modelcatalog.GlobalCatalogExecutionContext(),
+			status:           modelcatalog.SourceStatus{SourceID: sourceID, ProviderID: providerID}, removeSource: true,
+		}, nil
+	}
+	executionContext, rows, status, err := normalizeModelCatalogReplacement(
+		replacement.ExecutionContext,
+		replacement.SourceID,
+		replacement.ProviderID,
+		replacement.Rows,
+		replacement.Status,
+	)
+	return normalizedModelCatalogReplacement{executionContext: executionContext, rows: rows, status: status}, err
+}
+
+func deleteModelCatalogSource(
+	ctx context.Context,
+	exec modelCatalogSQLExecutor,
+	status modelcatalog.SourceStatus,
+) error {
+	if err := sqlcgen.New(exec).DeleteModelCatalogSource(ctx, sqlcgen.DeleteModelCatalogSourceParams{
+		SourceID: status.SourceID, ProviderID: status.ProviderID,
+	}); err != nil {
+		return fmt.Errorf("store: delete model catalog source: %w", err)
+	}
+	return deleteUnusedModelCatalogExecutionContexts(ctx, exec)
 }

--- a/internal/store/globaldb/global_db_model_catalog_test.go
+++ b/internal/store/globaldb/global_db_model_catalog_test.go
@@ -273,6 +273,106 @@ func TestGlobalDBModelCatalogExecutionContextMigration(t *testing.T) {
 func TestGlobalDBModelCatalogStore(t *testing.T) {
 	t.Parallel()
 
+	t.Run(
+		"Should atomically remove every context of a live source while preserving other providers",
+		func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			db := openTestGlobalDB(t)
+			const provider = "claude-secondary"
+			sourceID := modelcatalog.SourceKindProviderLiveID(provider)
+			for _, profile := range []string{"profile-a", "profile-b"} {
+				execution := modelcatalog.CatalogExecutionContext{
+					Scope:              modelcatalog.ExecutionScopeProfile,
+					ProfileID:          profile,
+					CommandFingerprint: "account-command",
+				}
+				row := modelCatalogRow(sourceID, provider, "haiku", modelcatalog.SourceKindProviderLive, 110)
+				if err := db.ReplaceSourceRows(
+					ctx,
+					execution,
+					sourceID,
+					provider,
+					[]modelcatalog.ModelRow{row},
+					modelCatalogStatus(sourceID, provider, modelcatalog.SourceKindProviderLive, 110),
+				); err != nil {
+					t.Fatal(err)
+				}
+			}
+			replaceModelCatalogRows(
+				t,
+				db,
+				"provider_live:claude",
+				"claude",
+				modelcatalog.SourceKindProviderLive,
+				110,
+				[]modelcatalog.ModelRow{
+					modelCatalogRow(
+						"provider_live:claude",
+						"claude",
+						"sonnet",
+						modelcatalog.SourceKindProviderLive,
+						110,
+					),
+				},
+			)
+			removal := modelcatalog.SourceRowsReplacement{SourceID: sourceID, ProviderID: provider, RemoveSource: true}
+			invalid := modelCatalogRow("config", "codex", "new-model", modelcatalog.SourceKindConfig, 120)
+			invalid.ReasoningEfforts = []modelcatalog.ReasoningEffort{
+				modelcatalog.ReasoningEffortHigh,
+				modelcatalog.ReasoningEffortHigh,
+			}
+			err := db.ReplaceSourceRowsBatch(ctx, []modelcatalog.SourceRowsReplacement{
+				removal,
+				{
+					ExecutionContext: modelcatalog.GlobalCatalogExecutionContext(),
+					SourceID:         "config",
+					ProviderID:       "codex",
+					Rows: []modelcatalog.ModelRow{
+						invalid,
+					},
+					Status: modelCatalogStatus("config", "codex", modelcatalog.SourceKindConfig, 120),
+				},
+			})
+			if err == nil {
+				t.Fatal("invalid later publication did not fail")
+			}
+			var count int
+			if err := db.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM model_catalog_rows WHERE provider_id = ?", provider).
+				Scan(&count); err != nil {
+				t.Fatal(err)
+			}
+			if count != 2 {
+				t.Fatalf("failed batch removed account rows: %d", count)
+			}
+			if err := db.ReplaceSourceRowsBatch(ctx, []modelcatalog.SourceRowsReplacement{removal}); err != nil {
+				t.Fatal(err)
+			}
+			for _, table := range []string{"model_catalog_rows", "model_catalog_sources"} {
+				if err := db.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table+" WHERE provider_id = ?", provider).
+					Scan(&count); err != nil {
+					t.Fatal(err)
+				}
+				if count != 0 {
+					t.Fatalf("removed account still has %d %s entries", count, table)
+				}
+			}
+			rows, err := db.ListRows(
+				ctx,
+				modelcatalog.ListOptions{
+					ProviderID:       "claude",
+					ExecutionContext: modelCatalogTestExecutionContext(modelcatalog.SourceKindProviderLive),
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(rows) != 1 || rows[0].ModelID != "sonnet" {
+				t.Fatalf("other provider rows = %#v", rows)
+			}
+		},
+	)
+
 	t.Run("Should isolate live rows and prune superseded fingerprints within one workspace", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/store/globaldb/queries/model_catalog.sql
+++ b/internal/store/globaldb/queries/model_catalog.sql
@@ -224,3 +224,7 @@ WHERE s.context_id = CAST(sqlc.arg(context_id) AS TEXT)
     OR r.stale = 0)
 ORDER BY s.source_id ASC, s.provider_id ASC, s.model_id ASC,
   s.transport_model_id ASC, s.option_id ASC;
+
+-- name: DeleteModelCatalogSource :exec
+DELETE FROM model_catalog_sources
+WHERE source_id = sqlc.arg(source_id) AND provider_id = sqlc.arg(provider_id);

--- a/internal/store/globaldb/sqlcgen/model_catalog.sql.go
+++ b/internal/store/globaldb/sqlcgen/model_catalog.sql.go
@@ -78,6 +78,21 @@ func (q *Queries) DeleteModelCatalogRows(ctx context.Context, arg DeleteModelCat
 	return err
 }
 
+const deleteModelCatalogSource = `-- name: DeleteModelCatalogSource :exec
+DELETE FROM model_catalog_sources
+WHERE source_id = ?1 AND provider_id = ?2
+`
+
+type DeleteModelCatalogSourceParams struct {
+	SourceID   string `json:"source_id"`
+	ProviderID string `json:"provider_id"`
+}
+
+func (q *Queries) DeleteModelCatalogSource(ctx context.Context, arg DeleteModelCatalogSourceParams) error {
+	_, err := q.db.ExecContext(ctx, deleteModelCatalogSource, arg.SourceID, arg.ProviderID)
+	return err
+}
+
 const deleteModelCatalogTransportBindingSelections = `-- name: DeleteModelCatalogTransportBindingSelections :exec
 DELETE FROM model_catalog_transport_binding_selections
 WHERE context_id = ?1

--- a/packages/site/content/docs/agents/model-catalog.mdx
+++ b/packages/site/content/docs/agents/model-catalog.mdx
@@ -56,7 +56,9 @@ the last successful rows with an empty catalog.
 A provider overlay with `runtime_provider = "claude"` uses the Claude live-discovery adapter while
 keeping its own provider ID, launch command, environment/home policy, credential bindings, and
 profile/workspace catalog scope. Creating or deleting an overlay through Settings updates live
-source registration without a daemon restart. Source health appears as `provider_live:<overlay-id>`.
+source registration without a daemon restart. Removal clears that overlay's live discovery cache
+across profiles/workspaces; recreating it requires a new successful discovery. Source health appears
+as `provider_live:<overlay-id>`.
 
 Claude's advertised aliases, such as `haiku` and `sonnet`, map to logical catalog IDs using the
 runtime family's built-in identities and the overlay's configured model identities. Session creation

--- a/packages/site/content/docs/agents/model-catalog.mdx
+++ b/packages/site/content/docs/agents/model-catalog.mdx
@@ -51,6 +51,32 @@ catalog read with no recorded status bootstraps these sources before returning; 
 rows and refresh them in the background. A failed attempt is recorded as source status and never replaces
 the last successful rows with an empty catalog.
 
+## Provider overlays
+
+A provider overlay with `runtime_provider = "claude"` uses the Claude live-discovery adapter while
+keeping its own provider ID, launch command, environment/home policy, credential bindings, and
+profile/workspace catalog scope. Creating or deleting an overlay through Settings updates live
+source registration without a daemon restart. Source health appears as `provider_live:<overlay-id>`.
+
+Claude's advertised aliases, such as `haiku` and `sonnet`, map to logical catalog IDs using the
+runtime family's built-in identities and the overlay's configured model identities. Session creation
+resolves the private transport alias from that overlay's live catalog. Another account's catalog
+cannot establish availability for the overlay. Built-in identity hints do not add unadvertised rows.
+
+Refresh and inspect the overlay before curating a model:
+
+```sh
+compozy provider models refresh claude-secondary
+compozy provider models list claude-secondary --all
+compozy provider models set claude-secondary <model-id-from-list>
+```
+
+Command-based overlays such as Cursor and OpenCode must configure `models.discovery.command` for
+their account. The built-in discovery command is not inherited across account commands.
+
+An empty or failed live response remains visible in source status; it does not make static model
+IDs startable. Existing explicit `models.curated` entries still control the curated view.
+
 ## Automatic model updates
 
 Live provider catalogs have a five-minute freshness window. The daemon refreshes them periodically and

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -959,3 +959,8 @@ or `output`. The stable entry sequence remains the result identity. Use these
 hints to reveal the correct work row instead of inferring a location from snippets.
 
 A queued edit arriving after dispatch started returns409 with `code: "entry_dispatching"`, including when the entry is already sent. The Web preserves the refused edit after the current composer draft. A raw stream replaying an older session_stopped episode stays live when the session has resumed; current session status owns stream termination.
+
+Provider overlays inherit live-discovery adapters through `runtime_provider` while retaining their own
+`provider_live:<id>` source, execution command, credentials, and catalog scope. Refresh and list the
+overlay's models before curating them; a built-in provider's live result does not authorize another
+account's model. Claude logical IDs resolve to aliases advertised by the selected overlay.


### PR DESCRIPTION
Closes #627

## Problem and behavior

A provider such as `claude-secondary` with `runtime_provider = "claude"` could launch its own account command, but live model discovery registered adapters only by the provider ID. The operator therefore received no live models to inspect or curate. Session creation also consulted the built-in Claude account's catalog when resolving logical IDs, rather than the selected overlay's catalog.

Overlays now register `provider_live:<overlay-id>` using the registered runtime-family adapter when their own ID has none. An advertised Claude alias such as `haiku` becomes a logical catalog row with its private transport binding; session creation looks up that binding under the overlay ID. A binding advertised only by another account is rejected.

## Implementation and boundaries

- Preserve the overlay command, working directory, auth mode, credential slots, environment/home policies, provider/source identity and profile/workspace execution scope. Command and runtime-family changes invalidate discovery inputs.
- Use built-in model identities only to interpret advertised Claude aliases. Do not manufacture overlay rows or live availability from static seeds. Explicit short curated aliases remain supported.
- Stage newly created/deleted live sources with the existing atomic catalog generation. Publish the registry only after durable source replacement succeeds, and update periodic discovery targets without a daemon restart. Removal deletes only the overlay's derived live cache across all execution contexts, with transactional rollback; an offline re-add cannot revive deleted account observations.
- Command-based overlays (for example Cursor/OpenCode) require an explicit `models.discovery.command`; inheriting a global command could query the wrong account. ACP overlays use their configured launch command.
- Keep the existing schemas, config keys and database shapes. No migration, public removal or authentication-classifier change is required.

PR #550 remains independent and unmerged. Its curated-merge and broader picker/startability changes are excluded. When integrating its overlapping Claude binding work, preserve the selected overlay's provider/source identity. Issue #623 owns auth classification.

## Verification

Development checks completed before the CI-only delivery override:

- Focused race tests for live-source registration and session creation, including rejection of another account's catalog binding.
- Existing daemon model-catalog wiring suite and the added hot registration/removal case with SQLite.
- Catalog integration with two real ACP fixture subprocesses advertising different model lists and SQLite persistence.
- Changed test-shape checks passed for modelcatalog/daemon. The checker reports pre-existing unrelated top-level cases in the session test file; the added cases follow the existing `Should` subtest suite.

Final delivery gates run in GitHub Actions under the explicit CI-only instruction. The existing Go shard workflow now runs the catalog integration suite with the ACP fixture driver on one shard. A local gate started before that override exited on formatting drift; formatting was applied, and the local gate was not restarted. Both CodeRabbit and Greptile completed the initial review. All three findings were validated and addressed in the next commit: durable cache removal, runtime-family admission dispatch, and a precise rejection assertion. Final-head CI and review of the remediation are pending.

The subprocess evidence verifies actual ACP transport and persistence, but does not establish real vendor authentication or account entitlement. No user's daemon or native login state was changed. No Web component/layout changes are included.

The remediation extends the owning SQLite suite with removal rollback/account preservation, daemon reconciliation with offline re-add, and the existing runtime-selection suite with active/stopped Cursor overlays. These changes are verified in GitHub CI, without local delivery suites.

## Cross-surface and documentation impact

The audit is recorded in `docs/_memory/change-impact.md` under issue 627. Native tools, CLI, HTTP, UDS, Extension Host and Web selectors consume the corrected shared catalog without DTO or tool-ID changes. Model catalog documentation, the official skill's runtime reference, and the cold-catalog QA scenario describe overlay ownership, curation and source lifecycle.
