### PR TITLE
fix: preserve unicode terminal prompt redraws

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,6 +640,11 @@ jobs:
         with:
           install-playwright: "true"
 
+      - name: Install terminal scenario shell
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes zsh
+
       - name: Restore Turbo cache
         uses: actions/cache/restore@v6
         with:
@@ -670,6 +675,15 @@ jobs:
         with:
           name: session-lifecycle-evidence-shard-${{ matrix.shard }}
           path: .tmp/playwright/test-results/*session-harden*/compozy-artifacts
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Unicode terminal prompt QA evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: terminal-unicode-evidence-shard-${{ matrix.shard }}
+          path: .tmp/playwright/test-results/*E2E-020*/compozy-artifacts
           if-no-files-found: ignore
           retention-days: 7
 

--- a/docs/_memory/change-impact.md
+++ b/docs/_memory/change-impact.md
@@ -28,6 +28,25 @@
   source lifecycle handling. Its overlapping Claude binding code must preserve overlay ownership
   when that PR is integrated. Issue #623 owns auth classification; it is excluded here.
 
+## Issue 629 — Unicode terminal prompt redraw
+
+- **Native tools / CLI / HTTP / UDS:** existing terminal input, stream, read, wait and quote paths
+  preserve UTF-8 characters containing C1 byte values. No IDs, DTOs, routes or flags change.
+- **Extensibility / hooks / config:** marker authentication and OSC/DCS security policies remain;
+  scanning recognizes controls at character boundaries, including UTF-8 encoded C1 code points. No hook, SDK or config
+  changes. The bug also occurs with shell integration disabled.
+- **Workspace / profile isolation:** state is held by the existing per-session input/output filter.
+  No database or file format changes, migrations, ownership changes or user-state loss. Existing
+  sessions need the upgraded daemon/new terminal to use the corrected parser; previously discarded
+  output cannot be recovered. Existing size bounds and ACK backpressure remain authoritative.
+- **Official skill:** checked `skills/compozy/references/terminal.md`; existing untrusted-output,
+  terminal-read and quote contracts remain accurate, with no new operation or guidance required.
+- **Web / docs / QA:** browser rendering consumes corrected bytes without frontend production
+  changes. The canonical terminal E2E suite owns separate zsh keystrokes, quote parity and reconnect.
+  `ET-terminal-shell-config-fidelity` gains the controlled Unicode/ASCII walk; the
+  [targeted report](../qa/reports/2026-09-12-terminal-unicode-prompt.md) records evidence and limits.
+  Display-width tables, raw-mode visibility (#628), and ZDOTDIR behavior (#626) are outside this fix.
+
 ## Issue 616 — Supervised work recovery
 
 - **Native tools:** existing session stop, task inspection/recovery and Loop status IDs and schemas

--- a/docs/qa/reports/2026-09-12-terminal-unicode-prompt.md
+++ b/docs/qa/reports/2026-09-12-terminal-unicode-prompt.md
@@ -1,0 +1,47 @@
+# Unicode prompt redraw verification
+
+Scope: issue #629, the terminal security filter and its model-facing read path.
+
+## Contract and cause
+
+The output filter classified the `0x9d` continuation byte inside U+276F (`e2 9d af`)
+as a standalone C1 OSC introducer. A colored prompt was truncated after `e2`, and
+subsequent single-character redraws remained buffered as an unterminated control.
+The ASCII control prompt delivered each character. The canonical filter regression
+fails on the original implementation for exactly this controlled pair.
+
+The same byte-based scanning also mistook UTF-8 continuation bytes for DCS starts
+and string terminators. Both stream and model-facing filtering now scan rune
+boundaries. Stream parsing retains only an incomplete UTF-8 suffix between reads,
+flushes it at EOF, and keeps existing control-size bounds and fail-closed behavior.
+The downstream VT UTF-8 carry, display-width tables, ANSI handling, and ACK flow
+control remain unchanged.
+
+The browser's xterm input handler decodes UTF-8 to code points before parsing C1
+controls. Therefore U+0090/U+009D/U+009C must still be recognized when UTF-8 encoded;
+only continuation bytes inside other characters are ignored. The canonical suite
+covers both raw and UTF-8 encoded controls, including split discard terminators.
+
+This evidence establishes a filtering defect. It does not validate the reporter's
+display-width hypothesis, clipboard observation, or distinguish every condition
+under which the original plain-output experiment succeeded.
+
+## Verification matrix
+
+| Journey / owning suite | Result | Evidence |
+| --- | --- | --- |
+| Filter preservation across every tested chunk size; input/output, raw C1, ANSI, oversized controls, EOF and model reads | Pass | `CGO_ENABLED=1 go test -race ./internal/terminal/... -count=1`; original regression fails, corrected suite passes |
+| Fresh real zsh, ASCII versus U+276F, shell integration disabled and daemon restarted; separate browser keys before Enter | Pending | Canonical browser `terminal.spec.ts`, E2E-020 |
+| CLI quote parity, reconnect, backspace and subsequent command execution | Pending | E2E-020 |
+| Required local gates and current-head PR CI | Pending | Recorded at delivery |
+
+The browser fixtures allocate isolated daemon/operator homes, workspaces and sockets,
+and dispose their processes after each case. No operator daemon is restarted.
+Linux and macOS results must be reported separately; a passing macOS replay alone
+does not establish Linux parity. Other terminal issues (#626 and #628) are excluded.
+
+Delivery override: the operator explicitly moved all final gates and browser/runtime
+validation to existing GitHub Actions workflows. The in-flight local gate was canceled;
+the checks recorded above completed before that override. No local gate completion or
+local browser replay is claimed. Per-command `HUSKY=0` skips gate hooks for delivery
+under this authorization without changing hook configuration.

--- a/docs/qa/scenarios/ET-terminal-shell-config-fidelity.md
+++ b/docs/qa/scenarios/ET-terminal-shell-config-fidelity.md
@@ -35,3 +35,13 @@ Walk:
 native/integrated trace equality and authenticated command markers. See
 [Zsh startup fidelity](../reports/2026-09-12-zsh-startup-fidelity.md). Prior fish and Web evidence
 is unchanged; this replay does not claim a new rendered Web or packaged-desktop walk.
+
+9. After restarting the isolated daemon with shell integration disabled, compare fresh zsh terminals
+   with `PROMPT=$'%F{blue}%~%f\n%F{magenta}❯%f '` and the identical prompt ending in `>`.
+   Type `a`, `b`, and `c` separately; each key must appear before Enter. Compare `terminal quote`
+   with the visible screen, reconnect, erase a character, and execute a command. Confirm Unicode
+   and ANSI colors survive and input remains responsive.
+
+2026-09-12 QA impact: step 9 owns the Unicode/C1 filtering regression in #629; its targeted replay
+is tracked in [the Unicode prompt report](../reports/2026-09-12-terminal-unicode-prompt.md).
+Earlier evidence remains applicable to unchanged fish and shell-config loading behavior.

--- a/internal/terminal/model_output.go
+++ b/internal/terminal/model_output.go
@@ -5,68 +5,27 @@ import "bytes"
 func modelFacingOutput(input []byte) []byte {
 	output := make([]byte, 0, len(input))
 	for offset := 0; offset < len(input); {
-		kind, prefix, ok := modelControlAt(input[offset:])
-		if !ok {
-			output = append(output, input[offset])
-			offset++
-			continue
+		start, kind, prefix := controlStart(input[offset:])
+		if start < 0 {
+			output = append(output, input[offset:]...)
+			break
 		}
-		end := modelControlEnd(input[offset+prefix:], kind == modelControlOSC)
+		output = append(output, input[offset:offset+start]...)
+		offset += start
+		end, terminator := controlEnd(input[offset+prefix:], kind)
 		if end < 0 {
-			if kind == modelControlOSC && !blockedModelOSC(input[offset+prefix:]) {
+			if kind == 'o' && !blockedModelOSC(input[offset+prefix:]) {
 				output = append(output, input[offset:]...)
 			}
 			break
 		}
-		wholeEnd := offset + prefix + end
-		if kind == modelControlOSC && !blockedModelOSC(input[offset+prefix:wholeEnd]) {
+		wholeEnd := offset + prefix + end + terminator
+		if kind == 'o' && !blockedModelOSC(input[offset+prefix:wholeEnd]) {
 			output = append(output, input[offset:wholeEnd]...)
 		}
 		offset = wholeEnd
 	}
 	return output
-}
-
-type modelControl uint8
-
-const (
-	modelControlOSC modelControl = iota + 1
-	modelControlDCS
-)
-
-func modelControlAt(input []byte) (modelControl, int, bool) {
-	if len(input) >= 2 && input[0] == 0x1b {
-		switch input[1] {
-		case ']':
-			return modelControlOSC, 2, true
-		case 'P':
-			return modelControlDCS, 2, true
-		}
-	}
-	if len(input) > 0 {
-		switch input[0] {
-		case 0x9d:
-			return modelControlOSC, 1, true
-		case 0x90:
-			return modelControlDCS, 1, true
-		}
-	}
-	return 0, 0, false
-}
-
-func modelControlEnd(input []byte, allowBell bool) int {
-	for index, value := range input {
-		if allowBell && value == 0x07 {
-			return index + 1
-		}
-		if value == 0x9c {
-			return index + 1
-		}
-		if value == 0x1b && index+1 < len(input) && input[index+1] == '\\' {
-			return index + 2
-		}
-	}
-	return -1
 }
 
 func blockedModelOSC(content []byte) bool {

--- a/internal/terminal/osc_filter.go
+++ b/internal/terminal/osc_filter.go
@@ -13,6 +13,7 @@ const maxPendingOSCBytes = 64 << 10
 
 type outputFilter interface {
 	Filter(input []byte) FilterResult
+	Flush() FilterResult
 	FilterInput(input []byte) []byte
 }
 
@@ -25,6 +26,7 @@ type oscSecurityFilter struct {
 
 type oscParser struct {
 	pending       []byte
+	utf8Carry     []byte
 	discarding    bool
 	discardEscape bool
 	discardKind   byte
@@ -35,12 +37,17 @@ func newOSCSecurityFilter(nonce string, onTitle func(string)) *oscSecurityFilter
 }
 
 func (f *oscSecurityFilter) Filter(input []byte) FilterResult {
-	display, facts := f.output.filter(input, f.nonce, f.onTitle, true)
+	display, facts := f.output.filter(input, f.nonce, f.onTitle, true, false)
+	return FilterResult{DisplayBytes: display, MarkerFacts: facts}
+}
+
+func (f *oscSecurityFilter) Flush() FilterResult {
+	display, facts := f.output.filter(nil, f.nonce, f.onTitle, true, true)
 	return FilterResult{DisplayBytes: display, MarkerFacts: facts}
 }
 
 func (f *oscSecurityFilter) FilterInput(input []byte) []byte {
-	display, _ := f.input.filter(input, "", nil, false)
+	display, _ := f.input.filter(input, "", nil, false, false)
 	return display
 }
 
@@ -49,8 +56,19 @@ func (p *oscParser) filter(
 	nonce string,
 	onTitle func(string),
 	parseMarkers bool,
+	final bool,
 ) ([]byte, []MarkerFacts) {
 	data := input
+	if len(p.utf8Carry) > 0 {
+		p.utf8Carry = append(p.utf8Carry, input...)
+		data = p.utf8Carry
+		p.utf8Carry = nil
+	}
+	if !final {
+		var carry []byte
+		data, carry = splitCompleteUTF8(data)
+		p.utf8Carry = bytes.Clone(carry)
+	}
 	if p.discarding {
 		data = p.discardUntilTerminator(data)
 		if p.discarding {
@@ -129,58 +147,47 @@ func (p *oscParser) discardUntilTerminator(input []byte) []byte {
 }
 
 func controlStart(input []byte) (int, byte, int) {
-	osc := bytes.Index(input, []byte{0x1b, ']'})
-	dcs := bytes.Index(input, []byte{0x1b, 'P'})
-	c1OSC := bytes.IndexByte(input, 0x9d)
-	c1DCS := bytes.IndexByte(input, 0x90)
-	start, kind, prefixBytes := -1, byte(0), 0
-	for _, candidate := range []struct {
-		start       int
-		kind        byte
-		prefixBytes int
-	}{
-		{start: osc, kind: 'o', prefixBytes: 2},
-		{start: dcs, kind: 'd', prefixBytes: 2},
-		{start: c1OSC, kind: 'o', prefixBytes: 1},
-		{start: c1DCS, kind: 'd', prefixBytes: 1},
-	} {
-		if candidate.start >= 0 && (start < 0 || candidate.start < start) {
-			start, kind, prefixBytes = candidate.start, candidate.kind, candidate.prefixBytes
+	for index := 0; index < len(input); {
+		value, size := utf8.DecodeRune(input[index:])
+		// Decode first so continuation bytes cannot masquerade as controls.
+		if value == utf8.RuneError && size == 1 {
+			value = rune(input[index])
 		}
+		switch value {
+		case 0x9d:
+			return index, 'o', size
+		case 0x90:
+			return index, 'd', size
+		}
+		if value == 0x1b && index+1 < len(input) {
+			switch input[index+1] {
+			case ']':
+				return index, 'o', 2
+			case 'P':
+				return index, 'd', 2
+			}
+		}
+		index += size
 	}
-	return start, kind, prefixBytes
+	return -1, 0, 0
 }
 
 func controlEnd(input []byte, kind byte) (int, int) {
-	if kind == 'd' {
-		return dcsEnd(input)
-	}
-	return oscEnd(input)
-}
-
-func dcsEnd(input []byte) (int, int) {
-	for index, value := range input {
-		if value == 0x9c {
+	for index := 0; index < len(input); {
+		value, size := utf8.DecodeRune(input[index:])
+		if value == utf8.RuneError && size == 1 {
+			value = rune(input[index])
+		}
+		if kind == 'o' && value == 0x07 {
 			return index, 1
+		}
+		if value == 0x9c {
+			return index, size
 		}
 		if value == 0x1b && index+1 < len(input) && input[index+1] == '\\' {
 			return index, 2
 		}
-	}
-	return -1, 0
-}
-
-func oscEnd(input []byte) (int, int) {
-	for index, value := range input {
-		if value == 0x07 {
-			return index, 1
-		}
-		if value == 0x9c {
-			return index, 1
-		}
-		if value == 0x1b && index+1 < len(input) && input[index+1] == '\\' {
-			return index, 2
-		}
+		index += size
 	}
 	return -1, 0
 }

--- a/internal/terminal/osc_filter_test.go
+++ b/internal/terminal/osc_filter_test.go
@@ -4,12 +4,117 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	terminalwire "github.com/compozy/compozy/internal/terminal/wire"
 )
+
+func TestOSCSecurityFilterUnicode(t *testing.T) {
+	t.Parallel()
+	for _, sample := range []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"Should preserve colored Unicode prompts and ANSI redraws", "\x1b[34m~/project\x1b[39m\r\n\x1b[35m❯\x1b[39m abc\b \b", "\x1b[34m~/project\x1b[39m\r\n\x1b[35m❯\x1b[39m abc\b \b"},
+		{"Should preserve multibyte characters containing C1 bytes", "❯❮⇡⇣≡✦ АÝ✜🔐", "❯❮⇡⇣≡✦ АÝ✜🔐"},
+		{"Should keep Unicode ST bytes inside blocked controls", "before\x1b]52;c;✜secret\x07after\x1bP✜private\x1b\\done", "beforeafterdone"},
+		{"Should retain raw C1 filtering beside Unicode", "❯\x9d52;c;✜secret\x9cА\x90✜private\x9cÝ", "❯АÝ"},
+		{"Should filter UTF-8 encoded C1 controls beside printable Unicode", "❯\u009d52;c;✜secret\u009cА\u0090✜private\u009cÝ", "❯АÝ"},
+		{"Should preserve unknown OSC with Unicode content", "\x1b]133;✜❯\x07abc", "\x1b]133;✜❯\x07abc"},
+		{"Should retain invalid bytes without hiding adjacent controls", "\xff\xe2x\x9d52;c;secret\x07ready", "\xff\xe2xready"},
+	} {
+		t.Run(sample.name, func(t *testing.T) {
+			t.Parallel()
+			for chunkSize := 1; chunkSize <= len(sample.input); chunkSize++ {
+				for _, inputSide := range []bool{false, true} {
+					filter := newOSCSecurityFilter("nonce-1", nil)
+					var got []byte
+					for offset := 0; offset < len(sample.input); offset += chunkSize {
+						chunk := []byte(sample.input[offset:min(offset+chunkSize, len(sample.input))])
+						if inputSide {
+							got = append(got, filter.FilterInput(chunk)...)
+						} else {
+							got = append(got, filter.Filter(chunk).DisplayBytes...)
+						}
+					}
+					if string(got) != sample.want {
+						t.Fatalf("chunk=%d inputSide=%v: got %q, want %q", chunkSize, inputSide, got, sample.want)
+					}
+				}
+			}
+		})
+	}
+	t.Run("Should flush an incomplete final rune without releasing blocked control content", func(t *testing.T) {
+		t.Parallel()
+		for _, sample := range []struct{ name, input, want string }{
+			{"Should retain final malformed bytes before a raw OSC", "visible\xe2\x9d", "visible\xe2"},
+			{"Should retain an incomplete final character", "visible\xf0\x9f", "visible\xf0\x9f"},
+			{"Should keep an unterminated clipboard control blocked", "visible\x1b]52;c;secret\xf0\x9f", "visible"},
+		} {
+			t.Run(sample.name, func(t *testing.T) {
+				t.Parallel()
+				filter := newOSCSecurityFilter("nonce-1", nil)
+				got := filter.Filter([]byte(sample.input)).DisplayBytes
+				got = append(got, filter.Flush().DisplayBytes...)
+				if string(got) != sample.want {
+					t.Fatalf("input=%q flushed=%q, want %q", sample.input, got, sample.want)
+				}
+			})
+		}
+	})
+	t.Run("Should preserve Unicode in model facing output", func(t *testing.T) {
+		t.Parallel()
+		input := []byte("❯АÝ✜🔐\x1b]8;;https://example.com/✜\x1b\\link\x1bP✜private\x1b\\done" +
+			"\u009d8;;https://example.com\u009c\u0090private\u009c")
+		if got := string(modelFacingOutput(input)); got != "❯АÝ✜🔐linkdone" {
+			t.Fatalf("modelFacingOutput() = %q", got)
+		}
+	})
+	t.Run("Should discard oversized controls through their real terminator", func(t *testing.T) {
+		t.Parallel()
+		for _, prefix := range []string{"\x1b]52;c;", "\x1bP"} {
+			t.Run(fmt.Sprintf("Should discard control %x", prefix), func(t *testing.T) {
+				t.Parallel()
+				for _, terminator := range []string{"\x1b\\", "\x9c", "\u009c"} {
+					t.Run(fmt.Sprintf("Should resume after terminator %x", terminator), func(t *testing.T) {
+						t.Parallel()
+						filter := newOSCSecurityFilter("nonce-1", nil)
+						first := filter.Filter([]byte(prefix + strings.Repeat("x", maxPendingOSCBytes)))
+						got := first.DisplayBytes
+						for _, value := range []byte("✜secret" + terminator + "❯ ready") {
+							got = append(got, filter.Filter([]byte{value}).DisplayBytes...)
+						}
+						if string(got) != "❯ ready" {
+							t.Fatalf("prefix=%q terminator=%q display=%q", prefix, terminator, got)
+						}
+					})
+				}
+			})
+		}
+	})
+	t.Run("Should deliver each key after an ASCII or Unicode prompt", func(t *testing.T) {
+		t.Parallel()
+		for _, glyph := range []string{">", "❯"} {
+			t.Run(fmt.Sprintf("Should deliver keys after prompt %s", glyph), func(t *testing.T) {
+				t.Parallel()
+				filter := newOSCSecurityFilter("nonce-1", nil)
+				prompt := fmt.Sprintf("\x1b[34m~/project\x1b[39m\r\n\x1b[35m%s\x1b[39m ", glyph)
+				if got := string(filter.Filter([]byte(prompt)).DisplayBytes); got != prompt {
+					t.Errorf("prompt %q: got %q", glyph, got)
+				}
+				for _, key := range []string{"a", "b", "c"} {
+					if got := string(filter.Filter([]byte(key)).DisplayBytes); got != key {
+						t.Errorf("prompt %q key %q: got %q", glyph, key, got)
+					}
+				}
+			})
+		}
+	})
+}
 
 func TestOSCSecurityFilterShouldAuthenticateMarkersAndSplitDisplay(t *testing.T) {
 	t.Parallel()

--- a/internal/terminal/session_output.go
+++ b/internal/terminal/session_output.go
@@ -21,6 +21,11 @@ func (s *session) readOutput() {
 		select {
 		case read := <-reads:
 			filtered := s.filter.Filter(read.data)
+			if read.err != nil {
+				final := s.filter.Flush()
+				filtered.DisplayBytes = append(filtered.DisplayBytes, final.DisplayBytes...)
+				filtered.MarkerFacts = append(filtered.MarkerFacts, final.MarkerFacts...)
+			}
 			if len(filtered.MarkerFacts) > 0 {
 				if err := s.manager.journal.ConsumeMarkerFacts(
 					s.ctx, s.Info(), filtered.MarkerFacts,

--- a/web/e2e/__tests__/terminal.spec.ts
+++ b/web/e2e/__tests__/terminal.spec.ts
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
+import { promisify, stripVTControlCharacters } from "node:util";
 
 import type { Locator, Page } from "@playwright/test";
 
@@ -41,6 +41,121 @@ const CLI_EXIT_FAILURE = 1;
 const CLI_EXIT_DATA_ERROR = 65;
 const CLI_EXIT_UNAVAILABLE = 69;
 const CLI_EXIT_CONFIG_INVALID = 78;
+
+// Invariant: separate browser keystrokes redraw a real zsh prompt before Enter,
+// and reconnect/CLI quote retain that same screen. Owner: terminal browser stream.
+for (const glyph of [">", "❯"]) {
+  test(`E2E-020: zsh prompt ${glyph} redraws each key with shell integration disabled`, async ({
+    appPage,
+    runtime,
+    browserArtifacts,
+  }) => {
+    assertLaunchRuntime(runtime);
+    test.skip(process.platform === "win32", "zsh prompt reproduction requires a Unix PTY");
+    const { stdout: shellPath } = await execFileAsync("which", ["zsh"]);
+    const workspace = await runtimeWorkspace(runtime);
+    await writeFile(
+      path.join(runtime.paths.operatorHomeDir, ".zshrc"),
+      `bindkey -e\nPROMPT=$'%F{blue}%~%f\\n%F{magenta}${glyph}%f '\nRPROMPT=''\n`,
+      { mode: 0o600 }
+    );
+    const general = await runtime.requestJSON<{
+      config: Record<string, unknown> & { terminal: Record<string, unknown> };
+    }>("/api/settings/general");
+    await runtime.requestJSON("/api/settings/general", {
+      method: "PATCH",
+      body: JSON.stringify({
+        config: {
+          ...general.config,
+          terminal: { ...general.config.terminal, shell_integration: false },
+        },
+      }),
+    });
+    const restart = await runtime.requestJSON<SettingsRestartAction>(
+      "/api/settings/actions/restart",
+      { method: "POST", body: "{}" }
+    );
+    await expect
+      .poll(async () => await pollRestartStatus(runtime, restart.status_url), { timeout: 45_000 })
+      .toBe("ready");
+    await reloadDaemonServedPage(appPage, runtime, "/", { readyTestId: "os-desktop" });
+    const opened = await runTerminalCLI<TerminalEnvelope>(runtime.paths, [
+      "open",
+      "--workspace",
+      workspace.id,
+      "--shell",
+      shellPath.trim(),
+      "--title",
+      "unicode-prompt",
+      "--detach",
+      "-o",
+      "json",
+    ]);
+    const terminalID = opened.terminal.id;
+    await ensureProjectWorkspace(appPage, runtime);
+    await openAppWindow(appPage, "Terminal", "terminal");
+    let window = focusedTerminalWindow(appPage);
+    await expect(window.getByTestId(`terminal-pane-${terminalID}`)).toBeVisible();
+    let log = await interactiveTerminalLog(window);
+    await expect
+      .poll(async () => (await terminalScreen(runtime, workspace.id, terminalID)).content)
+      .toContain(glyph);
+    await expect(log.getByText(glyph, { exact: true })).toBeVisible();
+    await log.click();
+    for (const [index, key] of [..."abc"].entries()) {
+      await appPage.keyboard.press(key);
+      await expect
+        .poll(async () => (await terminalScreen(runtime, workspace.id, terminalID)).content)
+        .toContain(`${glyph} ${"abc".slice(0, index + 1)}`);
+      await expect(
+        log.getByText(`${glyph} ${"abc".slice(0, index + 1)}`, { exact: true })
+      ).toBeVisible();
+      await browserArtifacts.captureScreenshot(
+        `prompt-${glyph === ">" ? "ascii" : "unicode"}-key-${key}`,
+        appPage
+      );
+    }
+    const quote = await runTerminalCLI<{ quote: string }>(runtime.paths, [
+      "quote",
+      terminalID,
+      "--workspace",
+      workspace.id,
+      "--lines",
+      "1-40",
+      "-o",
+      "json",
+    ]);
+    expect(stripVTControlCharacters(quote.quote)).toContain(
+      `${glyph === ">" ? "&gt;" : glyph} abc`
+    );
+    expect(quote.quote).not.toContain("�");
+    await appPage.reload({ waitUntil: "domcontentloaded" });
+    window = focusedTerminalWindow(appPage);
+    log = await interactiveTerminalLog(window);
+    await expect(log.getByText(`${glyph} abc`, { exact: true })).toBeVisible();
+    await log.click();
+    await appPage.keyboard.press("Backspace");
+    await expect
+      .poll(async () =>
+        (await terminalScreen(runtime, workspace.id, terminalID)).content
+          .trimEnd()
+          .endsWith(`${glyph} ab`)
+      )
+      .toBe(true);
+    await expect(log.getByText(`${glyph} ab`, { exact: true })).toBeVisible();
+    await appPage.keyboard.press("Control+u");
+    await appPage.keyboard.type("printf 'unicode-input-%s\\n' ready", { delay: 20 });
+    await appPage.keyboard.press("Enter");
+    await expect
+      .poll(async () => (await terminalScreen(runtime, workspace.id, terminalID)).content)
+      .toContain("unicode-input-ready");
+    await expect(log.getByText("unicode-input-ready", { exact: true })).toBeVisible();
+    await browserArtifacts.captureScreenshot(
+      `prompt-${glyph === ">" ? "ascii" : "unicode"}-reconnected`,
+      appPage
+    );
+  });
+}
 
 interface TerminalRecord {
   capabilities: { interactive: boolean };


### PR DESCRIPTION
A colored zsh prompt ending in `❯` could truncate terminal output and hide every subsequent keystroke. This fixes UTF-8 handling at the security-filter boundary so Unicode prompts remain visible and interactive.

Closes #629

## Trigger, cause, and behavior

`❯` is encoded as `e2 9d af`. The security filter searched for raw C1 control bytes anywhere in the byte stream, so it interpreted the middle byte `9d` as an OSC introducer. With the reported colored, two-line prompt, it emitted only `e2` and buffered later `a`, `b`, and `c` redraws as an unterminated control. The otherwise-identical ASCII `>` prompt passed each update. The canonical regression demonstrates this failure on the original code.

This happens before `session_output.go` feeds the VT emulator. The existing downstream UTF-8 splitting cannot repair bytes already removed by the filter. No display-width hypothesis or width-table adjustment is needed for this confirmed mechanism. The reporter's clipboard observation and the exact conditions of the earlier successful plain-output experiment remain unverified.

## Implementation

- Recognize OSC/DCS starts and terminators only at UTF-8 rune boundaries. Valid Unicode continuation bytes are never interpreted as standalone C1 controls; actual C1 controls retain their filtering behavior in both raw-byte and UTF-8 encoded forms, matching xterm code-point decoding.
- Carry incomplete UTF-8 suffixes between input/output calls before parsing controls, including while discarding an oversized control. Flush final output through the same parser on EOF without releasing blocked control content.
- Reuse the same boundary scanning for model-facing reads/quotes, removing the second byte-wise scanner that also corrupted Unicode.
- Preserve ANSI bytes, authenticated marker handling, control-size limits, downstream VT processing, sequence accounting, and ACK backpressure.

## Verification

- Extended the existing `osc_filter_test.go` suite: chunk sizes down to one byte, the controlled prompt pair with separate updates, Pure symbols and other C1-bearing Unicode, real C1 controls, ANSI redraws, invalid bytes, EOF, oversized controls, and model-facing output.
- Added E2E-020 to the existing browser terminal suite: fresh real zsh terminals, ASCII/Unicode prompt pair, shell integration disabled followed by isolated-daemon restart, separate browser keystrokes checked before Enter against both daemon snapshots and existing browser-rendered accessibility rows, screenshots captured after those assertions, CLI quote content, reconnect, backspace, and subsequent command execution.
- Before the operator's CI-only override, the original regression failed as expected and the corrected terminal package tree passed race-enabled tests. The local gate was canceled under that override; no completed local delivery gate or local browser replay is claimed.
- Final validation runs in existing GitHub Actions workflows. CI and CodeRabbit/Greptile review are in progress; delivery is not complete until required checks pass for the current head and all actionable feedback is addressed.

## Impact and compatibility

The change-impact audit and targeted QA report are recorded in `docs/_memory/change-impact.md` and `docs/qa/reports/2026-09-12-terminal-unicode-prompt.md`; `ET-terminal-shell-config-fidelity` now includes the controlled per-key walk.

Existing terminal native tools, CLI, HTTP/UDS, Web stream and quote contracts keep their IDs and schemas. No configuration keys, hooks, SDK contracts, persisted formats, migrations, or workspace/profile authorization changes. Parser state remains session-local. The official terminal skill's existing read/quote and untrusted-output guidance remains accurate. Previously discarded output cannot be recovered; upgraded daemon/new terminals use the corrected filter. Raw visibility (#628) and ZDOTDIR (#626) are excluded. Linux/browser proof remains pending CI rather than inferred from pre-override macOS unit checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal output handling for Unicode and multibyte characters.
  - Fixed filtering of control sequences so blocked content is removed without affecting nearby text or keystrokes.
  - Ensured incomplete output is processed and displayed when a session ends.
  - Improved handling of oversized or unterminated control sequences.
  - Preserved valid colored prompts, screen redraws, and other supported terminal formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->